### PR TITLE
fix: cargo fmt + make sccache non-fatal in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,6 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
-  # sccache config
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
   # cmake 4.x compat for audiopus
   CMAKE_POLICY_VERSION_MINIMUM: "3.5"
 
@@ -40,7 +37,18 @@ jobs:
         sudo apt-get install -y mold
 
     - name: Setup sccache
-      uses: mozilla-actions/sccache-action@v0.0.7
+      uses: mozilla-actions/sccache-action@v0.0.9
+      continue-on-error: true
+
+    - name: Configure sccache
+      run: |
+        if sccache --show-stats > /dev/null 2>&1; then
+          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+          echo "sccache is available — enabling"
+        else
+          echo "sccache unavailable — building without cache"
+        fi
 
     - name: Check formatting
       run: cargo fmt --all -- --check
@@ -56,4 +64,5 @@ jobs:
       run: cargo test --workspace --all-features
 
     - name: Show sccache stats
+      if: env.RUSTC_WRAPPER == 'sccache'
       run: sccache --show-stats

--- a/.github/workflows/mistralrs-tests.yml
+++ b/.github/workflows/mistralrs-tests.yml
@@ -18,8 +18,6 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
 
 jobs:
   mistralrs-check:
@@ -44,7 +42,18 @@ jobs:
         sudo apt-get install -y mold
 
     - name: Setup sccache
-      uses: mozilla-actions/sccache-action@v0.0.7
+      uses: mozilla-actions/sccache-action@v0.0.9
+      continue-on-error: true
+
+    - name: Configure sccache
+      run: |
+        if sccache --show-stats > /dev/null 2>&1; then
+          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+          echo "sccache is available — enabling"
+        else
+          echo "sccache unavailable — building without cache"
+        fi
 
     - name: Run clippy
       env:
@@ -61,4 +70,5 @@ jobs:
         cargo test --doc
 
     - name: Show sccache stats
+      if: env.RUSTC_WRAPPER == 'sccache'
       run: sccache --show-stats

--- a/adk-realtime/examples/livekit_bridge.rs
+++ b/adk-realtime/examples/livekit_bridge.rs
@@ -57,10 +57,10 @@
 
 use std::sync::Arc;
 
-use adk_realtime::livekit::{bridge_input, LiveKitEventHandler};
+use adk_realtime::RealtimeConfig;
+use adk_realtime::livekit::{LiveKitEventHandler, bridge_input};
 use adk_realtime::openai::OpenAIRealtimeModel;
 use adk_realtime::runner::{EventHandler, RealtimeRunner};
-use adk_realtime::RealtimeConfig;
 
 use livekit::options::TrackPublishOptions;
 use livekit::prelude::*;
@@ -71,10 +71,8 @@ use livekit::webrtc::audio_source::{AudioSourceOptions, RtcAudioSource};
 /// for publishing model audio, and the first remote audio track from a participant.
 ///
 /// In a production app you'd handle track subscriptions more robustly.
-async fn connect_to_livekit() -> Result<
-    (Room, NativeAudioSource, livekit::track::RemoteAudioTrack),
-    Box<dyn std::error::Error>,
-> {
+async fn connect_to_livekit()
+-> Result<(Room, NativeAudioSource, livekit::track::RemoteAudioTrack), Box<dyn std::error::Error>> {
     let url = std::env::var("LIVEKIT_URL").expect("LIVEKIT_URL env var is required");
     let token = std::env::var("LIVEKIT_TOKEN").expect("LIVEKIT_TOKEN env var is required");
 
@@ -94,9 +92,7 @@ async fn connect_to_livekit() -> Result<
     let rtc_source = RtcAudioSource::Native(audio_source.clone());
     let local_track = LocalAudioTrack::create_audio_track("ai-agent-audio", rtc_source);
     let publish_options = TrackPublishOptions::default();
-    room.local_participant()
-        .publish_track(LocalTrack::Audio(local_track), publish_options)
-        .await?;
+    room.local_participant().publish_track(LocalTrack::Audio(local_track), publish_options).await?;
     println!("Published AI agent audio track to room.");
 
     // --- Wait for a remote participant's audio track ---

--- a/adk-realtime/examples/vertex_live_voice.rs
+++ b/adk-realtime/examples/vertex_live_voice.rs
@@ -36,14 +36,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // --- 2. Build the Vertex AI Live backend ---
     let region = std::env::var("GOOGLE_CLOUD_REGION").unwrap_or_else(|_| "us-central1".into());
-    let project_id = std::env::var("GOOGLE_CLOUD_PROJECT")
-        .expect("GOOGLE_CLOUD_PROJECT env var is required");
+    let project_id =
+        std::env::var("GOOGLE_CLOUD_PROJECT").expect("GOOGLE_CLOUD_PROJECT env var is required");
 
-    let backend = GeminiLiveBackend::Vertex {
-        credentials,
-        region,
-        project_id,
-    };
+    let backend = GeminiLiveBackend::Vertex { credentials, region, project_id };
 
     // --- 3. Create the model and session configuration ---
     let model = GeminiRealtimeModel::new(backend, "models/gemini-live-2.5-flash-native-audio");

--- a/adk-realtime/src/gemini/mod.rs
+++ b/adk-realtime/src/gemini/mod.rs
@@ -56,8 +56,7 @@ pub const GEMINI_LIVE_URL: &str = "wss://generativelanguage.googleapis.com/ws/go
 /// URL template for Vertex AI Live WebSocket endpoint.
 /// Use `build_vertex_live_url()` to construct the full URL with region and project ID.
 #[cfg(feature = "vertex-live")]
-pub const VERTEX_LIVE_URL_TEMPLATE: &str =
-    "wss://{region}-aiplatform.googleapis.com/ws/google.cloud.aiplatform.v1beta1.LlmBidiService/BidiGenerateContent?project_id={project_id}";
+pub const VERTEX_LIVE_URL_TEMPLATE: &str = "wss://{region}-aiplatform.googleapis.com/ws/google.cloud.aiplatform.v1beta1.LlmBidiService/BidiGenerateContent?project_id={project_id}";
 
 /// Default model for Gemini Live.
 pub const DEFAULT_MODEL: &str = "models/gemini-live-2.5-flash-native-audio";

--- a/adk-realtime/src/livekit/bridge.rs
+++ b/adk-realtime/src/livekit/bridge.rs
@@ -26,15 +26,9 @@ const DEFAULT_NUM_CHANNELS: i32 = 1;
 ///
 /// * `track` — The LiveKit remote audio track to read from.
 /// * `runner` — The realtime runner to send audio to.
-pub async fn bridge_input(
-    track: RemoteAudioTrack,
-    runner: &RealtimeRunner,
-) -> Result<()> {
-    let mut stream = NativeAudioStream::new(
-        track.rtc_track(),
-        DEFAULT_SAMPLE_RATE,
-        DEFAULT_NUM_CHANNELS,
-    );
+pub async fn bridge_input(track: RemoteAudioTrack, runner: &RealtimeRunner) -> Result<()> {
+    let mut stream =
+        NativeAudioStream::new(track.rtc_track(), DEFAULT_SAMPLE_RATE, DEFAULT_NUM_CHANNELS);
 
     while let Some(frame) = stream.next().await {
         // Convert i16 samples to little-endian PCM16 bytes
@@ -56,16 +50,10 @@ pub async fn bridge_input(
 ///
 /// * `track` — The LiveKit remote audio track to read from.
 /// * `runner` — The realtime runner to send audio to.
-pub async fn bridge_gemini_input(
-    track: RemoteAudioTrack,
-    runner: &RealtimeRunner,
-) -> Result<()> {
+pub async fn bridge_gemini_input(track: RemoteAudioTrack, runner: &RealtimeRunner) -> Result<()> {
     // Request 16kHz mono from LiveKit — it handles resampling for us.
-    let mut stream = NativeAudioStream::new(
-        track.rtc_track(),
-        GEMINI_SAMPLE_RATE,
-        DEFAULT_NUM_CHANNELS,
-    );
+    let mut stream =
+        NativeAudioStream::new(track.rtc_track(), GEMINI_SAMPLE_RATE, DEFAULT_NUM_CHANNELS);
 
     while let Some(frame) = stream.next().await {
         let chunk = AudioChunk::from_i16_samples(&frame.data, AudioFormat::pcm16_16khz());

--- a/adk-realtime/src/livekit/handler.rs
+++ b/adk-realtime/src/livekit/handler.rs
@@ -37,12 +37,7 @@ impl<H: EventHandler> LiveKitEventHandler<H> {
         sample_rate: u32,
         num_channels: u32,
     ) -> Self {
-        Self {
-            inner,
-            audio_source,
-            sample_rate,
-            num_channels,
-        }
+        Self { inner, audio_source, sample_rate, num_channels }
     }
 }
 

--- a/adk-realtime/src/openai/mod.rs
+++ b/adk-realtime/src/openai/mod.rs
@@ -64,4 +64,3 @@ pub enum OpenAITransport {
     #[cfg(feature = "openai-webrtc")]
     WebRTC,
 }
-

--- a/adk-realtime/src/openai/model.rs
+++ b/adk-realtime/src/openai/model.rs
@@ -8,7 +8,7 @@ use crate::session::BoxedSession;
 use async_trait::async_trait;
 
 use super::session::OpenAIRealtimeSession;
-use super::{OpenAITransport, DEFAULT_MODEL, OPENAI_REALTIME_URL, OPENAI_VOICES};
+use super::{DEFAULT_MODEL, OPENAI_REALTIME_URL, OPENAI_VOICES, OpenAITransport};
 
 /// OpenAI Realtime model for creating realtime sessions.
 ///
@@ -111,12 +111,9 @@ impl RealtimeModel for OpenAIRealtimeModel {
     async fn connect(&self, config: RealtimeConfig) -> Result<BoxedSession> {
         match self.transport {
             OpenAITransport::WebSocket => {
-                let session = OpenAIRealtimeSession::connect(
-                    &self.websocket_url(),
-                    &self.api_key,
-                    config,
-                )
-                .await?;
+                let session =
+                    OpenAIRealtimeSession::connect(&self.websocket_url(), &self.api_key, config)
+                        .await?;
                 Ok(Box::new(session))
             }
             #[cfg(feature = "openai-webrtc")]

--- a/adk-realtime/tests/openai_webrtc_integration_tests.rs
+++ b/adk-realtime/tests/openai_webrtc_integration_tests.rs
@@ -37,8 +37,7 @@ use adk_realtime::{RealtimeConfig, RealtimeModel, RealtimeSession, ServerEvent};
 async fn test_openai_webrtc_text_exchange() {
     let timeout = tokio::time::Duration::from_secs(30);
     tokio::time::timeout(timeout, async {
-        let api_key =
-            std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY env var is required");
+        let api_key = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY env var is required");
 
         let model = OpenAIRealtimeModel::new(api_key, "gpt-4o-realtime-preview-2024-12-17")
             .with_transport(OpenAITransport::WebRTC);
@@ -48,10 +47,7 @@ async fn test_openai_webrtc_text_exchange() {
             .with_voice("alloy");
 
         // Connect via WebRTC (SDP signaling happens internally)
-        let session = model
-            .connect(config)
-            .await
-            .expect("Failed to connect via OpenAI WebRTC");
+        let session = model.connect(config).await.expect("Failed to connect via OpenAI WebRTC");
 
         assert!(
             session.is_connected(),
@@ -82,10 +78,7 @@ async fn test_openai_webrtc_text_exchange() {
             }
         }
 
-        assert!(
-            received_event,
-            "Should have received at least one response event via WebRTC"
-        );
+        assert!(received_event, "Should have received at least one response event via WebRTC");
 
         session.close().await.expect("Failed to close WebRTC session");
     })
@@ -105,8 +98,7 @@ async fn test_openai_webrtc_text_exchange() {
 async fn test_openai_webrtc_audio_roundtrip() {
     let timeout = tokio::time::Duration::from_secs(30);
     tokio::time::timeout(timeout, async {
-        let api_key =
-            std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY env var is required");
+        let api_key = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY env var is required");
 
         let model = OpenAIRealtimeModel::new(api_key, "gpt-4o-realtime-preview-2024-12-17")
             .with_transport(OpenAITransport::WebRTC);
@@ -115,17 +107,11 @@ async fn test_openai_webrtc_audio_roundtrip() {
             .with_instruction("You are a helpful assistant.")
             .with_voice("alloy");
 
-        let session = model
-            .connect(config)
-            .await
-            .expect("Failed to connect via OpenAI WebRTC");
+        let session = model.connect(config).await.expect("Failed to connect via OpenAI WebRTC");
 
         // Create a short PCM16 audio chunk (480 samples of silence at 24kHz = 20ms)
         let silence_pcm: Vec<i16> = vec![0i16; 480];
-        let pcm_bytes: Vec<u8> = silence_pcm
-            .iter()
-            .flat_map(|s| s.to_le_bytes())
-            .collect();
+        let pcm_bytes: Vec<u8> = silence_pcm.iter().flat_map(|s| s.to_le_bytes()).collect();
         let audio_chunk = adk_realtime::audio::AudioChunk::pcm16_24khz(pcm_bytes);
 
         // Send audio and commit to trigger processing
@@ -134,17 +120,11 @@ async fn test_openai_webrtc_audio_roundtrip() {
             .await
             .expect("Failed to send audio over WebRTC media track");
 
-        session
-            .commit_audio()
-            .await
-            .expect("Failed to commit audio buffer");
+        session.commit_audio().await.expect("Failed to commit audio buffer");
 
         // We may or may not get a meaningful response from silence,
         // but the session should remain connected and not error out.
-        assert!(
-            session.is_connected(),
-            "Session should remain connected after sending audio"
-        );
+        assert!(session.is_connected(), "Session should remain connected after sending audio");
 
         session.close().await.expect("Failed to close WebRTC session");
     })
@@ -160,18 +140,14 @@ async fn test_openai_webrtc_audio_roundtrip() {
 async fn test_openai_webrtc_session_id() {
     let timeout = tokio::time::Duration::from_secs(30);
     tokio::time::timeout(timeout, async {
-        let api_key =
-            std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY env var is required");
+        let api_key = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY env var is required");
 
         let model = OpenAIRealtimeModel::new(api_key, "gpt-4o-realtime-preview-2024-12-17")
             .with_transport(OpenAITransport::WebRTC);
 
         let config = RealtimeConfig::default();
 
-        let session = model
-            .connect(config)
-            .await
-            .expect("Failed to connect via OpenAI WebRTC");
+        let session = model.connect(config).await.expect("Failed to connect via OpenAI WebRTC");
 
         assert!(
             !session.session_id().is_empty(),

--- a/adk-realtime/tests/opus_roundtrip_tests.rs
+++ b/adk-realtime/tests/opus_roundtrip_tests.rs
@@ -32,9 +32,7 @@ fn arb_frame_size() -> impl Strategy<Value = usize> {
 
 /// Generator for PCM16 audio samples of a valid Opus frame size at 24kHz mono.
 fn arb_pcm16_frame() -> impl Strategy<Value = Vec<i16>> {
-    arb_frame_size().prop_flat_map(|size| {
-        proptest::collection::vec(any::<i16>(), size..=size)
-    })
+    arb_frame_size().prop_flat_map(|size| proptest::collection::vec(any::<i16>(), size..=size))
 }
 
 proptest! {
@@ -112,8 +110,7 @@ proptest! {
 /// **Validates: Requirements 11.2**
 #[test]
 fn test_sample_rate_matches_configured() {
-    let codec = OpusCodec::new(24000, 1)
-        .expect("Failed to create OpusCodec at 24kHz mono");
+    let codec = OpusCodec::new(24000, 1).expect("Failed to create OpusCodec at 24kHz mono");
 
     assert_eq!(
         codec.sample_rate(),
@@ -127,12 +124,7 @@ fn test_sample_rate_matches_configured() {
 /// **Validates: Requirements 11.3**
 #[test]
 fn test_channel_count_matches_configured() {
-    let codec = OpusCodec::new(24000, 1)
-        .expect("Failed to create OpusCodec at 24kHz mono");
+    let codec = OpusCodec::new(24000, 1).expect("Failed to create OpusCodec at 24kHz mono");
 
-    assert_eq!(
-        codec.channels(),
-        Channels::Mono,
-        "Codec channels do not match configured mono"
-    );
+    assert_eq!(codec.channels(), Channels::Mono, "Codec channels do not match configured mono");
 }

--- a/adk-realtime/tests/sdp_offer_tests.rs
+++ b/adk-realtime/tests/sdp_offer_tests.rs
@@ -24,7 +24,7 @@ use str0m::media::{Direction, MediaKind};
 /// across any session configuration the developer might choose.
 fn arb_session_config() -> impl Strategy<Value = (String, String)> {
     (
-        "[a-z]{3,10}",  // model name component
+        "[a-z]{3,10}", // model name component
         prop_oneof![
             Just("alloy".to_string()),
             Just("echo".to_string()),
@@ -47,9 +47,8 @@ fn generate_sdp_offer() -> String {
     // Add the "oai-events" data channel for JSON event exchange
     changes.add_channel("oai-events".to_string());
 
-    let (offer, _pending) = changes
-        .apply()
-        .expect("SDP offer generation should succeed for audio + data channel");
+    let (offer, _pending) =
+        changes.apply().expect("SDP offer generation should succeed for audio + data channel");
 
     offer.to_sdp_string()
 }
@@ -192,9 +191,5 @@ fn test_sdp_offer_contains_ice_credentials() {
         "SDP offer missing a=ice-ufrag. SDP:\n{}",
         sdp_string
     );
-    assert!(
-        sdp_string.contains("a=ice-pwd"),
-        "SDP offer missing a=ice-pwd. SDP:\n{}",
-        sdp_string
-    );
+    assert!(sdp_string.contains("a=ice-pwd"), "SDP offer missing a=ice-pwd. SDP:\n{}", sdp_string);
 }

--- a/adk-realtime/tests/vertex_live_integration_tests.rs
+++ b/adk-realtime/tests/vertex_live_integration_tests.rs
@@ -40,44 +40,28 @@ async fn test_vertex_live_text_exchange() {
         // Read required environment variables
         let project_id = std::env::var("GOOGLE_CLOUD_PROJECT")
             .expect("GOOGLE_CLOUD_PROJECT env var is required");
-        let region = std::env::var("GOOGLE_CLOUD_REGION")
-            .unwrap_or_else(|_| "us-central1".to_string());
+        let region =
+            std::env::var("GOOGLE_CLOUD_REGION").unwrap_or_else(|_| "us-central1".to_string());
 
         // Obtain ADC credentials via Builder (synchronous build, no .await)
         let credentials = google_cloud_auth::credentials::Builder::default()
             .build()
             .expect("Failed to obtain Application Default Credentials");
 
-        let backend = GeminiLiveBackend::Vertex {
-            credentials,
-            region,
-            project_id,
-        };
+        let backend = GeminiLiveBackend::Vertex { credentials, region, project_id };
 
-        let model = GeminiRealtimeModel::new(
-            backend,
-            "models/gemini-live-2.5-flash-native-audio",
-        );
+        let model = GeminiRealtimeModel::new(backend, "models/gemini-live-2.5-flash-native-audio");
 
         let config = RealtimeConfig::default()
             .with_instruction("You are a helpful assistant. Respond briefly.");
 
         // Connect to Vertex AI Live
-        let session = model
-            .connect(config)
-            .await
-            .expect("Failed to connect to Vertex AI Live");
+        let session = model.connect(config).await.expect("Failed to connect to Vertex AI Live");
 
-        assert!(
-            session.is_connected(),
-            "Session should be connected after successful connect"
-        );
+        assert!(session.is_connected(), "Session should be connected after successful connect");
 
         // Send a text message
-        session
-            .send_text("Hello, say one word.")
-            .await
-            .expect("Failed to send text");
+        session.send_text("Hello, say one word.").await.expect("Failed to send text");
 
         // Verify we receive at least one ServerEvent response
         let mut received_event = false;
@@ -119,30 +103,20 @@ async fn test_vertex_live_session_id() {
     tokio::time::timeout(timeout, async {
         let project_id = std::env::var("GOOGLE_CLOUD_PROJECT")
             .expect("GOOGLE_CLOUD_PROJECT env var is required");
-        let region = std::env::var("GOOGLE_CLOUD_REGION")
-            .unwrap_or_else(|_| "us-central1".to_string());
+        let region =
+            std::env::var("GOOGLE_CLOUD_REGION").unwrap_or_else(|_| "us-central1".to_string());
 
         let credentials = google_cloud_auth::credentials::Builder::default()
             .build()
             .expect("Failed to obtain Application Default Credentials");
 
-        let backend = GeminiLiveBackend::Vertex {
-            credentials,
-            region,
-            project_id,
-        };
+        let backend = GeminiLiveBackend::Vertex { credentials, region, project_id };
 
-        let model = GeminiRealtimeModel::new(
-            backend,
-            "models/gemini-live-2.5-flash-native-audio",
-        );
+        let model = GeminiRealtimeModel::new(backend, "models/gemini-live-2.5-flash-native-audio");
 
         let config = RealtimeConfig::default();
 
-        let session = model
-            .connect(config)
-            .await
-            .expect("Failed to connect to Vertex AI Live");
+        let session = model.connect(config).await.expect("Failed to connect to Vertex AI Live");
 
         // Session ID should be non-empty after connection
         assert!(


### PR DESCRIPTION
Fixes two CI failures:

1. **cargo fmt** — formatting diffs in `livekit_bridge.rs` and `vertex_live_integration_tests.rs`
2. **sccache crash** — when GHA cache service is unavailable, sccache crashes `clippy-driver`. Now sccache setup uses `continue-on-error` and `RUSTC_WRAPPER` is only set if sccache is actually healthy. Builds fall back to plain rustc if cache is down.

Both `ci.yml` and `mistralrs-tests.yml` updated.