### PR TITLE
feat(gemini): add service account auth and configurable retry logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,6 +338,7 @@ dependencies = [
  "base64 0.21.7",
  "claudius",
  "futures",
+ "gcp_auth",
  "ollama-rs",
  "reqwest 0.12.28",
  "schemars 1.2.0",
@@ -2976,6 +2977,32 @@ checksum = "794ac25cfda3fa11d2b07ff8c65889c6c03411646df54e59e606878d899e1d5a"
 dependencies = [
  "defmac",
  "unchecked-index",
+]
+
+[[package]]
+name = "gcp_auth"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2b3d0b409a042a380111af38136310839af8ac1a0917fb6e84515ed1e4bf3ee"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-rustls",
+ "hyper-util",
+ "ring",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "url",
 ]
 
 [[package]]
@@ -8865,6 +8892,16 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]

--- a/adk-model/Cargo.toml
+++ b/adk-model/Cargo.toml
@@ -30,10 +30,11 @@ tracing.workspace = true
 base64 = "0.21"
 ollama-rs = { version = "0.3", optional = true, default-features = false, features = ["stream"] }
 schemars = { version = "1.0", optional = true }
+gcp_auth = { version = "0.12", optional = true }
 
 [features]
 default = ["gemini"]
-gemini = ["dep:adk-gemini"]
+gemini = ["dep:adk-gemini", "dep:reqwest", "dep:gcp_auth"]
 openai = ["dep:async-openai"]
 anthropic = ["dep:claudius"]
 deepseek = ["dep:reqwest"]

--- a/adk-model/src/gemini/mod.rs
+++ b/adk-model/src/gemini/mod.rs
@@ -1,4 +1,4 @@
 pub mod client;
 pub mod streaming;
 
-pub use client::GeminiModel;
+pub use client::{GeminiModel, GeminiModelBuilder, RetryConfig};

--- a/docs/implementation/gemini_service_account.md
+++ b/docs/implementation/gemini_service_account.md
@@ -1,0 +1,220 @@
+# Using GeminiModel with Service Account Authentication
+
+This guide explains how to use GeminiModel with Google Cloud service account authentication instead of API keys.
+
+## Overview
+
+The `GeminiModel` now supports authentication using Google Cloud service accounts. This is useful when:
+- Running in Google Cloud environments (GCE, GKE, Cloud Run, etc.)
+- You need more fine-grained access control
+- You want to use Google Cloud IAM for managing permissions
+- API keys are not suitable for your security requirements
+
+## Prerequisites
+
+1. A Google Cloud service account with appropriate permissions
+2. The service account JSON key file
+3. The `gemini` feature enabled in your `Cargo.toml`:
+
+```toml
+[dependencies]
+adk-model = { version = "0.2.1", features = ["gemini"] }
+```
+
+## Usage
+
+Service account authentication requires using Vertex AI endpoints.
+
+### Using the Builder Pattern (Recommended)
+
+```rust
+use adk_model::gemini::{GeminiModel, RetryConfig};
+
+// From service account file
+let model = GeminiModel::builder("gemini-2.5-flash")
+    .service_account_path("/path/to/service-account.json")?
+    .project_id("my-project-id")
+    .location("us-central1")
+    .retry_config(
+        RetryConfig::new()
+            .with_max_retries(10)
+            .with_initial_delay(Duration::from_millis(500))
+    )
+    .build()
+    .await?;
+
+// From service account JSON string
+let model = GeminiModel::builder("gemini-2.5-flash")
+    .service_account_json(json_string)
+    .project_id("my-project-id")
+    .location("us-central1")
+    .build()
+    .await?;
+```
+
+### Convenience Methods
+
+For simpler use cases, you can use the convenience methods:
+
+#### Method 1: From Service Account JSON File
+
+```rust
+use adk_model::gemini::GeminiModel;
+
+let model = GeminiModel::new_with_service_account_path(
+    "/path/to/service-account.json",
+    "my-project-id",
+    "us-central1",
+    "gemini-2.5-flash"
+).await?;
+```
+
+#### Method 2: From Service Account JSON String
+
+```rust
+let service_account_json = std::fs::read_to_string("service-account.json")?;
+let model = GeminiModel::new_with_service_account_json(
+    service_account_json,
+    "my-project-id",
+    "us-central1",
+    "gemini-2.5-flash"
+).await?;
+```
+
+## Example
+
+See the complete example at `examples/gemini_service_account.rs`:
+
+```bash
+# Required: Set your GCP project ID
+export GOOGLE_PROJECT_ID=my-project-id
+
+# Optional: Set location (defaults to us-central1)
+export GOOGLE_LOCATION=us-central1
+
+# Option 1: Set the service account file path
+export GOOGLE_SERVICE_ACCOUNT_PATH=/path/to/service-account.json
+
+# Option 2: Or provide the JSON content directly
+export GOOGLE_SERVICE_ACCOUNT_JSON='{"type":"service_account",...}'
+
+# Run the example
+cargo run --example gemini_service_account --features gemini
+```
+
+## How It Works
+
+Under the hood, the implementation:
+1. Uses the `gcp_auth` crate to parse the service account JSON and obtain OAuth tokens
+2. Creates an authenticated HTTP client with Bearer token authorization
+3. Configures the Gemini client to use Vertex AI endpoints (`{location}-aiplatform.googleapis.com`)
+4. Automatically handles token refresh through `gcp_auth`
+
+Service account authentication requires Vertex AI endpoints because the consumer Gemini API (`generativelanguage.googleapis.com`) is primarily designed for API key authentication.
+
+## Service Account Permissions
+
+Your service account needs the following permissions:
+- For Gemini API: `roles/aiplatform.user` or more specific permissions
+- The implementation requests these OAuth scopes:
+  - `https://www.googleapis.com/auth/generative-language` - Base scope for generative language API
+  - `https://www.googleapis.com/auth/generative-language.retriever` - For semantic retrieval features
+  - `https://www.googleapis.com/auth/cloud-platform` - General Google Cloud Platform access
+
+## Security Best Practices
+
+1. **Never commit service account files to version control**
+2. Store service account JSON in secure secret management systems
+3. Use environment variables or secure file storage for production
+4. Rotate service account keys regularly
+5. Use the principle of least privilege when assigning permissions
+
+## Configuring Retry Logic
+
+The GeminiModel includes automatic retry logic for handling rate limits (429 errors). You can customize this behavior:
+
+### Default Configuration
+By default, retries are enabled with:
+- 3 maximum retries
+- 1 second initial delay
+- 2x exponential backoff
+- 60 seconds maximum delay
+
+### Custom Configuration
+
+```rust
+use adk_model::gemini::{GeminiModel, RetryConfig};
+use std::time::Duration;
+
+// Using the builder pattern (recommended)
+let model = GeminiModel::builder("models/gemini-2.5-flash")
+    .api_key("your-api-key")
+    .retry_config(
+        RetryConfig::new()
+            .with_max_retries(5)
+            .with_initial_delay(Duration::from_millis(500))
+            .with_max_delay(Duration::from_secs(30))
+            .with_backoff_multiplier(1.5)
+    )
+    .build()
+    .await?;
+
+// Configure with closure
+let model = GeminiModel::builder("models/gemini-2.5-flash")
+    .api_key("your-api-key")
+    .configure_retries(|config| {
+        config
+            .with_max_retries(10)
+            .with_initial_delay(Duration::from_secs(2))
+    })
+    .build()
+    .await?;
+
+// Disable retries
+let model = GeminiModel::builder("models/gemini-2.5-flash")
+    .api_key("your-api-key")
+    .retry_config(RetryConfig::disabled())
+    .build()
+    .await?;
+```
+
+### With Service Accounts
+
+```rust
+let model = GeminiModel::builder("gemini-2.5-flash")
+    .service_account_path("service-account.json")?
+    .project_id("project-id")
+    .location("us-central1")
+    .retry_config(
+        RetryConfig::new()
+            .with_max_retries(10)  // More retries for production
+            .with_backoff_multiplier(3.0)  // More aggressive backoff
+    )
+    .build()
+    .await?;
+```
+
+## Troubleshooting
+
+### "Failed to parse service account JSON"
+- Ensure the JSON is valid and contains all required fields
+- Check that the file path is correct and the file is readable
+
+### "Failed to get access token"
+- Verify the service account has the necessary permissions
+- Check that the service account is not disabled
+- Ensure you have network connectivity to Google's OAuth2 endpoints
+
+### "404 Not Found" error
+- Verify your project ID is correct
+- Ensure the location/region is valid (e.g., "us-central1")
+- Check that the Vertex AI API is enabled in your GCP project
+- Verify the model name is correct (e.g., "gemini-2.5-flash")
+
+### "403 Forbidden" error
+- Ensure the service account has the `roles/aiplatform.user` role or equivalent permissions
+- Verify the service account belongs to the correct project
+
+### Token Expiration
+- Tokens are automatically refreshed by the `gcp_auth` crate
+- No manual token management is required

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -83,6 +83,16 @@ name = "structured_output"
 path = "structured_output/main.rs"
 
 [[example]]
+name = "gemini_service_account"
+path = "gemini_service_account.rs"
+required-features = ["gemini"]
+
+[[example]]
+name = "gemini_retry_config"
+path = "gemini_retry_config.rs"
+required-features = ["gemini"]
+
+[[example]]
 name = "openai_basic"
 path = "openai_basic/main.rs"
 required-features = ["openai"]
@@ -541,6 +551,7 @@ required-features = ["mistralrs"]
 
 [features]
 default = []
+gemini = ["adk-model/gemini"]
 openai = ["adk-model/openai"]
 http-transport = ["adk-tool/http-transport"]
 anthropic = ["adk-model/anthropic"]

--- a/examples/gemini_retry_config.rs
+++ b/examples/gemini_retry_config.rs
@@ -1,0 +1,111 @@
+//! Example of configuring retry behavior for GeminiModel
+
+use adk_model::gemini::{GeminiModel, RetryConfig};
+use adk_core::{Content, Llm, LlmRequest, Part};
+use std::time::Duration;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+
+    // Example 1: Default retry configuration (3 retries, 1s initial delay, 2x backoff)
+    let _model1 = GeminiModel::new("your-api-key", "models/gemini-2.5-flash").await?;
+    println!("Model 1: Using default retry config");
+
+    // Example 2: Using the builder pattern with custom retry configuration
+    let model2 = GeminiModel::builder("models/gemini-2.5-flash")
+        .api_key("your-api-key")
+        .retry_config(
+            RetryConfig::new()
+                .with_max_retries(5)
+                .with_initial_delay(Duration::from_millis(500))
+                .with_max_delay(Duration::from_secs(30))
+                .with_backoff_multiplier(1.5)
+        )
+        .build()
+        .await?;
+    println!("Model 2: 5 retries, 500ms start, 1.5x backoff, 30s max");
+
+    // Example 3: Configure retries using closure in builder
+    let _model3 = GeminiModel::builder("models/gemini-2.5-flash")
+        .api_key("your-api-key")
+        .configure_retries(|config| {
+            config
+                .with_max_retries(2)
+                .with_initial_delay(Duration::from_secs(2))
+        })
+        .build()
+        .await?;
+    println!("Model 3: 2 retries, 2s initial delay");
+
+    // Example 4: Disable retries entirely
+    let _model4 = GeminiModel::builder("models/gemini-2.5-flash")
+        .api_key("your-api-key")
+        .retry_config(RetryConfig::disabled())
+        .build()
+        .await?;
+    println!("Model 4: Retries disabled");
+
+    // Example 5: Service account with custom retry config using builder
+    use std::env;
+    if let (Ok(project_id), Ok(location)) = (
+        env::var("GOOGLE_PROJECT_ID"),
+        env::var("GOOGLE_LOCATION")
+    ) {
+        if let Ok(service_account_path) = env::var("GOOGLE_SERVICE_ACCOUNT_PATH") {
+            let _model5 = GeminiModel::builder("gemini-2.5-flash")
+                .service_account_path(service_account_path)?
+                .project_id(project_id)
+                .location(location)
+                .retry_config(
+                    RetryConfig::new()
+                        .with_max_retries(10)  // More retries for production
+                        .with_initial_delay(Duration::from_millis(100))
+                        .with_backoff_multiplier(3.0)  // Aggressive backoff
+                )
+                .build()
+                .await?;
+            println!("Model 5: Service account with aggressive retry strategy");
+        }
+    }
+
+    // Test one of the models
+    test_model(&model2).await?;
+
+    Ok(())
+}
+
+async fn test_model(model: &GeminiModel) -> Result<(), Box<dyn std::error::Error>> {
+    let request = LlmRequest {
+        model: model.name().to_string(),
+        contents: vec![
+            Content {
+                role: "user".to_string(),
+                parts: vec![
+                    Part::Text {
+                        text: "Hello! How are you?".to_string(),
+                    },
+                ],
+            },
+        ],
+        tools: Default::default(),
+        config: None,
+    };
+
+    println!("\nSending request (retries will be automatic on rate limits)...");
+    let mut stream = model.generate_content(request, false).await?;
+
+    while let Some(response) = futures::StreamExt::next(&mut stream).await {
+        let response = response?;
+
+        if let Some(content) = response.content {
+            for part in content.parts {
+                if let Part::Text { text } = part {
+                    println!("Response: {}", text);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/examples/gemini_service_account.rs
+++ b/examples/gemini_service_account.rs
@@ -1,0 +1,108 @@
+//! Example of using GeminiModel with service account authentication
+
+use adk_model::gemini::GeminiModel;
+use adk_core::{Content, Llm, LlmRequest, Part};
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize tracing (optional but recommended)
+    tracing_subscriber::fmt::init();
+
+    // Application code handles reading environment variables
+    let project_id = env::var("GOOGLE_PROJECT_ID")
+        .expect("GOOGLE_PROJECT_ID environment variable must be set");
+    let location = env::var("GOOGLE_LOCATION")
+        .unwrap_or_else(|_| "us-central1".to_string());
+
+    println!("Using Vertex AI endpoint");
+    println!("Project: {}, Location: {}", project_id, location);
+
+    // Option 1: From service account file
+    let service_account_path = env::var("GOOGLE_SERVICE_ACCOUNT_PATH")
+        .unwrap_or_else(|_| "service-account.json".to_string());
+
+    if std::path::Path::new(&service_account_path).exists() {
+        println!("Using service account file: {}", service_account_path);
+
+        let model = GeminiModel::new_with_service_account_path(
+            &service_account_path,
+            &project_id,
+            &location,
+            "gemini-2.5-flash"
+        ).await?;
+
+        println!("Testing with service account from file...");
+        test_model(model).await?;
+    }
+
+    // Option 2: From service account JSON in environment variable
+    if let Ok(service_account_json) = env::var("GOOGLE_SERVICE_ACCOUNT_JSON") {
+        println!("Using service account from environment variable");
+
+        let model = GeminiModel::new_with_service_account_json(
+            service_account_json,
+            &project_id,
+            &location,
+            "gemini-2.5-flash"
+        ).await?;
+
+        println!("Testing with service account from env...");
+        test_model(model).await?;
+    }
+
+    if !std::path::Path::new(&service_account_path).exists()
+        && env::var("GOOGLE_SERVICE_ACCOUNT_JSON").is_err() {
+        eprintln!("No service account found!");
+        eprintln!("Please set either:");
+        eprintln!("  - GOOGLE_SERVICE_ACCOUNT_PATH to point to a service account JSON file");
+        eprintln!("  - GOOGLE_SERVICE_ACCOUNT_JSON with the JSON content");
+    }
+
+    Ok(())
+}
+
+async fn test_model(model: GeminiModel) -> Result<(), Box<dyn std::error::Error>> {
+    // Create a simple request
+    let request = LlmRequest {
+        model: model.name().to_string(),
+        contents: vec![
+            Content {
+                role: "user".to_string(),
+                parts: vec![
+                    Part::Text {
+                        text: "What is the capital of France?".to_string(),
+                    },
+                ],
+            },
+        ],
+        tools: Default::default(),
+        config: None,
+    };
+
+    // Generate content
+    println!("Sending request to Gemini...");
+    let mut stream = model.generate_content(request, false).await?;
+
+    // Process response
+    while let Some(response) = futures::StreamExt::next(&mut stream).await {
+        let response = response?;
+
+        if let Some(content) = response.content {
+            for part in content.parts {
+                if let Part::Text { text } = part {
+                    println!("Response: {}", text);
+                }
+            }
+        }
+
+        if let Some(usage) = response.usage_metadata {
+            println!("\nUsage:");
+            println!("  Prompt tokens: {}", usage.prompt_token_count);
+            println!("  Response tokens: {}", usage.candidates_token_count);
+            println!("  Total tokens: {}", usage.total_token_count);
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
# Add Service Account Authentication and Configurable Retry Logic to GeminiModel

## 📋 Description

This PR adds Google Cloud service account authentication support and configurable retry logic to the `GeminiModel` implementation. Previously, GeminiModel only supported API key authentication. This enhancement enables usage in Google Cloud environments and provides better rate limit handling.

## 🚀 What's Changed

### 🔐 Service Account Authentication
- Added support for authenticating with Google Cloud service accounts via JSON files or JSON strings
- Integrated `gcp_auth` crate for OAuth2 token management and automatic token refresh
- Service account authentication uses Vertex AI endpoints (`{location}-aiplatform.googleapis.com`) as the consumer API doesn't support OAuth2

### 🔄 Configurable Retry Logic
- Implemented exponential backoff retry mechanism for handling rate limits (429/RESOURCE_EXHAUSTED errors)
- Added `RetryConfig` struct with customizable parameters:
  - `max_retries`: Maximum number of retry attempts (default: 3)
  - `initial_delay`: Initial delay between retries (default: 1s)
  - `max_delay`: Maximum delay cap (default: 60s)
  - `backoff_multiplier`: Exponential growth factor (default: 2.0)
- Retry logic is automatic and transparent to users

### 🏗️ Builder Pattern API
- Introduced `GeminiModelBuilder` for cleaner configuration
- Maintains backward compatibility with existing constructors
- Provides fluent API for setting authentication method, retry config, and other parameters

## 💻 API Examples

```rust
// Service account with custom retry config
let model = GeminiModel::builder("gemini-2.5-flash")
    .service_account_path("/path/to/service-account.json")?
    .project_id("my-project-id")
    .location("us-central1")
    .retry_config(
        RetryConfig::new()
            .with_max_retries(10)
            .with_initial_delay(Duration::from_millis(500))
    )
    .build()
    .await?;

// API key with default retry config
let model = GeminiModel::builder("gemini-2.5-flash")
    .api_key("your-api-key")
    .build()
    .await?;

// Convenience methods still available
let model = GeminiModel::new_with_service_account_path(
    "/path/to/service-account.json",
    "project-id",
    "us-central1",
    "gemini-2.5-flash"
).await?;
```

## 🎯 Live Demo

I've created a demonstration project that validates the service account authentication in a real-world scenario:

🔗 **Demo Repository**: [dhruv304c2/test-agent-sa](https://github.com/dhruv304c2/test-agent-sa)

The demo showcases:
- ✅ Service account initialization with ADK
- ✅ Agent creation using service account authenticated GeminiModel
- ✅ Practical usage patterns with retry configuration
- ✅ Integration with ADK's agent framework
- ✅ Error handling for common authentication issues

## 💡 Motivation

1. **Enterprise Usage**: Many organizations require service account authentication for security and compliance
2. **Google Cloud Integration**: Enables seamless usage in GCE, GKE, Cloud Run, and other GCP services
3. **Rate Limit Handling**: Automatic retry logic prevents transient failures due to rate limiting
4. **Better UX**: Builder pattern provides cleaner, more maintainable code

## 🔧 Implementation Details

- Service account authentication requires Vertex AI endpoints as the consumer API only supports API keys
- OAuth2 tokens are automatically managed and refreshed by `gcp_auth`
- Retry logic uses tokio's sleep for async-friendly delays
- All errors are properly propagated with context

## ⚠️ Breaking Changes

**None**. All existing code continues to work without modification.

## ✅ Testing

- [x] Tested service account authentication with real GCP service accounts
- [x] Verified automatic token refresh functionality
- [x] Tested retry logic with artificial rate limits
- [x] Confirmed backward compatibility with existing API key usage
- [x] Added comprehensive examples in `examples/gemini_service_account.rs` and `examples/gemini_retry_config.rs`
- [x] Created external test project demonstrating real-world usage

## 📚 Documentation

Added detailed documentation in `docs/gemini_service_account.md` covering:
- Setup instructions
- Usage examples
- Required permissions
- Troubleshooting guide
- Security best practices

Updated module documentation with new API examples and added inline documentation for all new public types and methods.

## 📦 Dependencies

Added `gcp_auth = "0.12"` as an optional dependency under the `gemini` feature

## ✔️ PR Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Added documentation for new APIs
- [x] Added examples demonstrating new features
- [x] No breaking changes to existing APIs
- [x] All tests pass
- [x] Feature is gated behind existing `gemini` feature flag
- [x] External validation via demo project

---

This enhancement significantly improves the usability of GeminiModel in production environments while maintaining the simplicity of the existing API.