### PR TITLE
 chore(adk-realtime): upgrade tokio-tungstenite to 0.26 and fix compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,7 +363,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.17",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.26.2",
  "tracing",
  "uuid 1.19.0",
 ]
@@ -948,7 +948,7 @@ dependencies = [
  "sha1",
  "sync_wrapper 1.0.2",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.24.0",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
@@ -4198,7 +4198,7 @@ dependencies = [
  "tokenizers",
  "tokio",
  "tokio-rayon",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.24.0",
  "toktrie_hf_tokenizers",
  "toml",
  "tqdm",
@@ -4224,7 +4224,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.24.0",
  "tracing",
  "utoipa",
  "uuid 1.19.0",
@@ -7678,10 +7678,24 @@ checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
 dependencies = [
  "futures-util",
  "log",
- "native-tls",
  "tokio",
- "tokio-native-tls",
- "tungstenite",
+ "tungstenite 0.24.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite 0.26.2",
 ]
 
 [[package]]
@@ -8031,10 +8045,28 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
- "native-tls",
  "rand 0.8.5",
  "sha1",
  "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.17",
  "utf-8",
 ]
 

--- a/adk-realtime/Cargo.toml
+++ b/adk-realtime/Cargo.toml
@@ -27,7 +27,7 @@ serde.workspace = true
 serde_json.workspace = true
 
 # WebSocket
-tokio-tungstenite = { version = "0.24", features = ["native-tls"], optional = true }
+tokio-tungstenite = { version = "0.26", default-features = false, features = ["rustls-tls-native-roots", "connect"], optional = true }
 
 # Error handling
 thiserror.workspace = true

--- a/adk-realtime/src/gemini/session.rs
+++ b/adk-realtime/src/gemini/session.rs
@@ -192,7 +192,7 @@ impl GeminiRealtimeSession {
 
         let mut sender = self.sender.lock().await;
         sender
-            .send(Message::Text(msg))
+            .send(Message::Text(msg.into()))
             .await
             .map_err(|e| RealtimeError::connection(format!("Send error: {}", e)))?;
 

--- a/adk-realtime/src/openai/session.rs
+++ b/adk-realtime/src/openai/session.rs
@@ -187,7 +187,7 @@ impl OpenAIRealtimeSession {
 
         let mut sender = self.sender.lock().await;
         sender
-            .send(Message::Text(msg))
+            .send(Message::Text(msg.into()))
             .await
             .map_err(|e| RealtimeError::connection(format!("Send error: {}", e)))?;
 


### PR DESCRIPTION
🎯 Motivation
This PR upgrades tokio-tungstenite to v0.26 to resolve dependency conflicts within the workspace. The previous version (v0.24) caused build failures when co-existing with projects requiring newer crate versions, particularly around the Utf8Bytes breaking change introduced in the Tungstenite ecosystem.

🛠️ Changes
Dependency Alignment
* Bumped tokio-tungstenite from 0.24 to 0.26.
* TLS Backend Migration: Switched from native-tls to rustls-tls-native-roots.
* Why: rustls is a pure-Rust implementation that simplifies cross-compilation and avoids linking against system C-libraries (OpenSSL/SChannel).
* Native Roots: Enforced rustls-tls-native-roots to ensure the client correctly utilizes the OS certificate store for verifying Google and OpenAI SSL certificates.
* Explicit Features: Enabled the connect feature to maintain client handshake capabilities after disabling default features to minimize bloat.

Protocol & Breaking Change Fixes
* In tokio-tungstenite 0.23+, the Message::Text payload shifted from a raw String to Utf8Bytes (a shared/zero-copy string wrapper).
* Updated gemini/session.rs and openai/session.rs to use the .into() pattern for WebSocket messages.
* This ensures the codebase remains idiomatic and type-safe across both v0.24 and v0.26 compatible wrappers.

// Protocol update to satisfy Utf8Bytes requirement
sender.send(Message::Text(msg.into())).await?;

🧪 Verification
* Compatibility: Verified that adk-studio (using axum 0.7) remains fully compatible.
* Compilation: Ran cargo check -p adk-realtime --all-features to confirm all provider paths (OpenAI/Gemini) compile without error.
* Portability: Confirmed rustls handshake succeeds against standard HTTPS/WSS endpoints.