### PR TITLE
chore: remove broken pre-commit-config symlink and add to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ devenv.lock
 .direnv/
 .envrc
 .envrc.local
+.pre-commit-config.yaml
 
 # Environment / Secrets
 .env

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,1 +1,0 @@
-/nix/store/k2yyf5sasskl3daqm40x3frn5d3hm0ja-pre-commit-config.json


### PR DESCRIPTION
Removes the .pre-commit-config.yaml Nix store symlink from PR #134 (broken on non-Nix machines) and adds it to .gitignore since devenv generates it dynamically via git-hooks.