### PR TITLE
ci: Add automatic docs sync to wiki and website

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -1,0 +1,47 @@
+name: Sync Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/official_docs/**'
+  workflow_dispatch:
+
+jobs:
+  sync-wiki:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Sync to Wiki
+        uses: Andrew-Chen-Wang/github-wiki-action@v4
+        with:
+          path: docs/official_docs
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync-website:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: adk-rust
+
+      - uses: actions/checkout@v4
+        with:
+          repository: zavora-ai/adk-rust-website
+          token: ${{ secrets.WEBSITE_SYNC_TOKEN }}
+          path: website
+
+      - name: Sync docs to website
+        run: |
+          rm -rf website/frontend/docs/*
+          cp -r adk-rust/docs/official_docs/* website/frontend/docs/
+          
+      - name: Commit and push
+        run: |
+          cd website
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git diff --staged --quiet || git commit -m "docs: Sync from adk-rust"
+          git push


### PR DESCRIPTION
Adds GitHub Action to automatically sync `docs/official_docs/` to:
1. **GitHub Wiki** - using github-wiki-action
2. **Website repo** - syncs to `zavora-ai/adk-rust-website` frontend/docs/

**Triggers:**
- Push to main with changes in `docs/official_docs/**`
- Manual workflow dispatch

**Setup required:**
- Create a PAT with repo access and add as `WEBSITE_SYNC_TOKEN` secret in adk-rust repo settings