### PR TITLE
feat(gemini): add Model::GeminiEmbedding001 (gemini-embedding-001)

### DIFF
--- a/adk-gemini/README.md
+++ b/adk-gemini/README.md
@@ -220,7 +220,7 @@ let parsed: serde_json::Value = serde_json::from_str(&response.text())?;
 ```rust
 use adk_gemini::{Gemini, Model, TaskType};
 
-let client = Gemini::with_model(api_key, Model::TextEmbedding004)?;
+let client = Gemini::with_model(api_key, Model::GeminiEmbedding001)?;
 
 let response = client
     .embed_content()

--- a/adk-gemini/src/client.rs
+++ b/adk-gemini/src/client.rs
@@ -55,6 +55,11 @@ pub enum Model {
     Gemini25FlashLite,
     #[serde(rename = "models/gemini-2.5-pro")]
     Gemini25Pro,
+    /// Gemini Embedding 001 (3072 dimensions). Replaces text-embedding-004.
+    #[serde(rename = "models/gemini-embedding-001")]
+    GeminiEmbedding001,
+    /// Deprecated: use `GeminiEmbedding001` instead.
+    #[deprecated(note = "Use Model::GeminiEmbedding001 (gemini-embedding-001) instead")]
     #[serde(rename = "models/text-embedding-004")]
     TextEmbedding004,
     #[serde(untagged)]
@@ -63,20 +68,24 @@ pub enum Model {
 
 impl Model {
     pub fn as_str(&self) -> &str {
+        #[allow(deprecated)]
         match self {
             Model::Gemini25Flash => "models/gemini-2.5-flash",
             Model::Gemini25FlashLite => "models/gemini-2.5-flash-lite",
             Model::Gemini25Pro => "models/gemini-2.5-pro",
+            Model::GeminiEmbedding001 => "models/gemini-embedding-001",
             Model::TextEmbedding004 => "models/text-embedding-004",
             Model::Custom(model) => model,
         }
     }
 
     pub fn vertex_model_path(&self, project_id: &str, location: &str) -> String {
+        #[allow(deprecated)]
         let model_id = match self {
             Model::Gemini25Flash => "gemini-2.5-flash",
             Model::Gemini25FlashLite => "gemini-2.5-flash-lite",
             Model::Gemini25Pro => "gemini-2.5-pro",
+            Model::GeminiEmbedding001 => "gemini-embedding-001",
             Model::TextEmbedding004 => "text-embedding-004",
             Model::Custom(model) => {
                 if model.starts_with("projects/") {
@@ -100,10 +109,12 @@ impl From<String> for Model {
 
 impl fmt::Display for Model {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        #[allow(deprecated)]
         match self {
             Model::Gemini25Flash => write!(f, "models/gemini-2.5-flash"),
             Model::Gemini25FlashLite => write!(f, "models/gemini-2.5-flash-lite"),
             Model::Gemini25Pro => write!(f, "models/gemini-2.5-pro"),
+            Model::GeminiEmbedding001 => write!(f, "models/gemini-embedding-001"),
             Model::TextEmbedding004 => write!(f, "models/text-embedding-004"),
             Model::Custom(model) => write!(f, "{}", model),
         }

--- a/examples/roadmap_gemini_sdk/main.rs
+++ b/examples/roadmap_gemini_sdk/main.rs
@@ -102,7 +102,7 @@ fn build_embedding_client(mode: SdkMode) -> Result<Gemini> {
             let Some(api_key) = google_api_key() else {
                 bail!("set GOOGLE_API_KEY (or GEMINI_API_KEY) for ROADMAP_SDK_MODE=v1_api_key");
             };
-            Ok(Gemini::with_model_v1(api_key, Model::TextEmbedding004)?)
+            Ok(Gemini::with_model_v1(api_key, Model::GeminiEmbedding001)?)
         }
         SdkMode::VertexApiKey => {
             let Some(api_key) = google_api_key() else {
@@ -113,19 +113,19 @@ fn build_embedding_client(mode: SdkMode) -> Result<Gemini> {
                 api_key,
                 project_id,
                 location,
-                Model::TextEmbedding004,
+                Model::GeminiEmbedding001,
             )?)
         }
         SdkMode::VertexAdc => {
             let project_id = project_id()?;
-            Ok(Gemini::with_google_cloud_adc_model(project_id, location, Model::TextEmbedding004)?)
+            Ok(Gemini::with_google_cloud_adc_model(project_id, location, Model::GeminiEmbedding001)?)
         }
         SdkMode::VertexServiceAccount => {
             let service_account_json =
                 read_json_value("GOOGLE_SERVICE_ACCOUNT_JSON", "GOOGLE_SERVICE_ACCOUNT_PATH")?;
             Ok(Gemini::with_service_account_json_model(
                 &service_account_json,
-                Model::TextEmbedding004,
+                Model::GeminiEmbedding001,
             )?)
         }
         SdkMode::VertexWif => {
@@ -135,7 +135,7 @@ fn build_embedding_client(mode: SdkMode) -> Result<Gemini> {
                 &wif_json,
                 project_id,
                 location,
-                Model::TextEmbedding004,
+                Model::GeminiEmbedding001,
             )?)
         }
     }

--- a/examples/verify_backend_selection/main.rs
+++ b/examples/verify_backend_selection/main.rs
@@ -96,7 +96,7 @@ async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
 
     // ── Test 5: Studio embedding ────────────────────────────────────
     info!("━━━ Test 5: Studio embedding ━━━");
-    let embed_client = Gemini::with_model(&api_key, Model::Custom("models/gemini-embedding-001".to_string()))?;
+    let embed_client = Gemini::with_model(&api_key, Model::GeminiEmbedding001)?;
     let embedding = embed_client
         .embed_content()
         .with_text("backend trait refactor validation")

--- a/examples/verify_vertex_streaming/main.rs
+++ b/examples/verify_vertex_streaming/main.rs
@@ -108,7 +108,7 @@ async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     let embed_client = build_vertex_client_with_model(
         &project,
         &location,
-        Model::Custom("models/gemini-embedding-001".to_string()),
+        Model::GeminiEmbedding001,
     )?;
 
     let embedding = embed_client


### PR DESCRIPTION
## Summary

Adds the new `gemini-embedding-001` model (3072 dimensions) as a first-class `Model` enum variant, replacing the deprecated `text-embedding-004`.

### Changes
- Add `Model::GeminiEmbedding001` variant with serde rename to `models/gemini-embedding-001`
- Mark `Model::TextEmbedding004` as `#[deprecated]` with compiler warning
- Update all examples (`verify_backend_selection`, `verify_vertex_streaming`, `roadmap_gemini_sdk`) to use new variant
- Update adk-gemini README embedding example

### Verification
- `cargo check -p adk-gemini` ✅
- `cargo test -p adk-gemini --lib` (37 tests) ✅
- `cargo check -p adk-examples --example verify_backend_selection --example verify_vertex_streaming --example roadmap_gemini_sdk` ✅