### PR TITLE
fix: allow http for localhost in vertex endpoint (test support)

### DIFF
--- a/adk-session/src/vertex.rs
+++ b/adk-session/src/vertex.rs
@@ -48,8 +48,8 @@ impl VertexAiSessionConfig {
             .endpoint
             .clone()
             .unwrap_or_else(|| format!("https://{}-aiplatform.googleapis.com", self.location));
-        // Enforce HTTPS to prevent cleartext transmission of session data
-        if !ep.starts_with("https://") {
+        // Enforce HTTPS for non-localhost endpoints to prevent cleartext transmission
+        if !ep.starts_with("https://") && !ep.contains("://127.0.0.1") && !ep.contains("://localhost") {
             format!("https://{}", ep.trim_start_matches("http://"))
         } else {
             ep


### PR DESCRIPTION
The HTTPS enforcement from PR #56 broke the vertex session contract test which uses a local mock server on http://127.0.0.1. This exempts localhost/127.0.0.1 endpoints from the HTTPS upgrade.