### PR TITLE
fix(studio): restrict CORS to localhost origins + cleanup dead code

### DIFF
--- a/adk-doc-audit/src/lib.rs
+++ b/adk-doc-audit/src/lib.rs
@@ -93,13 +93,6 @@ pub use version::{
     VersionValidationResult, VersionValidator, WorkspaceVersionInfo,
 };
 
-// Placeholder exports for components that will be implemented in later tasks
-// These will be uncommented as the components are implemented
-
-// pub mod orchestrator;
-
-// pub use orchestrator::{AuditOrchestrator};
-
 /// Version information for the crate.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 


### PR DESCRIPTION
Learnings from contributor PRs #72-#75 (mikefaille):

**CORS Security Fix (adk-studio)**
- Replaced `allow_origin(Any)` with a localhost-only predicate
- Only allows origins from 127.0.0.1, [::1], and localhost (any port)
- Prevents drive-by attacks while preserving local dev workflow

**Dead Code Cleanup (adk-doc-audit)**
- Removed stale commented-out placeholder exports that were superseded by actual implementations

Both changes compile clean.