### PR TITLE
fix(ci): add libva-dev for webrtc-sys build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Install system dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y mold cmake libglib2.0-dev
+        sudo apt-get install -y mold cmake libglib2.0-dev libva-dev
 
     - name: Setup sccache
       uses: mozilla-actions/sccache-action@v0.0.9


### PR DESCRIPTION
The `livekit` crate transitively depends on `webrtc-sys`, which requires `libva-dev` (Video Acceleration API headers) on Linux. Adds it to the CI apt-get install step.