### PR TITLE
fix(clippy): collapse nested if-let in livekit_bridge example

### DIFF
--- a/adk-realtime/examples/livekit_bridge.rs
+++ b/adk-realtime/examples/livekit_bridge.rs
@@ -98,13 +98,13 @@ async fn connect_to_livekit()
     // --- Wait for a remote participant's audio track ---
     println!("Waiting for a remote participant's audio track...");
     let remote_track = loop {
-        if let Some(event) = room_events.recv().await {
-            if let RoomEvent::TrackSubscribed { track, .. } = event {
-                if let RemoteTrack::Audio(audio_track) = track {
-                    println!("Subscribed to remote audio track.");
-                    break audio_track;
-                }
-            }
+        if let Some(RoomEvent::TrackSubscribed {
+            track: RemoteTrack::Audio(audio_track),
+            ..
+        }) = room_events.recv().await
+        {
+            println!("Subscribed to remote audio track.");
+            break audio_track;
         }
     };
 


### PR DESCRIPTION
Fixes `collapsible_match` clippy lint by collapsing three nested `if let` patterns into a single match in the livekit_bridge example.