### PR TITLE
docs: update README versions to 0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,22 +677,22 @@ Add to your `Cargo.toml`:
 adk-rust = "0.2.0"
 
 # Or individual crates for finer control
-adk-core = "0.2.0"
-adk-agent = "0.2.0"
-adk-model = { version = "0.2.0", features = ["openai", "anthropic"] }  # Enable providers
-adk-tool = "0.2.0"
-adk-runner = "0.2.0"
+adk-core = "0.2.1"
+adk-agent = "0.2.1"
+adk-model = { version = "0.2.1", features = ["openai", "anthropic"] }  # Enable providers
+adk-tool = "0.2.1"
+adk-runner = "0.2.1"
 
 # Optional dependencies
-adk-session = { version = "0.2.0", optional = true }
-adk-artifact = { version = "0.2.0", optional = true }
-adk-memory = { version = "0.2.0", optional = true }
-adk-server = { version = "0.2.0", optional = true }
-adk-cli = { version = "0.2.0", optional = true }
-adk-realtime = { version = "0.2.0", features = ["openai"], optional = true }
-adk-graph = { version = "0.2.0", features = ["sqlite"], optional = true }
-adk-browser = { version = "0.2.0", optional = true }
-adk-eval = { version = "0.2.0", optional = true }
+adk-session = { version = "0.2.1", optional = true }
+adk-artifact = { version = "0.2.1", optional = true }
+adk-memory = { version = "0.2.1", optional = true }
+adk-server = { version = "0.2.1", optional = true }
+adk-cli = { version = "0.2.1", optional = true }
+adk-realtime = { version = "0.2.1", features = ["openai"], optional = true }
+adk-graph = { version = "0.2.1", features = ["sqlite"], optional = true }
+adk-browser = { version = "0.2.1", optional = true }
+adk-eval = { version = "0.2.1", optional = true }
 ```
 
 ## Examples

--- a/adk-artifact/README.md
+++ b/adk-artifact/README.md
@@ -28,7 +28,7 @@ Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.2.0", features = ["artifacts"] }
+adk-rust = { version = "0.2.1", features = ["artifacts"] }
 ```
 
 ## Quick Start

--- a/adk-cli/README.md
+++ b/adk-cli/README.md
@@ -26,7 +26,7 @@ Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.2.0", features = ["cli"] }
+adk-rust = { version = "0.2.1", features = ["cli"] }
 ```
 
 ## Quick Start

--- a/adk-gemini/README.md
+++ b/adk-gemini/README.md
@@ -68,7 +68,7 @@ Or use it through `adk-model`:
 
 ```toml
 [dependencies]
-adk-model = { version = "0.2.0", features = ["gemini"] }
+adk-model = { version = "0.2.1", features = ["gemini"] }
 ```
 
 ## 🚀 Quick Start

--- a/adk-graph/README.md
+++ b/adk-graph/README.md
@@ -40,9 +40,9 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-graph = { version = "0.2.0", features = ["sqlite"] }
-adk-agent = "0.2.0"
-adk-model = "0.2.0"
+adk-graph = { version = "0.2.1", features = ["sqlite"] }
+adk-agent = "0.2.1"
+adk-model = "0.2.1"
 adk-core = "0.2.0"
 ```
 

--- a/adk-guardrail/README.md
+++ b/adk-guardrail/README.md
@@ -22,7 +22,7 @@ Guardrails framework for ADK agents - input/output validation, content filtering
 adk-guardrail = "0.2.0"
 
 # With JSON schema validation (default)
-adk-guardrail = { version = "0.2.0", features = ["schema"] }
+adk-guardrail = { version = "0.2.1", features = ["schema"] }
 ```
 
 ## Quick Start
@@ -63,7 +63,7 @@ let filter = ContentFilter::blocked_keywords(vec!["forbidden".into()]);
 Requires `guardrails` feature on `adk-agent`:
 
 ```toml
-adk-agent = { version = "0.2.0", features = ["guardrails"] }
+adk-agent = { version = "0.2.1", features = ["guardrails"] }
 ```
 
 ```rust

--- a/adk-memory/README.md
+++ b/adk-memory/README.md
@@ -26,7 +26,7 @@ Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.2.0", features = ["memory"] }
+adk-rust = { version = "0.2.1", features = ["memory"] }
 ```
 
 ## Quick Start

--- a/adk-model/README.md
+++ b/adk-model/README.md
@@ -32,7 +32,7 @@ Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.2.0", features = ["models"] }
+adk-rust = { version = "0.2.1", features = ["models"] }
 ```
 
 ## Quick Start
@@ -283,15 +283,15 @@ Enable specific providers with feature flags:
 ```toml
 [dependencies]
 # All providers (default)
-adk-model = { version = "0.2.0", features = ["all-providers"] }
+adk-model = { version = "0.2.1", features = ["all-providers"] }
 
 # Individual providers
-adk-model = { version = "0.2.0", features = ["gemini"] }
-adk-model = { version = "0.2.0", features = ["openai"] }
-adk-model = { version = "0.2.0", features = ["anthropic"] }
-adk-model = { version = "0.2.0", features = ["deepseek"] }
-adk-model = { version = "0.2.0", features = ["groq"] }
-adk-model = { version = "0.2.0", features = ["ollama"] }
+adk-model = { version = "0.2.1", features = ["gemini"] }
+adk-model = { version = "0.2.1", features = ["openai"] }
+adk-model = { version = "0.2.1", features = ["anthropic"] }
+adk-model = { version = "0.2.1", features = ["deepseek"] }
+adk-model = { version = "0.2.1", features = ["groq"] }
+adk-model = { version = "0.2.1", features = ["ollama"] }
 ```
 
 ## Related Crates

--- a/adk-realtime/README.md
+++ b/adk-realtime/README.md
@@ -51,7 +51,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-realtime = { version = "0.2.0", features = ["openai"] }
+adk-realtime = { version = "0.2.1", features = ["openai"] }
 ```
 
 ### Using RealtimeAgent (Recommended)

--- a/adk-rust/README.md
+++ b/adk-rust/README.md
@@ -202,10 +202,10 @@ cargo run -- serve --port 8080
 adk-rust = "0.2.0"
 
 # Minimal
-adk-rust = { version = "0.2.0", default-features = false, features = ["minimal"] }
+adk-rust = { version = "0.2.1", default-features = false, features = ["minimal"] }
 
 # Custom
-adk-rust = { version = "0.2.0", default-features = false, features = ["agents", "gemini", "tools"] }
+adk-rust = { version = "0.2.1", default-features = false, features = ["agents", "gemini", "tools"] }
 ```
 
 ## Documentation

--- a/adk-server/README.md
+++ b/adk-server/README.md
@@ -27,7 +27,7 @@ Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.2.0", features = ["server"] }
+adk-rust = { version = "0.2.1", features = ["server"] }
 ```
 
 ## Quick Start

--- a/adk-session/README.md
+++ b/adk-session/README.md
@@ -26,7 +26,7 @@ Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.2.0", features = ["sessions"] }
+adk-rust = { version = "0.2.1", features = ["sessions"] }
 ```
 
 ## Quick Start
@@ -85,7 +85,7 @@ let theme = session.state().get("user:theme");
 
 ```toml
 [dependencies]
-adk-session = { version = "0.2.0", features = ["database"] }
+adk-session = { version = "0.2.1", features = ["database"] }
 ```
 
 - `database` - Enable SQLite-backed sessions

--- a/adk-telemetry/README.md
+++ b/adk-telemetry/README.md
@@ -26,7 +26,7 @@ Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.2.0", features = ["telemetry"] }
+adk-rust = { version = "0.2.1", features = ["telemetry"] }
 ```
 
 ## Quick Start

--- a/adk-tool/README.md
+++ b/adk-tool/README.md
@@ -29,7 +29,7 @@ Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.2.0", features = ["tools"] }
+adk-rust = { version = "0.2.1", features = ["tools"] }
 ```
 
 ## Quick Start


### PR DESCRIPTION
Updates all crate README files to reference v0.2.1 instead of v0.2.0 in dependency examples.