### PR TITLE
refactor(realtime): replace glob LiveKit re-exports with explicit, API-quality type surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+#### adk-realtime
+- **LiveKit re-exports**: Replaced glob `pub use livekit::prelude::*` with explicit type re-exports in `adk_realtime::livekit` module, eliminating semver hazard from upstream prelude changes
+- **Breaking**: Removed crate-level `pub use ::livekit` and `pub use ::livekit_api` re-exports that collided with the `livekit` module namespace — use `adk_realtime::livekit::{AccessToken, VideoGrants}` instead of `adk_realtime::livekit_api::access_token::{AccessToken, VideoGrants}`
+- Added `AudioFrame` re-export to `adk_realtime::livekit` for downstream audio processing
+
 ## [0.3.2] - 2026-02-17
 
 ### ⭐ Highlights

--- a/adk-realtime/src/lib.rs
+++ b/adk-realtime/src/lib.rs
@@ -96,12 +96,6 @@ pub mod gemini;
 #[cfg(feature = "livekit")]
 pub mod livekit;
 
-// Re-export core dependencies for downstream crate ergonomics
-#[cfg(feature = "livekit")]
-pub use ::livekit;
-#[cfg(feature = "livekit")]
-pub use ::livekit_api;
-
 // Re-exports
 pub use agent::{RealtimeAgent, RealtimeAgentBuilder};
 pub use audio::{AudioEncoding, AudioFormat};

--- a/adk-realtime/src/livekit/mod.rs
+++ b/adk-realtime/src/livekit/mod.rs
@@ -1,38 +1,155 @@
 //! LiveKit WebRTC bridge for `adk-realtime`.
 //!
 //! This module provides a provider-agnostic bridge between LiveKit rooms and
-//! realtime AI sessions. It includes:
+//! realtime AI sessions. It re-exports the subset of [`livekit`] and
+//! [`livekit_api`] types that are needed to build a voice agent, so downstream
+//! crates only need `adk-realtime` in their `Cargo.toml`.
 //!
-//! - [`LiveKitEventHandler`] — wraps any [`EventHandler`](crate::runner::EventHandler)
-//!   to push model audio to a LiveKit [`NativeAudioSource`](livekit::native::NativeAudioSource).
-//! - [`bridge_input`] — reads audio from a LiveKit [`RemoteAudioTrack`](livekit::track::RemoteAudioTrack)
-//!   and feeds it to a [`RealtimeRunner`](crate::RealtimeRunner) as base64-encoded PCM16 at 24kHz.
-//! - [`bridge_gemini_input`] — same as `bridge_input` but resamples to 16kHz mono for Gemini.
+//! # Provided utilities
 //!
-//! # Feature Flag
+//! | Type | Purpose |
+//! |------|---------|
+//! | [`LiveKitEventHandler`] | Wraps any [`EventHandler`](crate::runner::EventHandler) to push model audio to a [`NativeAudioSource`]. |
+//! | [`bridge_input`] | Reads audio from a [`RemoteAudioTrack`] and feeds 24 kHz PCM16 to a [`RealtimeRunner`](crate::RealtimeRunner). |
+//! | [`bridge_gemini_input`] | Same as [`bridge_input`] but resamples to 16 kHz mono for Gemini Live. |
 //!
-//! This module is only available when the `livekit` feature is enabled:
+//! # Feature flag
+//!
+//! This module requires the **`livekit`** Cargo feature:
 //!
 //! ```toml
 //! [dependencies]
-//! adk-realtime = { version = "...", features = ["livekit"] }
+//! adk-realtime = { version = "0.3", features = ["livekit"] }
+//! ```
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use adk_realtime::livekit::{
+//!     AccessToken, AudioSourceOptions, LiveKitEventHandler, NativeAudioSource,
+//!     Room, RoomOptions, RtcAudioSource, TrackPublishOptions, VideoGrants,
+//!     bridge_gemini_input,
+//! };
+//!
+//! // 1. Generate a token
+//! let token = AccessToken::with_api_key(&key, &secret)
+//!     .with_identity("agent")
+//!     .with_grants(VideoGrants {
+//!         room_join: true,
+//!         room: "my-room".into(),
+//!         ..Default::default()
+//!     })
+//!     .to_jwt()?;
+//!
+//! // 2. Connect to the room
+//! let (room, mut events) = Room::connect(&url, &token, RoomOptions::default()).await?;
+//!
+//! // 3. Publish an audio track
+//! let audio_source = NativeAudioSource::new(AudioSourceOptions::default(), 24000, 1);
+//! let handler = LiveKitEventHandler::new(inner_handler, audio_source.clone());
 //! ```
 
 mod bridge;
 mod handler;
 
+// ── Our bridge utilities ────────────────────────────────────────────────
+
 pub use bridge::{bridge_gemini_input, bridge_input};
 pub use handler::LiveKitEventHandler;
 
-// Re-export common types at the module level for basic ergonomics
+// ── Room and connection ─────────────────────────────────────────────────
+//
+// Core types for connecting to and interacting with a LiveKit room.
+
+pub use livekit::prelude::{
+    ConnectionState, DataPacket, DataPacketKind, Room, RoomError, RoomEvent, RoomOptions,
+    RoomResult,
+};
+
+// ── Participants ────────────────────────────────────────────────────────
+
+pub use livekit::prelude::{LocalParticipant, Participant, RemoteParticipant};
+
+// ── Tracks ──────────────────────────────────────────────────────────────
+//
+// Track types used when subscribing to remote audio or publishing local
+// audio back into the room.
+
+pub use livekit::prelude::{
+    LocalAudioTrack, LocalTrack, RemoteAudioTrack, RemoteTrack, RemoteVideoTrack, Track, TrackKind,
+    TrackSource,
+};
+
+/// Options for publishing a local track (codec preferences, simulcast, etc.).
+pub use livekit::options::TrackPublishOptions;
+
+// ── Audio I/O ───────────────────────────────────────────────────────────
+//
+// Low-level audio primitives for pushing PCM frames into a room or
+// reading them from a subscribed track.
+
+/// A single audio frame (PCM samples + sample rate + channel count).
+pub use livekit::webrtc::audio_frame::AudioFrame;
+
+/// Builder options, source wrapper, and platform-native source for
+/// pushing audio frames into a LiveKit audio track.
+pub use livekit::webrtc::audio_source::{
+    AudioSourceOptions, RtcAudioSource, native::NativeAudioSource,
+};
+
+// ── Authentication ──────────────────────────────────────────────────────
+//
+// Token generation for room access. These come from the `livekit-api`
+// crate so downstream consumers do not need a direct dependency on it.
+
+/// JWT access token for authenticating participants.
 pub use livekit_api::access_token::AccessToken;
 
-/// A prelude for common LiveKit types and bridges.
+/// Permission grants embedded in an [`AccessToken`].
+pub use livekit_api::access_token::VideoGrants;
+
+/// Convenience prelude that re-exports everything above plus our bridge
+/// utilities.
 ///
-/// This simplifies imports for downstream crates that want to use `adk-realtime`
-/// as their primary entry point for LiveKit integration.
+/// ```rust,ignore
+/// use adk_realtime::livekit::prelude::*;
+/// ```
 pub mod prelude {
-    pub use crate::livekit::{LiveKitEventHandler, bridge_gemini_input, bridge_input};
-    pub use livekit::prelude::*;
-    pub use livekit_api::access_token::{AccessToken, VideoGrants};
+    pub use super::{
+        // Authentication
+        AccessToken,
+        // Audio I/O
+        AudioFrame,
+        AudioSourceOptions,
+        // Room & connection
+        ConnectionState,
+        DataPacket,
+        DataPacketKind,
+        // Bridge utilities
+        LiveKitEventHandler,
+        // Tracks
+        LocalAudioTrack,
+        // Participants
+        LocalParticipant,
+        LocalTrack,
+        NativeAudioSource,
+        Participant,
+        RemoteAudioTrack,
+        RemoteParticipant,
+        RemoteTrack,
+        RemoteVideoTrack,
+        Room,
+        RoomError,
+        RoomEvent,
+        RoomOptions,
+        RoomResult,
+        RtcAudioSource,
+        Track,
+        TrackKind,
+        TrackPublishOptions,
+        TrackSource,
+        VideoGrants,
+        bridge_gemini_input,
+        bridge_input,
+    };
 }


### PR DESCRIPTION
## Summary

Replace `pub use livekit::prelude::*` (glob) with categorized, explicit re-exports in `adk_realtime::livekit`. Removes two conflicting crate-level re-exports that collided with the `livekit` module namespace.

## Motivation

The existing glob re-export (`pub use livekit::prelude::*`) is a **semver hazard**: if the upstream `livekit` crate adds a new type to their prelude in a patch release, it could silently shadow or collide with names in downstream code. Explicit re-exports give `adk-realtime` full control over its public API surface.

The removed `pub use ::livekit` and `pub use ::livekit_api` at the crate root caused a **name collision** with the `pub mod livekit` module in `lib.rs` since Rust 2024 edition.

## Changes

### `adk-realtime/src/livekit/mod.rs`
- Replace glob with explicit re-exports organized by domain:
  - **Room & connection**: `Room`, `RoomEvent`, `RoomOptions`, `ConnectionState`, ...
  - **Participants**: `LocalParticipant`, `RemoteParticipant`, ...
  - **Tracks**: `RemoteAudioTrack`, `LocalAudioTrack`, `TrackPublishOptions`, ...
  - **Audio I/O**: `NativeAudioSource`, `RtcAudioSource`, `AudioSourceOptions`, `AudioFrame` (newly added)
  - **Authentication**: `AccessToken`, `VideoGrants`
- Add module-level rustdoc with feature flag instructions and usage example
- `prelude` submodule now delegates to `super::` (single source of truth, no duplication)

### `adk-realtime/src/lib.rs`
- Remove `pub use ::livekit` and `pub use ::livekit_api` crate-level re-exports that collided with the `livekit` module

### `CHANGELOG.md`
- Added `[Unreleased]` section documenting the breaking change

## Breaking Change

```diff
-use adk_realtime::livekit_api::access_token::{AccessToken, VideoGrants};
+use adk_realtime::livekit::{AccessToken, VideoGrants};
```

## Quality Gates

- [x] `cargo fmt`
- [x] `cargo clippy -p adk-realtime --features livekit -- -D warnings` — zero warnings
- [x] `cargo check` — full workspace