### PR TITLE
refactor(gemini): introduce GeminiBackend trait and switch clients to backend abstraction; add SDK migration log

### DIFF
--- a/adk-gemini/Cargo.toml
+++ b/adk-gemini/Cargo.toml
@@ -245,6 +245,7 @@ features = [
 ]
 default-features = false
 
+
 [dependencies.schemars]
 version = "1.0"
 

--- a/adk-gemini/docs/google_cloud_migration.md
+++ b/adk-gemini/docs/google_cloud_migration.md
@@ -1,0 +1,86 @@
+# Google Cloud Rust SDK Migration Plan
+
+## Motivation
+
+The long-term goal is to align `adk-gemini` with the official Google Cloud Rust SDK so that
+SDK-maintained authentication, endpoint discovery, and API evolution are handled upstream.
+This improves operational reliability and reduces the maintenance burden for the HTTP client
+surface that we currently own.
+
+## Refactoring Plan (Phased)
+
+### Phase 0: Alignment & Research
+- Inventory the `google-cloud-rust` API surface for Generative AI, including streaming, embeddings,
+  batch operations, file uploads, and caching.
+- Confirm auth patterns (ADC, workload identity, service accounts) and how they map to the existing
+  API key setup.
+
+### Phase 1: Backend Abstraction
+- Introduce an internal backend trait to allow multiple transport implementations without changing
+  public APIs.
+- Keep the HTTP backend as the default to preserve compatibility.
+
+### Phase 2: SDK Wrapper Scaffold
+- Add a `GoogleGeminiClient` wrapper that implements the backend trait once the SDK surface is verified.
+
+### Phase 3: Request/Response Mapping
+- Implement mapping helpers between ADK request/response structs and SDK request/response types.
+- Validate conversions for `Content`, `Part`, function calls, and safety settings.
+
+### Phase 4: End-to-End Parity
+- Implement streaming generation, embeddings, batch jobs, file management, and caching over the SDK.
+- Update examples to demonstrate ADC-based auth flows.
+
+### Phase 5: Deprecation & Cleanup
+- Mark the legacy HTTP implementation as deprecated.
+- Document migration guidance and eventually remove the HTTP backend in a major version.
+
+## Design Notes
+
+- **Public API stability:** `Gemini`, `GeminiBuilder`, and all builder/handle APIs remain unchanged.
+  The backend selection is internal, which keeps existing applications compatible.
+- **Backend selection:** A feature flag will toggle the SDK backend once the official API surface
+  is validated, so we can stabilize the integration without forcing downstream dependency changes.
+- **Error model:** The existing `ClientError` is retained. SDK errors should be translated into
+  this error type for consistent handling.
+
+## Task Breakdown
+
+1. **SDK research and mapping**
+   - Identify SDK client initialization patterns and request/response types.
+   - Map streaming behavior to `GenerationResponse` streaming semantics.
+2. **SDK integration**
+   - Wire up `GoogleGeminiClient` using verified SDK client types.
+   - Implement auth and endpoint configuration.
+3. **Type conversion layer**
+   - Introduce adapters for request/response conversion.
+   - Add unit tests to validate round-trip conversions.
+4. **Feature parity tests**
+   - Add integration tests for content generation, embeddings, batch jobs, file upload, and cache.
+5. **Docs & examples**
+   - Update README and examples to show SDK-based configuration and ADC usage.
+
+## Current State
+
+- The backend trait is in place and the SDK integration work is queued behind the
+  research phase (no SDK types are assumed or wired yet).
+- No SDK dependency is enabled until the official API surface is validated.
+
+## SDK API Validation Log
+
+The initial validation pass requires network access to the official crate metadata and
+repository. The following attempts were made and blocked by the environment:
+
+- `cargo search google-cloud-rust` → 403 (registry access blocked)
+- `curl https://crates.io/api/v1/crates/google-cloud-rust` → 403
+- `git ls-remote https://github.com/googleapis/google-cloud-rust` → 403
+- `git ls-remote https://github.com/jkmaina/google-cloud-rust` → 403
+- `git clone --depth 1 https://github.com/jkmaina/google-cloud-rust /tmp/google-cloud-rust` → 403
+- Retry after internet enabled: `git ls-remote https://github.com/jkmaina/google-cloud-rust` → 403
+- Retry after internet enabled: `git ls-remote https://github.com/googleapis/google-cloud-rust` → 403
+
+Once network access is available, repeat the steps above, then capture:
+
+- Crate version and feature flags
+- Module paths for Generative AI / Gemini clients
+- Request/response types for generation, streaming, embeddings, batch operations, files, and cache

--- a/adk-gemini/src/batch/builder.rs
+++ b/adk-gemini/src/batch/builder.rs
@@ -5,7 +5,7 @@ use tracing::{Span, instrument};
 use super::handle::BatchHandle;
 use super::model::*;
 use super::*;
-use crate::{client::GeminiClient, generation::GenerateContentRequest};
+use crate::{client::GeminiBackend, generation::GenerateContentRequest};
 
 /// A builder for creating and executing synchronous batch content generation requests.
 ///
@@ -13,14 +13,14 @@ use crate::{client::GeminiClient, generation::GenerateContentRequest};
 /// add multiple `GenerateContentRequest` items and then execute them as a single
 /// long-running operation.
 pub struct BatchBuilder {
-    client: Arc<GeminiClient>,
+    client: Arc<dyn GeminiBackend>,
     display_name: String,
     requests: Vec<GenerateContentRequest>,
 }
 
 impl BatchBuilder {
     /// Create a new batch builder
-    pub(crate) fn new(client: Arc<GeminiClient>) -> Self {
+    pub(crate) fn new(client: Arc<dyn GeminiBackend>) -> Self {
         Self { client, display_name: "RustBatch".to_string(), requests: Vec::new() }
     }
 

--- a/adk-gemini/src/batch/handle.rs
+++ b/adk-gemini/src/batch/handle.rs
@@ -70,7 +70,7 @@ use std::{result::Result, sync::Arc};
 use super::model::*;
 use crate::{
     GenerationResponse,
-    client::{Error as ClientError, GeminiClient},
+    client::{Error as ClientError, GeminiBackend},
     files::handle::FileHandle,
 };
 
@@ -137,7 +137,7 @@ pub enum BatchStatus {
 impl BatchStatus {
     async fn parse_response_file(
         response_file: crate::files::model::File,
-        client: Arc<GeminiClient>,
+        client: Arc<dyn GeminiBackend>,
     ) -> Result<Vec<BatchGenerationResponseItem>, Error> {
         let file = FileHandle::new(client.clone(), response_file);
         let file_content_bytes =
@@ -162,7 +162,7 @@ impl BatchStatus {
 
     async fn process_successful_response(
         response: BatchOperationResponse,
-        client: Arc<GeminiClient>,
+        client: Arc<dyn GeminiBackend>,
     ) -> Result<Vec<BatchGenerationResponseItem>, Error> {
         let results = match response {
             BatchOperationResponse::InlinedResponses { inlined_responses } => inlined_responses
@@ -183,7 +183,7 @@ impl BatchStatus {
 
     async fn from_operation(
         operation: BatchOperation,
-        client: Arc<GeminiClient>,
+        client: Arc<dyn GeminiBackend>,
     ) -> Result<Self, Error> {
         if operation.done {
             // According to Google API documentation, when done=true, result must be present
@@ -235,12 +235,12 @@ impl BatchStatus {
 pub struct BatchHandle {
     /// The unique resource name of the batch operation, e.g., `operations/batch-xxxxxxxx`.
     pub name: String,
-    client: Arc<GeminiClient>,
+    client: Arc<dyn GeminiBackend>,
 }
 
 impl BatchHandle {
     /// Creates a new Batch instance.
-    pub(crate) fn new(name: String, client: Arc<GeminiClient>) -> Self {
+    pub(crate) fn new(name: String, client: Arc<dyn GeminiBackend>) -> Self {
         Self { name, client }
     }
 

--- a/adk-gemini/src/cache/handle.rs
+++ b/adk-gemini/src/cache/handle.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use super::model::*;
 use super::*;
-use crate::client::GeminiClient;
+use crate::client::GeminiBackend;
 
 /// Represents a cached content resource, providing methods to manage its lifecycle.
 ///
@@ -12,12 +12,12 @@ use crate::client::GeminiClient;
 pub struct CachedContentHandle {
     /// The unique resource name of the cached content, e.g., `cachedContents/cache-xxxxxxxx`.
     pub name: String,
-    client: Arc<GeminiClient>,
+    client: Arc<dyn GeminiBackend>,
 }
 
 impl CachedContentHandle {
     /// Creates a new CachedContentHandle instance.
-    pub(crate) fn new(name: String, client: Arc<GeminiClient>) -> Self {
+    pub(crate) fn new(name: String, client: Arc<dyn GeminiBackend>) -> Self {
         Self { name, client }
     }
 

--- a/adk-gemini/src/embedding/builder.rs
+++ b/adk-gemini/src/embedding/builder.rs
@@ -7,12 +7,12 @@ use super::model::{
 };
 use crate::{
     Content, Message,
-    client::{Error as ClientError, GeminiClient},
+    client::{Error as ClientError, GeminiBackend},
 };
 
 /// Builder for embed generation requests
 pub struct EmbedBuilder {
-    client: Arc<GeminiClient>,
+    client: Arc<dyn GeminiBackend>,
     contents: Vec<Content>,
     task_type: Option<TaskType>,
     title: Option<String>,
@@ -21,7 +21,7 @@ pub struct EmbedBuilder {
 
 impl EmbedBuilder {
     /// Create a new embed builder
-    pub(crate) fn new(client: Arc<GeminiClient>) -> Self {
+    pub(crate) fn new(client: Arc<dyn GeminiBackend>) -> Self {
         Self {
             client,
             contents: Vec::new(),
@@ -75,7 +75,7 @@ impl EmbedBuilder {
     ))]
     pub async fn execute(self) -> Result<ContentEmbeddingResponse, ClientError> {
         let request = EmbedContentRequest {
-            model: self.client.model.clone(),
+            model: self.client.model().clone(),
             content: self.contents.first().expect("No content set").clone(),
             task_type: self.task_type,
             title: self.title,
@@ -97,7 +97,7 @@ impl EmbedBuilder {
 
         for content in self.contents {
             let request = EmbedContentRequest {
-                model: self.client.model.clone(),
+                model: self.client.model().clone(),
                 content: content.clone(),
                 task_type: self.task_type.clone(),
                 title: self.title.clone(),

--- a/adk-gemini/src/files/builder.rs
+++ b/adk-gemini/src/files/builder.rs
@@ -4,18 +4,18 @@ use std::sync::Arc;
 use tracing::instrument;
 
 use super::*;
-use crate::client::GeminiClient;
+use crate::client::GeminiBackend;
 
 /// A builder for creating a file resource.
 pub struct FileBuilder {
-    client: Arc<GeminiClient>,
+    client: Arc<dyn GeminiBackend>,
     file_bytes: Vec<u8>,
     display_name: Option<String>,
     mime_type: Option<Mime>,
 }
 
 impl FileBuilder {
-    pub(crate) fn new<B: Into<Vec<u8>>>(client: Arc<GeminiClient>, file_bytes: B) -> Self {
+    pub(crate) fn new<B: Into<Vec<u8>>>(client: Arc<dyn GeminiBackend>, file_bytes: B) -> Self {
         Self { client, file_bytes: file_bytes.into(), display_name: None, mime_type: None }
     }
 

--- a/adk-gemini/src/files/handle.rs
+++ b/adk-gemini/src/files/handle.rs
@@ -2,16 +2,16 @@ use snafu::ResultExt;
 use std::sync::Arc;
 
 use super::*;
-use crate::client::GeminiClient;
+use crate::client::GeminiBackend;
 
 /// A handle to a file on the Gemini API.
 pub struct FileHandle {
     inner: super::model::File,
-    client: Arc<GeminiClient>,
+    client: Arc<dyn GeminiBackend>,
 }
 
 impl FileHandle {
-    pub(crate) fn new(client: Arc<GeminiClient>, inner: super::model::File) -> Self {
+    pub(crate) fn new(client: Arc<dyn GeminiBackend>, inner: super::model::File) -> Self {
         Self { inner, client }
     }
 

--- a/adk-gemini/src/generation/builder.rs
+++ b/adk-gemini/src/generation/builder.rs
@@ -6,14 +6,14 @@ use crate::{
     Content, FunctionCallingMode, FunctionDeclaration, GenerationConfig, GenerationResponse,
     Message, Role, Tool,
     cache::CachedContentHandle,
-    client::{Error as ClientError, GeminiClient},
+    client::{Error as ClientError, GeminiBackend},
     generation::{GenerateContentRequest, SpeakerVoiceConfig, SpeechConfig, ThinkingConfig},
     tools::{FunctionCallingConfig, ToolConfig},
 };
 
 /// Builder for content generation requests
 pub struct ContentBuilder {
-    client: Arc<GeminiClient>,
+    client: Arc<dyn GeminiBackend>,
     pub contents: Vec<Content>,
     generation_config: Option<GenerationConfig>,
     tools: Option<Vec<Tool>>,
@@ -24,7 +24,7 @@ pub struct ContentBuilder {
 
 impl ContentBuilder {
     /// Creates a new `ContentBuilder`.
-    pub(crate) fn new(client: Arc<GeminiClient>) -> Self {
+    pub(crate) fn new(client: Arc<dyn GeminiBackend>) -> Self {
         Self {
             client,
             contents: Vec::new(),


### PR DESCRIPTION
### Motivation

- Decouple the public API from the concrete HTTP implementation so the SDK-backed Gemini client can be introduced without changing consumer-facing types. 
- Surface a clear integration point for swapping in an official `google-cloud-rust` SDK backend in the future. 
- Capture and document the current SDK validation attempts and network failures during migration research.

### Description

- Add a new `GeminiBackend` trait (with `#[async_trait]`) that centralizes async operations such as `generate_content_raw`, `generate_content_stream`, embedding, batch operations, file and cache APIs, and listing operations. 
- Implement `GeminiBackend` for the existing `GeminiClient` and adapt streaming to return a boxed stream via `BoxStream`. 
- Replace usages of `Arc<GeminiClient>` with `Arc<dyn GeminiBackend>` across builders and handles (`batch`, `cache`, `embedding`, `files`, `generation`, etc.) and update `GeminiBuilder`/`Gemini` to hold a backend instance via a new `BackendKind` enum. 
- Add an `UnsupportedBackend` error variant and a new documentation file `adk-gemini/docs/google_cloud_migration.md` that records the SDK migration plan and logs the repository access retries (including the observed `403`). 
- Minor formatting/whitespace adjustment in `adk-gemini/Cargo.toml`.

### Testing

- No automated tests were executed for this refactor and documentation change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697760a8e9a483228d96007edc50aa47)