### PR TITLE
docs: update all model names to 2026 versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ ADK supports multiple LLM providers with a unified API:
 
 | Provider | Model Examples | Feature Flag |
 |----------|---------------|--------------|
-| Gemini | `gemini-3-pro-preview`, `gemini-2.5-flash`, `gemini-2.5-pro` | (default) |
-| OpenAI | `gpt-5.2`, `gpt-5`, `gpt-4o`, `gpt-4o-mini` | `openai` |
-| Anthropic | `claude-opus-4-20250514`, `claude-sonnet-4-20250514` | `anthropic` |
-| DeepSeek | `deepseek-chat`, `deepseek-reasoner` | `deepseek` |
-| Groq | `llama-3.3-70b-versatile`, `mixtral-8x7b-32768` | `groq` |
-| Ollama | `llama3.2`, `qwen2.5`, `mistral` | `ollama` |
+| Gemini | `gemini-2.5-flash`, `gemini-2.5-pro`, `gemini-3-pro`, `gemini-3-flash` | (default) |
+| OpenAI | `gpt-5-mini`, `gpt-5`, `gpt-5.1` | `openai` |
+| Anthropic | `claude-sonnet-4.5`, `claude-opus-4.5`, `claude-haiku-4.5` | `anthropic` |
+| DeepSeek | `deepseek-chat`, `deepseek-r1`, `deepseek-v3.1` | `deepseek` |
+| Groq | `llama-4-scout`, `llama-3.1-70b-versatile`, `mixtral-8x7b-32768` | `groq` |
+| Ollama | `llama3.2:3b`, `qwen2.5:7b`, `mistral:7b` | `ollama` |
 | mistral.rs | Phi-3, Mistral, Llama, Gemma, LLaVa, FLUX | git dependency |
 
 All providers support streaming, function calling, and multimodal inputs (where available).
@@ -185,7 +185,7 @@ use adk_rust::Launcher;
 async fn main() -> AnyhowResult<()> {
     dotenvy::dotenv().ok();
     let api_key = std::env::var("OPENAI_API_KEY")?;
-    let model = OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-4o"))?;
+    let model = OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-5-mini"))?;
 
     let agent = LlmAgentBuilder::new("assistant")
         .instruction("You are a helpful assistant.")
@@ -207,7 +207,7 @@ use adk_rust::Launcher;
 async fn main() -> AnyhowResult<()> {
     dotenvy::dotenv().ok();
     let api_key = std::env::var("ANTHROPIC_API_KEY")?;
-    let model = AnthropicClient::new(AnthropicConfig::new(api_key, "claude-sonnet-4-20250514"))?;
+    let model = AnthropicClient::new(AnthropicConfig::new(api_key, "claude-sonnet-4.5"))?;
 
     let agent = LlmAgentBuilder::new("assistant")
         .instruction("You are a helpful assistant.")
@@ -405,7 +405,7 @@ use adk_model::GeminiModel;
 
 // Create LLM agents for different tasks
 let translator = Arc::new(LlmAgentBuilder::new("translator")
-    .model(Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?))
+    .model(Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?))
     .instruction("Translate the input text to French.")
     .build()?);
 

--- a/adk-model/README.md
+++ b/adk-model/README.md
@@ -10,10 +10,10 @@ LLM model integrations for Rust Agent Development Kit (ADK-Rust) with Gemini, Op
 
 `adk-model` provides LLM integrations for the Rust Agent Development Kit ([ADK-Rust](https://github.com/zavora-ai/adk-rust)). Supports all major providers:
 
-- **Gemini** - Google's Gemini models (3.0 Pro, 2.5 Pro, 2.0 Flash, etc.)
-- **OpenAI** - GPT-5.2, GPT-5.1, GPT-5, GPT-4o, GPT-4o-mini, Azure OpenAI
-- **Anthropic** - Claude Opus 4.5, Claude Sonnet 4.5, Claude Sonnet 4, Claude 3.5
-- **DeepSeek** - DeepSeek-Chat, DeepSeek-Reasoner with thinking mode
+- **Gemini** - Google's Gemini models (3 Pro, 3 Flash, 2.5 Pro, 2.5 Flash, etc.)
+- **OpenAI** - GPT-5.1, GPT-5, GPT-5 Mini, GPT-4o (legacy)
+- **Anthropic** - Claude Opus 4.5, Claude Sonnet 4.5, Claude Haiku 4.5, Claude 4
+- **DeepSeek** - DeepSeek R1, DeepSeek V3.1, DeepSeek-Chat with thinking mode
 - **Groq** - Ultra-fast inference (LLaMA 3.3, Mixtral, Gemma)
 - **Ollama** - Local LLMs (LLaMA, Mistral, Qwen, Gemma, etc.)
 - **Streaming** - Real-time response streaming for all providers
@@ -67,7 +67,7 @@ use std::sync::Arc;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let api_key = std::env::var("OPENAI_API_KEY")?;
-    let model = OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-4o"))?;
+    let model = OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-5-mini"))?;
 
     let agent = LlmAgentBuilder::new("assistant")
         .model(Arc::new(model))
@@ -87,7 +87,7 @@ use std::sync::Arc;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let api_key = std::env::var("ANTHROPIC_API_KEY")?;
-    let model = AnthropicClient::new(AnthropicConfig::new(api_key, "claude-sonnet-4-20250514"))?;
+    let model = AnthropicClient::new(AnthropicConfig::new(api_key, "claude-sonnet-4.5"))?;
 
     let agent = LlmAgentBuilder::new("assistant")
         .model(Arc::new(model))
@@ -168,11 +168,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 | Model | Description |
 |-------|-------------|
-| `gemini-3-pro-preview` | Most intelligent multimodal model with agentic capabilities |
-| `gemini-2.5-pro` | Advanced reasoning model |
-| `gemini-2.5-flash` | Latest fast model (recommended) |
-| `gemini-2.5-flash-lite` | Lightweight, cost-effective |
-| `gemini-2.0-flash` | Fast and efficient |
+| `gemini-3-pro` | Most intelligent model for complex agentic workflows (2M context) |
+| `gemini-3-flash` | Fast and efficient for most tasks (1M context) |
+| `gemini-2.5-pro` | Advanced reasoning and multimodal understanding |
+| `gemini-2.5-flash` | Balanced speed and capability (recommended) |
+| `gemini-2.5-flash-lite` | Ultra-fast for high-volume tasks |
+| `gemini-2.0-flash` | Previous generation (retiring March 2026) |
 
 See [Gemini models documentation](https://ai.google.dev/gemini-api/docs/models/gemini) for the full list.
 
@@ -180,11 +181,11 @@ See [Gemini models documentation](https://ai.google.dev/gemini-api/docs/models/g
 
 | Model | Description |
 |-------|-------------|
-| `gpt-5.2` | Latest GPT-5 with enhanced reasoning |
-| `gpt-5.1` | GPT-5 with improved tool use |
-| `gpt-5` | GPT-5 base model |
-| `gpt-4o` | Most capable GPT-4 model |
-| `gpt-4o-mini` | Fast, cost-effective GPT-4 |
+| `gpt-5.1` | Latest iteration with improved performance (256K context) |
+| `gpt-5` | State-of-the-art unified model with adaptive thinking |
+| `gpt-5-mini` | Efficient version for most tasks (128K context) |
+| `gpt-4o` | Multimodal model (deprecated August 2025) |
+| `gpt-4o-mini` | Fast and affordable (deprecated August 2025) |
 
 See [OpenAI models documentation](https://platform.openai.com/docs/models) for the full list.
 
@@ -192,10 +193,11 @@ See [OpenAI models documentation](https://platform.openai.com/docs/models) for t
 
 | Model | Description |
 |-------|-------------|
-| `claude-opus-4-20250514` | Claude Opus 4.5 - Most capable |
-| `claude-sonnet-4-20250514` | Claude Sonnet 4.5 - Balanced |
-| `claude-3-5-sonnet-20241022` | Claude 3.5 Sonnet |
-| `claude-3-opus-20240229` | Claude 3 Opus |
+| `claude-opus-4.5` | Most capable model for complex autonomous tasks (200K context) |
+| `claude-sonnet-4.5` | Balanced intelligence and cost for production |
+| `claude-haiku-4.5` | Ultra-efficient for high-volume workloads |
+| `claude-opus-4` | Hybrid model with extended thinking |
+| `claude-sonnet-4` | Balanced model with extended thinking |
 
 See [Anthropic models documentation](https://docs.anthropic.com/claude/docs/models-overview) for the full list.
 
@@ -203,8 +205,11 @@ See [Anthropic models documentation](https://docs.anthropic.com/claude/docs/mode
 
 | Model | Description |
 |-------|-------------|
-| `deepseek-chat` | General-purpose chat model |
-| `deepseek-reasoner` | Reasoning model with chain-of-thought |
+| `deepseek-r1-0528` | Latest reasoning model with enhanced thinking depth (128K context) |
+| `deepseek-r1` | Advanced reasoning comparable to o1 |
+| `deepseek-v3.1` | Latest 671B MoE model for general tasks |
+| `deepseek-chat` | 671B MoE model, excellent for code (V3) |
+| `deepseek-vl2` | Vision-language model (32K context) |
 
 **Features:**
 - **Thinking Mode** - Chain-of-thought reasoning with `<thinking>` tags
@@ -217,10 +222,12 @@ See [DeepSeek API documentation](https://api-docs.deepseek.com/) for the full li
 
 | Model | Description |
 |-------|-------------|
-| `llama-3.3-70b-versatile` | LLaMA 3.3 70B - Most capable |
-| `llama-3.1-8b-instant` | LLaMA 3.1 8B - Ultra fast |
-| `mixtral-8x7b-32768` | Mixtral 8x7B - 32K context |
-| `gemma2-9b-it` | Gemma 2 9B |
+| `llama-4-scout` | Llama 4 Scout (17Bx16E) - Fast via Groq LPU (128K context) |
+| `llama-3.2-90b-text-preview` | Large text model |
+| `llama-3.2-11b-text-preview` | Balanced text model |
+| `llama-3.1-70b-versatile` | Versatile large model |
+| `llama-3.1-8b-instant` | Ultra-fast instruction model |
+| `mixtral-8x7b-32768` | MoE model with 32K context |
 
 **Features:**
 - **Ultra-Fast** - LPU-based inference (fastest in the industry)
@@ -233,10 +240,18 @@ See [Groq documentation](https://console.groq.com/docs/models) for the full list
 
 | Model | Description |
 |-------|-------------|
-| `llama3.2` | LLaMA 3.2 - Fast and capable |
-| `mistral` | Mistral 7B |
-| `qwen2.5:7b` | Qwen 2.5 with excellent tool support (recommended) |
-| `gemma2` | Gemma 2 |
+| `llama3.3:70b` | Llama 3.3 70B - Latest for local deployment (128K context) |
+| `llama3.2:3b` | Efficient small model |
+| `llama3.1:8b` | Popular balanced model |
+| `deepseek-r1:14b` | Distilled reasoning model |
+| `deepseek-r1:32b` | Larger distilled reasoning model |
+| `qwen3:14b` | Strong multilingual and coding |
+| `qwen2.5:7b` | Efficient multilingual model (recommended for tool calling) |
+| `mistral:7b` | Fast and capable |
+| `mistral-nemo:12b` | Enhanced Mistral variant (128K context) |
+| `gemma3:9b` | Google's efficient open model |
+| `devstral:24b` | Optimized for coding tasks |
+| `codellama:13b` | Code-focused Llama variant |
 
 **Features:**
 - **Local Inference** - No API key required

--- a/docs/official_docs/core/core.md
+++ b/docs/official_docs/core/core.md
@@ -580,7 +580,7 @@ The trait that all LLM providers implement:
 ```rust
 #[async_trait]
 pub trait Llm: Send + Sync {
-    /// Model identifier (e.g., "gemini-2.0-flash", "gpt-4o")
+    /// Model identifier (e.g., "gemini-2.5-flash", "gpt-5-mini")
     fn name(&self) -> &str;
     
     /// Generate content (streaming or non-streaming)

--- a/docs/official_docs/introduction.md
+++ b/docs/official_docs/introduction.md
@@ -129,12 +129,12 @@ Events form the conversation history and enable replay and debugging.
 
 The underlying LLM that powers LlmAgents. ADK-Rust is optimized for Gemini but supports multiple providers through the `Llm` trait:
 
-- **Gemini**: Google's Gemini models (`gemini-3-pro-preview`, `gemini-2.5-flash`, `gemini-2.5-pro`)
-- **OpenAI**: `gpt-5.2`, `gpt-4o`, `gpt-4o-mini`, Azure OpenAI
-- **Anthropic**: `claude-sonnet-4-5`, `claude-opus-4-5`, `claude-sonnet-4`
-- **DeepSeek**: `deepseek-chat`, `deepseek-reasoner` with thinking mode
-- **Groq**: Ultra-fast inference with `llama-3.3-70b-versatile`, `mixtral-8x7b-32768`
-- **Ollama**: Local inference with `llama3.2`, `qwen2.5`, `mistral`, `phi4`
+- **Gemini**: Google's Gemini models (`gemini-3-pro`, `gemini-3-flash`, `gemini-2.5-flash`, `gemini-2.5-pro`)
+- **OpenAI**: `gpt-5.1`, `gpt-5`, `gpt-5-mini`, Azure OpenAI
+- **Anthropic**: `claude-opus-4.5`, `claude-sonnet-4.5`, `claude-haiku-4.5`
+- **DeepSeek**: `deepseek-r1`, `deepseek-v3.1`, `deepseek-chat` with thinking mode
+- **Groq**: Ultra-fast inference with `llama-4-scout`, `llama-3.1-70b-versatile`, `mixtral-8x7b-32768`
+- **Ollama**: Local inference with `llama3.2:3b`, `qwen2.5:7b`, `mistral:7b`, `deepseek-r1:14b`
 - **mistral.rs**: High-performance local inference with hardware acceleration
 
 All providers implement the same trait for interchangeable use:
@@ -173,7 +173,7 @@ adk-rust = { version = "0.3.0", default-features = false, features = ["agents", 
 Available features:
 - `agents`: Agent implementations (LlmAgent, CustomAgent, workflow agents)
 - `models`: Model integrations (Gemini)
-- `openai`: OpenAI models (GPT-5, GPT-4o)
+- `openai`: OpenAI models (GPT-5, GPT-5 Mini)
 - `anthropic`: Anthropic models (Claude 4.5, Claude 4)
 - `deepseek`: DeepSeek models (chat, reasoner)
 - `groq`: Groq ultra-fast inference

--- a/docs/official_docs/models/ollama.md
+++ b/docs/official_docs/models/ollama.md
@@ -79,13 +79,16 @@ In a new terminal:
 
 ```bash
 # Recommended starter model (3B parameters, fast)
-ollama pull llama3.2
+ollama pull llama3.2:3b
 
 # Other popular models
-ollama pull qwen2.5:7b    # Excellent tool calling
-ollama pull mistral       # Good for code
-ollama pull codellama     # Code generation
-ollama pull gemma2        # Google's efficient model
+ollama pull qwen2.5:7b       # Excellent tool calling
+ollama pull qwen3:14b         # Strong multilingual and coding
+ollama pull mistral:7b        # Good for code
+ollama pull deepseek-r1:14b   # Reasoning model
+ollama pull devstral:24b      # Optimized for coding
+ollama pull gemma3:9b         # Google's efficient model
+ollama pull codellama:13b     # Code generation
 ```
 
 ---
@@ -181,20 +184,26 @@ let model = OllamaModel::new(config)?;
 
 | Model | Size | RAM Needed | Best For |
 |-------|------|------------|----------|
-| `llama3.2` | 3B | 4GB | Fast, general purpose |
-| `llama3.2:7b` | 7B | 8GB | Better quality |
+| `llama3.2:3b` | 3B | 4GB | Fast, general purpose |
+| `llama3.1:8b` | 8B | 8GB | Popular balanced model |
 | `qwen2.5:7b` | 7B | 8GB | **Best tool calling** |
-| `mistral` | 7B | 8GB | Code and reasoning |
-| `codellama` | 7B | 8GB | Code generation |
-| `gemma2` | 9B | 10GB | Balanced performance |
-| `llama3.1:70b` | 70B | 48GB | Highest quality |
+| `qwen3:14b` | 14B | 16GB | Strong multilingual and coding |
+| `mistral:7b` | 7B | 8GB | Code and reasoning |
+| `mistral-nemo:12b` | 12B | 12GB | Enhanced Mistral (128K context) |
+| `deepseek-r1:14b` | 14B | 16GB | Distilled reasoning |
+| `deepseek-r1:32b` | 32B | 32GB | Larger reasoning model |
+| `gemma3:9b` | 9B | 10GB | Google's efficient open model |
+| `devstral:24b` | 24B | 24GB | Optimized for coding |
+| `codellama:13b` | 13B | 16GB | Code generation |
+| `llama3.3:70b` | 70B | 48GB | Highest quality |
 
 ### Choosing a Model
 
-- **Limited RAM (8GB)?** → `llama3.2` (3B)
-- **Need tool calling?** → `qwen2.5:7b`
-- **Writing code?** → `codellama` or `mistral`
-- **Best quality?** → `llama3.1:70b` (needs 48GB+ RAM)
+- **Limited RAM (8GB)?** → `llama3.2:3b`
+- **Need tool calling?** → `qwen2.5:7b` or `qwen3:14b`
+- **Writing code?** → `devstral:24b` or `codellama:13b`
+- **Need reasoning?** → `deepseek-r1:14b` or `deepseek-r1:32b`
+- **Best quality?** → `llama3.3:70b` (needs 48GB+ RAM)
 
 ---
 

--- a/docs/official_docs/models/providers.md
+++ b/docs/official_docs/models/providers.md
@@ -85,7 +85,7 @@ async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
     
     let api_key = std::env::var("GOOGLE_API_KEY")?;
-    let model = GeminiModel::new(&api_key, "gemini-2.0-flash")?;
+    let model = GeminiModel::new(&api_key, "gemini-2.5-flash")?;
 
     let agent = LlmAgentBuilder::new("gemini_assistant")
         .description("Gemini-powered assistant")
@@ -102,9 +102,12 @@ async fn main() -> anyhow::Result<()> {
 
 | Model | Description | Context |
 |-------|-------------|---------|
-| `gemini-2.0-flash` | Fast, efficient (recommended) | 1M tokens |
-| `gemini-2.5-flash` | Latest flash model | 1M tokens |
-| `gemini-2.5-pro` | Most capable | 2M tokens |
+| `gemini-3-pro` | Most intelligent, complex agentic workflows | 2M tokens |
+| `gemini-3-flash` | Fast and efficient for most tasks | 1M tokens |
+| `gemini-2.5-pro` | Advanced reasoning and multimodal | 1M tokens |
+| `gemini-2.5-flash` | Balanced speed and capability (recommended) | 1M tokens |
+| `gemini-2.5-flash-lite` | Ultra-fast for high-volume | 1M tokens |
+| `gemini-2.0-flash` | Previous generation (retiring March 2026) | 1M tokens |
 
 ### Example Output
 
@@ -118,7 +121,7 @@ It has green eyes and distinctive striped markings typical of tabby cats.
 
 ---
 
-## OpenAI (GPT-4o) 🔥 Popular
+## OpenAI (GPT-5) 🔥 Popular
 
 > **Best for**: Production apps, reliable performance, broad capabilities
 > 
@@ -141,11 +144,11 @@ async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
     
     let api_key = std::env::var("OPENAI_API_KEY")?;
-    let model = OpenAIClient::new(OpenAIConfig::new(&api_key, "gpt-4o"))?;
+    let model = OpenAIClient::new(OpenAIConfig::new(&api_key, "gpt-5-mini"))?;
 
     let agent = LlmAgentBuilder::new("openai_assistant")
         .description("OpenAI-powered assistant")
-        .instruction("You are a helpful assistant powered by OpenAI GPT-4o. Be concise.")
+        .instruction("You are a helpful assistant powered by OpenAI GPT-5. Be concise.")
         .model(Arc::new(model))
         .build()?;
 
@@ -163,7 +166,7 @@ use adk_rust::prelude::*;
 use serde_json::json;
 use std::sync::Arc;
 
-let model = OpenAIClient::new(OpenAIConfig::new(&api_key, "gpt-4o"))?;
+let model = OpenAIClient::new(OpenAIConfig::new(&api_key, "gpt-5-mini"))?;
 
 let agent = LlmAgentBuilder::new("data_extractor")
     .model(Arc::new(model))
@@ -224,17 +227,18 @@ let model = OpenAIClient::new(config)?;
 
 | Model | Description | Context |
 |-------|-------------|---------|
-| `gpt-4o` | Most capable, multimodal | 128K tokens |
-| `gpt-4o-mini` | Fast, cost-effective | 128K tokens |
-| `gpt-4-turbo` | Previous flagship | 128K tokens |
-| `o1` | Reasoning model | 128K tokens |
+| `gpt-5.1` | Latest iteration with improved performance | 256K tokens |
+| `gpt-5` | State-of-the-art unified model with adaptive thinking | 256K tokens |
+| `gpt-5-mini` | Efficient version for most tasks (recommended) | 128K tokens |
+| `gpt-4o` | Multimodal model (deprecated August 2025) | 128K tokens |
+| `gpt-4o-mini` | Fast and affordable (deprecated August 2025) | 128K tokens |
 
 ### Example Output
 
 ```
 👤 User: Write a haiku about Rust programming
 
-🤖 GPT-4o: Memory so safe,
+🤖 GPT-5: Memory so safe,
 Ownership guards every byte—
 Compiler, my friend.
 ```
@@ -263,7 +267,7 @@ async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
     
     let api_key = std::env::var("ANTHROPIC_API_KEY")?;
-    let model = AnthropicClient::new(AnthropicConfig::new(&api_key, "claude-sonnet-4-20250514"))?;
+    let model = AnthropicClient::new(AnthropicConfig::new(&api_key, "claude-sonnet-4.5"))?;
 
     let agent = LlmAgentBuilder::new("anthropic_assistant")
         .description("Anthropic-powered assistant")
@@ -280,9 +284,11 @@ async fn main() -> anyhow::Result<()> {
 
 | Model | Description | Context |
 |-------|-------------|---------|
-| `claude-sonnet-4-20250514` | Latest Claude 4 Sonnet | 200K tokens |
-| `claude-opus-4-20250514` | Most capable Claude 4 | 200K tokens |
-| `claude-3-5-sonnet-20241022` | Claude 3.5 Sonnet | 200K tokens |
+| `claude-opus-4.5` | Most capable for complex autonomous tasks | 200K tokens |
+| `claude-sonnet-4.5` | Balanced intelligence and cost (recommended) | 200K tokens |
+| `claude-haiku-4.5` | Ultra-efficient for high-volume workloads | 200K tokens |
+| `claude-opus-4` | Hybrid model with extended thinking | 200K tokens |
+| `claude-sonnet-4` | Balanced model with extended thinking | 200K tokens |
 
 ### Example Output
 
@@ -342,8 +348,11 @@ async fn main() -> anyhow::Result<()> {
 
 | Model | Description | Special Feature |
 |-------|-------------|-----------------|
-| `deepseek-chat` | Fast chat model | General purpose |
-| `deepseek-reasoner` | Reasoning model | Shows thinking process |
+| `deepseek-r1-0528` | Latest reasoning model | Enhanced thinking depth |
+| `deepseek-r1` | Advanced reasoning | Comparable to o1 |
+| `deepseek-v3.1` | Latest 671B MoE model | General tasks |
+| `deepseek-chat` | 671B MoE model (V3) | General purpose, cheap |
+| `deepseek-vl2` | Vision-language model | Multimodal |
 
 ### Example Output (Reasoner with Thinking Mode)
 
@@ -402,9 +411,12 @@ async fn main() -> anyhow::Result<()> {
 
 | Model | Method | Description |
 |-------|--------|-------------|
-| `llama-3.3-70b-versatile` | `GroqClient::llama70b()` | Most capable |
+| `llama-4-scout` | `GroqClient::new(GroqConfig::new(key, "llama-4-scout"))` | Llama 4 Scout (17Bx16E) |
+| `llama-3.2-90b-text-preview` | `GroqClient::new(GroqConfig::new(key, "llama-3.2-90b-text-preview"))` | Large text model |
+| `llama-3.1-70b-versatile` | `GroqClient::llama70b()` | Versatile large model |
 | `llama-3.1-8b-instant` | `GroqClient::llama8b()` | Fastest |
-| `mixtral-8x7b-32768` | Custom config | Good balance |
+| `mixtral-8x7b-32768` | `GroqClient::mixtral()` | Good balance |
+| Any model | `GroqClient::new(GroqConfig::new(key, "model"))` | Custom model |
 
 ### Example Output
 
@@ -432,9 +444,9 @@ use std::sync::Arc;
 // Just change the model - everything else stays the same!
 let model: Arc<dyn adk_core::Llm> = Arc::new(
     // Pick one:
-    // GeminiModel::new(&api_key, "gemini-2.0-flash")?
-    // OpenAIClient::new(OpenAIConfig::new(&api_key, "gpt-4o"))?
-    // AnthropicClient::new(AnthropicConfig::new(&api_key, "claude-sonnet-4-20250514"))?
+    // GeminiModel::new(&api_key, "gemini-2.5-flash")?
+    // OpenAIClient::new(OpenAIConfig::new(&api_key, "gpt-5-mini"))?
+    // AnthropicClient::new(AnthropicConfig::new(&api_key, "claude-sonnet-4.5"))?
     // DeepSeekClient::chat(&api_key)?
     // GroqClient::llama70b(&api_key)?
 );

--- a/docs/official_docs/quickstart.md
+++ b/docs/official_docs/quickstart.md
@@ -294,7 +294,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     dotenvy::dotenv().ok();
 
     let api_key = std::env::var("OPENAI_API_KEY")?;
-    let model = OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-4o"))?;
+    let model = OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-5-mini"))?;
 
     let agent = LlmAgentBuilder::new("assistant")
         .instruction("You are a helpful assistant.")
@@ -319,7 +319,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     dotenvy::dotenv().ok();
 
     let api_key = std::env::var("ANTHROPIC_API_KEY")?;
-    let model = AnthropicClient::new(AnthropicConfig::new(api_key, "claude-sonnet-4-20250514"))?;
+    let model = AnthropicClient::new(AnthropicConfig::new(api_key, "claude-sonnet-4.5"))?;
 
     let agent = LlmAgentBuilder::new("assistant")
         .instruction("You are a helpful assistant.")
@@ -416,12 +416,12 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
 | Provider | Model Examples | Feature Flag |
 |----------|---------------|--------------|
-| Gemini | `gemini-3-pro-preview`, `gemini-3-flash-preview`, `gemini-2.5-flash`, `gemini-2.5-pro`, `gemini-2.0-flash` | (default) |
-| OpenAI | `gpt-5.2`, `gpt-5.2-mini`, `gpt-5-mini`, `gpt-5-nano`, `gpt-4.1`, `gpt-4.1-mini`, `o3-mini`, `gpt-4o`, `gpt-4o-mini` | `openai` |
-| Anthropic | `claude-sonnet-4-5`, `claude-haiku-4-5`, `claude-opus-4-5`, `claude-sonnet-4`, `claude-opus-4`, `claude-haiku-4` | `anthropic` |
-| DeepSeek | `deepseek-chat`, `deepseek-reasoner` | `deepseek` |
-| Groq | `gpt-oss-120b`, `qwen3-32b`, `llama-3.3-70b-versatile`, `mixtral-8x7b-32768` | `groq` |
-| Ollama | `gemma3`, `qwen2.5`, `llama3.2`, `mistral`, `phi4`, `codellama` | `ollama` |
+| Gemini | `gemini-2.5-flash`, `gemini-2.5-pro`, `gemini-3-pro`, `gemini-3-flash` | (default) |
+| OpenAI | `gpt-5-mini`, `gpt-5`, `gpt-5.1` | `openai` |
+| Anthropic | `claude-sonnet-4.5`, `claude-opus-4.5`, `claude-haiku-4.5` | `anthropic` |
+| DeepSeek | `deepseek-chat`, `deepseek-r1`, `deepseek-v3.1` | `deepseek` |
+| Groq | `llama-4-scout`, `llama-3.1-70b-versatile`, `llama-3.1-8b-instant`, `mixtral-8x7b-32768` | `groq` |
+| Ollama | `llama3.2:3b`, `qwen2.5:7b`, `mistral:7b`, `deepseek-r1:14b`, `gemma3:9b` | `ollama` |
 
 ## Next Steps
 


### PR DESCRIPTION
Update model tables, code examples, and references across all documentation to reflect current 2026 model names.

**Changes:**
- Gemini: Added gemini-3-pro, gemini-3-flash; gemini-2.0-flash marked as retiring
- OpenAI: gpt-5.1, gpt-5, gpt-5-mini as current; gpt-4o/gpt-4o-mini marked deprecated
- Anthropic: claude-opus-4.5, claude-sonnet-4.5, claude-haiku-4.5 as current
- DeepSeek: Added deepseek-r1-0528, deepseek-v3.1, deepseek-vl2
- Groq: Added llama-4-scout, expanded model list
- Ollama: Expanded from 4 to 12 models (deepseek-r1, qwen3, devstral, etc.)

All code examples updated to use recommended 2026 models. Source of truth: `adk-studio/ui/src/data/models.ts`

Closes #76 #77