### PR TITLE
feat(agent): add generate_content_config to LlmAgentBuilder

### DIFF
--- a/adk-core/src/model.rs
+++ b/adk-core/src/model.rs
@@ -22,7 +22,7 @@ pub struct LlmRequest {
     pub tools: HashMap<String, serde_json::Value>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct GenerateContentConfig {
     pub temperature: Option<f32>,
     pub top_p: Option<f32>,


### PR DESCRIPTION
## Summary

Add `generate_content_config` to `LlmAgentBuilder` so users can set default generation parameters (temperature, top_p, top_k, max_output_tokens) at the agent level.

## Changes

- **adk-core**: Derive `Default` for `GenerateContentConfig`
- **adk-agent**: Add `generate_content_config` field to `LlmAgent` and `LlmAgentBuilder`
- **adk-agent**: Add builder methods: `generate_content_config()`, `temperature()`, `top_p()`, `top_k()`, `max_output_tokens()`
- **adk-agent**: Merge agent-level config with `output_schema` in the main execution loop

## Usage

```rust
// Full config
let agent = LlmAgentBuilder::new("my-agent")
    .model(model)
    .generate_content_config(GenerateContentConfig {
        temperature: Some(0.7),
        max_output_tokens: Some(2048),
        ..Default::default()
    })
    .build()?;

// Convenience methods
let agent = LlmAgentBuilder::new("my-agent")
    .model(model)
    .temperature(0.7)
    .max_output_tokens(2048)
    .build()?;
```

Fixes #129