### PR TITLE
fix: add required-features for vertex_live_tools example

### DIFF
--- a/adk-realtime/Cargo.toml
+++ b/adk-realtime/Cargo.toml
@@ -80,6 +80,10 @@ name = "vertex_live_voice"
 required-features = ["vertex-live"]
 
 [[example]]
+name = "vertex_live_tools"
+required-features = ["vertex-live"]
+
+[[example]]
 name = "livekit_bridge"
 required-features = ["livekit", "openai"]
 


### PR DESCRIPTION
Adds missing [[example]] entry with required-features = ["vertex-live"] for vertex_live_tools, fixing clippy build without the feature enabled.