### PR TITLE
chore: update model name defaults and docs across source crates

### DIFF
--- a/adk-eval/src/criteria.rs
+++ b/adk-eval/src/criteria.rs
@@ -201,7 +201,7 @@ impl Default for SemanticMatchConfig {
 }
 
 fn default_judge_model() -> String {
-    "gemini-2.0-flash".to_string()
+    "gemini-2.5-flash".to_string()
 }
 
 /// Configuration for rubric-based evaluation

--- a/adk-gemini/examples/batch_embedding.rs
+++ b/adk-gemini/examples/batch_embedding.rs
@@ -26,7 +26,7 @@ async fn main() -> ExitCode {
 async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     let api_key = std::env::var("GEMINI_API_KEY")?;
 
-    // Create client with the default model (gemini-2.0-flash)
+    // Create client with the default model (gemini-2.5-flash)
     let client = Gemini::with_model(api_key, Model::TextEmbedding004)
         .expect("unable to create Gemini API client");
 

--- a/adk-gemini/examples/curl_equivalent.rs
+++ b/adk-gemini/examples/curl_equivalent.rs
@@ -29,7 +29,7 @@ async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
 
     // This is equivalent to the curl example:
-    // curl "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=$YOUR_API_KEY" \
+    // curl "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=$YOUR_API_KEY" \
     //   -H 'Content-Type: application/json' \
     //   -X POST \
     //   -d '{
@@ -44,7 +44,7 @@ async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     //     ]
     //   }'
 
-    // Create client - now using gemini-2.0-flash by default
+    // Create client - now using gemini-2.5-flash by default
     let client = Gemini::new(api_key).expect("unable to create Gemini API client");
 
     // Method 1: Using the high-level API (simplest approach)

--- a/adk-gemini/examples/curl_google_search.rs
+++ b/adk-gemini/examples/curl_google_search.rs
@@ -31,7 +31,7 @@ async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     info!("starting curl equivalent with google search tool example");
 
     // This is equivalent to the curl example:
-    // curl "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=$GEMINI_API_KEY" \
+    // curl "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=$GEMINI_API_KEY" \
     //   -H "Content-Type: application/json" \
     //   -d '{
     //       "contents": [

--- a/adk-gemini/examples/embedding.rs
+++ b/adk-gemini/examples/embedding.rs
@@ -26,7 +26,7 @@ async fn main() -> ExitCode {
 async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     let api_key = std::env::var("GEMINI_API_KEY")?;
 
-    // Create client with the default model (gemini-2.0-flash)
+    // Create client with the default model (gemini-2.5-flash)
     let client = Gemini::with_model(api_key, Model::TextEmbedding004)
         .expect("unable to create Gemini API client");
 

--- a/adk-gemini/examples/gemini_pro_example.rs
+++ b/adk-gemini/examples/gemini_pro_example.rs
@@ -33,7 +33,7 @@ async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     let gemini = Gemini::pro(api_key).expect("unable to create Gemini API client");
 
     // This example matches the exact curl request format:
-    // curl "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=$GEMINI_API_KEY" \
+    // curl "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=$GEMINI_API_KEY" \
     //   -H 'Content-Type: application/json' \
     //   -d '{
     //     "system_instruction": {

--- a/adk-gemini/examples/test_api.rs
+++ b/adk-gemini/examples/test_api.rs
@@ -27,7 +27,7 @@ async fn main() -> ExitCode {
 async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     let api_key = env::var("GEMINI_API_KEY")?;
 
-    // Create client with the default model (gemini-2.0-flash)
+    // Create client with the default model (gemini-2.5-flash)
     let client = Gemini::new(api_key).expect("unable to create Gemini API client");
 
     info!("sending request to gemini api");

--- a/adk-model/src/anthropic/client.rs
+++ b/adk-model/src/anthropic/client.rs
@@ -37,7 +37,7 @@ impl AnthropicClient {
 
     /// Create a client with just an API key (uses default model).
     pub fn from_api_key(api_key: impl Into<String>) -> Result<Self, AdkError> {
-        Self::new(AnthropicConfig::new(api_key, "claude-sonnet-4-20250514"))
+        Self::new(AnthropicConfig::new(api_key, "claude-sonnet-4.5"))
     }
 
     #[must_use]

--- a/adk-model/src/anthropic/config.rs
+++ b/adk-model/src/anthropic/config.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 pub struct AnthropicConfig {
     /// Anthropic API key.
     pub api_key: String,
-    /// Model name (e.g., "claude-sonnet-4-20250514", "claude-3-5-sonnet-20241022").
+    /// Model name (e.g., "claude-sonnet-4.5", "claude-3-5-sonnet-20241022").
     pub model: String,
     /// Maximum tokens to generate.
     #[serde(default = "default_max_tokens")]
@@ -25,7 +25,7 @@ impl Default for AnthropicConfig {
     fn default() -> Self {
         Self {
             api_key: String::new(),
-            model: "claude-sonnet-4-20250514".to_string(),
+            model: "claude-sonnet-4.5".to_string(),
             max_tokens: default_max_tokens(),
             base_url: None,
         }

--- a/adk-model/src/anthropic/mod.rs
+++ b/adk-model/src/anthropic/mod.rs
@@ -9,7 +9,7 @@
 //!
 //! let client = AnthropicClient::new(AnthropicConfig::new(
 //!     std::env::var("ANTHROPIC_API_KEY").unwrap(),
-//!     "claude-sonnet-4-20250514",
+//!     "claude-sonnet-4.5",
 //! ))?;
 //! ```
 

--- a/adk-model/src/lib.rs
+++ b/adk-model/src/lib.rs
@@ -45,7 +45,7 @@
 //!
 //! let model = AnthropicClient::new(AnthropicConfig::new(
 //!     std::env::var("ANTHROPIC_API_KEY").unwrap(),
-//!     "claude-sonnet-4-20250514",
+//!     "claude-sonnet-4.5",
 //! )).unwrap();
 //! ```
 //!
@@ -80,7 +80,7 @@
 //! ### Anthropic
 //! | Model | Description |
 //! |-------|-------------|
-//! | `claude-sonnet-4-20250514` | Latest Claude 4 Sonnet |
+//! | `claude-sonnet-4.5` | Latest Claude 4 Sonnet |
 //! | `claude-3-5-sonnet-20241022` | Claude 3.5 Sonnet |
 //! | `claude-3-opus-20240229` | Most capable Claude 3 |
 //!

--- a/adk-model/src/openai/config.rs
+++ b/adk-model/src/openai/config.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 pub struct OpenAIConfig {
     /// OpenAI API key.
     pub api_key: String,
-    /// Model name (e.g., "gpt-4o", "gpt-4o-mini", "gpt-4-turbo").
+    /// Model name (e.g., "gpt-5-mini", "gpt-4-turbo").
     pub model: String,
     /// Optional organization ID.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/adk-realtime/src/gemini/mod.rs
+++ b/adk-realtime/src/gemini/mod.rs
@@ -23,7 +23,7 @@
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     let model = GeminiRealtimeModel::new(
 //!         std::env::var("GOOGLE_API_KEY")?,
-//!         "models/gemini-2.0-flash-live-preview-04-09",
+//!         "models/gemini-live-2.5-flash-native-audio",
 //!     );
 //!
 //!     let config = RealtimeConfig::default()
@@ -47,7 +47,7 @@ pub use session::GeminiRealtimeSession;
 pub const GEMINI_LIVE_URL: &str = "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent";
 
 /// Default model for Gemini Live.
-pub const DEFAULT_MODEL: &str = "models/gemini-2.0-flash-live-preview-04-09";
+pub const DEFAULT_MODEL: &str = "models/gemini-live-2.5-flash-native-audio";
 
 /// Available voices for Gemini Live (varies by model).
 pub const GEMINI_VOICES: &[&str] = &["Puck", "Charon", "Kore", "Fenrir", "Aoede"];

--- a/adk-realtime/src/gemini/model.rs
+++ b/adk-realtime/src/gemini/model.rs
@@ -18,7 +18,7 @@ use super::{DEFAULT_MODEL, GEMINI_LIVE_URL, GEMINI_VOICES};
 /// use adk_realtime::gemini::GeminiRealtimeModel;
 /// use adk_realtime::RealtimeModel;
 ///
-/// let model = GeminiRealtimeModel::new("your-api-key", "models/gemini-2.0-flash-live-preview-04-09");
+/// let model = GeminiRealtimeModel::new("your-api-key", "models/gemini-live-2.5-flash-native-audio");
 /// let session = model.connect(config).await?;
 /// ```
 #[derive(Debug, Clone)]
@@ -34,7 +34,7 @@ impl GeminiRealtimeModel {
     /// # Arguments
     ///
     /// * `api_key` - Your Google API key
-    /// * `model_id` - The model ID (e.g., "models/gemini-2.0-flash-live-preview-04-09")
+    /// * `model_id` - The model ID (e.g., "models/gemini-live-2.5-flash-native-audio")
     pub fn new(api_key: impl Into<String>, model_id: impl Into<String>) -> Self {
         Self { api_key: api_key.into(), model_id: model_id.into(), base_url: None }
     }

--- a/adk-studio/src/codegen/mod.rs
+++ b/adk-studio/src/codegen/mod.rs
@@ -53,7 +53,7 @@ fn detect_provider(model: &str) -> &'static str {
 fn collect_providers(project: &ProjectSchema) -> std::collections::HashSet<&'static str> {
     let mut providers = std::collections::HashSet::new();
     for agent in project.agents.values() {
-        let model = agent.model.as_deref().unwrap_or("gemini-2.0-flash");
+        let model = agent.model.as_deref().unwrap_or("gemini-2.5-flash");
         providers.insert(detect_provider(model));
     }
     // If project has a default_provider set, include it
@@ -1108,7 +1108,7 @@ fn generate_main_rs(project: &ProjectSchema) -> String {
 
 fn generate_router_node(id: &str, agent: &AgentSchema) -> String {
     let mut code = String::new();
-    let model = agent.model.as_deref().unwrap_or("gemini-2.0-flash");
+    let model = agent.model.as_deref().unwrap_or("gemini-2.5-flash");
 
     code.push_str(&format!("    // Router: {}\n", id));
     code.push_str(&format!("    let {}_llm = Arc::new(\n", id));
@@ -1184,7 +1184,7 @@ fn generate_llm_node_v2(
     is_parallel_branch: bool,
 ) -> String {
     let mut code = String::new();
-    let model = agent.model.as_deref().unwrap_or("gemini-2.0-flash");
+    let model = agent.model.as_deref().unwrap_or("gemini-2.5-flash");
 
     code.push_str(&format!("    // Agent: {}\n", id));
 
@@ -1511,7 +1511,7 @@ fn generate_container_node(id: &str, agent: &AgentSchema, project: &ProjectSchem
     // Generate sub-agents first
     for sub_id in &agent.sub_agents {
         if let Some(sub) = project.agents.get(sub_id) {
-            let model = sub.model.as_deref().unwrap_or("gemini-2.0-flash");
+            let model = sub.model.as_deref().unwrap_or("gemini-2.5-flash");
             let has_tools = !sub.tools.is_empty();
             let has_instruction = !sub.instruction.is_empty();
             let mut_kw = if has_tools || has_instruction { "mut " } else { "" };

--- a/adk-studio/tests/codegen_tests.rs
+++ b/adk-studio/tests/codegen_tests.rs
@@ -47,7 +47,7 @@ fn project_with_workflow(
 fn llm_agent(instruction: &str) -> AgentSchema {
     AgentSchema {
         agent_type: AgentType::Llm,
-        model: Some("gemini-2.0-flash".to_string()),
+        model: Some("gemini-2.5-flash".to_string()),
         instruction: instruction.to_string(),
         tools: vec![],
         sub_agents: vec![],
@@ -86,7 +86,7 @@ fn llm_agent_includes_model() {
     agents.insert("assistant".to_string(), llm_agent("Test."));
 
     let code = get_main_rs(&project("test", agents));
-    assert!(code.contains("gemini-2.0-flash"));
+    assert!(code.contains("gemini-2.5-flash"));
 }
 
 #[test]
@@ -364,7 +364,7 @@ fn router_agent_generates_classifier() {
         "router".to_string(),
         AgentSchema {
             agent_type: AgentType::Router,
-            model: Some("gemini-2.0-flash".to_string()),
+            model: Some("gemini-2.5-flash".to_string()),
             instruction: "Classify the request.".to_string(),
             tools: vec![],
             sub_agents: vec![],
@@ -397,7 +397,7 @@ fn router_agent_includes_routes() {
         "router".to_string(),
         AgentSchema {
             agent_type: AgentType::Router,
-            model: Some("gemini-2.0-flash".to_string()),
+            model: Some("gemini-2.5-flash".to_string()),
             instruction: "Route.".to_string(),
             tools: vec![],
             sub_agents: vec![],
@@ -723,7 +723,7 @@ fn template_simple_chat_generates_code() {
         "chat_agent".to_string(),
         AgentSchema {
             agent_type: AgentType::Llm,
-            model: Some("gemini-2.0-flash".to_string()),
+            model: Some("gemini-2.5-flash".to_string()),
             instruction: "You are a helpful assistant.".to_string(),
             tools: vec![],
             sub_agents: vec![],
@@ -752,7 +752,7 @@ fn template_research_pipeline_generates_code() {
         "researcher".to_string(),
         AgentSchema {
             agent_type: AgentType::Llm,
-            model: Some("gemini-2.0-flash".to_string()),
+            model: Some("gemini-2.5-flash".to_string()),
             instruction: "Research the topic.".to_string(),
             tools: vec!["google_search".to_string()],
             sub_agents: vec![],
@@ -765,7 +765,7 @@ fn template_research_pipeline_generates_code() {
         "summarizer".to_string(),
         AgentSchema {
             agent_type: AgentType::Llm,
-            model: Some("gemini-2.0-flash".to_string()),
+            model: Some("gemini-2.5-flash".to_string()),
             instruction: "Summarize the research.".to_string(),
             tools: vec![],
             sub_agents: vec![],
@@ -808,7 +808,7 @@ fn template_content_refiner_generates_code() {
         "improver".to_string(),
         AgentSchema {
             agent_type: AgentType::Llm,
-            model: Some("gemini-2.0-flash".to_string()),
+            model: Some("gemini-2.5-flash".to_string()),
             instruction: "Improve the content.".to_string(),
             tools: vec![],
             sub_agents: vec![],
@@ -821,7 +821,7 @@ fn template_content_refiner_generates_code() {
         "reviewer".to_string(),
         AgentSchema {
             agent_type: AgentType::Llm,
-            model: Some("gemini-2.0-flash".to_string()),
+            model: Some("gemini-2.5-flash".to_string()),
             instruction: "Review and decide if done.".to_string(),
             tools: vec!["exit_loop".to_string()],
             sub_agents: vec![],
@@ -864,7 +864,7 @@ fn template_parallel_analyzer_generates_code() {
         "sentiment_analyzer".to_string(),
         AgentSchema {
             agent_type: AgentType::Llm,
-            model: Some("gemini-2.0-flash".to_string()),
+            model: Some("gemini-2.5-flash".to_string()),
             instruction: "Analyze sentiment.".to_string(),
             tools: vec![],
             sub_agents: vec![],
@@ -877,7 +877,7 @@ fn template_parallel_analyzer_generates_code() {
         "entity_extractor".to_string(),
         AgentSchema {
             agent_type: AgentType::Llm,
-            model: Some("gemini-2.0-flash".to_string()),
+            model: Some("gemini-2.5-flash".to_string()),
             instruction: "Extract entities.".to_string(),
             tools: vec![],
             sub_agents: vec![],
@@ -919,7 +919,7 @@ fn template_support_router_generates_code() {
         "router".to_string(),
         AgentSchema {
             agent_type: AgentType::Router,
-            model: Some("gemini-2.0-flash".to_string()),
+            model: Some("gemini-2.5-flash".to_string()),
             instruction: "Classify the request.".to_string(),
             tools: vec![],
             sub_agents: vec![],
@@ -936,7 +936,7 @@ fn template_support_router_generates_code() {
         "tech_support".to_string(),
         AgentSchema {
             agent_type: AgentType::Llm,
-            model: Some("gemini-2.0-flash".to_string()),
+            model: Some("gemini-2.5-flash".to_string()),
             instruction: "Handle technical issues.".to_string(),
             tools: vec![],
             sub_agents: vec![],
@@ -949,7 +949,7 @@ fn template_support_router_generates_code() {
         "billing_support".to_string(),
         AgentSchema {
             agent_type: AgentType::Llm,
-            model: Some("gemini-2.0-flash".to_string()),
+            model: Some("gemini-2.5-flash".to_string()),
             instruction: "Handle billing issues.".to_string(),
             tools: vec![],
             sub_agents: vec![],
@@ -962,7 +962,7 @@ fn template_support_router_generates_code() {
         "general_support".to_string(),
         AgentSchema {
             agent_type: AgentType::Llm,
-            model: Some("gemini-2.0-flash".to_string()),
+            model: Some("gemini-2.5-flash".to_string()),
             instruction: "Handle general questions.".to_string(),
             tools: vec![],
             sub_agents: vec![],
@@ -1001,7 +1001,7 @@ fn template_web_researcher_generates_code() {
         "web_agent".to_string(),
         AgentSchema {
             agent_type: AgentType::Llm,
-            model: Some("gemini-2.0-flash".to_string()),
+            model: Some("gemini-2.5-flash".to_string()),
             instruction: "Research using browser.".to_string(),
             tools: vec!["browser".to_string()],
             sub_agents: vec![],
@@ -1030,7 +1030,7 @@ fn template_writing_team_generates_code() {
         "writer".to_string(),
         AgentSchema {
             agent_type: AgentType::Llm,
-            model: Some("gemini-2.0-flash".to_string()),
+            model: Some("gemini-2.5-flash".to_string()),
             instruction: "Write content.".to_string(),
             tools: vec![],
             sub_agents: vec![],
@@ -1043,7 +1043,7 @@ fn template_writing_team_generates_code() {
         "editor".to_string(),
         AgentSchema {
             agent_type: AgentType::Llm,
-            model: Some("gemini-2.0-flash".to_string()),
+            model: Some("gemini-2.5-flash".to_string()),
             instruction: "Edit content.".to_string(),
             tools: vec![],
             sub_agents: vec![],
@@ -1056,7 +1056,7 @@ fn template_writing_team_generates_code() {
         "fact_checker".to_string(),
         AgentSchema {
             agent_type: AgentType::Llm,
-            model: Some("gemini-2.0-flash".to_string()),
+            model: Some("gemini-2.5-flash".to_string()),
             instruction: "Check facts.".to_string(),
             tools: vec!["google_search".to_string()],
             sub_agents: vec![],
@@ -1104,7 +1104,7 @@ fn template_eval_loop_generates_code() {
         "generator".to_string(),
         AgentSchema {
             agent_type: AgentType::Llm,
-            model: Some("gemini-2.0-flash".to_string()),
+            model: Some("gemini-2.5-flash".to_string()),
             instruction: "Generate response.".to_string(),
             tools: vec![],
             sub_agents: vec![],
@@ -1117,7 +1117,7 @@ fn template_eval_loop_generates_code() {
         "evaluator".to_string(),
         AgentSchema {
             agent_type: AgentType::Llm,
-            model: Some("gemini-2.0-flash".to_string()),
+            model: Some("gemini-2.5-flash".to_string()),
             instruction: "Evaluate response.".to_string(),
             tools: vec!["exit_loop".to_string()],
             sub_agents: vec![],
@@ -1159,7 +1159,7 @@ fn template_voice_assistant_generates_code() {
         "voice_agent".to_string(),
         AgentSchema {
             agent_type: AgentType::Llm,
-            model: Some("gemini-2.0-flash".to_string()),
+            model: Some("gemini-2.5-flash".to_string()),
             instruction: "Respond naturally for voice.".to_string(),
             tools: vec![],
             sub_agents: vec![],
@@ -1183,7 +1183,7 @@ fn template_realtime_translator_generates_code() {
         "translator".to_string(),
         AgentSchema {
             agent_type: AgentType::Llm,
-            model: Some("gemini-2.0-flash".to_string()),
+            model: Some("gemini-2.5-flash".to_string()),
             instruction: "Translate in real-time.".to_string(),
             tools: vec![],
             sub_agents: vec![],


### PR DESCRIPTION
Updates all hardcoded model defaults and doc comments across source crates to 2026 model names.

- adk-studio codegen defaults + 23 test fixtures
- adk-eval judge default
- adk-model anthropic/openai defaults and docs
- adk-gemini example comments
- adk-realtime live model ID

Final sweep confirms zero remaining old model names in source (excluding target/).

Completes the 2026 model name refresh (follows PRs #79, #80, #81).