### PR TITLE
fix(adk-session): fix DatabaseSessionService append_event scope and p…

### DIFF
--- a/adk-session/tests/database_tests.rs
+++ b/adk-session/tests/database_tests.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "database")]
 mod tests {
     use adk_session::*;
+    use serde_json::json;
     use std::collections::HashMap;
 
     #[tokio::test]
@@ -118,5 +119,111 @@ mod tests {
             .await;
 
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_database_append_event_persists_event() {
+        let service = DatabaseSessionService::new(":memory:").await.unwrap();
+        service.migrate().await.unwrap();
+
+        service
+            .create(CreateRequest {
+                app_name: "test_app".to_string(),
+                user_id: "user1".to_string(),
+                session_id: Some("session1".to_string()),
+                state: HashMap::new(),
+            })
+            .await
+            .unwrap();
+
+        let event = Event::new("inv1");
+        service.append_event("session1", event).await.unwrap();
+
+        let session = service
+            .get(GetRequest {
+                app_name: "test_app".to_string(),
+                user_id: "user1".to_string(),
+                session_id: "session1".to_string(),
+                num_recent_events: None,
+                after: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(session.events().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_database_append_event_applies_state_delta() {
+        let service = DatabaseSessionService::new(":memory:").await.unwrap();
+        service.migrate().await.unwrap();
+
+        service
+            .create(CreateRequest {
+                app_name: "test_app".to_string(),
+                user_id: "user1".to_string(),
+                session_id: Some("session1".to_string()),
+                state: HashMap::new(),
+            })
+            .await
+            .unwrap();
+
+        let mut event = Event::new("inv1");
+        event.actions.state_delta.insert("session_key".to_string(), json!("session_value"));
+        event.actions.state_delta.insert("app:app_key".to_string(), json!("app_value"));
+        event.actions.state_delta.insert("user:user_key".to_string(), json!("user_value"));
+        event.actions.state_delta.insert("temp:temp_key".to_string(), json!("temp_value"));
+
+        service.append_event("session1", event).await.unwrap();
+
+        let session = service
+            .get(GetRequest {
+                app_name: "test_app".to_string(),
+                user_id: "user1".to_string(),
+                session_id: "session1".to_string(),
+                num_recent_events: None,
+                after: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(session.state().get("session_key"), Some(json!("session_value")));
+        assert_eq!(session.state().get("app:app_key"), Some(json!("app_value")));
+        assert_eq!(session.state().get("user:user_key"), Some(json!("user_value")));
+        assert_eq!(session.state().get("temp:temp_key"), None);
+    }
+
+    #[tokio::test]
+    async fn test_database_append_event_rejects_ambiguous_session_id() {
+        let service = DatabaseSessionService::new(":memory:").await.unwrap();
+        service.migrate().await.unwrap();
+
+        service
+            .create(CreateRequest {
+                app_name: "app_one".to_string(),
+                user_id: "user_one".to_string(),
+                session_id: Some("shared_session".to_string()),
+                state: HashMap::new(),
+            })
+            .await
+            .unwrap();
+
+        service
+            .create(CreateRequest {
+                app_name: "app_two".to_string(),
+                user_id: "user_two".to_string(),
+                session_id: Some("shared_session".to_string()),
+                state: HashMap::new(),
+            })
+            .await
+            .unwrap();
+
+        let event = Event::new("inv1");
+        let err = service.append_event("shared_session", event).await.unwrap_err();
+        assert!(
+            err.to_string().contains("ambiguous"),
+            "expected ambiguous session_id error, got: {}",
+            err
+        );
     }
 }


### PR DESCRIPTION
## Summary
This PR fixes DB-backed session event persistence in `adk-session`.

Fork: [illegalcall/adk-rust](https://github.com/illegalcall/adk-rust)

Fixes #31

## Root Cause
`DatabaseSessionService::append_event` inserted event rows with empty:
- `app_name`
- `user_id`

That caused:
- FK failures when SQLite foreign keys are enforced
- orphaned/missing events when FK checks are not enforced

## What changed
- Resolve `(app_name, user_id, state)` from `session_id` before event insert
- Insert event rows with correct `(app_name, user_id, session_id)`
- Apply `state_delta` to DB-backed app/user/session state
- Perform updates + event insert in a single transaction
- Return explicit error for ambiguous `session_id` across scopes

## Tests added
In `adk-session/tests/database_tests.rs`:
- `test_database_append_event_persists_event`
- `test_database_append_event_applies_state_delta`
- `test_database_append_event_rejects_ambiguous_session_id`

## Verification
- `cargo test --manifest-path adk-session/Cargo.toml --features database --test database_tests --quiet`
- `cargo test --manifest-path adk-session/Cargo.toml --features database --quiet`
