### PR TITLE
feat(adk-studio): Multi-provider LLM support in code generation

### DIFF
--- a/adk-model/src/gemini/client.rs
+++ b/adk-model/src/gemini/client.rs
@@ -14,10 +14,11 @@ pub struct GeminiModel {
 
 impl GeminiModel {
     pub fn new(api_key: impl Into<String>, model: impl Into<String>) -> Result<Self> {
-        let client =
-            Gemini::new(api_key.into()).map_err(|e| adk_core::AdkError::Model(e.to_string()))?;
+        let model_name = model.into();
+        let client = Gemini::with_model(api_key.into(), model_name.clone())
+            .map_err(|e| adk_core::AdkError::Model(e.to_string()))?;
 
-        Ok(Self { client, model_name: model.into(), retry_config: RetryConfig::default() })
+        Ok(Self { client, model_name, retry_config: RetryConfig::default() })
     }
 
     pub fn new_google_cloud(

--- a/adk-studio/src/codegen/validation.rs
+++ b/adk-studio/src/codegen/validation.rs
@@ -596,18 +596,60 @@ mod tests {
 pub fn get_required_env_vars(project: &ProjectSchema) -> Vec<EnvVarRequirement> {
     let mut env_vars = Vec::new();
 
-    // All projects using Gemini models need an API key
-    let uses_gemini = project
-        .agents
-        .values()
-        .any(|a| a.model.as_ref().map(|m| m.contains("gemini")).unwrap_or(true));
+    // Detect which providers are used across all agents
+    let providers = super::collect_providers(project);
 
-    if uses_gemini {
+    if providers.contains("gemini") {
         env_vars.push(EnvVarRequirement {
             name: "GOOGLE_API_KEY".to_string(),
             description: "Google AI API key for Gemini models".to_string(),
             alternatives: vec!["GEMINI_API_KEY".to_string()],
             required: true,
+        });
+    }
+
+    if providers.contains("openai") {
+        env_vars.push(EnvVarRequirement {
+            name: "OPENAI_API_KEY".to_string(),
+            description: "OpenAI API key for GPT models".to_string(),
+            alternatives: vec![],
+            required: true,
+        });
+    }
+
+    if providers.contains("anthropic") {
+        env_vars.push(EnvVarRequirement {
+            name: "ANTHROPIC_API_KEY".to_string(),
+            description: "Anthropic API key for Claude models".to_string(),
+            alternatives: vec![],
+            required: true,
+        });
+    }
+
+    if providers.contains("deepseek") {
+        env_vars.push(EnvVarRequirement {
+            name: "DEEPSEEK_API_KEY".to_string(),
+            description: "DeepSeek API key".to_string(),
+            alternatives: vec![],
+            required: true,
+        });
+    }
+
+    if providers.contains("groq") {
+        env_vars.push(EnvVarRequirement {
+            name: "GROQ_API_KEY".to_string(),
+            description: "Groq API key for fast inference".to_string(),
+            alternatives: vec![],
+            required: true,
+        });
+    }
+
+    if providers.contains("ollama") {
+        env_vars.push(EnvVarRequirement {
+            name: "OLLAMA_HOST".to_string(),
+            description: "Ollama server URL (defaults to http://localhost:11434)".to_string(),
+            alternatives: vec![],
+            required: false, // Ollama defaults to localhost
         });
     }
 


### PR DESCRIPTION
## Summary

ADK Studio's code generation was hardcoded to only use Gemini models, causing the app to get stuck at "agent thinking" when users had API keys for other providers but not Google.

## Changes

### Code Generation (`adk-studio/src/codegen/mod.rs`)
- Added `detect_provider()` — Rust-side equivalent of the UI's `detectProviderFromModel()`, detecting provider from model name strings
- Added `collect_providers()` — scans all agents in a project to determine which providers are needed
- `generate_main_rs()` now generates provider-specific imports and API key resolution instead of hardcoded Gemini
- `generate_llm_node_v2()` now generates the correct model constructor per provider:
  - Gemini → `GeminiModel::new(&gemini_api_key, model)`
  - OpenAI → `OpenAIClient::new(OpenAIConfig::new(&openai_api_key, model))`
  - Anthropic → `AnthropicClient::new(AnthropicConfig::new(&anthropic_api_key, model))`
  - DeepSeek → `DeepSeekClient::chat()` / `DeepSeekClient::reasoner()`
  - Groq → `GroqClient::new(GroqConfig::new(&groq_api_key, model))`
  - Ollama → `OllamaModel::new(OllamaConfig::new(model))`
- `generate_cargo_toml()` now adds the correct `adk-model` feature flags based on providers used

### Env Var Handling (`adk-studio/src/server/sse.rs`)
- Added `GEMINI_API_KEY` and `OLLAMA_HOST` to the list of env vars passed to child processes
- Added `OLLAMA_HOST` to the API key detection chain
- Updated error message to list all supported providers including Ollama

### Validation (`adk-studio/src/codegen/validation.rs`)
- `get_required_env_vars()` now checks for the correct env vars per provider instead of always requiring `GOOGLE_API_KEY`

### Bug Fix (`adk-model/src/gemini/client.rs`)
- Fixed `GeminiModel::new()` ignoring the user-provided model name (was always using default `gemini-2.5-flash`)

## Supported Providers
| Provider | Env Var | Feature Flag |
|----------|---------|-------------|
| Google Gemini | `GOOGLE_API_KEY` / `GEMINI_API_KEY` | `gemini` |
| OpenAI | `OPENAI_API_KEY` | `openai` |
| Anthropic | `ANTHROPIC_API_KEY` | `anthropic` |
| DeepSeek | `DEEPSEEK_API_KEY` | `deepseek` |
| Groq | `GROQ_API_KEY` | `groq` |
| Ollama | `OLLAMA_HOST` (optional) | `ollama` |

Fixes #76, Fixes #77