### PR TITLE
fix(ci): install glib and cmake system deps for --all-features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,10 @@ jobs:
       with:
         components: rustfmt, clippy
 
-    - name: Install mold linker
+    - name: Install system dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y mold
+        sudo apt-get install -y mold cmake libglib2.0-dev
 
     - name: Setup sccache
       uses: mozilla-actions/sccache-action@v0.0.9


### PR DESCRIPTION
CI was failing because `cargo clippy --all-features` enables the `livekit` feature, which pulls in `glib-sys` on Linux. That crate requires `libglib2.0-dev` to be installed.

Also adds `cmake` explicitly (needed for `audiopus` when `openai-webrtc` is enabled).

Consolidates the apt-get step into a single `Install system dependencies` step.