### PR TITLE
chore: update example model names to 2026 versions

### DIFF
--- a/examples/anthropic_basic/main.rs
+++ b/examples/anthropic_basic/main.rs
@@ -19,7 +19,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let api_key = std::env::var("ANTHROPIC_API_KEY").expect("ANTHROPIC_API_KEY must be set");
 
     // Create the Anthropic client with Claude Sonnet
-    let model = AnthropicClient::new(AnthropicConfig::new(api_key, "claude-sonnet-4-20250514"))?;
+    let model = AnthropicClient::new(AnthropicConfig::new(api_key, "claude-sonnet-4.5"))?;
 
     // Create an agent using the Claude model
     let agent = LlmAgentBuilder::new("claude_assistant")
@@ -32,7 +32,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         .build()?;
 
     println!("Anthropic Claude Agent created: {}", agent.name());
-    println!("Model: claude-sonnet-4-20250514");
+    println!("Model: claude-sonnet-4.5");
     println!("\nTry asking Claude a question!\n");
 
     // Run with the default launcher

--- a/examples/anthropic_tools/main.rs
+++ b/examples/anthropic_tools/main.rs
@@ -101,7 +101,7 @@ async fn calculator(_ctx: Arc<dyn ToolContext>, args: Value) -> Result<Value, ad
 async fn main() -> Result<()> {
     let api_key = std::env::var("ANTHROPIC_API_KEY").expect("ANTHROPIC_API_KEY must be set");
 
-    let model = AnthropicClient::new(AnthropicConfig::new(api_key, "claude-sonnet-4-20250514"))?;
+    let model = AnthropicClient::new(AnthropicConfig::new(api_key, "claude-sonnet-4.5"))?;
 
     // Create weather tool with schema
     let weather_tool =
@@ -130,7 +130,7 @@ async fn main() -> Result<()> {
         .build()?;
 
     println!("=== Anthropic Claude Tools Example ===");
-    println!("Model: claude-sonnet-4-20250514");
+    println!("Model: claude-sonnet-4.5");
     println!();
     println!("Available tools:");
     println!("  - get_weather: Get weather for a city");

--- a/examples/browser_agent/main.rs
+++ b/examples/browser_agent/main.rs
@@ -217,7 +217,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Browser tools loaded: {}\n", tools.len());
 
     // Create model
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     // Create agent
     let mut builder = LlmAgentBuilder::new("web_researcher")

--- a/examples/browser_basic/main.rs
+++ b/examples/browser_basic/main.rs
@@ -250,7 +250,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // -------------------------------------------------------------------------
     println!("\n4. Creating browser automation agent...\n");
 
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     let mut builder = LlmAgentBuilder::new("browser_agent")
         .model(model)

--- a/examples/browser_interactive/main.rs
+++ b/examples/browser_interactive/main.rs
@@ -213,7 +213,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("All {} browser tools loaded\n", tools.len());
 
     // Create model
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     // Create agent with comprehensive instructions
     let mut builder = LlmAgentBuilder::new("interactive_browser")

--- a/examples/browser_openai/main.rs
+++ b/examples/browser_openai/main.rs
@@ -163,7 +163,7 @@ async fn run_agent(
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("=== Browser Agent Example (OpenAI GPT-4o) ===\n");
+    println!("=== Browser Agent Example (OpenAI GPT-5) ===\n");
 
     // Load API key
     let _ = dotenvy::dotenv();
@@ -214,12 +214,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Browser tools loaded: {}\n", tools.len());
 
     // Create OpenAI model
-    let model = Arc::new(OpenAIClient::new(OpenAIConfig::new(&api_key, "gpt-4o"))?);
+    let model = Arc::new(OpenAIClient::new(OpenAIConfig::new(&api_key, "gpt-5-mini"))?);
 
     // Create agent
     let mut builder = LlmAgentBuilder::new("web_agent_openai")
         .model(model)
-        .description("A web automation assistant powered by GPT-4o")
+        .description("A web automation assistant powered by GPT-5")
         .instruction(
             r#"You are a web automation assistant. Use the browser tools to:
 - Navigate to websites (browser_navigate)
@@ -236,7 +236,7 @@ Be concise and accurate. Always verify information by actually browsing."#,
     }
 
     let agent = Arc::new(builder.build()?);
-    println!("Agent created: {} (OpenAI GPT-4o)\n", agent.name());
+    println!("Agent created: {} (OpenAI GPT-5)\n", agent.name());
 
     // =========================================================================
     // Task 1: Basic navigation and extraction

--- a/examples/debug_openai_error/main.rs
+++ b/examples/debug_openai_error/main.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let api_key = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY must be set");
-    let model = OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-4o-mini"))?;
+    let model = OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-5-mini"))?;
 
     println!("=== Test A: Empty assistant message (no text, no tool calls) ===");
     test_request(
@@ -139,7 +139,7 @@ async fn test_request(
     contents: Vec<Content>,
     tools: HashMap<String, serde_json::Value>,
 ) {
-    let request = LlmRequest { model: "gpt-4o-mini".to_string(), contents, tools, config: None };
+    let request = LlmRequest { model: "gpt-5-mini".to_string(), contents, tools, config: None };
 
     println!("Sending request...");
     match model.generate_content(request, true).await {

--- a/examples/eval_agent/main.rs
+++ b/examples/eval_agent/main.rs
@@ -169,7 +169,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // -------------------------------------------------------------------------
     println!("1. Creating weather agent...\n");
 
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     let agent = LlmAgentBuilder::new("weather_agent")
         .model(model.clone())
@@ -180,7 +180,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("   Agent: {}", agent.name());
     println!("   Tools: get_weather, get_forecast");
-    println!("   Model: gemini-2.0-flash\n");
+    println!("   Model: gemini-2.5-flash\n");
 
     // -------------------------------------------------------------------------
     // 2. Define Test Cases

--- a/examples/eval_graph/main.rs
+++ b/examples/eval_graph/main.rs
@@ -282,7 +282,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let _ = dotenvy::dotenv();
     if let Ok(api_key) = std::env::var("GOOGLE_API_KEY") {
-        let judge_model: Arc<dyn Llm> = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+        let judge_model: Arc<dyn Llm> = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
         let judge = LlmJudge::with_config(
             judge_model.clone(),
             LlmJudgeConfig { max_tokens: 512, temperature: 0.0 },

--- a/examples/eval_llm_gemini/main.rs
+++ b/examples/eval_llm_gemini/main.rs
@@ -39,8 +39,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // -------------------------------------------------------------------------
     println!("1. Creating Gemini judge model...\n");
 
-    let judge_model: Arc<dyn Llm> = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
-    println!("   Model: gemini-2.0-flash");
+    let judge_model: Arc<dyn Llm> = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
+    println!("   Model: gemini-2.5-flash");
     println!("   Purpose: Semantic evaluation and rubric scoring\n");
 
     // -------------------------------------------------------------------------

--- a/examples/eval_llm_openai/main.rs
+++ b/examples/eval_llm_openai/main.rs
@@ -40,9 +40,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // -------------------------------------------------------------------------
     println!("1. Creating OpenAI judge model...\n");
 
-    let config = OpenAIConfig::new(api_key, "gpt-4o-mini"); // Cost-effective for evaluation
+    let config = OpenAIConfig::new(api_key, "gpt-5-mini"); // Cost-effective for evaluation
     let judge_model: Arc<dyn Llm> = Arc::new(OpenAIClient::new(config)?);
-    println!("   Model: gpt-4o-mini");
+    println!("   Model: gpt-5-mini");
     println!("   Purpose: Semantic evaluation and rubric scoring\n");
 
     // -------------------------------------------------------------------------
@@ -218,7 +218,7 @@ fn is_prime(n: u64) -> bool {
     // -------------------------------------------------------------------------
     println!("=== Example Complete ===\n");
     println!("Key takeaways:");
-    println!("  - OpenAI models (gpt-4o-mini) are cost-effective judges");
+    println!("  - OpenAI models (gpt-5-mini) are cost-effective judges");
     println!("  - Semantic matching handles paraphrasing well");
     println!("  - Rubrics enable multi-dimensional quality assessment");
     println!("  - Use temperature=0.0 for reproducible evaluations");

--- a/examples/eval_realtime/main.rs
+++ b/examples/eval_realtime/main.rs
@@ -285,7 +285,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let _ = dotenvy::dotenv();
     if let Ok(api_key) = std::env::var("GOOGLE_API_KEY") {
-        let judge_model: Arc<dyn Llm> = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+        let judge_model: Arc<dyn Llm> = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
         let judge = LlmJudge::with_config(
             judge_model.clone(),
             LlmJudgeConfig { max_tokens: 512, temperature: 0.0 },

--- a/examples/eval_rubric/main.rs
+++ b/examples/eval_rubric/main.rs
@@ -247,7 +247,7 @@ let criteria = EvaluationCriteria::default()
     ]);
 
 // Create evaluator with LLM judge (required for rubric evaluation)
-let judge_model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+let judge_model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 let evaluator = Evaluator::with_llm_judge(
     EvaluationConfig::with_criteria(criteria),
     judge_model,

--- a/examples/eval_semantic/main.rs
+++ b/examples/eval_semantic/main.rs
@@ -34,7 +34,7 @@ REASONING: Both responses correctly state that Python is a programming language,
 
     println!("Created LlmJudge with mock model");
     println!("  In production, use:");
-    println!("    - GeminiModel::new(&api_key, \"gemini-2.0-flash\")");
+    println!("    - GeminiModel::new(&api_key, \"gemini-2.5-flash\")");
     println!("    - OpenAIClient::new(config)");
     println!("    - AnthropicClient::new(config)\n");
 
@@ -173,7 +173,7 @@ use adk_model::GeminiModel;
 
 let api_key = std::env::var("GOOGLE_API_KEY")?;
 let judge_model = Arc::new(
-    GeminiModel::new(&api_key, "gemini-2.0-flash")?
+    GeminiModel::new(&api_key, "gemini-2.5-flash")?
 );
 
 let criteria = EvaluationCriteria::semantic_match(0.85)

--- a/examples/graph_agent/main.rs
+++ b/examples/graph_agent/main.rs
@@ -38,7 +38,7 @@ async fn main() -> anyhow::Result<()> {
         }
     };
 
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     // Create specialized LLM agents
     let translator_agent = Arc::new(

--- a/examples/graph_checkpoint/main.rs
+++ b/examples/graph_checkpoint/main.rs
@@ -40,7 +40,7 @@ async fn main() -> anyhow::Result<()> {
         }
     };
 
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     // Create a checkpointer to persist state
     let checkpointer = Arc::new(MemoryCheckpointer::new());

--- a/examples/graph_conditional/main.rs
+++ b/examples/graph_conditional/main.rs
@@ -38,7 +38,7 @@ async fn main() -> anyhow::Result<()> {
         }
     };
 
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     // Create classifier agent
     let classifier_agent = Arc::new(

--- a/examples/graph_gemini/main.rs
+++ b/examples/graph_gemini/main.rs
@@ -64,7 +64,7 @@ async fn main() -> anyhow::Result<()> {
     };
 
     // Initialize Gemini model
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     // Clone for each node that needs the model
     let model_analyze = model.clone();

--- a/examples/graph_hitl/main.rs
+++ b/examples/graph_hitl/main.rs
@@ -40,7 +40,7 @@ async fn main() -> anyhow::Result<()> {
         }
     };
 
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     // Create a checkpointer to persist state across interrupts
     let checkpointer = Arc::new(MemoryCheckpointer::new());

--- a/examples/graph_llm/main.rs
+++ b/examples/graph_llm/main.rs
@@ -55,7 +55,7 @@ async fn main() -> anyhow::Result<()> {
         .or_else(|_| std::env::var("GEMINI_API_KEY"))
         .expect("GOOGLE_API_KEY or GEMINI_API_KEY must be set");
 
-    let model_name = "gemini-2.0-flash";
+    let model_name = "gemini-2.5-flash";
     let model = Arc::new(GeminiModel::new(&api_key, model_name)?);
     let model1 = model.clone();
     let model2 = model.clone();

--- a/examples/graph_openai/main.rs
+++ b/examples/graph_openai/main.rs
@@ -50,7 +50,7 @@ async fn main() -> anyhow::Result<()> {
 
     let client = Arc::new(OpenAIClient::new(OpenAIConfig {
         api_key,
-        model: "gpt-4o-mini".to_string(),
+        model: "gpt-5-mini".to_string(),
         ..Default::default()
     })?);
     let client_classify = client.clone();

--- a/examples/graph_react/main.rs
+++ b/examples/graph_react/main.rs
@@ -95,7 +95,7 @@ async fn main() -> anyhow::Result<()> {
         }
     };
 
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     // Create the reasoner agent with tools
     let reasoner_agent = Arc::new(

--- a/examples/graph_streaming/main.rs
+++ b/examples/graph_streaming/main.rs
@@ -40,7 +40,7 @@ async fn main() -> Result<()> {
     };
 
     // Create model and agent
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
     let agent = Arc::new(
         LlmAgentBuilder::new("storyteller")
             .model(model)

--- a/examples/graph_supervisor/main.rs
+++ b/examples/graph_supervisor/main.rs
@@ -39,7 +39,7 @@ async fn main() -> anyhow::Result<()> {
         }
     };
 
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     // Create the supervisor agent
     let supervisor_agent = Arc::new(

--- a/examples/graph_workflow/main.rs
+++ b/examples/graph_workflow/main.rs
@@ -38,7 +38,7 @@ async fn main() -> anyhow::Result<()> {
         }
     };
 
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     // Create specialized LlmAgent instances
     let extractor_agent = Arc::new(

--- a/examples/guardrail_agent/main.rs
+++ b/examples/guardrail_agent/main.rs
@@ -30,7 +30,7 @@ async fn main() -> anyhow::Result<()> {
         }
     };
 
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     // Input guardrails: block harmful content, redact PII
     let input_guardrails =

--- a/examples/mcp_http/main.rs
+++ b/examples/mcp_http/main.rs
@@ -164,7 +164,7 @@ async fn main() -> Result<()> {
     println!("\n✅ Total tools available: {}\n", all_tools.len());
 
     // Create model
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     // Build agent with MCP tools
     let mut agent_builder = LlmAgentBuilder::new("mcp-http-agent")

--- a/examples/mcp_oauth/main.rs
+++ b/examples/mcp_oauth/main.rs
@@ -154,7 +154,7 @@ where
 
             // Create agent if we have an API key
             if let Some(api_key) = google_api_key {
-                let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+                let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
                 let mut agent_builder = LlmAgentBuilder::new("mcp-oauth-agent")
                     .description("Agent with authenticated MCP tools")

--- a/examples/openai_a2a/main.rs
+++ b/examples/openai_a2a/main.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<()> {
     let api_key = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY must be set");
 
     // Create a weather agent that will be exposed via A2A
-    let model = OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-4o-mini"))?;
+    let model = OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-5-mini"))?;
 
     let weather_agent = LlmAgentBuilder::new("weather_agent")
         .description("Agent to answer questions about weather")

--- a/examples/openai_agent_tool/main.rs
+++ b/examples/openai_agent_tool/main.rs
@@ -65,7 +65,7 @@ async fn calculator(_ctx: Arc<dyn ToolContext>, args: Value) -> Result<Value, ad
 async fn main() -> Result<()> {
     let api_key = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY must be set");
 
-    let model = Arc::new(OpenAIClient::new(OpenAIConfig::new(api_key.clone(), "gpt-4o-mini"))?);
+    let model = Arc::new(OpenAIClient::new(OpenAIConfig::new(api_key.clone(), "gpt-5-mini"))?);
 
     // Create the calculator tool with schema
     let calc_tool = FunctionTool::new(
@@ -93,7 +93,7 @@ async fn main() -> Result<()> {
             "You are a trivia expert. Answer questions accurately and concisely. \
              If you're unsure, say so.",
         )
-        .model(Arc::new(OpenAIClient::new(OpenAIConfig::new(api_key.clone(), "gpt-4o-mini"))?))
+        .model(Arc::new(OpenAIClient::new(OpenAIConfig::new(api_key.clone(), "gpt-5-mini"))?))
         .build()?;
 
     // Wrap agents as tools
@@ -109,7 +109,7 @@ async fn main() -> Result<()> {
              - For trivia/facts -> use trivia_expert\n\n\
              Summarize the specialist's response for the user.",
         )
-        .model(Arc::new(OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-4o-mini"))?))
+        .model(Arc::new(OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-5-mini"))?))
         .tool(Arc::new(math_tool))
         .tool(Arc::new(trivia_tool))
         .build()?;

--- a/examples/openai_artifacts/main.rs
+++ b/examples/openai_artifacts/main.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 async fn main() -> Result<()> {
     let api_key = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY must be set");
 
-    let model = OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-4o-mini"))?;
+    let model = OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-5-mini"))?;
 
     let _agent = LlmAgentBuilder::new("artifact_agent")
         .description("Agent that can load and analyze artifacts")

--- a/examples/openai_basic/main.rs
+++ b/examples/openai_basic/main.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let api_key = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY must be set");
 
     // Create OpenAI client
-    let model = OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-4o-mini"))?;
+    let model = OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-5-mini"))?;
 
     // Build agent
     let agent = LlmAgentBuilder::new("assistant")

--- a/examples/openai_loop/main.rs
+++ b/examples/openai_loop/main.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 async fn main() -> Result<()> {
     let api_key = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY must be set");
 
-    let model = OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-4o-mini"))?;
+    let model = OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-5-mini"))?;
 
     let refiner = LlmAgentBuilder::new("refiner")
         .description("Refines and improves content iteratively")

--- a/examples/openai_mcp/main.rs
+++ b/examples/openai_mcp/main.rs
@@ -155,7 +155,7 @@ async fn main() -> anyhow::Result<()> {
     print_usage_pattern();
 
     // Show we can still create an agent without MCP tools
-    let model = Arc::new(OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-4o-mini"))?);
+    let model = Arc::new(OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-5-mini"))?);
 
     let agent = LlmAgentBuilder::new("mcp-demo-agent")
         .description("Agent demonstrating MCP integration pattern with OpenAI")
@@ -203,7 +203,7 @@ use std::sync::Arc;
 async fn main() -> anyhow::Result<()> {{
     // 1. Create OpenAI model
     let api_key = std::env::var("OPENAI_API_KEY")?;
-    let model = Arc::new(OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-4o-mini"))?);
+    let model = Arc::new(OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-5-mini"))?);
 
     // 2. Create MCP client connection to a local server
     let client = ().serve(TokioChildProcess::new(

--- a/examples/openai_parallel/main.rs
+++ b/examples/openai_parallel/main.rs
@@ -21,14 +21,14 @@ async fn main() -> Result<()> {
     let technical = LlmAgentBuilder::new("technical_analyst")
         .description("Provides technical analysis")
         .instruction("Analyze the topic from a technical perspective. Be concise (2-3 sentences).")
-        .model(Arc::new(OpenAIClient::new(OpenAIConfig::new(api_key.clone(), "gpt-4o-mini"))?))
+        .model(Arc::new(OpenAIClient::new(OpenAIConfig::new(api_key.clone(), "gpt-5-mini"))?))
         .build()?;
 
     // Agent 2: Business perspective
     let business = LlmAgentBuilder::new("business_analyst")
         .description("Provides business analysis")
         .instruction("Analyze the topic from a business perspective. Be concise (2-3 sentences).")
-        .model(Arc::new(OpenAIClient::new(OpenAIConfig::new(api_key.clone(), "gpt-4o-mini"))?))
+        .model(Arc::new(OpenAIClient::new(OpenAIConfig::new(api_key.clone(), "gpt-5-mini"))?))
         .build()?;
 
     // Agent 3: User perspective
@@ -37,7 +37,7 @@ async fn main() -> Result<()> {
         .instruction(
             "Analyze the topic from a user experience perspective. Be concise (2-3 sentences).",
         )
-        .model(Arc::new(OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-4o-mini"))?))
+        .model(Arc::new(OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-5-mini"))?))
         .build()?;
 
     let parallel = ParallelAgent::new(

--- a/examples/openai_research_paper/main.rs
+++ b/examples/openai_research_paper/main.rs
@@ -123,7 +123,7 @@ async fn format_citation(_ctx: Arc<dyn ToolContext>, args: Value) -> Result<Valu
 async fn main() -> Result<()> {
     let api_key = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY must be set");
 
-    let model = Arc::new(OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-4o-mini"))?);
+    let model = Arc::new(OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-5-mini"))?);
 
     // Create research tool
     let research_tool = FunctionTool::new(

--- a/examples/openai_sequential_code/main.rs
+++ b/examples/openai_sequential_code/main.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<()> {
              - Error handling strategy\n\
              Be thorough but concise.",
         )
-        .model(Arc::new(OpenAIClient::new(OpenAIConfig::new(api_key.clone(), "gpt-4o-mini"))?))
+        .model(Arc::new(OpenAIClient::new(OpenAIConfig::new(api_key.clone(), "gpt-5-mini"))?))
         .build()?;
 
     let implementer = LlmAgentBuilder::new("implementer")
@@ -43,7 +43,7 @@ async fn main() -> Result<()> {
              - Comments for complex logic\n\
              Output the complete implementation.",
         )
-        .model(Arc::new(OpenAIClient::new(OpenAIConfig::new(api_key.clone(), "gpt-4o-mini"))?))
+        .model(Arc::new(OpenAIClient::new(OpenAIConfig::new(api_key.clone(), "gpt-5-mini"))?))
         .build()?;
 
     let reviewer = LlmAgentBuilder::new("reviewer")
@@ -56,7 +56,7 @@ async fn main() -> Result<()> {
              - Security concerns\n\
              Provide the final polished code with any necessary fixes.",
         )
-        .model(Arc::new(OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-4o-mini"))?))
+        .model(Arc::new(OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-5-mini"))?))
         .build()?;
 
     let workflow = SequentialAgent::new(

--- a/examples/openai_server/main.rs
+++ b/examples/openai_server/main.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 async fn main() -> Result<()> {
     let api_key = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY must be set");
 
-    let model = OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-4o-mini"))?;
+    let model = OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-5-mini"))?;
 
     let agent = LlmAgentBuilder::new("assistant")
         .description("A helpful AI assistant powered by OpenAI.")

--- a/examples/openai_structured/main.rs
+++ b/examples/openai_structured/main.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 #[tokio::main]
 async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let api_key = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY must be set");
-    let model = OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-4o-mini"))?;
+    let model = OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-5-mini"))?;
 
     // Create an agent with a defined output schema
     // This encourages the model to respond with JSON matching this structure

--- a/examples/openai_structured_basic/main.rs
+++ b/examples/openai_structured_basic/main.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let api_key =
         std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY environment variable required");
 
-    let model_name = std::env::var("OPENAI_MODEL").unwrap_or_else(|_| "gpt-4o-mini".to_string());
+    let model_name = std::env::var("OPENAI_MODEL").unwrap_or_else(|_| "gpt-5-mini".to_string());
 
     let config = OpenAIConfig::new(&api_key, &model_name);
     let model = OpenAIClient::new(config)?;

--- a/examples/openai_structured_strict/main.rs
+++ b/examples/openai_structured_strict/main.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let api_key =
         std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY environment variable required");
 
-    let model_name = std::env::var("OPENAI_MODEL").unwrap_or_else(|_| "gpt-4o-mini".to_string());
+    let model_name = std::env::var("OPENAI_MODEL").unwrap_or_else(|_| "gpt-5-mini".to_string());
 
     let config = OpenAIConfig::new(&api_key, &model_name);
     let model = OpenAIClient::new(config)?;

--- a/examples/openai_template/main.rs
+++ b/examples/openai_template/main.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let api_key = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY must be set");
 
-    let model = OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-4o-mini"))?;
+    let model = OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-5-mini"))?;
 
     // Define the agent with dynamic instructions using template placeholders
     // The placeholders {user:name}, {user:language}, etc. will be replaced

--- a/examples/openai_tools/main.rs
+++ b/examples/openai_tools/main.rs
@@ -82,7 +82,7 @@ async fn get_weather(_ctx: Arc<dyn ToolContext>, args: Value) -> Result<Value, a
 async fn main() -> Result<()> {
     let api_key = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY must be set");
 
-    let model = OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-4o-mini"))?;
+    let model = OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-5-mini"))?;
 
     // Create calculator tool with schema
     let calc_tool = FunctionTool::new(

--- a/examples/openai_web/main.rs
+++ b/examples/openai_web/main.rs
@@ -24,19 +24,19 @@ async fn main() -> Result<()> {
             "Provide weather information for cities. Since you don't have real-time data, \
              give general climate information and typical weather patterns for locations.",
         )
-        .model(Arc::new(OpenAIClient::new(OpenAIConfig::new(api_key.clone(), "gpt-4o-mini"))?))
+        .model(Arc::new(OpenAIClient::new(OpenAIConfig::new(api_key.clone(), "gpt-5-mini"))?))
         .build()?;
 
     let research_agent = LlmAgentBuilder::new("research_agent")
         .description("Research and analysis agent")
         .instruction("Research topics and provide detailed analysis based on your knowledge.")
-        .model(Arc::new(OpenAIClient::new(OpenAIConfig::new(api_key.clone(), "gpt-4o-mini"))?))
+        .model(Arc::new(OpenAIClient::new(OpenAIConfig::new(api_key.clone(), "gpt-5-mini"))?))
         .build()?;
 
     let summary_agent = LlmAgentBuilder::new("summary_agent")
         .description("Summarization agent")
         .instruction("Create concise summaries of information provided to you.")
-        .model(Arc::new(OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-4o-mini"))?))
+        .model(Arc::new(OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-5-mini"))?))
         .build()?;
 
     let agent_loader = Arc::new(MultiAgentLoader::new(vec![

--- a/examples/openai_workflow/main.rs
+++ b/examples/openai_workflow/main.rs
@@ -21,21 +21,21 @@ async fn main() -> Result<()> {
     let analyzer = LlmAgentBuilder::new("analyzer")
         .description("Analyzes topics")
         .instruction("Analyze the given topic and identify 3-5 key points. Be concise.")
-        .model(Arc::new(OpenAIClient::new(OpenAIConfig::new(api_key.clone(), "gpt-4o-mini"))?))
+        .model(Arc::new(OpenAIClient::new(OpenAIConfig::new(api_key.clone(), "gpt-5-mini"))?))
         .build()?;
 
     // Step 2: Expand on the analysis
     let expander = LlmAgentBuilder::new("expander")
         .description("Expands on analysis")
         .instruction("Take the analysis and expand on each key point with 1-2 sentences of detail.")
-        .model(Arc::new(OpenAIClient::new(OpenAIConfig::new(api_key.clone(), "gpt-4o-mini"))?))
+        .model(Arc::new(OpenAIClient::new(OpenAIConfig::new(api_key.clone(), "gpt-5-mini"))?))
         .build()?;
 
     // Step 3: Summarize
     let summarizer = LlmAgentBuilder::new("summarizer")
         .description("Summarizes content")
         .instruction("Create a concise 2-3 sentence summary of the expanded analysis.")
-        .model(Arc::new(OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-4o-mini"))?))
+        .model(Arc::new(OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-5-mini"))?))
         .build()?;
 
     let sequential = SequentialAgent::new(

--- a/examples/roadmap_retry_matrix/main.rs
+++ b/examples/roadmap_retry_matrix/main.rs
@@ -92,7 +92,7 @@ async fn main() -> Result<()> {
     #[cfg(feature = "openai")]
     {
         if let Ok(api_key) = env::var("OPENAI_API_KEY") {
-            let openai = OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-4o-mini"))?
+            let openai = OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-5-mini"))?
                 .with_retry_config(retry.clone());
             print_retry("OpenAI", openai.retry_config());
             if run_provider.as_deref() == Some("openai") {
@@ -107,7 +107,7 @@ async fn main() -> Result<()> {
     {
         if let Ok(api_key) = env::var("ANTHROPIC_API_KEY") {
             let anthropic =
-                AnthropicClient::new(AnthropicConfig::new(api_key, "claude-sonnet-4-20250514"))?
+                AnthropicClient::new(AnthropicConfig::new(api_key, "claude-sonnet-4.5"))?
                     .with_retry_config(retry.clone());
             print_retry("Anthropic", anthropic.retry_config());
             if run_provider.as_deref() == Some("anthropic") {

--- a/examples/test_llm_direct/main.rs
+++ b/examples/test_llm_direct/main.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let api_key = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY must be set");
-    let model = OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-4o-mini"))?;
+    let model = OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-5-mini"))?;
 
     // Define a simple tool
     let mut tools = HashMap::new();
@@ -33,7 +33,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create request
     let request = LlmRequest {
-        model: "gpt-4o-mini".to_string(),
+        model: "gpt-5-mini".to_string(),
         contents: vec![Content {
             role: "user".to_string(),
             parts: vec![Part::Text { text: "What is 25 * 17?".to_string() }],

--- a/examples/translator/main.rs
+++ b/examples/translator/main.rs
@@ -84,7 +84,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Use environment variable for model name with sensible default
     let model_name =
-        std::env::var("TRANSLATOR_MODEL").unwrap_or_else(|_| "gemini-2.0-flash".to_string());
+        std::env::var("TRANSLATOR_MODEL").unwrap_or_else(|_| "gemini-2.5-flash".to_string());
 
     let model = Arc::new(GeminiModel::new(&api_key, &model_name)?);
 


### PR DESCRIPTION
Update all 48 example files to use current 2026 model names.

- `gemini-2.0-flash` → `gemini-2.5-flash` (23 examples)
- `gpt-4o-mini` → `gpt-5-mini` (20 examples)
- `gpt-4o` → `gpt-5-mini` (browser_openai)
- `claude-sonnet-4-20250514` → `claude-sonnet-4.5` (3 examples)

Remaining: `docs/official_docs_examples/` and `adk-studio/` source files will follow in a separate PR.