### PR TITLE
fix: clippy gate, NumberInput validation, debug stderr leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `StudioBackend` — AI Studio REST implementation (default)
 - `VertexBackend` — Vertex AI REST SSE streaming with gRPC fallback, ADC/service account/WIF auth
 - `GeminiBuilder` for constructing clients with explicit backend selection
+- `Model::GeminiEmbedding001` variant for `gemini-embedding-001` (3072 dimensions, replaces `text-embedding-004`)
+- `Model::TextEmbedding004` marked `#[deprecated]` with compiler warning
 - 25 response parsing tests: basic text, multi-candidate, safety ratings (string + numeric), blocked prompts, streaming chunks, function calls, inline data, grounding metadata, citations, usage metadata with thinking tokens, all FinishReason variants, unknown enum graceful degradation, round-trip serialization
 
 #### adk-studio
@@ -35,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **adk-model**: `GeminiModel::new()` now uses `Gemini::with_model(api_key, model_name)` instead of ignoring the provided model name (bug #77)
 - **adk-studio**: CORS restricted to localhost origins only (was allowing all origins)
+- **adk-ui**: `NumberInput` validation no longer false-fails when only `min` is set (`Some(min) > None` was always true)
+- **adk-graph**: Replaced `eprintln!("DEBUG: ...")` with `tracing::debug!()` in `AgentNode::execute_stream` and `CompiledGraph::stream` (stderr leakage in library code)
 - **adk-doc-audit**: Line numbers now use `syn::Span::start().line` instead of hardcoded `0`
 - **adk-doc-audit**: `suggest_similar_crate_names` and `suggest_similar_api_names` made static (removed dead `_static` variants)
 - **adk-doc-audit**: Deleted stale `test.md` artifact

--- a/adk-gemini/examples/batch_embedding.rs
+++ b/adk-gemini/examples/batch_embedding.rs
@@ -27,7 +27,7 @@ async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     let api_key = std::env::var("GEMINI_API_KEY")?;
 
     // Create client with the default model (gemini-2.5-flash)
-    let client = Gemini::with_model(api_key, Model::TextEmbedding004)
+    let client = Gemini::with_model(api_key, Model::GeminiEmbedding001)
         .expect("unable to create Gemini API client");
 
     info!("sending batch embedding request to gemini api");

--- a/adk-gemini/examples/custom_models.rs
+++ b/adk-gemini/examples/custom_models.rs
@@ -43,8 +43,8 @@ async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     let client_flash_lite = Gemini::with_model(api_key.clone(), Model::Gemini25FlashLite)?;
     info!("created client with Gemini 2.5 Flash Lite using Model enum");
 
-    let client_embedding = Gemini::with_model(api_key.clone(), Model::TextEmbedding004)?;
-    info!("created client with Text Embedding 004 model using Model enum");
+    let client_embedding = Gemini::with_model(api_key.clone(), Model::GeminiEmbedding001)?;
+    info!("created client with Gemini Embedding 001 model using Model enum");
 
     // 4. Using custom model strings for specific versions or preview models
     let client_custom_string =

--- a/adk-gemini/examples/embedding.rs
+++ b/adk-gemini/examples/embedding.rs
@@ -27,7 +27,7 @@ async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     let api_key = std::env::var("GEMINI_API_KEY")?;
 
     // Create client with the default model (gemini-2.5-flash)
-    let client = Gemini::with_model(api_key, Model::TextEmbedding004)
+    let client = Gemini::with_model(api_key, Model::GeminiEmbedding001)
         .expect("unable to create Gemini API client");
 
     info!("sending embedding request to gemini api");

--- a/adk-gemini/examples/error_handling.rs
+++ b/adk-gemini/examples/error_handling.rs
@@ -5,7 +5,7 @@ use display_error_chain::DisplayErrorChain;
 use tracing::{error, info};
 
 async fn do_main(api_key: &str) -> Result<(), ClientError> {
-    let client = Gemini::with_model(api_key, Model::TextEmbedding004)
+    let client = Gemini::with_model(api_key, Model::GeminiEmbedding001)
         .expect("unable to create Gemini API client");
 
     info!("sending embedding request to gemini api");

--- a/adk-graph/src/executor.rs
+++ b/adk-graph/src/executor.rs
@@ -382,7 +382,7 @@ impl CompiledGraph {
         config: ExecutionConfig,
         mode: StreamMode,
     ) -> impl futures::Stream<Item = Result<StreamEvent>> + '_ {
-        eprintln!("DEBUG: CompiledGraph::stream called with mode {:?}", mode);
+        tracing::debug!("CompiledGraph::stream called with mode {:?}", mode);
         let executor = PregelExecutor::new(self, config);
         executor.run_stream(input, mode)
     }

--- a/adk-graph/src/node.rs
+++ b/adk-graph/src/node.rs
@@ -383,7 +383,7 @@ impl Node for AgentNode {
         let content = (input_mapper)(&ctx.state);
 
         Box::pin(async_stream::stream! {
-            eprintln!("DEBUG: AgentNode::execute_stream called for {}", name);
+            tracing::debug!("AgentNode::execute_stream called for {}", name);
             let invocation_ctx = Arc::new(GraphInvocationContext::new(
                 thread_id,
                 content,

--- a/adk-ui/src/validation.rs
+++ b/adk-ui/src/validation.rs
@@ -105,11 +105,13 @@ impl Validate for NumberInput {
                 message: "NumberInput name cannot be empty".to_string(),
             });
         }
-        if self.min > self.max {
-            errors.push(ValidationError {
-                path: format!("{}.min", path),
-                message: "min cannot be greater than max".to_string(),
-            });
+        if let (Some(min), Some(max)) = (self.min, self.max) {
+            if min > max {
+                errors.push(ValidationError {
+                    path: format!("{}.min", path),
+                    message: "min cannot be greater than max".to_string(),
+                });
+            }
         }
         errors
     }


### PR DESCRIPTION
Fixes three issues found during code review:

### P1: Clippy `-D warnings` gate failure
4 adk-gemini examples used deprecated `Model::TextEmbedding004`, causing clippy to fail with `-D warnings`. Updated to `Model::GeminiEmbedding001`.
- `error_handling.rs`
- `custom_models.rs`
- `embedding.rs`
- `batch_embedding.rs`

### P1: NumberInput validation false-fail
`self.min > self.max` compared `Option<f64>` directly. In Rust, `Some(x) > None` is always `true`, so setting only `min` (without `max`) incorrectly triggered a validation error. Fixed to only compare when both are `Some`.

### P2: Debug stderr leakage
- `adk-graph/src/node.rs:386` — `AgentNode::execute_stream`
- `adk-graph/src/executor.rs:385` — `CompiledGraph::stream`


### Verification
- `cargo clippy -p adk-gemini --examples -- -D warnings` ✅
- `cargo clippy -p adk-graph -- -D warnings` ✅
- `cargo test -p adk-ui` (88 tests) ✅