### PR TITLE
fix(runner): preserve tool/function role in conversation history

### DIFF
--- a/adk-runner/src/context.rs
+++ b/adk-runner/src/context.rs
@@ -120,13 +120,13 @@ impl adk_core::Session for MutableSession {
             }
 
             if let Some(content) = &event.llm_response.content {
-                let role = match event.author.as_str() {
-                    "user" => "user".to_string(),
-                    _ => "model".to_string(),
-                };
-
                 let mut mapped_content = content.clone();
-                mapped_content.role = role;
+                mapped_content.role = match (event.author.as_str(), content.role.as_str()) {
+                    ("user", _) => "user",
+                    (_, "function" | "tool") => content.role.as_str(),
+                    _ => "model",
+                }
+                .to_string();
                 history.push(mapped_content);
             }
         }


### PR DESCRIPTION
## Summary
- `conversation_history()` in `MutableSession` was unconditionally mapping all non-user event roles to `"model"`, which overwrote `"function"` and `"tool"` roles on tool response events
- The role mapping now checks the original `content.role` and preserves `"function"` / `"tool"` roles, so LLM providers receive correctly structured conversation history with tool responses intact
- Added two targeted tests: one verifying tool roles are preserved through a full user → function_call → function_response cycle, and one confirming regular agent events still map to `"model"`

## Test plan
- [x] `cargo +nightly test -p adk-runner --test context_tests` — all 13 tests pass
- [x] Verified in an end-to-end OpenAI agent run that tool-use conversations complete without provider errors