### PR TITLE
fix(fmt): apply rustfmt to livekit_bridge example

### DIFF
--- a/adk-realtime/examples/livekit_bridge.rs
+++ b/adk-realtime/examples/livekit_bridge.rs
@@ -98,10 +98,8 @@ async fn connect_to_livekit()
     // --- Wait for a remote participant's audio track ---
     println!("Waiting for a remote participant's audio track...");
     let remote_track = loop {
-        if let Some(RoomEvent::TrackSubscribed {
-            track: RemoteTrack::Audio(audio_track),
-            ..
-        }) = room_events.recv().await
+        if let Some(RoomEvent::TrackSubscribed { track: RemoteTrack::Audio(audio_track), .. }) =
+            room_events.recv().await
         {
             println!("Subscribed to remote audio track.");
             break audio_track;


### PR DESCRIPTION
Applies rustfmt formatting to the collapsed if-let pattern from #120.