### PR TITLE
fix: remove mistralrs CI warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,10 @@ jobs:
     - name: Run clippy
       env:
         RUSTFLAGS: "-C link-arg=-fuse-ld=mold -C debuginfo=0"
-      run: cargo clippy --workspace --exclude adk-mistralrs --all-targets --all-features -- -D warnings
+      run: cargo clippy --workspace --all-targets --all-features -- -D warnings
     
     - name: Run tests
       env:
         RUSTFLAGS: "-C link-arg=-fuse-ld=mold -C debuginfo=0"
-      run: cargo test --workspace --exclude adk-mistralrs --all-features
+      run: cargo test --workspace --all-features
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -539,50 +539,8 @@ name = "auth_google"
 path = "auth_google/main.rs"
 required-features = ["sso"]
 
-[[example]]
-name = "mistralrs_basic"
-path = "mistralrs_basic/main.rs"
-required-features = ["mistralrs"]
-
-[[example]]
-name = "mistralrs_tools"
-path = "mistralrs_tools/main.rs"
-required-features = ["mistralrs"]
-
-[[example]]
-name = "mistralrs_vision"
-path = "mistralrs_vision/main.rs"
-required-features = ["mistralrs"]
-
-[[example]]
-name = "mistralrs_isq"
-path = "mistralrs_isq/main.rs"
-required-features = ["mistralrs"]
-
-[[example]]
-name = "mistralrs_lora"
-path = "mistralrs_lora/main.rs"
-required-features = ["mistralrs"]
-
-[[example]]
-name = "mistralrs_multimodel"
-path = "mistralrs_multimodel/main.rs"
-required-features = ["mistralrs"]
-
-[[example]]
-name = "mistralrs_mcp"
-path = "mistralrs_mcp/main.rs"
-required-features = ["mistralrs"]
-
-[[example]]
-name = "mistralrs_speech"
-path = "mistralrs_speech/main.rs"
-required-features = ["mistralrs"]
-
-[[example]]
-name = "mistralrs_diffusion"
-path = "mistralrs_diffusion/main.rs"
-required-features = ["mistralrs"]
+# Note: mistralrs examples are part of the adk-mistralrs crate (excluded from workspace)
+# Build them explicitly: cargo build -p adk-mistralrs --examples
 
 # Note: ralph is now a separate crate at examples/ralph/
 # Run with: cargo run -p ralph


### PR DESCRIPTION
Removes CI warnings about adk-mistralrs not found in workspace and invalid mistralrs feature in required-features.

- Remove `--exclude adk-mistralrs` from CI clippy/test commands (not a workspace member, so flag is pointless)
- Remove 9 `mistralrs_*` example entries that reference nonexistent `mistralrs` feature
- mistralrs examples live in the `adk-mistralrs` crate which has its own CI workflow