### PR TITLE
docs: update all version references to 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,22 +680,22 @@ Add to your `Cargo.toml`:
 adk-rust = "0.3.0"
 
 # Or individual crates for finer control
-adk-core = "0.2.1"
-adk-agent = "0.2.1"
-adk-model = { version = "0.2.1", features = ["openai", "anthropic"] }  # Enable providers
-adk-tool = "0.2.1"
-adk-runner = "0.2.1"
+adk-core = "0.3.0"
+adk-agent = "0.3.0"
+adk-model = { version = "0.3.0", features = ["openai", "anthropic"] }  # Enable providers
+adk-tool = "0.3.0"
+adk-runner = "0.3.0"
 
 # Optional dependencies
-adk-session = { version = "0.2.1", optional = true }
-adk-artifact = { version = "0.2.1", optional = true }
-adk-memory = { version = "0.2.1", optional = true }
-adk-server = { version = "0.2.1", optional = true }
-adk-cli = { version = "0.2.1", optional = true }
-adk-realtime = { version = "0.2.1", features = ["openai"], optional = true }
-adk-graph = { version = "0.2.1", features = ["sqlite"], optional = true }
-adk-browser = { version = "0.2.1", optional = true }
-adk-eval = { version = "0.2.1", optional = true }
+adk-session = { version = "0.3.0", optional = true }
+adk-artifact = { version = "0.3.0", optional = true }
+adk-memory = { version = "0.3.0", optional = true }
+adk-server = { version = "0.3.0", optional = true }
+adk-cli = { version = "0.3.0", optional = true }
+adk-realtime = { version = "0.3.0", features = ["openai"], optional = true }
+adk-graph = { version = "0.3.0", features = ["sqlite"], optional = true }
+adk-browser = { version = "0.3.0", optional = true }
+adk-eval = { version = "0.3.0", optional = true }
 ```
 
 ## Examples

--- a/adk-artifact/README.md
+++ b/adk-artifact/README.md
@@ -28,7 +28,7 @@ Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.2.1", features = ["artifacts"] }
+adk-rust = { version = "0.3.0", features = ["artifacts"] }
 ```
 
 ## Quick Start

--- a/adk-graph/README.md
+++ b/adk-graph/README.md
@@ -40,9 +40,9 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-graph = { version = "0.2.1", features = ["sqlite"] }
-adk-agent = "0.2.1"
-adk-model = "0.2.1"
+adk-graph = { version = "0.3.0", features = ["sqlite"] }
+adk-agent = "0.3.0"
+adk-model = "0.3.0"
 adk-core = "0.3.0"
 ```
 

--- a/adk-guardrail/README.md
+++ b/adk-guardrail/README.md
@@ -22,7 +22,7 @@ Guardrails framework for ADK agents - input/output validation, content filtering
 adk-guardrail = "0.3.0"
 
 # With JSON schema validation (default)
-adk-guardrail = { version = "0.2.1", features = ["schema"] }
+adk-guardrail = { version = "0.3.0", features = ["schema"] }
 ```
 
 ## Quick Start
@@ -63,7 +63,7 @@ let filter = ContentFilter::blocked_keywords(vec!["forbidden".into()]);
 Requires `guardrails` feature on `adk-agent`:
 
 ```toml
-adk-agent = { version = "0.2.1", features = ["guardrails"] }
+adk-agent = { version = "0.3.0", features = ["guardrails"] }
 ```
 
 ```rust

--- a/adk-model/README.md
+++ b/adk-model/README.md
@@ -32,7 +32,7 @@ Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.2.1", features = ["models"] }
+adk-rust = { version = "0.3.0", features = ["models"] }
 ```
 
 ## Quick Start
@@ -283,15 +283,15 @@ Enable specific providers with feature flags:
 ```toml
 [dependencies]
 # All providers (default)
-adk-model = { version = "0.2.1", features = ["all-providers"] }
+adk-model = { version = "0.3.0", features = ["all-providers"] }
 
 # Individual providers
-adk-model = { version = "0.2.1", features = ["gemini"] }
-adk-model = { version = "0.2.1", features = ["openai"] }
-adk-model = { version = "0.2.1", features = ["anthropic"] }
-adk-model = { version = "0.2.1", features = ["deepseek"] }
-adk-model = { version = "0.2.1", features = ["groq"] }
-adk-model = { version = "0.2.1", features = ["ollama"] }
+adk-model = { version = "0.3.0", features = ["gemini"] }
+adk-model = { version = "0.3.0", features = ["openai"] }
+adk-model = { version = "0.3.0", features = ["anthropic"] }
+adk-model = { version = "0.3.0", features = ["deepseek"] }
+adk-model = { version = "0.3.0", features = ["groq"] }
+adk-model = { version = "0.3.0", features = ["ollama"] }
 ```
 
 ## Related Crates

--- a/adk-realtime/README.md
+++ b/adk-realtime/README.md
@@ -51,7 +51,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-realtime = { version = "0.2.1", features = ["openai"] }
+adk-realtime = { version = "0.3.0", features = ["openai"] }
 ```
 
 ### Using RealtimeAgent (Recommended)

--- a/adk-rust/README.md
+++ b/adk-rust/README.md
@@ -202,10 +202,10 @@ cargo run -- serve --port 8080
 adk-rust = "0.3.0"
 
 # Minimal
-adk-rust = { version = "0.2.1", default-features = false, features = ["minimal"] }
+adk-rust = { version = "0.3.0", default-features = false, features = ["minimal"] }
 
 # Custom
-adk-rust = { version = "0.2.1", default-features = false, features = ["agents", "gemini", "tools"] }
+adk-rust = { version = "0.3.0", default-features = false, features = ["agents", "gemini", "tools"] }
 ```
 
 ## Documentation

--- a/adk-rust/src/lib.rs
+++ b/adk-rust/src/lib.rs
@@ -40,7 +40,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-rust = "0.2"
+//! adk-rust = "0.3"
 //! tokio = { version = "1.40", features = ["full"] }
 //! dotenvy = "0.15"  # For loading .env files
 //! ```
@@ -49,13 +49,13 @@
 //!
 //! ```toml
 //! # Full (default) - Everything included
-//! adk-rust = "0.2"
+//! adk-rust = "0.3"
 //!
 //! # Minimal - Agents + Gemini + Runner only
-//! adk-rust = { version = "0.2", default-features = false, features = ["minimal"] }
+//! adk-rust = { version = "0.3", default-features = false, features = ["minimal"] }
 //!
 //! # Custom - Pick exactly what you need
-//! adk-rust = { version = "0.2", default-features = false, features = [
+//! adk-rust = { version = "0.3", default-features = false, features = [
 //!     "agents", "gemini", "tools", "sessions"
 //! ] }
 //! ```

--- a/adk-session/README.md
+++ b/adk-session/README.md
@@ -26,7 +26,7 @@ Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.2.1", features = ["sessions"] }
+adk-rust = { version = "0.3.0", features = ["sessions"] }
 ```
 
 ## Quick Start
@@ -86,7 +86,7 @@ let theme = session.state().get("user:theme");
 
 ```toml
 [dependencies]
-adk-session = { version = "0.2.1", features = ["database"] }
+adk-session = { version = "0.3.0", features = ["database"] }
 ```
 
 - `database` - Enable SQLite-backed sessions

--- a/adk-telemetry/README.md
+++ b/adk-telemetry/README.md
@@ -26,7 +26,7 @@ Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.2.1", features = ["telemetry"] }
+adk-rust = { version = "0.3.0", features = ["telemetry"] }
 ```
 
 ## Quick Start

--- a/adk-tool/README.md
+++ b/adk-tool/README.md
@@ -22,17 +22,17 @@ Tool system for Rust Agent Development Kit (ADK-Rust) agents (FunctionTool, MCP,
 
 ```toml
 [dependencies]
-adk-tool = "0.2.2"
+adk-tool = "0.3.0"
 
 # For remote MCP servers via HTTP:
-adk-tool = { version = "0.2.2", features = ["http-transport"] }
+adk-tool = { version = "0.3.0", features = ["http-transport"] }
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.2.2", features = ["tools"] }
+adk-rust = { version = "0.3.0", features = ["tools"] }
 ```
 
 ## Quick Start

--- a/examples/mcp/README.md
+++ b/examples/mcp/README.md
@@ -120,11 +120,11 @@ let toolset = McpHttpClientBuilder::new("https://private-mcp.example.com")
 ```toml
 [dependencies]
 # For local MCP servers (stdio)
-adk-tool = "0.2.2"
+adk-tool = "0.3.0"
 rmcp = { version = "0.14", features = ["client", "transport-child-process"] }
 
 # For remote MCP servers (HTTP)
-adk-tool = { version = "0.2.2", features = ["http-transport"] }
+adk-tool = { version = "0.3.0", features = ["http-transport"] }
 ```
 
 ## Related Documentation


### PR DESCRIPTION
Updates all stale version references (0.2.1, 0.2.2) to 0.3.0 across 12 files:

- **README.md**: Use as Library section (14 crate references)
- **adk-rust/src/lib.rs**: rustdoc shown on docs.rs (0.2 → 0.3)
- **adk-rust/README.md**: Installation Options section
- **Crate READMEs**: adk-artifact, adk-graph, adk-guardrail, adk-model, adk-realtime, adk-session, adk-telemetry, adk-tool
- **examples/mcp/README.md**: dependency versions

Note: The docs.rs page currently shows 0.2 in the rustdoc because it was built from the published 0.3.0 crate which had the old lib.rs. This fix will take effect on the next crate publish (0.3.1+).

The wiki sync workflow will auto-trigger on merge since docs/official_docs/quickstart.md already has 0.3.0.