### PR TITLE
fix(studio): override ajv to 6.14.0 — Dependabot #38

### DIFF
--- a/adk-studio/ui/package.json
+++ b/adk-studio/ui/package.json
@@ -24,7 +24,8 @@
   },
   "pnpm": {
     "overrides": {
-      "minimatch@<10.2.1": "^10.2.1"
+      "minimatch@<10.2.1": "^10.2.1",
+      "ajv@<6.14.0": "^6.14.0"
     }
   },
   "devDependencies": {

--- a/adk-studio/ui/pnpm-lock.yaml
+++ b/adk-studio/ui/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   minimatch@<10.2.1: ^10.2.1
+  ajv@<6.14.0: ^6.14.0
 
 importers:
 
@@ -800,8 +801,8 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
-  ajv@6.12.6:
-    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+  ajv@6.14.0:
+    resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
@@ -2361,7 +2362,7 @@ snapshots:
 
   '@eslint/eslintrc@3.3.3':
     dependencies:
-      ajv: 6.12.6
+      ajv: 6.14.0
       debug: 4.4.3
       espree: 10.4.0
       globals: 14.0.0
@@ -2780,7 +2781,7 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ajv@6.12.6:
+  ajv@6.14.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
@@ -3071,7 +3072,7 @@ snapshots:
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
       '@types/estree': 1.0.8
-      ajv: 6.12.6
+      ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
       debug: 4.4.3


### PR DESCRIPTION
Overrides transitive ajv 6.12.6 (via eslint/typescript-eslint) to 6.14.0 to fix ReDoS vulnerability.

Semver-compatible minor bump. Lint and all 252 UI tests pass.

Fixes #38