### PR TITLE
Update documentation to version 0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Non-exhaustive pattern match for `Part::FileData` in `adk-server/src/a2a/parts.rs`
 - Non-exhaustive pattern match for `Part::FileData` in `adk-cli/src/console.rs`
 
-## [0.1.8] - 2025-12-28
+## [0.1.9] - 2025-12-28
 
 ### ⭐ Highlights
 - **ADK Studio**: Complete visual agent builder with drag-and-drop workflow design
@@ -109,8 +109,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Standardized workspace dependencies for consistency
 
 ### Changed
-- All ADK crates bumped to version 0.1.8
-- Generated `Cargo.toml` now uses ADK version 0.1.8
+- All ADK crates bumped to version 0.1.9
+- Generated `Cargo.toml` now uses ADK version 0.1.9
 - Improved sub-agent display in containers (robot icon, LLM Agent label, tool descriptions)
 - Sequential agent now properly passes conversation history between sub-agents
 - Output mapper now accumulates text correctly across agent events
@@ -391,8 +391,8 @@ Initial release - Published to crates.io.
 - Google API key for Gemini
 
 [Unreleased]: https://github.com/zavora-ai/adk-rust/compare/v0.1.9...HEAD
-[0.1.9]: https://github.com/zavora-ai/adk-rust/compare/v0.1.8...v0.1.9
-[0.1.8]: https://github.com/zavora-ai/adk-rust/compare/v0.1.7...v0.1.8
+[0.1.9]: https://github.com/zavora-ai/adk-rust/compare/v0.1.9...v0.1.9
+[0.1.9]: https://github.com/zavora-ai/adk-rust/compare/v0.1.7...v0.1.9
 [0.1.7]: https://github.com/zavora-ai/adk-rust/compare/v0.1.6...v0.1.7
 [0.1.6]: https://github.com/zavora-ai/adk-rust/compare/v0.1.5...v0.1.6
 [0.1.5]: https://github.com/zavora-ai/adk-rust/compare/v0.1.4...v0.1.5

--- a/adk-agent/README.md
+++ b/adk-agent/README.md
@@ -21,14 +21,14 @@ Agent implementations for Rust Agent Development Kit (ADK-Rust, LLM, Custom, Wor
 
 ```toml
 [dependencies]
-adk-agent = "0.1.8"
+adk-agent = "0.1.9"
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.1.8", features = ["agents"] }
+adk-rust = { version = "0.1.9", features = ["agents"] }
 ```
 
 ## Quick Start

--- a/adk-artifact/README.md
+++ b/adk-artifact/README.md
@@ -21,14 +21,14 @@ Artifacts are useful for storing images, documents, audio, and other binary data
 
 ```toml
 [dependencies]
-adk-artifact = "0.1.8"
+adk-artifact = "0.1.9"
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.1.8", features = ["artifacts"] }
+adk-rust = { version = "0.1.9", features = ["artifacts"] }
 ```
 
 ## Quick Start

--- a/adk-browser/README.md
+++ b/adk-browser/README.md
@@ -20,9 +20,9 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-browser = "0.1.8"
-adk-agent = "0.1.8"
-adk-model = "0.1.8"
+adk-browser = "0.1.9"
+adk-agent = "0.1.9"
+adk-model = "0.1.9"
 ```
 
 ### Prerequisites

--- a/adk-cli/README.md
+++ b/adk-cli/README.md
@@ -19,14 +19,14 @@ Command-line launcher for Rust Agent Development Kit (ADK-Rust) agents.
 
 ```toml
 [dependencies]
-adk-cli = "0.1.8"
+adk-cli = "0.1.9"
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.1.8", features = ["cli"] }
+adk-rust = { version = "0.1.9", features = ["cli"] }
 ```
 
 ## Quick Start

--- a/adk-core/README.md
+++ b/adk-core/README.md
@@ -22,14 +22,14 @@ This crate is model-agnostic and contains no LLM-specific code.
 
 ```toml
 [dependencies]
-adk-core = "0.1.8"
+adk-core = "0.1.9"
 ```
 
 Or use the meta-crate for all components:
 
 ```toml
 [dependencies]
-adk-rust = "0.1.8"
+adk-rust = "0.1.9"
 ```
 
 ## Core Traits

--- a/adk-graph/README.md
+++ b/adk-graph/README.md
@@ -40,10 +40,10 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-graph = { version = "0.1.8", features = ["sqlite"] }
-adk-agent = "0.1.8"
-adk-model = "0.1.8"
-adk-core = "0.1.8"
+adk-graph = { version = "0.1.9", features = ["sqlite"] }
+adk-agent = "0.1.9"
+adk-model = "0.1.9"
+adk-core = "0.1.9"
 ```
 
 ### Basic Graph with AgentNode

--- a/adk-guardrail/README.md
+++ b/adk-guardrail/README.md
@@ -19,10 +19,10 @@ Guardrails framework for ADK agents - input/output validation, content filtering
 
 ```toml
 [dependencies]
-adk-guardrail = "0.1.8"
+adk-guardrail = "0.1.9"
 
 # With JSON schema validation (default)
-adk-guardrail = { version = "0.1.8", features = ["schema"] }
+adk-guardrail = { version = "0.1.9", features = ["schema"] }
 ```
 
 ## Quick Start

--- a/adk-memory/README.md
+++ b/adk-memory/README.md
@@ -19,14 +19,14 @@ Semantic memory and search for Rust Agent Development Kit (ADK-Rust) agents.
 
 ```toml
 [dependencies]
-adk-memory = "0.1.8"
+adk-memory = "0.1.9"
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.1.8", features = ["memory"] }
+adk-rust = { version = "0.1.9", features = ["memory"] }
 ```
 
 ## Quick Start

--- a/adk-model/README.md
+++ b/adk-model/README.md
@@ -25,14 +25,14 @@ The crate implements the `Llm` trait from `adk-core`, allowing models to be used
 
 ```toml
 [dependencies]
-adk-model = "0.1.8"
+adk-model = "0.1.9"
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.1.8", features = ["models"] }
+adk-rust = { version = "0.1.9", features = ["models"] }
 ```
 
 ## Quick Start
@@ -283,15 +283,15 @@ Enable specific providers with feature flags:
 ```toml
 [dependencies]
 # All providers (default)
-adk-model = { version = "0.1.8", features = ["all-providers"] }
+adk-model = { version = "0.1.9", features = ["all-providers"] }
 
 # Individual providers
-adk-model = { version = "0.1.8", features = ["gemini"] }
-adk-model = { version = "0.1.8", features = ["openai"] }
-adk-model = { version = "0.1.8", features = ["anthropic"] }
-adk-model = { version = "0.1.8", features = ["deepseek"] }
-adk-model = { version = "0.1.8", features = ["groq"] }
-adk-model = { version = "0.1.8", features = ["ollama"] }
+adk-model = { version = "0.1.9", features = ["gemini"] }
+adk-model = { version = "0.1.9", features = ["openai"] }
+adk-model = { version = "0.1.9", features = ["anthropic"] }
+adk-model = { version = "0.1.9", features = ["deepseek"] }
+adk-model = { version = "0.1.9", features = ["groq"] }
+adk-model = { version = "0.1.9", features = ["ollama"] }
 ```
 
 ## Related Crates

--- a/adk-realtime/README.md
+++ b/adk-realtime/README.md
@@ -51,7 +51,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-realtime = { version = "0.1.8", features = ["openai"] }
+adk-realtime = { version = "0.1.9", features = ["openai"] }
 ```
 
 ### Using RealtimeAgent (Recommended)

--- a/adk-runner/README.md
+++ b/adk-runner/README.md
@@ -20,14 +20,14 @@ Agent execution runtime for Rust Agent Development Kit (ADK-Rust) agents.
 
 ```toml
 [dependencies]
-adk-runner = "0.1.8"
+adk-runner = "0.1.9"
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.1.8", features = ["runner"] }
+adk-rust = { version = "0.1.9", features = ["runner"] }
 ```
 
 ## Quick Start

--- a/adk-rust/README.md
+++ b/adk-rust/README.md
@@ -20,7 +20,7 @@ cargo new my_agent && cd my_agent
 
 ```toml
 [dependencies]
-adk-rust = "0.1.8"
+adk-rust = "0.1.9"
 tokio = { version = "1.40", features = ["full"] }
 dotenv = "0.15"
 ```
@@ -192,13 +192,13 @@ cargo run -- serve --port 8080
 
 ```toml
 # Full (default)
-adk-rust = "0.1.8"
+adk-rust = "0.1.9"
 
 # Minimal
-adk-rust = { version = "0.1.8", default-features = false, features = ["minimal"] }
+adk-rust = { version = "0.1.9", default-features = false, features = ["minimal"] }
 
 # Custom
-adk-rust = { version = "0.1.8", default-features = false, features = ["agents", "gemini", "tools"] }
+adk-rust = { version = "0.1.9", default-features = false, features = ["agents", "gemini", "tools"] }
 ```
 
 ## Documentation

--- a/adk-server/README.md
+++ b/adk-server/README.md
@@ -20,14 +20,14 @@ HTTP server and A2A protocol for Rust Agent Development Kit (ADK-Rust) agents.
 
 ```toml
 [dependencies]
-adk-server = "0.1.8"
+adk-server = "0.1.9"
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.1.8", features = ["server"] }
+adk-rust = { version = "0.1.9", features = ["server"] }
 ```
 
 ## Quick Start

--- a/adk-session/README.md
+++ b/adk-session/README.md
@@ -19,14 +19,14 @@ Session management and state persistence for Rust Agent Development Kit (ADK-Rus
 
 ```toml
 [dependencies]
-adk-session = "0.1.8"
+adk-session = "0.1.9"
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.1.8", features = ["sessions"] }
+adk-rust = { version = "0.1.9", features = ["sessions"] }
 ```
 
 ## Quick Start
@@ -75,7 +75,7 @@ session.state().set("temp:current_step", "2".into());
 
 ```toml
 [dependencies]
-adk-session = { version = "0.1.8", features = ["database"] }
+adk-session = { version = "0.1.9", features = ["database"] }
 ```
 
 - `database` - Enable SQLite-backed sessions

--- a/adk-telemetry/README.md
+++ b/adk-telemetry/README.md
@@ -19,14 +19,14 @@ OpenTelemetry integration for Rust Agent Development Kit (ADK-Rust) agent observ
 
 ```toml
 [dependencies]
-adk-telemetry = "0.1.8"
+adk-telemetry = "0.1.9"
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.1.8", features = ["telemetry"] }
+adk-rust = { version = "0.1.9", features = ["telemetry"] }
 ```
 
 ## Quick Start

--- a/adk-tool/README.md
+++ b/adk-tool/README.md
@@ -21,14 +21,14 @@ Tool system for Rust Agent Development Kit (ADK-Rust) agents (FunctionTool, MCP,
 
 ```toml
 [dependencies]
-adk-tool = "0.1.8"
+adk-tool = "0.1.9"
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.1.8", features = ["tools"] }
+adk-rust = { version = "0.1.9", features = ["tools"] }
 ```
 
 ## Quick Start

--- a/adk-ui/README.md
+++ b/adk-ui/README.md
@@ -16,7 +16,7 @@ Dynamic UI generation for AI agents. Enables agents to render rich user interfac
 
 ```toml
 [dependencies]
-adk-ui = "0.1.8"
+adk-ui = "0.1.9"
 ```
 
 ```rust

--- a/docs/official_docs/security/access-control.md
+++ b/docs/official_docs/security/access-control.md
@@ -126,10 +126,10 @@ sso.check_token(token, &permission).await?;
 
 ```toml
 [dependencies]
-adk-auth = "0.1.8"
+adk-auth = "0.1.9"
 
 # For SSO/OAuth support
-adk-auth = { version = "0.1.8", features = ["sso"] }
+adk-auth = { version = "0.1.9", features = ["sso"] }
 ```
 
 ## Core Components


### PR DESCRIPTION
- Update all README files to reference version 0.1.9 instead of 0.1.8
- Update CHANGELOG.md version references
- Ensure documentation matches published crate versions