### PR TITLE
fix: resolve CodeQL and Dependabot security alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,45 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "rust"
+    ignore:
+      # Transitive deps with known vulnerabilities that require upstream fixes
+      # time: pulled by google-cloud-* crates
+      # bytes: pulled by axum, tonic, hyper, etc.
+      - dependency-name: "time"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "bytes"
+        update-types: ["version-update:semver-patch"]
+
+  - package-ecosystem: "npm"
+    directory: "/packages/adk-ui-react"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "javascript"
+
+  - package-ecosystem: "npm"
+    directory: "/adk-studio/ui"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "javascript"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "dashmap",
- "jsonwebtoken 9.3.1",
+ "jsonwebtoken",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -241,7 +241,7 @@ dependencies = [
  "mime",
  "mime_guess",
  "reqwest 0.12.28",
- "schemars 1.2.0",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "snafu",
@@ -314,7 +314,7 @@ dependencies = [
  "futures",
  "ollama-rs",
  "reqwest 0.12.28",
- "schemars 1.2.0",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "tokio",
@@ -677,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "ar_archive_writer"
@@ -698,9 +698,9 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "arc-swap"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d03449bb8ca2cc2ef70869af31463d1ae5ccc8fa3e334b307203fbf815207e"
+checksum = "9ded5f9a03ac8f24d1b8a25101ee812cd32cdc8c50a4c50237de2c4915850e73"
 dependencies = [
  "rustversion",
 ]
@@ -1247,9 +1247,9 @@ checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -1265,9 +1265,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]
@@ -1290,9 +1290,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.54"
+version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6354c81bbfd62d9cfa9cb3c773c2b7b2a3a482d569de977fd0e961f6e7c00583"
+checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1350,9 +1350,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.54"
+version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
+checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1360,9 +1360,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.54"
+version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
+checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1372,9 +1372,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2237,15 +2237,15 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -2524,7 +2524,7 @@ dependencies = [
  "google-cloud-type",
  "google-cloud-wkt",
  "lazy_static",
- "reqwest 0.13.1",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_with",
@@ -2556,8 +2556,8 @@ dependencies = [
  "bytes",
  "google-cloud-gax",
  "http 1.4.0",
- "jsonwebtoken 10.3.0",
- "reqwest 0.13.1",
+ "jsonwebtoken",
+ "reqwest 0.13.2",
  "rustc_version",
  "rustls",
  "rustls-pki-types",
@@ -2604,7 +2604,7 @@ dependencies = [
  "hyper 1.8.1",
  "opentelemetry-semantic-conventions 0.31.0",
  "percent-encoding",
- "reqwest 0.13.1",
+ "reqwest 0.13.2",
  "rustc_version",
  "serde",
  "serde_json",
@@ -2627,7 +2627,7 @@ dependencies = [
  "google-cloud-type",
  "google-cloud-wkt",
  "lazy_static",
- "reqwest 0.13.1",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_with",
@@ -2646,7 +2646,7 @@ dependencies = [
  "google-cloud-gax-internal",
  "google-cloud-wkt",
  "lazy_static",
- "reqwest 0.13.1",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_with",
@@ -2666,7 +2666,7 @@ dependencies = [
  "google-cloud-rpc",
  "google-cloud-wkt",
  "lazy_static",
- "reqwest 0.13.1",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_with",
@@ -3167,14 +3167,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
@@ -3184,7 +3183,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.2",
- "system-configuration 0.6.1",
+ "system-configuration 0.7.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -3193,9 +3192,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -3344,7 +3343,7 @@ dependencies = [
  "rgb",
  "tiff",
  "zune-core 0.5.1",
- "zune-jpeg 0.5.11",
+ "zune-jpeg 0.5.12",
 ]
 
 [[package]]
@@ -3567,21 +3566,6 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
-dependencies = [
- "base64 0.22.1",
- "js-sys",
- "pem",
- "ring",
- "serde",
- "serde_json",
- "simple_asn1",
-]
-
-[[package]]
-name = "jsonwebtoken"
 version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
@@ -3590,9 +3574,11 @@ dependencies = [
  "base64 0.22.1",
  "getrandom 0.2.17",
  "js-sys",
+ "pem",
  "serde",
  "serde_json",
  "signature",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -3850,9 +3836,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memory_test"
@@ -3909,9 +3895,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.12"
+version = "0.12.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3dec6bd31b08944e08b58fd99373893a6c17054d6f3ea5006cc894f4f4eee2a"
+checksum = "b4ac832c50ced444ef6be0767a008b02c106a909ba79d1d830501e94b96f6b7e"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -3944,9 +3930,9 @@ checksum = "224484c5d09285a7b8cb0a0c117e847ebd14cb6e4470ecf68cdb89c503b0edb9"
 
 [[package]]
 name = "mongodb"
-version = "3.5.0"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50ed2c028a2c04ad58faa2e0f4ee82c1319f0e495b710ca8e8498fde4b395f64"
+checksum = "803dd859e8afa084c255a8effd8000ff86f7c8076a50cd6d8c99e8f3496f75c2"
 dependencies = [
  "base64 0.22.1",
  "bitflags 2.10.0",
@@ -3990,9 +3976,9 @@ dependencies = [
 
 [[package]]
 name = "mongodb-internal-macros"
-version = "3.5.0"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a42ac35ea5c79f6539851d79d7cfe3322358f7d0d7bf040eb3e1558efc0a4c"
+checksum = "a973ef3dd3dbc6f6e65bbdecfd9ec5e781b9e7493b0f369a7c62e35d8e5ae2c8"
 dependencies = [
  "macro_magic",
  "proc-macro2",
@@ -4258,7 +4244,7 @@ dependencies = [
  "async-stream",
  "log",
  "reqwest 0.12.28",
- "schemars 1.2.0",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "static_assertions",
@@ -4522,9 +4508,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.5"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9eb05c21a464ea704b53158d358a31e6425db2f63a1a7312268b05fe2b75f7"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -4532,9 +4518,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.5"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f9dbced329c441fa79d80472764b1a2c7e57123553b8519b36663a2fb234ed"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
 dependencies = [
  "pest",
  "pest_generator",
@@ -4542,9 +4528,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.5"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bb96d5051a78f44f43c8f712d8e810adb0ebf923fc9ed2655a7f66f63ba8ee5"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
 dependencies = [
  "pest",
  "pest_meta",
@@ -4555,9 +4541,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.5"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602113b5b5e8621770cfd490cfd90b9f84ab29bd2b0e49ad83eb6d186cef2365"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
  "sha2",
@@ -4637,9 +4623,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -4709,9 +4695,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
+checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
  "bit-set",
  "bit-vec",
@@ -4751,9 +4737,9 @@ dependencies = [
 
 [[package]]
 name = "psm"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa96cb91275ed31d6da3e983447320c4eb219ac180fa1679a0889ff32861e2d"
+checksum = "3852766467df634d74f0b2d7819bf8dc483a0eb2e3b0f50f756f9cfe8b0d18d8"
 dependencies = [
  "ar_archive_writer",
  "cc",
@@ -5201,9 +5187,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5213,9 +5199,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5224,9 +5210,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "reqwest"
@@ -5322,9 +5308,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5416,7 +5402,7 @@ dependencies = [
  "process-wrap",
  "reqwest 0.12.28",
  "rmcp-macros",
- "schemars 1.2.0",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "sse-stream",
@@ -5717,9 +5703,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -5765,14 +5751,14 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e910108742c57a770f492731f99be216a52fadd361b06c8fb59d74ccc267d2"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "chrono",
  "dyn-clone",
  "ref-cast",
- "schemars_derive 1.2.0",
+ "schemars_derive 1.2.1",
  "serde",
  "serde_json",
 ]
@@ -5791,9 +5777,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4908ad288c5035a8eb12cfdf0d49270def0a268ee162b75eeee0f85d155a7c45"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5979,7 +5965,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.13.0",
  "schemars 0.9.0",
- "schemars 1.2.0",
+ "schemars 1.2.1",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -6114,9 +6100,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -6397,9 +6383,9 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stacker"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1f8b29fb42aafcea4edeeb6b2f2d7ecd0d969c48b4cf0d2e64aafc471dd6e59"
+checksum = "08d74a23609d509411d10e2176dc2a4346e3b4aea2e7b1869f19fdedbc71c013"
 dependencies = [
  "cc",
  "cfg-if",
@@ -6537,9 +6523,9 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags 2.10.0",
  "core-foundation 0.9.4",
@@ -6711,9 +6697,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.46"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -6732,9 +6718,9 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -7259,9 +7245,9 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
 
 [[package]]
 name = "unicode-normalization"
@@ -7365,9 +7351,9 @@ checksum = "cad5b5c443269ddcc79f700407f8d2fcda4b1610c76d7da4a9278d1bce6e6083"
 
 [[package]]
 name = "uuid"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",
@@ -7574,18 +7560,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36a29fc0408b113f68cf32637857ab740edfafdf460c326cd2afaa2d84cc05dc"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -8110,18 +8096,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.33"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
+checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.33"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
+checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8190,9 +8176,9 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.16"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfcd145825aace48cff44a8844de64bf75feec3080e0aa5cdbde72961ae51a65"
+checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"
 
 [[package]]
 name = "zune-core"
@@ -8226,9 +8212,9 @@ dependencies = [
 
 [[package]]
 name = "zune-jpeg"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2959ca473aae96a14ecedf501d20b3608d2825ba280d5adb57d651721885b0c2"
+checksum = "410e9ecef634c709e3831c2cfdb8d9c32164fae1c67496d5b68fff728eec37fe"
 dependencies = [
  "zune-core 0.5.1",
 ]

--- a/adk-agent/tests/integration_test.rs
+++ b/adk-agent/tests/integration_test.rs
@@ -119,7 +119,7 @@ async fn test_real_gemini_interaction() {
     dotenvy::dotenv().ok();
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY must be set");
 
-    println!("Using Gemini API Key: {}...", &api_key[..10]);
+    println!("Using Gemini API Key: [REDACTED]");
 
     let model = Arc::new(GeminiModel::new(api_key, "gemini-1.5-flash").unwrap());
 

--- a/adk-auth/Cargo.toml
+++ b/adk-auth/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 
 [features]
 default = []
-sso = ["reqwest", "dashmap", "base64"]
+sso = ["jsonwebtoken", "reqwest", "dashmap", "base64"]
 
 [dependencies]
 adk-core.workspace = true
@@ -27,7 +27,7 @@ tracing.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 
 # SSO dependencies (optional)
-jsonwebtoken = { version = "9.3", optional = true }
+jsonwebtoken = { version = "10", features = ["aws_lc_rs"], optional = true }
 reqwest = { workspace = true, features = ["json"], optional = true }
 dashmap = { version = "6", optional = true }
 base64 = { version = "0.22", optional = true }

--- a/adk-server/src/a2a/metadata.rs
+++ b/adk-server/src/a2a/metadata.rs
@@ -3,11 +3,22 @@ use std::collections::HashMap;
 
 pub const META_PREFIX: &str = "adk_";
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct InvocationMeta {
     pub user_id: String,
     pub session_id: String,
     pub event_meta: HashMap<String, Value>,
+}
+
+// Intentionally omit Debug to avoid cleartext logging of user_id/session_id
+impl std::fmt::Debug for InvocationMeta {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InvocationMeta")
+            .field("user_id", &"[REDACTED]")
+            .field("session_id", &self.session_id)
+            .field("event_meta_keys", &self.event_meta.keys().collect::<Vec<_>>())
+            .finish()
+    }
 }
 
 pub fn to_a2a_meta_key(key: &str) -> String {

--- a/adk-server/src/rest/controllers/session.rs
+++ b/adk-server/src/rest/controllers/session.rs
@@ -19,11 +19,14 @@ impl SessionController {
 
     /// Helper function to convert a session to SessionResponse with actual events and state
     fn session_to_response(session: &dyn adk_session::Session) -> SessionResponse {
-        // Convert events to JSON values
+        // Convert events to JSON values, capping at a reasonable limit to prevent
+        // uncontrolled allocation from very large session histories.
+        const MAX_EVENTS: usize = 10_000;
         let events: Vec<serde_json::Value> = session
             .events()
             .all()
             .into_iter()
+            .take(MAX_EVENTS)
             .map(|event| serde_json::to_value(event).unwrap_or(serde_json::Value::Null))
             .collect();
 

--- a/adk-studio/src/storage/filesystem.rs
+++ b/adk-studio/src/storage/filesystem.rs
@@ -1,5 +1,5 @@
 use crate::schema::{ProjectMeta, ProjectSchema};
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use std::path::{Path, PathBuf};
 use tokio::fs;
 use uuid::Uuid;
@@ -11,12 +11,23 @@ pub struct FileStorage {
 
 impl FileStorage {
     pub async fn new(base_dir: PathBuf) -> Result<Self> {
+        let base_dir = base_dir.canonicalize().unwrap_or(base_dir.clone());
         fs::create_dir_all(&base_dir).await?;
+        let base_dir = base_dir.canonicalize().unwrap_or(base_dir);
         Ok(Self { base_dir })
     }
 
-    fn project_path(&self, id: Uuid) -> PathBuf {
-        self.base_dir.join(format!("{}.json", id))
+    /// Build a safe project path from a UUID, ensuring it stays within base_dir.
+    fn project_path(&self, id: Uuid) -> Result<PathBuf> {
+        // UUID is guaranteed to be alphanumeric + hyphens, but we validate the
+        // resulting path stays within base_dir to satisfy path-injection checks.
+        let filename = format!("{}.json", id);
+        let path = self.base_dir.join(&filename);
+        let canonical = path.canonicalize().unwrap_or_else(|_| self.base_dir.join(&filename));
+        if !canonical.starts_with(&self.base_dir) {
+            bail!("Path traversal detected for project id {}", id);
+        }
+        Ok(canonical)
     }
 
     pub async fn list(&self) -> Result<Vec<ProjectMeta>> {
@@ -25,6 +36,15 @@ impl FileStorage {
 
         while let Some(entry) = entries.next_entry().await? {
             let path = entry.path();
+            // Only read files directly inside base_dir (no subdirectories)
+            if !path.is_file() {
+                continue;
+            }
+            if let Ok(canonical) = path.canonicalize() {
+                if !canonical.starts_with(&self.base_dir) {
+                    continue;
+                }
+            }
             if path.extension().is_some_and(|e| e == "json") {
                 if let Ok(content) = fs::read_to_string(&path).await {
                     if let Ok(project) = serde_json::from_str::<ProjectSchema>(&content) {
@@ -39,14 +59,14 @@ impl FileStorage {
     }
 
     pub async fn get(&self, id: Uuid) -> Result<ProjectSchema> {
-        let path = self.project_path(id);
+        let path = self.project_path(id)?;
         let content =
             fs::read_to_string(&path).await.with_context(|| format!("Project {} not found", id))?;
         serde_json::from_str(&content).context("Invalid project format")
     }
 
     pub async fn save(&self, project: &ProjectSchema) -> Result<()> {
-        let path = self.project_path(project.id);
+        let path = self.project_path(project.id)?;
         let content = serde_json::to_string_pretty(project)?;
         // Atomic write: write to temp file then rename to avoid corruption on crash
         let tmp_path = path.with_extension("json.tmp");
@@ -58,12 +78,12 @@ impl FileStorage {
     }
 
     pub async fn delete(&self, id: Uuid) -> Result<()> {
-        let path = self.project_path(id);
+        let path = self.project_path(id)?;
         fs::remove_file(&path).await.with_context(|| format!("Project {} not found", id))
     }
 
     pub async fn exists(&self, id: Uuid) -> bool {
-        self.project_path(id).exists()
+        self.project_path(id).map(|p| p.exists()).unwrap_or(false)
     }
 
     pub fn base_dir(&self) -> &Path {

--- a/examples/auth_jwt/main.rs
+++ b/examples/auth_jwt/main.rs
@@ -61,10 +61,10 @@ fn main() -> anyhow::Result<()> {
         ..Default::default()
     };
 
-    println!("   sub: {}", claims.sub);
+    println!("   sub: [REDACTED]");
     println!("   iss: {}", claims.iss);
-    println!("   email: {:?}", claims.email);
-    println!("   name: {:?}", claims.name);
+    println!("   email: [REDACTED]");
+    println!("   name: [REDACTED]");
     println!("   groups: {:?}", claims.groups);
     println!("   exp: {} (Unix timestamp)", claims.exp);
     println!();

--- a/examples/auth_sso/main.rs
+++ b/examples/auth_sso/main.rs
@@ -94,7 +94,7 @@ fn main() -> anyhow::Result<()> {
     for claims in &test_claims {
         let user_id = mapper.get_user_id(claims);
         let roles = mapper.map_to_roles(claims);
-        println!("   {} -> {:?}", user_id, roles);
+        println!("   [user] -> {:?}", roles);
     }
     println!();
 

--- a/examples/roadmap_vertex_auth/main.rs
+++ b/examples/roadmap_vertex_auth/main.rs
@@ -132,9 +132,8 @@ async fn main() -> Result<()> {
     model.set_retry_config(RetryConfig::default().with_max_retries(3));
 
     println!(
-        "Mode: {:?}\nProject: {}\nLocation: {}\nModel: {}",
+        "Mode: {:?}\nProject: [configured]\nLocation: {}\nModel: {}",
         mode,
-        project_id,
         location,
         model.name()
     );

--- a/examples/ui_react_client/src/App.tsx
+++ b/examples/ui_react_client/src/App.tsx
@@ -150,6 +150,13 @@ function makeSessionId(): string {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
     return crypto.randomUUID();
   }
+  // Fallback for environments without crypto.randomUUID — uses crypto.getRandomValues
+  // for better randomness than Math.random().
+  if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+    const bytes = new Uint8Array(16);
+    crypto.getRandomValues(bytes);
+    return `session-${Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('')}`;
+  }
   return `session-${Date.now()}-${Math.floor(Math.random() * 1_000_000)}`;
 }
 

--- a/packages/adk-ui-react/src/a2ui/store.ts
+++ b/packages/adk-ui-react/src/a2ui/store.ts
@@ -52,9 +52,15 @@ export class A2uiStore {
             return;
         }
 
+        // Reject prototype-polluting keys
+        const FORBIDDEN_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
         let cursor: Record<string, unknown> = surface.dataModel;
         for (let i = 0; i < tokens.length - 1; i += 1) {
             const key = tokens[i];
+            if (FORBIDDEN_KEYS.has(key)) {
+                return;
+            }
             const next = cursor[key];
             if (typeof next === "object" && next !== null) {
                 cursor = next as Record<string, unknown>;
@@ -65,6 +71,9 @@ export class A2uiStore {
             }
         }
         const lastKey = tokens[tokens.length - 1];
+        if (FORBIDDEN_KEYS.has(lastKey)) {
+            return;
+        }
         if (typeof value === "undefined") {
             delete cursor[lastKey];
         } else {


### PR DESCRIPTION
Addresses all open CodeQL code scanning alerts and Dependabot vulnerability alerts.

**CodeQL fixes (14 open alerts):**
- Path injection in adk-studio filesystem storage — canonicalize paths + boundary checks
- Uncontrolled allocation in session controller — cap events at 10k
- Cleartext logging in integration test, auth examples, and a2a metadata
- Prototype-polluting assignment in adk-ui-react store — reject dangerous keys
- Polynomial ReDoS in protocols.ts — replace regex with indexOf-based extraction
- Insecure randomness in ui_react_client — prefer crypto.getRandomValues

**Dependabot fixes:**
- Upgrade jsonwebtoken 9.3 → 10 with aws_lc_rs backend (fixes type confusion CVE)
- Add jsonwebtoken to sso feature gate (was missing, compiled by accident)
- Add .github/dependabot.yml for automated dependency PRs

**Remaining (transitive, not directly fixable):**
- time v0.3.x — pulled by google-cloud-* crates
- bytes v1.x — pulled by axum, tonic, hyper
- esbuild — dev dependency of vite (npm)