### PR TITLE
fix: unused variable warning in auth_sso example

### DIFF
--- a/examples/auth_sso/main.rs
+++ b/examples/auth_sso/main.rs
@@ -92,7 +92,7 @@ fn main() -> anyhow::Result<()> {
     ];
 
     for claims in &test_claims {
-        let user_id = mapper.get_user_id(claims);
+        let _user_id = mapper.get_user_id(claims);
         let roles = mapper.map_to_roles(claims);
         println!("   [user] -> {:?}", roles);
     }


### PR DESCRIPTION
Prefix `user_id` with underscore since it's no longer printed (cleartext logging fix from #36).