### PR TITLE
chore: update remaining model names to 2026 versions

### DIFF
--- a/adk-studio/examples/codegen_demo.rs
+++ b/adk-studio/examples/codegen_demo.rs
@@ -69,7 +69,7 @@ fn simple_chat_project() -> ProjectSchema {
         "chat_agent".to_string(),
         AgentSchema {
             agent_type: AgentType::Llm,
-            model: Some("gemini-2.0-flash".to_string()),
+            model: Some("gemini-2.5-flash".to_string()),
             instruction:
                 "You are a helpful, friendly assistant. Answer questions clearly and concisely."
                     .to_string(),
@@ -92,7 +92,7 @@ fn research_pipeline_project() -> ProjectSchema {
         "researcher".to_string(),
         AgentSchema {
             agent_type: AgentType::Llm,
-            model: Some("gemini-2.0-flash".to_string()),
+            model: Some("gemini-2.5-flash".to_string()),
             instruction:
                 "Research the topic using Google Search. Gather key facts and recent developments."
                     .to_string(),
@@ -107,7 +107,7 @@ fn research_pipeline_project() -> ProjectSchema {
         "summarizer".to_string(),
         AgentSchema {
             agent_type: AgentType::Llm,
-            model: Some("gemini-2.0-flash".to_string()),
+            model: Some("gemini-2.5-flash".to_string()),
             instruction: "Summarize the research into key takeaways and conclusions.".to_string(),
             tools: vec![],
             sub_agents: vec![],
@@ -143,7 +143,7 @@ fn content_refiner_project() -> ProjectSchema {
         "improver".to_string(),
         AgentSchema {
             agent_type: AgentType::Llm,
-            model: Some("gemini-2.0-flash".to_string()),
+            model: Some("gemini-2.5-flash".to_string()),
             instruction: "Improve the content: fix errors, enhance clarity, improve flow."
                 .to_string(),
             tools: vec![],
@@ -157,7 +157,7 @@ fn content_refiner_project() -> ProjectSchema {
         "reviewer".to_string(),
         AgentSchema {
             agent_type: AgentType::Llm,
-            model: Some("gemini-2.0-flash".to_string()),
+            model: Some("gemini-2.5-flash".to_string()),
             instruction:
                 "Review content quality. Call exit_loop when polished, otherwise continue."
                     .to_string(),
@@ -195,7 +195,7 @@ fn parallel_analyzer_project() -> ProjectSchema {
         "sentiment".to_string(),
         AgentSchema {
             agent_type: AgentType::Llm,
-            model: Some("gemini-2.0-flash".to_string()),
+            model: Some("gemini-2.5-flash".to_string()),
             instruction: "Analyze sentiment: positive/negative/neutral with key emotional tones."
                 .to_string(),
             tools: vec![],
@@ -209,7 +209,7 @@ fn parallel_analyzer_project() -> ProjectSchema {
         "entities".to_string(),
         AgentSchema {
             agent_type: AgentType::Llm,
-            model: Some("gemini-2.0-flash".to_string()),
+            model: Some("gemini-2.5-flash".to_string()),
             instruction: "Extract entities: people, organizations, locations, dates.".to_string(),
             tools: vec![],
             sub_agents: vec![],
@@ -245,7 +245,7 @@ fn support_router_project() -> ProjectSchema {
         "router".to_string(),
         AgentSchema {
             agent_type: AgentType::Router,
-            model: Some("gemini-2.0-flash".to_string()),
+            model: Some("gemini-2.5-flash".to_string()),
             instruction: "Classify request as: technical, billing, or general.".to_string(),
             tools: vec![],
             sub_agents: vec![],
@@ -263,7 +263,7 @@ fn support_router_project() -> ProjectSchema {
         "tech_agent".to_string(),
         AgentSchema {
             agent_type: AgentType::Llm,
-            model: Some("gemini-2.0-flash".to_string()),
+            model: Some("gemini-2.5-flash".to_string()),
             instruction: "You are technical support. Help with coding and bugs.".to_string(),
             tools: vec![],
             sub_agents: vec![],
@@ -276,7 +276,7 @@ fn support_router_project() -> ProjectSchema {
         "billing_agent".to_string(),
         AgentSchema {
             agent_type: AgentType::Llm,
-            model: Some("gemini-2.0-flash".to_string()),
+            model: Some("gemini-2.5-flash".to_string()),
             instruction: "You are billing support. Help with payments and subscriptions."
                 .to_string(),
             tools: vec![],
@@ -290,7 +290,7 @@ fn support_router_project() -> ProjectSchema {
         "general_agent".to_string(),
         AgentSchema {
             agent_type: AgentType::Llm,
-            model: Some("gemini-2.0-flash".to_string()),
+            model: Some("gemini-2.5-flash".to_string()),
             instruction: "You are general support. Help with general questions.".to_string(),
             tools: vec![],
             sub_agents: vec![],

--- a/adk-studio/src/codegen/validation.rs
+++ b/adk-studio/src/codegen/validation.rs
@@ -417,7 +417,7 @@ mod tests {
             "agent1".to_string(),
             AgentSchema {
                 agent_type: AgentType::Llm,
-                model: Some("gemini-2.0-flash".to_string()),
+                model: Some("gemini-2.5-flash".to_string()),
                 instruction: "Test instruction".to_string(),
                 tools: vec![],
                 sub_agents: vec![],
@@ -480,7 +480,7 @@ mod tests {
             "agent2".to_string(),
             AgentSchema {
                 agent_type: AgentType::Llm,
-                model: Some("gemini-2.0-flash".to_string()),
+                model: Some("gemini-2.5-flash".to_string()),
                 instruction: "Disconnected".to_string(),
                 tools: vec![],
                 sub_agents: vec![],
@@ -502,7 +502,7 @@ mod tests {
             "router".to_string(),
             AgentSchema {
                 agent_type: AgentType::Router,
-                model: Some("gemini-2.0-flash".to_string()),
+                model: Some("gemini-2.5-flash".to_string()),
                 instruction: "Route".to_string(),
                 tools: vec![],
                 sub_agents: vec![],
@@ -524,7 +524,7 @@ mod tests {
             "router".to_string(),
             AgentSchema {
                 agent_type: AgentType::Router,
-                model: Some("gemini-2.0-flash".to_string()),
+                model: Some("gemini-2.5-flash".to_string()),
                 instruction: "Route".to_string(),
                 tools: vec![],
                 sub_agents: vec![],
@@ -787,7 +787,7 @@ mod env_var_tests {
             "agent".to_string(),
             AgentSchema {
                 agent_type: AgentType::Llm,
-                model: Some("gemini-2.0-flash".to_string()),
+                model: Some("gemini-2.5-flash".to_string()),
                 instruction: "Test".to_string(),
                 tools: vec![],
                 sub_agents: vec![],
@@ -808,7 +808,7 @@ mod env_var_tests {
             "agent".to_string(),
             AgentSchema {
                 agent_type: AgentType::Llm,
-                model: Some("gemini-2.0-flash".to_string()),
+                model: Some("gemini-2.5-flash".to_string()),
                 instruction: "Test".to_string(),
                 tools: vec!["browser".to_string()],
                 sub_agents: vec![],
@@ -829,7 +829,7 @@ mod env_var_tests {
             "agent".to_string(),
             AgentSchema {
                 agent_type: AgentType::Llm,
-                model: Some("gemini-2.0-flash".to_string()),
+                model: Some("gemini-2.5-flash".to_string()),
                 instruction: "Test".to_string(),
                 tools: vec!["mcp".to_string()],
                 sub_agents: vec![],

--- a/adk-studio/src/schema/deploy.rs
+++ b/adk-studio/src/schema/deploy.rs
@@ -449,7 +449,7 @@ mod tests {
         project.workflow.workflow_type = WorkflowType::Sequential;
         project.agents.insert(
             "router".to_string(),
-            AgentSchema::llm("gemini-2.0-flash")
+            AgentSchema::llm("gemini-2.5-flash")
                 .with_instruction("route support tickets")
                 .with_tools(vec!["google_search".to_string()]),
         );

--- a/adk-studio/src/schema/project.rs
+++ b/adk-studio/src/schema/project.rs
@@ -134,7 +134,7 @@ pub struct AutobuildTriggers {
 }
 
 fn default_model() -> String {
-    "gemini-2.0-flash".to_string()
+    "gemini-2.5-flash".to_string()
 }
 
 fn default_adk_version() -> Option<String> {

--- a/adk-telemetry/src/spans.rs
+++ b/adk-telemetry/src/spans.rs
@@ -34,7 +34,7 @@ pub fn agent_run_span(agent_name: &str, invocation_id: &str) -> Span {
 /// # Example
 /// ```
 /// use adk_telemetry::model_call_span;
-/// let span = model_call_span("gemini-2.0-flash");
+/// let span = model_call_span("gemini-2.5-flash");
 /// let _enter = span.enter();
 /// // Model call code here
 /// ```

--- a/docs/official_docs_examples/agents/graph_agent_test/src/checkpointing.rs
+++ b/docs/official_docs_examples/agents/graph_agent_test/src/checkpointing.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
     let api_key = std::env::var("GOOGLE_API_KEY")?;
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     println!("💾 Starting Checkpointing Example");
     println!("This demonstrates state persistence and time travel debugging\n");

--- a/docs/official_docs_examples/agents/graph_agent_test/src/conditional_routing.rs
+++ b/docs/official_docs_examples/agents/graph_agent_test/src/conditional_routing.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
     let api_key = std::env::var("GOOGLE_API_KEY")?;
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     println!("🎯 Starting Conditional Routing Example");
     println!("This demonstrates sentiment-based routing to different response handlers\n");

--- a/docs/official_docs_examples/agents/graph_agent_test/src/human_in_loop.rs
+++ b/docs/official_docs_examples/agents/graph_agent_test/src/human_in_loop.rs
@@ -16,7 +16,7 @@ use std::io;
 async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
     let api_key = std::env::var("GOOGLE_API_KEY")?;
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     println!("🛡️  Starting Human-in-the-Loop Example");
     println!("This demonstrates risk-based approval workflow with dynamic interrupts\n");

--- a/docs/official_docs_examples/agents/graph_agent_test/src/parallel_processing.rs
+++ b/docs/official_docs_examples/agents/graph_agent_test/src/parallel_processing.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
     let api_key = std::env::var("GOOGLE_API_KEY")?;
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     println!("🚀 Starting Parallel Processing Example");
     println!("This demonstrates translation and summarization running in parallel\n");

--- a/docs/official_docs_examples/agents/graph_agent_test/src/react_pattern.rs
+++ b/docs/official_docs_examples/agents/graph_agent_test/src/react_pattern.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
     let api_key = std::env::var("GOOGLE_API_KEY")?;
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     println!("🔄 Starting ReAct Pattern Example");
     println!("This demonstrates iterative reasoning with tools\n");

--- a/docs/official_docs_examples/agents/graph_agent_test/src/supervisor_routing.rs
+++ b/docs/official_docs_examples/agents/graph_agent_test/src/supervisor_routing.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
     let api_key = std::env::var("GOOGLE_API_KEY")?;
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     println!("👥 Starting Supervisor Routing Example");
     println!("This demonstrates routing tasks to specialist agents\n");

--- a/docs/official_docs_examples/artifacts/artifacts_test/src/csv_analysis.rs
+++ b/docs/official_docs_examples/artifacts/artifacts_test/src/csv_analysis.rs
@@ -18,7 +18,7 @@ async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
 
     let api_key = std::env::var("GOOGLE_API_KEY")?;
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     println!("CSV Data Analysis Example");
     println!("=========================\n");

--- a/docs/official_docs_examples/artifacts/artifacts_test/src/image_analysis.rs
+++ b/docs/official_docs_examples/artifacts/artifacts_test/src/image_analysis.rs
@@ -18,7 +18,7 @@ async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
 
     let api_key = std::env::var("GOOGLE_API_KEY")?;
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     println!("Image Analysis Example");
     println!("======================\n");

--- a/docs/official_docs_examples/artifacts/artifacts_test/src/pdf_analysis.rs
+++ b/docs/official_docs_examples/artifacts/artifacts_test/src/pdf_analysis.rs
@@ -18,7 +18,7 @@ async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
 
     let api_key = std::env::var("GOOGLE_API_KEY")?;
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     println!("PDF Document Analysis Example");
     println!("==============================\n");

--- a/docs/official_docs_examples/callbacks/callbacks_test/src/guardrails.rs
+++ b/docs/official_docs_examples/callbacks/callbacks_test/src/guardrails.rs
@@ -15,7 +15,7 @@ async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
 
     let api_key = std::env::var("GOOGLE_API_KEY")?;
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     println!("Input Guardrails Example");
     println!("========================\n");

--- a/docs/official_docs_examples/callbacks/callbacks_test/src/logging.rs
+++ b/docs/official_docs_examples/callbacks/callbacks_test/src/logging.rs
@@ -14,7 +14,7 @@ async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
 
     let api_key = std::env::var("GOOGLE_API_KEY")?;
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     println!("Logging Callbacks Example");
     println!("=========================\n");

--- a/docs/official_docs_examples/core/runner_test/src/basic.rs
+++ b/docs/official_docs_examples/core/runner_test/src/basic.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create a mock agent (won't actually call LLM)
     let api_key = std::env::var("GOOGLE_API_KEY").unwrap_or_else(|_| "test-key".to_string());
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
     let agent =
         Arc::new(LlmAgentBuilder::new("test_agent").model(model).instruction("Test").build()?);
 

--- a/docs/official_docs_examples/deployment/a2a_test/src/server.rs
+++ b/docs/official_docs_examples/deployment/a2a_test/src/server.rs
@@ -18,7 +18,7 @@ async fn main() -> adk_core::Result<()> {
 
     let api_key =
         std::env::var("GOOGLE_API_KEY").expect("GOOGLE_API_KEY environment variable not set");
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     // Create agent to expose via A2A
     let agent = LlmAgentBuilder::new("math_helper")

--- a/docs/official_docs_examples/deployment/launcher_test/src/basic.rs
+++ b/docs/official_docs_examples/deployment/launcher_test/src/basic.rs
@@ -19,7 +19,7 @@ async fn main() -> adk_core::Result<()> {
 
     let api_key =
         std::env::var("GOOGLE_API_KEY").expect("GOOGLE_API_KEY environment variable not set");
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     let agent = LlmAgentBuilder::new("launcher_demo")
         .description("A demo agent for the Launcher")

--- a/docs/official_docs_examples/models/providers_test/src/anthropic_example.rs
+++ b/docs/official_docs_examples/models/providers_test/src/anthropic_example.rs
@@ -13,9 +13,9 @@ async fn main() -> anyhow::Result<()> {
     println!("=============================\n");
     
     let api_key = std::env::var("ANTHROPIC_API_KEY")?;
-    let model = AnthropicClient::new(AnthropicConfig::new(&api_key, "claude-sonnet-4-20250514"))?;
+    let model = AnthropicClient::new(AnthropicConfig::new(&api_key, "claude-sonnet-4.5"))?;
 
-    println!("✅ Model: claude-sonnet-4-20250514");
+    println!("✅ Model: claude-sonnet-4.5");
     println!("📝 Key highlights:");
     println!("   • Exceptional reasoning ability");
     println!("   • Most safety-focused");

--- a/docs/official_docs_examples/models/providers_test/src/gemini_example.rs
+++ b/docs/official_docs_examples/models/providers_test/src/gemini_example.rs
@@ -13,9 +13,9 @@ async fn main() -> anyhow::Result<()> {
     println!("==========================\n");
     
     let api_key = std::env::var("GOOGLE_API_KEY")?;
-    let model = GeminiModel::new(&api_key, "gemini-2.0-flash")?;
+    let model = GeminiModel::new(&api_key, "gemini-2.5-flash")?;
 
-    println!("✅ Model: gemini-2.0-flash");
+    println!("✅ Model: gemini-2.5-flash");
     println!("📝 Key highlights:");
     println!("   • Native multimodal (images, video, audio, PDF)");
     println!("   • Up to 2M token context window");

--- a/docs/official_docs_examples/models/providers_test/src/openai_example.rs
+++ b/docs/official_docs_examples/models/providers_test/src/openai_example.rs
@@ -13,9 +13,9 @@ async fn main() -> anyhow::Result<()> {
     println!("==========================\n");
     
     let api_key = std::env::var("OPENAI_API_KEY")?;
-    let model = OpenAIClient::new(OpenAIConfig::new(&api_key, "gpt-4o"))?;
+    let model = OpenAIClient::new(OpenAIConfig::new(&api_key, "gpt-5-mini"))?;
 
-    println!("✅ Model: gpt-4o");
+    println!("✅ Model: gpt-5-mini");
     println!("📝 Key highlights:");
     println!("   • Industry standard");
     println!("   • Excellent tool/function calling");

--- a/docs/official_docs_examples/observability/telemetry_test/src/spans.rs
+++ b/docs/official_docs_examples/observability/telemetry_test/src/spans.rs
@@ -32,7 +32,7 @@ async fn main() {
     // 2. Model call span
     println!("\n2. Model call span:");
     {
-        let span = model_call_span("gemini-2.0-flash");
+        let span = model_call_span("gemini-2.5-flash");
         let _enter = span.enter();
 
         info!("Calling LLM");

--- a/docs/official_docs_examples/readme_validation/src/anthropic_basic.rs
+++ b/docs/official_docs_examples/readme_validation/src/anthropic_basic.rs
@@ -7,7 +7,7 @@ use adk_rust::prelude::*;
 async fn main() -> AnyhowResult<()> {
     dotenvy::dotenv().ok();
     let api_key = std::env::var("ANTHROPIC_API_KEY")?;
-    let model = AnthropicClient::new(AnthropicConfig::new(api_key, "claude-sonnet-4-20250514"))?;
+    let model = AnthropicClient::new(AnthropicConfig::new(api_key, "claude-sonnet-4.5"))?;
 
     let agent = LlmAgentBuilder::new("assistant")
         .instruction("You are a helpful assistant.")

--- a/docs/official_docs_examples/readme_validation/src/browser_snippet.rs
+++ b/docs/official_docs_examples/readme_validation/src/browser_snippet.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let api_key = std::env::var("GOOGLE_API_KEY").unwrap_or_default();
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     // Create browser session
     let config = BrowserConfig::new().webdriver_url("http://localhost:4444");

--- a/docs/official_docs_examples/readme_validation/src/graph_snippet.rs
+++ b/docs/official_docs_examples/readme_validation/src/graph_snippet.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let api_key = std::env::var("GOOGLE_API_KEY").unwrap_or_default();
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     // Create LLM agents for different tasks
     let translator = Arc::new(

--- a/docs/official_docs_examples/readme_validation/src/openai_basic.rs
+++ b/docs/official_docs_examples/readme_validation/src/openai_basic.rs
@@ -7,7 +7,7 @@ use adk_rust::prelude::*;
 async fn main() -> AnyhowResult<()> {
     dotenvy::dotenv().ok();
     let api_key = std::env::var("OPENAI_API_KEY")?;
-    let model = OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-4o"))?;
+    let model = OpenAIClient::new(OpenAIConfig::new(api_key, "gpt-5-mini"))?;
 
     let agent = LlmAgentBuilder::new("assistant")
         .instruction("You are a helpful assistant.")

--- a/docs/official_docs_examples/readme_validation/src/ui_snippet.rs
+++ b/docs/official_docs_examples/readme_validation/src/ui_snippet.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 fn main() -> anyhow::Result<()> {
     let api_key = std::env::var("GOOGLE_API_KEY").unwrap_or_default();
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     // Get all UI tools
     let tools = UiToolset::all_tools();

--- a/docs/official_docs_examples/tools/mcp_test/src/basic.rs
+++ b/docs/official_docs_examples/tools/mcp_test/src/basic.rs
@@ -51,7 +51,7 @@ async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
 
     let api_key = std::env::var("GOOGLE_API_KEY")?;
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     println!("MCP Tools Basic Example");
     println!("=======================\n");

--- a/docs/official_docs_examples/tools/mcp_test/src/filtered.rs
+++ b/docs/official_docs_examples/tools/mcp_test/src/filtered.rs
@@ -51,7 +51,7 @@ async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
 
     let api_key = std::env::var("GOOGLE_API_KEY")?;
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     println!("MCP Tools Filtered Example");
     println!("==========================\n");

--- a/docs/official_docs_examples/tools/mcp_test/src/task_support.rs
+++ b/docs/official_docs_examples/tools/mcp_test/src/task_support.rs
@@ -53,7 +53,7 @@ async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
 
     let api_key = std::env::var("GOOGLE_API_KEY")?;
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     println!("MCP Task Support Example (SEP-1686)");
     println!("===================================\n");


### PR DESCRIPTION
Updates gemini-2.0-flash → gemini-2.5-flash, gpt-4o → gpt-5-mini, claude-sonnet-4-20250514 → claude-sonnet-4.5 across docs/official_docs_examples, adk-studio codegen/schema, and adk-telemetry.

31 files, completing the 2026 model name refresh (follows PRs #79 and #80).