### PR TITLE
fix: resolve remaining CodeQL security alerts

### DIFF
--- a/examples/auth_jwt/main.rs
+++ b/examples/auth_jwt/main.rs
@@ -71,7 +71,7 @@ fn main() -> anyhow::Result<()> {
 
     // Helper methods
     println!("   Helper methods:");
-    println!("   - user_id(): {}", claims.user_id());
+    println!("   - user_id(): [REDACTED]");
     println!("   - all_groups(): {:?}", claims.all_groups());
     println!("   - is_expired(): {}", claims.is_expired());
     println!();

--- a/packages/adk-ui-react/dist/index.mjs
+++ b/packages/adk-ui-react/dist/index.mjs
@@ -1514,8 +1514,9 @@ var A2uiStore = class {
   }
   applyUpdateComponents(surfaceId, components) {
     const surface = this.ensureSurface(surfaceId);
+    const FORBIDDEN_KEYS = /* @__PURE__ */ new Set(["__proto__", "constructor", "prototype"]);
     for (const component of components) {
-      if (!component.id) {
+      if (!component.id || FORBIDDEN_KEYS.has(component.id)) {
         continue;
       }
       surface.components.set(component.id, component);
@@ -1535,23 +1536,33 @@ var A2uiStore = class {
       surface.dataModel = value ?? {};
       return;
     }
+    const FORBIDDEN_KEYS = /* @__PURE__ */ new Set(["__proto__", "constructor", "prototype"]);
+    function isSafeKey(k) {
+      return !FORBIDDEN_KEYS.has(k);
+    }
     let cursor = surface.dataModel;
     for (let i = 0; i < tokens.length - 1; i += 1) {
       const key = tokens[i];
-      const next = cursor[key];
+      if (!isSafeKey(key)) {
+        return;
+      }
+      const next = Object.prototype.hasOwnProperty.call(cursor, key) ? cursor[key] : void 0;
       if (typeof next === "object" && next !== null) {
         cursor = next;
       } else {
-        const created = {};
-        cursor[key] = created;
+        const created = /* @__PURE__ */ Object.create(null);
+        Object.defineProperty(cursor, key, { value: created, writable: true, enumerable: true, configurable: true });
         cursor = created;
       }
     }
     const lastKey = tokens[tokens.length - 1];
+    if (!isSafeKey(lastKey)) {
+      return;
+    }
     if (typeof value === "undefined") {
       delete cursor[lastKey];
     } else {
-      cursor[lastKey] = value;
+      Object.defineProperty(cursor, lastKey, { value, writable: true, enumerable: true, configurable: true });
     }
   }
 };
@@ -1655,12 +1666,16 @@ function extractSurfaceFromAgUiEvents(events) {
   return null;
 }
 function extractSurfaceScriptFromHtml(html) {
-  const scriptPattern = /<script[^>]*id=["']adk-ui-surface["'][^>]*>([\s\S]*?)<\/script>/i;
-  const match = html.match(scriptPattern);
-  if (!match || !match[1]) {
-    return null;
-  }
-  return match[1].trim();
+  const openTagStart = html.indexOf("<script");
+  if (openTagStart === -1) return null;
+  const idAttr = html.indexOf("adk-ui-surface", openTagStart);
+  if (idAttr === -1) return null;
+  const openTagEnd = html.indexOf(">", idAttr);
+  if (openTagEnd === -1) return null;
+  const closeTag = html.indexOf("</script>", openTagEnd);
+  if (closeTag === -1) return null;
+  const content = html.substring(openTagEnd + 1, closeTag).trim();
+  return content.length > 0 ? content : null;
 }
 function extractSurfaceFromMcpPayload(payload) {
   const resourceReadResponse = payload.resourceReadResponse;


### PR DESCRIPTION
Fixes remaining open CodeQL alerts:

**Prototype pollution (alerts 24, 25, 37):**
- `store.ts`: Use `Object.defineProperty` and `Object.create(null)` instead of direct bracket assignment
- `store.ts`: Add `FORBIDDEN_KEYS` check in `applyUpdateComponents`

**Cleartext logging (alerts 14, 31):**
- `auth_jwt`: Redact `claims.user_id()` in println output
- `roadmap_vertex_auth`: project_id already redacted (false positive — flows into API constructor, not logged)

**Uncontrolled allocation (alert 17):**
- `session.rs`: Cap initial state entries at 1,000 in `create_session_from_path`

**Cleartext transmission (alerts 32, 33):**
- `vertex.rs`: Enforce HTTPS on custom endpoints
- `vertex.rs`: Remove cleartext user_id/session_id from error messages

**Dist rebuild (alerts 26-28, 30):**
- Rebuilt `adk-ui-react/dist/` to pick up source-level fixes

**Remaining (false positives / not fixable):**
- Alert 16 (metadata.rs): user_id stored in event_meta is functional A2A protocol data, not logging
- Alert 31 (roadmap_vertex_auth): project_id flows into API constructor, println already shows `[configured]`
- Dependabot #4 (esbuild): transitive npm dev dep from vite, requires vite upgrade