### PR TITLE
feat(adk-rust): add missing module re-exports to facade crate

### DIFF
--- a/adk-rust/Cargo.toml
+++ b/adk-rust/Cargo.toml
@@ -31,7 +31,13 @@ full = [
     "cli",
     "graph",
     "ui",
-    "doc-audit"
+    "doc-audit",
+    "realtime",
+    "browser",
+    "eval",
+    "guardrail",
+    "auth",
+    "plugin"
 ]
 
 # CLI launcher support
@@ -51,6 +57,12 @@ telemetry = ["dep:adk-telemetry"]
 graph = ["dep:adk-graph"]
 ui = ["dep:adk-ui"]
 doc-audit = ["dep:adk-doc-audit"]
+realtime = ["dep:adk-realtime"]
+browser = ["dep:adk-browser"]
+eval = ["dep:adk-eval"]
+guardrail = ["dep:adk-guardrail"]
+auth = ["dep:adk-auth"]
+plugin = ["dep:adk-plugin"]
 
 # Minimal preset (just agents + models + runner)
 minimal = ["agents", "models", "runner"]
@@ -81,6 +93,12 @@ adk-cli = { workspace = true, optional = true }
 adk-graph = { workspace = true, optional = true }
 adk-ui = { workspace = true, optional = true }
 adk-doc-audit = { workspace = true, optional = true }
+adk-realtime = { workspace = true, optional = true }
+adk-browser = { workspace = true, optional = true }
+adk-eval = { workspace = true, optional = true }
+adk-guardrail = { workspace = true, optional = true }
+adk-auth = { workspace = true, optional = true }
+adk-plugin = { workspace = true, optional = true }
 
 # Re-export common dependencies
 tokio = { workspace = true }

--- a/adk-rust/src/lib.rs
+++ b/adk-rust/src/lib.rs
@@ -668,6 +668,85 @@ pub mod doc_audit {
 #[cfg_attr(docsrs, doc(cfg(feature = "cli")))]
 pub use adk_cli::{Launcher, SingleAgentLoader};
 
+/// Real-time bidirectional streaming (voice, video).
+///
+/// Provides real-time audio/video streaming for voice-enabled agents:
+/// - [`RealtimeAgent`](realtime::RealtimeAgent) - Agent with voice capabilities
+/// - [`RealtimeRunner`](realtime::RealtimeRunner) - Session management and tool execution
+/// - Multiple providers: OpenAI Realtime, Gemini Live
+///
+/// Available with feature: `realtime`
+#[cfg(feature = "realtime")]
+#[cfg_attr(docsrs, doc(cfg(feature = "realtime")))]
+pub mod realtime {
+    pub use adk_realtime::*;
+}
+
+/// Browser automation (WebDriver).
+///
+/// Provides browser automation tools for agents:
+/// - [`BrowserSession`](browser::BrowserSession) - WebDriver session management
+/// - [`BrowserToolset`](browser::BrowserToolset) - Browser tools for agents
+///
+/// Available with feature: `browser`
+#[cfg(feature = "browser")]
+#[cfg_attr(docsrs, doc(cfg(feature = "browser")))]
+pub mod browser {
+    pub use adk_browser::*;
+}
+
+/// Agent evaluation framework.
+///
+/// Test and validate agent behavior:
+/// - [`Evaluator`](eval::Evaluator) - Run evaluation suites
+/// - [`EvaluationConfig`](eval::EvaluationConfig) - Configure evaluation parameters
+///
+/// Available with feature: `eval`
+#[cfg(feature = "eval")]
+#[cfg_attr(docsrs, doc(cfg(feature = "eval")))]
+pub mod eval {
+    pub use adk_eval::*;
+}
+
+/// Guardrails for safety and policy enforcement.
+///
+/// Validate agent inputs and outputs:
+/// - [`GuardrailSet`](guardrail::GuardrailSet) - Collection of guardrails
+/// - [`ContentFilter`](guardrail::ContentFilter) - Content safety filtering
+///
+/// Available with feature: `guardrail`
+#[cfg(feature = "guardrail")]
+#[cfg_attr(docsrs, doc(cfg(feature = "guardrail")))]
+pub mod guardrail {
+    pub use adk_guardrail::*;
+}
+
+/// Authentication and access control.
+///
+/// Manage agent permissions and identity:
+/// - [`Permission`](auth::Permission) - Permission definitions
+/// - [`AccessControl`](auth::AccessControl) - Access control enforcement
+///
+/// Available with feature: `auth`
+#[cfg(feature = "auth")]
+#[cfg_attr(docsrs, doc(cfg(feature = "auth")))]
+pub mod auth {
+    pub use adk_auth::*;
+}
+
+/// Plugin system for extending agent behavior.
+///
+/// Extensible callback architecture for agent lifecycle hooks:
+/// - Plugin registration and discovery
+/// - Before/after hooks for agent operations
+///
+/// Available with feature: `plugin`
+#[cfg(feature = "plugin")]
+#[cfg_attr(docsrs, doc(cfg(feature = "plugin")))]
+pub mod plugin {
+    pub use adk_plugin::*;
+}
+
 // ============================================================================
 // Prelude
 // ============================================================================


### PR DESCRIPTION
## Summary

Adds 6 missing module re-exports to the `adk-rust` facade crate: `realtime`, `browser`, `eval`, `guardrail`, `auth`, and `plugin`.

## Motivation

These crates existed in the workspace but weren't accessible through the unified `adk-rust` facade. Users had to depend on individual crates directly. Now everything is available through a single dependency with feature flags.

## Changes

**Cargo.toml:**
- Added `realtime`, `browser`, `eval`, `guardrail`, `auth`, `plugin` feature flags
- Added corresponding optional dependencies
- Updated `full` feature to include all new flags

**lib.rs:**
- Added 6 new feature-gated module re-exports with rustdoc comments
- Each module uses `#[cfg_attr(docsrs, doc(cfg(...)))]` for docs.rs

## Verification

```
cargo check -p adk-rust                    # full (default) — OK
cargo check -p adk-rust --no-default-features  # bare minimum — OK
```

Inspired by mikefaille/adk-rust facade enhancement (#46).

Co-authored-by: mikefaille <978196+mikefaille@users.noreply.github.com>