### PR TITLE
docs: fix remaining stale model names across 20 files

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 |----------|-------|-------------|
 | OpenAI | `gpt-4o-realtime-preview-2024-12-17` | Stable realtime model |
 | OpenAI | `gpt-realtime` | Latest model with improved speech quality and function calling |
-| Google | `gemini-2.0-flash-live-preview-04-09` | Gemini Live API |
+| Google | `gemini-live-2.5-flash-native-audio` | Gemini Live API |
 
 **Features**:
 - OpenAI Realtime API and Gemini Live API support

--- a/adk-browser/README.md
+++ b/adk-browser/README.md
@@ -52,7 +52,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let tools = toolset.all_tools();
 
     // Create AI agent with browser tools
-    let model = Arc::new(GeminiModel::from_env("gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::from_env("gemini-2.5-flash")?);
 
     let mut builder = LlmAgentBuilder::new("web_agent")
         .model(model)

--- a/adk-eval/README.md
+++ b/adk-eval/README.md
@@ -141,7 +141,7 @@ use adk_model::GeminiModel;
 use std::sync::Arc;
 
 // Create evaluator with LLM judge
-let judge_model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+let judge_model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 let config = EvaluationConfig::with_criteria(
     EvaluationCriteria::semantic_match(0.85)  // 85% semantic similarity required
 );

--- a/adk-graph/README.md
+++ b/adk-graph/README.md
@@ -63,7 +63,7 @@ use std::sync::Arc;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let api_key = std::env::var("GOOGLE_API_KEY")?;
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     // Create LLM agents
     let translator = Arc::new(

--- a/adk-realtime/README.md
+++ b/adk-realtime/README.md
@@ -43,7 +43,7 @@ Real-time bidirectional audio streaming for Rust Agent Development Kit (ADK-Rust
 |----------|-------|--------------|-------------|
 | OpenAI | `gpt-4o-realtime-preview-2024-12-17` | `openai` | Stable realtime model |
 | OpenAI | `gpt-realtime` | `openai` | Latest model with improved speech & function calling |
-| Google | `gemini-2.0-flash-live-preview-04-09` | `gemini` | Gemini Live API |
+| Google | `gemini-live-2.5-flash-native-audio` | `gemini` | Gemini Live API |
 
 ## Quick Start
 

--- a/adk-studio/docs/sse-schema-v2.md
+++ b/adk-studio/docs/sse-schema-v2.md
@@ -250,7 +250,7 @@ event: trace
 data: {"type":"node_start","node":"researcher","step":1,"state_snapshot":{"input":{"query":"test"},"output":{}},"state_keys":["query"]}
 
 event: log
-data: {"message":"Calling gemini-2.0-flash (tools: 2)"}
+data: {"message":"Calling gemini-2.5-flash (tools: 2)"}
 
 event: tool_call
 data: {"name":"search","args":{"query":"test"}}

--- a/docs/implementation/openai-provider.md
+++ b/docs/implementation/openai-provider.md
@@ -416,7 +416,7 @@ use adk_agent::LlmAgent;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let model = OpenAIClient::new(OpenAIProvider {
         api_key: std::env::var("OPENAI_API_KEY")?,
-        model: "gpt-4o-mini".to_string(),
+        model: "gpt-5-mini".to_string(),
         organization_id: None,
         project_id: None,
     })?;
@@ -441,7 +441,7 @@ let model = AzureOpenAIClient::new(AzureOpenAIProvider {
     api_key: std::env::var("AZURE_OPENAI_API_KEY")?,
     api_base: "https://my-resource.openai.azure.com".to_string(),
     api_version: "2024-02-15-preview".to_string(),
-    deployment_id: "gpt-4o-deployment".to_string(),
+    deployment_id: "gpt-5-deployment".to_string(),
 })?;
 ```
 

--- a/docs/official_docs/agents/graph-agents.md
+++ b/docs/official_docs/agents/graph-agents.md
@@ -150,7 +150,7 @@ use std::sync::Arc;
 async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
     let api_key = std::env::var("GOOGLE_API_KEY")?;
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     // Create specialized LLM agents
     let translator_agent = Arc::new(
@@ -390,7 +390,7 @@ use std::sync::Arc;
 async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
     let api_key = std::env::var("GOOGLE_API_KEY")?;
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     // Create classifier agent
     let classifier_agent = Arc::new(
@@ -591,7 +591,7 @@ use std::sync::Arc;
 async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
     let api_key = std::env::var("GOOGLE_API_KEY")?;
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     // Create tools
     let weather_tool = Arc::new(FunctionTool::new(

--- a/docs/official_docs/agents/realtime-agents.md
+++ b/docs/official_docs/agents/realtime-agents.md
@@ -107,7 +107,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 |----------|-------|--------------|--------------|
 | OpenAI | `gpt-4o-realtime-preview-2024-12-17` | `openai` | PCM16 24kHz |
 | OpenAI | `gpt-realtime` | `openai` | PCM16 24kHz |
-| Google | `gemini-2.0-flash-live-preview-04-09` | `gemini` | PCM16 16kHz/24kHz |
+| Google | `gemini-live-2.5-flash-native-audio` | `gemini` | PCM16 16kHz/24kHz |
 
 > **Note**: `gpt-realtime` is OpenAI's latest realtime model with improved speech quality, emotion, and function calling capabilities.
 

--- a/docs/official_docs/core/core.md
+++ b/docs/official_docs/core/core.md
@@ -665,7 +665,7 @@ All providers (Gemini, OpenAI, Anthropic, Ollama, etc.) implement this trait, ma
 
 ```rust
 // Switch providers by changing one line
-let model: Arc<dyn Llm> = Arc::new(GeminiModel::new(&key, "gemini-2.0-flash")?);
+let model: Arc<dyn Llm> = Arc::new(GeminiModel::new(&key, "gemini-2.5-flash")?);
 // let model: Arc<dyn Llm> = Arc::new(OpenAIClient::new(config)?);
 // let model: Arc<dyn Llm> = Arc::new(AnthropicClient::new(config)?);
 

--- a/docs/official_docs/evaluation/evaluation.md
+++ b/docs/official_docs/evaluation/evaluation.md
@@ -143,7 +143,7 @@ use adk_eval::{Evaluator, EvaluationConfig, EvaluationCriteria, LlmJudge};
 use adk_model::GeminiModel;
 
 // Create evaluator with LLM judge
-let judge_model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+let judge_model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 let config = EvaluationConfig::with_criteria(
     EvaluationCriteria::semantic_match(0.85)
 );

--- a/docs/official_docs/models/providers.md
+++ b/docs/official_docs/models/providers.md
@@ -42,7 +42,7 @@ Add the providers you need to your `Cargo.toml`:
 [dependencies]
 # Pick one or more providers:
 adk-model = { version = "0.3.0", features = ["gemini"] }        # Google Gemini (default)
-adk-model = { version = "0.3.0", features = ["openai"] }        # OpenAI GPT-4o
+adk-model = { version = "0.3.0", features = ["openai"] }        # OpenAI GPT-5
 adk-model = { version = "0.3.0", features = ["anthropic"] }     # Anthropic Claude
 adk-model = { version = "0.3.0", features = ["deepseek"] }      # DeepSeek
 adk-model = { version = "0.3.0", features = ["groq"] }          # Groq (ultra-fast)

--- a/docs/official_docs/observability/telemetry.md
+++ b/docs/official_docs/observability/telemetry.md
@@ -189,7 +189,7 @@ let _enter = span.enter();
 ```rust
 use adk_telemetry::model_call_span;
 
-let span = model_call_span("gemini-2.0-flash");
+let span = model_call_span("gemini-2.5-flash");
 let _enter = span.enter();
 
 // Model API call here

--- a/docs/official_docs/sessions/context-compaction.md
+++ b/docs/official_docs/sessions/context-compaction.md
@@ -110,4 +110,4 @@ After invocation 6, the agent sees: `[Summary B, event 6 overlap events, event 7
 - Compaction failure is non-fatal — the runner logs a warning and continues
 - Compaction runs after the invocation stream completes, not during
 - The compaction event is persisted to the session service for durability
-- Use a fast, inexpensive model for summarization (e.g., `gemini-2.0-flash`)
+- Use a fast, inexpensive model for summarization (e.g., `gemini-2.5-flash`)

--- a/docs/official_docs/sessions/sessions.md
+++ b/docs/official_docs/sessions/sessions.md
@@ -302,7 +302,7 @@ use std::sync::Arc;
 async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
     let api_key = std::env::var("GOOGLE_API_KEY")?;
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     let agent = LlmAgentBuilder::new("assistant")
         .model(model)

--- a/docs/official_docs/tools/browser-tools.md
+++ b/docs/official_docs/tools/browser-tools.md
@@ -62,7 +62,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create AI agent with browser tools
     let api_key = std::env::var("GOOGLE_API_KEY")?;
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     let mut builder = LlmAgentBuilder::new("web_agent")
         .model(model)

--- a/docs/official_docs/tools/mcp-tools.md
+++ b/docs/official_docs/tools/mcp-tools.md
@@ -37,7 +37,7 @@ use std::sync::Arc;
 async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
     let api_key = std::env::var("GOOGLE_API_KEY")?;
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     // 1. Start MCP server and connect
     let mut cmd = Command::new("npx");
@@ -343,7 +343,7 @@ async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
 
     let api_key = std::env::var("GOOGLE_API_KEY")?;
-    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
 
     println!("Starting MCP server...");
     let mut cmd = Command::new("npx");

--- a/docs/official_docs/tools/ui-tools.md
+++ b/docs/official_docs/tools/ui-tools.md
@@ -130,7 +130,7 @@ use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let model = Arc::new(GeminiModel::from_env("gemini-2.0-flash")?);
+    let model = Arc::new(GeminiModel::from_env("gemini-2.5-flash")?);
 
     // Get all 10 UI tools
     let ui_tools = UiToolset::all_tools();

--- a/docs/roadmap/adk-studio-ui-architecture.md
+++ b/docs/roadmap/adk-studio-ui-architecture.md
@@ -676,7 +676,7 @@ export function useNodeActions() {
     const defaults: Record<string, Partial<AgentSchema>> = {
       llm: {
         type: 'llm',
-        model: 'gemini-2.0-flash',
+        model: 'gemini-2.5-flash',
         instruction: 'You are a helpful assistant.',
         tools: [],
       },
@@ -695,7 +695,7 @@ export function useNodeActions() {
       },
       router: {
         type: 'router',
-        model: 'gemini-2.0-flash',
+        model: 'gemini-2.5-flash',
         instruction: 'Classify the request.',
         routes: [],
       },

--- a/docs/roadmap/realtime-streaming.md
+++ b/docs/roadmap/realtime-streaming.md
@@ -584,7 +584,7 @@ async fn main() -> Result<()> {
     let api_key = std::env::var("GOOGLE_API_KEY")?;
 
     // Create realtime model
-    let model = GeminiLiveModel::new(&api_key, "gemini-2.0-flash-live")?;
+    let model = GeminiLiveModel::new(&api_key, "gemini-live-2.5-flash-native-audio")?;
 
     // Configure session
     let config = RealtimeConfig {


### PR DESCRIPTION
PRs #79-#82 updated model names in source code and most examples, but missed 20 documentation files that still referenced old model names in code examples.

### Changes (20 files)
- `gemini-2.0-flash` → `gemini-2.5-flash` in all code examples
- `gemini-2.0-flash-live-preview-04-09` → `gemini-live-2.5-flash-native-audio` in realtime tables
- `gpt-4o-mini` → `gpt-5-mini` in OpenAI code examples
- `gpt-4o-deployment` → `gpt-5-deployment` in Azure examples
- `GPT-4o` → `GPT-5` in feature comments

### Files
Official docs (11), crate READMEs (4), roadmap docs (2), implementation docs (1), studio docs (1), root README (1)

Note: Intentional references to deprecated models in version tables (e.g. 'retiring March 2026') are preserved.