### PR TITLE
style: cargo fmt --all

### DIFF
--- a/adk-doc-audit/src/analyzer.rs
+++ b/adk-doc-audit/src/analyzer.rs
@@ -155,10 +155,7 @@ impl CodeAnalyzer {
             Some(info) => info,
             None => {
                 // Create suggestion using helper method
-                let suggestion = Self::suggest_similar_crate_names(
-                    &api_ref.crate_name,
-                    registry,
-                );
+                let suggestion = Self::suggest_similar_crate_names(&api_ref.crate_name, registry);
                 return Ok(ValidationResult {
                     success: false,
                     errors: vec![format!("Crate '{}' not found in workspace", api_ref.crate_name)],
@@ -180,10 +177,7 @@ impl CodeAnalyzer {
 
         match matching_apis.len() {
             0 => {
-                let suggestion = Self::suggest_similar_api_names(
-                    &api_ref.item_path,
-                    crate_info,
-                );
+                let suggestion = Self::suggest_similar_api_names(&api_ref.item_path, crate_info);
                 Ok(ValidationResult {
                     success: false,
                     errors: vec![format!(
@@ -365,8 +359,7 @@ impl CodeAnalyzer {
                 match registry.crates.get(parts[0]) {
                     Some(info) => info,
                     None => {
-                        let suggestion =
-                            Self::suggest_similar_crate_names(parts[0], registry);
+                        let suggestion = Self::suggest_similar_crate_names(parts[0], registry);
                         return Ok(ValidationResult {
                             success: false,
                             errors: vec![format!("Crate '{}' not found in workspace", parts[0])],
@@ -396,8 +389,7 @@ impl CodeAnalyzer {
             crate_info.public_apis.iter().filter(|api| api.path.ends_with(&item_path)).collect();
 
         if matching_apis.is_empty() {
-            let suggestion =
-                Self::suggest_similar_api_names(&item_path, crate_info);
+            let suggestion = Self::suggest_similar_api_names(&item_path, crate_info);
             Ok(ValidationResult {
                 success: false,
                 errors: vec![format!("Item '{}' not found in crate '{}'", item_path, crate_name)],

--- a/adk-gemini/src/backend/mod.rs
+++ b/adk-gemini/src/backend/mod.rs
@@ -11,8 +11,7 @@ pub mod vertex;
 
 use crate::{
     batch::model::{
-        BatchGenerateContentRequest, BatchGenerateContentResponse,
-        ListBatchesResponse,
+        BatchGenerateContentRequest, BatchGenerateContentResponse, ListBatchesResponse,
     },
     cache::model::{
         CacheExpirationRequest, CachedContent, CreateCachedContentRequest,
@@ -79,10 +78,7 @@ pub trait GeminiBackend: Send + Sync + std::fmt::Debug {
         Err(Error::GoogleCloudUnsupported { operation: "batchGenerateContent" })
     }
 
-    async fn get_batch_operation(
-        &self,
-        _name: &str,
-    ) -> Result<serde_json::Value, Error> {
+    async fn get_batch_operation(&self, _name: &str) -> Result<serde_json::Value, Error> {
         Err(Error::GoogleCloudUnsupported { operation: "getBatchOperation" })
     }
 

--- a/adk-gemini/src/backend/vertex.rs
+++ b/adk-gemini/src/backend/vertex.rs
@@ -181,8 +181,7 @@ impl GeminiBackend for VertexBackend {
             .eventsource()
             .map_err(|e| Error::BadPart { source: e })
             .and_then(|event| async move {
-                serde_json::from_str::<GenerationResponse>(&event.data)
-                    .context(DeserializeSnafu)
+                serde_json::from_str::<GenerationResponse>(&event.data).context(DeserializeSnafu)
             });
 
         Ok(Box::pin(stream))

--- a/adk-gemini/src/client.rs
+++ b/adk-gemini/src/client.rs
@@ -17,10 +17,7 @@ use futures::Stream;
 use google_cloud_aiplatform_v1::client::PredictionService;
 use google_cloud_auth::credentials::{self, Credentials};
 use mime::Mime;
-use reqwest::{
-    ClientBuilder,
-    header::InvalidHeaderValue,
-};
+use reqwest::{ClientBuilder, header::InvalidHeaderValue};
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 use std::{
@@ -129,62 +126,103 @@ impl fmt::Display for Model {
 #[snafu(visibility(pub))]
 pub enum Error {
     #[snafu(display("failed to parse API key"))]
-    InvalidApiKey { source: InvalidHeaderValue },
+    InvalidApiKey {
+        source: InvalidHeaderValue,
+    },
 
     #[snafu(display("failed to construct URL (probably incorrect model name): {suffix}"))]
-    ConstructUrl { source: url::ParseError, suffix: String },
+    ConstructUrl {
+        source: url::ParseError,
+        suffix: String,
+    },
 
-    PerformRequestNew { source: reqwest::Error },
+    PerformRequestNew {
+        source: reqwest::Error,
+    },
 
     #[snafu(display("failed to perform request to '{url}'"))]
-    PerformRequest { source: reqwest::Error, url: Url },
+    PerformRequest {
+        source: reqwest::Error,
+        url: Url,
+    },
 
     #[snafu(display("bad response from server; code {code}; description: {}", description.as_deref().unwrap_or("none")))]
-    BadResponse { code: u16, description: Option<String> },
+    BadResponse {
+        code: u16,
+        description: Option<String>,
+    },
 
-    MissingResponseHeader { header: String },
+    MissingResponseHeader {
+        header: String,
+    },
 
     #[snafu(display("failed to obtain stream SSE part"))]
-    BadPart { source: EventStreamError<reqwest::Error> },
+    BadPart {
+        source: EventStreamError<reqwest::Error>,
+    },
 
     #[snafu(display("failed to deserialize JSON response"))]
-    Deserialize { source: serde_json::Error },
+    Deserialize {
+        source: serde_json::Error,
+    },
 
     #[snafu(display("failed to generate content"))]
-    DecodeResponse { source: reqwest::Error },
+    DecodeResponse {
+        source: reqwest::Error,
+    },
 
     #[snafu(display("failed to parse URL"))]
-    UrlParse { source: url::ParseError },
+    UrlParse {
+        source: url::ParseError,
+    },
 
     #[snafu(display("failed to build google cloud credentials"))]
-    GoogleCloudAuth { source: google_cloud_auth::build_errors::Error },
+    GoogleCloudAuth {
+        source: google_cloud_auth::build_errors::Error,
+    },
 
     #[snafu(display("failed to obtain google cloud auth headers"))]
-    GoogleCloudCredentialHeaders { source: google_cloud_auth::errors::CredentialsError },
+    GoogleCloudCredentialHeaders {
+        source: google_cloud_auth::errors::CredentialsError,
+    },
 
     #[snafu(display("google cloud credentials returned NotModified without cached headers"))]
     GoogleCloudCredentialHeadersUnavailable,
 
     #[snafu(display("failed to parse google cloud credentials JSON"))]
-    GoogleCloudCredentialParse { source: serde_json::Error },
+    GoogleCloudCredentialParse {
+        source: serde_json::Error,
+    },
 
     #[snafu(display("failed to build google cloud vertex client"))]
-    GoogleCloudClientBuild { source: google_cloud_gax::client_builder::Error },
+    GoogleCloudClientBuild {
+        source: google_cloud_gax::client_builder::Error,
+    },
 
     #[snafu(display("failed to send google cloud vertex request"))]
-    GoogleCloudRequest { source: google_cloud_aiplatform_v1::Error },
+    GoogleCloudRequest {
+        source: google_cloud_aiplatform_v1::Error,
+    },
 
     #[snafu(display("failed to serialize google cloud request"))]
-    GoogleCloudRequestSerialize { source: serde_json::Error },
+    GoogleCloudRequestSerialize {
+        source: serde_json::Error,
+    },
 
     #[snafu(display("failed to deserialize google cloud request"))]
-    GoogleCloudRequestDeserialize { source: serde_json::Error },
+    GoogleCloudRequestDeserialize {
+        source: serde_json::Error,
+    },
 
     #[snafu(display("failed to serialize google cloud response"))]
-    GoogleCloudResponseSerialize { source: serde_json::Error },
+    GoogleCloudResponseSerialize {
+        source: serde_json::Error,
+    },
 
     #[snafu(display("failed to deserialize google cloud response"))]
-    GoogleCloudResponseDeserialize { source: serde_json::Error },
+    GoogleCloudResponseDeserialize {
+        source: serde_json::Error,
+    },
 
     #[snafu(display("google cloud request payload is not an object"))]
     GoogleCloudRequestNotObject,
@@ -201,17 +239,25 @@ pub enum Error {
     #[snafu(display("api key is required for this configuration"))]
     MissingApiKey,
 
-    #[snafu(display("operation '{operation}' is not supported with the google cloud sdk backend (PredictionService currently exposes generateContent/embedContent only)"))]
-    GoogleCloudUnsupported { operation: &'static str },
+    #[snafu(display(
+        "operation '{operation}' is not supported with the google cloud sdk backend (PredictionService currently exposes generateContent/embedContent only)"
+    ))]
+    GoogleCloudUnsupported {
+        operation: &'static str,
+    },
 
     #[snafu(display("failed to create tokio runtime for google cloud client"))]
-    TokioRuntime { source: std::io::Error },
+    TokioRuntime {
+        source: std::io::Error,
+    },
 
     #[snafu(display("google cloud client initialization thread panicked"))]
     GoogleCloudInitThreadPanicked,
 
     #[snafu(display("I/O error during file operations"))]
-    Io { source: std::io::Error },
+    Io {
+        source: std::io::Error,
+    },
 }
 
 // ══════════════════════════════════════════════════════════════════════
@@ -625,9 +671,7 @@ impl GeminiBuilder {
                 endpoint,
             );
 
-            return Ok(Gemini {
-                client: Arc::new(GeminiClient::with_vertex(model, vertex)),
-            });
+            return Ok(Gemini { client: Arc::new(GeminiClient::with_vertex(model, vertex)) });
         }
 
         // ── AI Studio REST path ─────────────────────────────────────────
@@ -639,12 +683,9 @@ impl GeminiBuilder {
         let studio =
             backend::studio::StudioBackend::new(&api_key, self.model.clone(), self.base_url)?;
 
-        Ok(Gemini {
-            client: Arc::new(GeminiClient::with_studio(self.model, studio)),
-        })
+        Ok(Gemini { client: Arc::new(GeminiClient::with_studio(self.model, studio)) })
     }
 }
-
 
 // ══════════════════════════════════════════════════════════════════════
 // Gemini — the main public-facing client
@@ -784,14 +825,9 @@ impl Gemini {
         base_url: Url,
     ) -> Result<Self, Error> {
         let model = model.into();
-        let studio = backend::studio::StudioBackend::new(
-            api_key.as_ref(),
-            model.clone(),
-            base_url,
-        )?;
-        Ok(Self {
-            client: Arc::new(GeminiClient::with_studio(model, studio)),
-        })
+        let studio =
+            backend::studio::StudioBackend::new(api_key.as_ref(), model.clone(), base_url)?;
+        Ok(Self { client: Arc::new(GeminiClient::with_studio(model, studio)) })
     }
 
     /// Start building a content generation request

--- a/adk-gemini/src/response_parsing_tests.rs
+++ b/adk-gemini/src/response_parsing_tests.rs
@@ -6,8 +6,8 @@
 //! blocked prompts, grounding metadata, and mixed part types.
 
 use crate::{
-    BlockReason, FinishReason, GenerationResponse, HarmCategory, HarmProbability,
-    Modality, Part, SafetyRating,
+    BlockReason, FinishReason, GenerationResponse, HarmCategory, HarmProbability, Modality, Part,
+    SafetyRating,
 };
 use serde_json::json;
 
@@ -568,10 +568,7 @@ fn parse_unknown_finish_reason_string() {
     });
 
     let resp: GenerationResponse = serde_json::from_value(json).unwrap();
-    assert_eq!(
-        resp.candidates[0].finish_reason,
-        Some(FinishReason::Other)
-    );
+    assert_eq!(resp.candidates[0].finish_reason, Some(FinishReason::Other));
 }
 
 #[test]
@@ -584,10 +581,7 @@ fn parse_unknown_finish_reason_number() {
     });
 
     let resp: GenerationResponse = serde_json::from_value(json).unwrap();
-    assert_eq!(
-        resp.candidates[0].finish_reason,
-        Some(FinishReason::Other)
-    );
+    assert_eq!(resp.candidates[0].finish_reason, Some(FinishReason::Other));
 }
 
 #[test]

--- a/adk-studio/src/codegen/mod.rs
+++ b/adk-studio/src/codegen/mod.rs
@@ -42,7 +42,11 @@ fn detect_provider(model: &str) -> &'static str {
     } else if m.contains("llama") || m.contains("mixtral") {
         // Ollama-style tags have colons (e.g. "llama3.2:3b")
         if m.contains(':') { "ollama" } else { "groq" }
-    } else if m.contains("qwen") || m.contains("mistral") || m.contains("codellama") || m.contains("devstral") {
+    } else if m.contains("qwen")
+        || m.contains("mistral")
+        || m.contains("codellama")
+        || m.contains("devstral")
+    {
         "ollama"
     } else {
         "gemini" // default
@@ -3959,15 +3963,30 @@ fn generate_cargo_toml(project: &ProjectSchema) -> String {
     // Determine which adk-model features are needed based on providers used
     let providers = collect_providers(project);
     let mut model_features: Vec<&str> = Vec::new();
-    if providers.contains("gemini") { model_features.push("gemini"); }
-    if providers.contains("openai") { model_features.push("openai"); }
-    if providers.contains("anthropic") { model_features.push("anthropic"); }
-    if providers.contains("deepseek") { model_features.push("deepseek"); }
-    if providers.contains("groq") { model_features.push("groq"); }
-    if providers.contains("ollama") { model_features.push("ollama"); }
+    if providers.contains("gemini") {
+        model_features.push("gemini");
+    }
+    if providers.contains("openai") {
+        model_features.push("openai");
+    }
+    if providers.contains("anthropic") {
+        model_features.push("anthropic");
+    }
+    if providers.contains("deepseek") {
+        model_features.push("deepseek");
+    }
+    if providers.contains("groq") {
+        model_features.push("groq");
+    }
+    if providers.contains("ollama") {
+        model_features.push("ollama");
+    }
     // Default to gemini if no providers detected
-    if model_features.is_empty() { model_features.push("gemini"); }
-    let features_str = model_features.iter().map(|f| format!("\"{}\"", f)).collect::<Vec<_>>().join(", ");
+    if model_features.is_empty() {
+        model_features.push("gemini");
+    }
+    let features_str =
+        model_features.iter().map(|f| format!("\"{}\"", f)).collect::<Vec<_>>().join(", ");
 
     let adk_deps = if use_path_deps {
         format!(

--- a/adk-studio/src/server/sse.rs
+++ b/adk-studio/src/server/sse.rs
@@ -551,9 +551,7 @@ async fn get_or_create_session(
         }
     }
 
-    let mut child = cmd
-        .spawn()
-        .map_err(|e| format!("Failed to start binary: {}", e))?;
+    let mut child = cmd.spawn().map_err(|e| format!("Failed to start binary: {}", e))?;
 
     let stdin = BufWriter::new(
         child.stdin.take().ok_or_else(|| "Failed to capture child stdin".to_string())?,
@@ -599,17 +597,20 @@ pub async fn stream_handler(
     Query(query): Query<StreamQuery>,
     State(app_state): State<AppState>,
 ) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
-    let api_key = query.api_key.or_else(|| {
-        // Try all known provider API keys, not just Google
-        std::env::var("GOOGLE_API_KEY")
-            .or_else(|_| std::env::var("GEMINI_API_KEY"))
-            .or_else(|_| std::env::var("ANTHROPIC_API_KEY"))
-            .or_else(|_| std::env::var("OPENAI_API_KEY"))
-            .or_else(|_| std::env::var("DEEPSEEK_API_KEY"))
-            .or_else(|_| std::env::var("GROQ_API_KEY"))
-            .or_else(|_| std::env::var("OLLAMA_HOST"))
-            .ok()
-    }).unwrap_or_default();
+    let api_key = query
+        .api_key
+        .or_else(|| {
+            // Try all known provider API keys, not just Google
+            std::env::var("GOOGLE_API_KEY")
+                .or_else(|_| std::env::var("GEMINI_API_KEY"))
+                .or_else(|_| std::env::var("ANTHROPIC_API_KEY"))
+                .or_else(|_| std::env::var("OPENAI_API_KEY"))
+                .or_else(|_| std::env::var("DEEPSEEK_API_KEY"))
+                .or_else(|_| std::env::var("GROQ_API_KEY"))
+                .or_else(|_| std::env::var("OLLAMA_HOST"))
+                .ok()
+        })
+        .unwrap_or_default();
     let input = query.input.clone();
     let binary_path = query.binary_path;
     let session_id = query.session_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());

--- a/examples/roadmap_gemini_sdk/main.rs
+++ b/examples/roadmap_gemini_sdk/main.rs
@@ -118,7 +118,11 @@ fn build_embedding_client(mode: SdkMode) -> Result<Gemini> {
         }
         SdkMode::VertexAdc => {
             let project_id = project_id()?;
-            Ok(Gemini::with_google_cloud_adc_model(project_id, location, Model::GeminiEmbedding001)?)
+            Ok(Gemini::with_google_cloud_adc_model(
+                project_id,
+                location,
+                Model::GeminiEmbedding001,
+            )?)
         }
         SdkMode::VertexServiceAccount => {
             let service_account_json =

--- a/examples/verify_backend_selection/main.rs
+++ b/examples/verify_backend_selection/main.rs
@@ -61,9 +61,7 @@ async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
 
     // ── Test 3: GeminiBuilder → Studio backend ──────────────────────
     info!("━━━ Test 3: GeminiBuilder → Studio backend ━━━");
-    let client = GeminiBuilder::new(&api_key)
-        .with_model(Model::Gemini25Flash)
-        .build()?;
+    let client = GeminiBuilder::new(&api_key).with_model(Model::Gemini25Flash).build()?;
     let response = client
         .generate_content()
         .with_user_message("Say 'builder works' in exactly those words.")
@@ -74,11 +72,8 @@ async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
 
     // ── Test 4: Studio streaming ────────────────────────────────────
     info!("━━━ Test 4: Studio streaming ━━━");
-    let mut stream = client
-        .generate_content()
-        .with_user_message("Count from 1 to 3.")
-        .execute_stream()
-        .await?;
+    let mut stream =
+        client.generate_content().with_user_message("Count from 1 to 3.").execute_stream().await?;
 
     let mut chunks = 0u32;
     while let Some(chunk) = stream.try_next().await? {
@@ -110,11 +105,7 @@ async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     // ── Test 6: v1 API constructor ──────────────────────────────────
     info!("━━━ Test 6: Gemini::with_v1() ━━━");
     let client = Gemini::with_v1(&api_key)?;
-    let response = client
-        .generate_content()
-        .with_user_message("Say 'v1 works'.")
-        .execute()
-        .await?;
+    let response = client.generate_content().with_user_message("Say 'v1 works'.").execute().await?;
     info!(response = %response.text(), "v1 API works");
     info!("✅ v1 API constructor");
 

--- a/examples/verify_vertex_streaming/main.rs
+++ b/examples/verify_vertex_streaming/main.rs
@@ -57,8 +57,7 @@ async fn main() -> ExitCode {
 async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     let project = env::var("GOOGLE_CLOUD_PROJECT")
         .expect("GOOGLE_CLOUD_PROJECT environment variable required");
-    let location =
-        env::var("GOOGLE_CLOUD_LOCATION").unwrap_or_else(|_| "us-central1".to_string());
+    let location = env::var("GOOGLE_CLOUD_LOCATION").unwrap_or_else(|_| "us-central1".to_string());
 
     info!(project = %project, location = %location, "building Vertex AI client");
 
@@ -105,17 +104,11 @@ async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
 
     // ── Test 3: Embedding ───────────────────────────────────────────
     info!("━━━ Test 3: Embedding ━━━");
-    let embed_client = build_vertex_client_with_model(
-        &project,
-        &location,
-        Model::GeminiEmbedding001,
-    )?;
+    let embed_client =
+        build_vertex_client_with_model(&project, &location, Model::GeminiEmbedding001)?;
 
-    let embedding = embed_client
-        .embed_content()
-        .with_text("Vertex AI streaming now works")
-        .execute()
-        .await?;
+    let embedding =
+        embed_client.embed_content().with_text("Vertex AI streaming now works").execute().await?;
 
     let dim = embedding.embedding.values.len();
     info!(dimensions = dim, "embedding received");
@@ -155,8 +148,9 @@ fn build_vertex_client_with_model(
     }
 
     // Fall back to API key
-    let api_key = env::var("GEMINI_API_KEY")
-        .expect("one of GOOGLE_APPLICATION_CREDENTIALS, VERTEX_USE_ADC, or GEMINI_API_KEY required");
+    let api_key = env::var("GEMINI_API_KEY").expect(
+        "one of GOOGLE_APPLICATION_CREDENTIALS, VERTEX_USE_ADC, or GEMINI_API_KEY required",
+    );
     info!("using API key authentication");
     Gemini::with_google_cloud_model(api_key, project, location, model)
 }


### PR DESCRIPTION
Ran `cargo fmt --all` to fix formatting drift from PRs #84-#90.

11 files reformatted:
- adk-doc-audit/src/analyzer.rs
- adk-gemini/src/backend/mod.rs
- adk-gemini/src/backend/studio.rs
- adk-gemini/src/backend/vertex.rs
- adk-gemini/src/client.rs
- adk-gemini/src/response_parsing_tests.rs
- adk-studio/src/codegen/mod.rs
- adk-studio/src/server/sse.rs
- examples/roadmap_gemini_sdk/main.rs
- examples/verify_backend_selection/main.rs
- examples/verify_vertex_streaming/main.rs

No functional changes.