### PR TITLE
fix(realtime): enable tokio-tungstenite in livekit feature and fix gl…

### DIFF
--- a/adk-realtime/Cargo.toml
+++ b/adk-realtime/Cargo.toml
@@ -100,7 +100,7 @@ gemini = ["dep:tokio-tungstenite", "dep:adk-gemini"]
 # Enable Vertex AI Live API support (requires gemini + OAuth2/ADC auth)
 vertex-live = ["gemini", "dep:google-cloud-auth"]
 # Enable LiveKit WebRTC bridge
-livekit = ["dep:livekit", "dep:livekit-api"]
+livekit = ["dep:livekit", "dep:livekit-api", "dep:tokio-tungstenite"]
 # Enable OpenAI WebRTC transport (requires openai + Sans-IO WebRTC + Opus codec)
 openai-webrtc = ["openai", "dep:str0m", "dep:audiopus", "dep:reqwest"]
 # Enable all providers and transports (except openai-webrtc which requires cmake)

--- a/devenv.nix
+++ b/devenv.nix
@@ -61,6 +61,7 @@
 
     # System libraries required by livekit-webrtc
     glib
+    pkgs.glib.dev
     libva
 
     # Protobuf (for gRPC codegen if needed)
@@ -98,6 +99,9 @@
 
     # Explicitly set PROTOC for build-scripts (e.g., lance-encoding)
     PROTOC = "${pkgs.protobuf}/bin/protoc";
+
+    # Ensure pkg-config can find glib
+    PKG_CONFIG_PATH = "${pkgs.glib.dev}/lib/pkgconfig:$PKG_CONFIG_PATH";
   };
 
   # --------------------------------------------------------------------------


### PR DESCRIPTION
## What

Fixes compilation errors for the `livekit` feature in `adk-realtime` and resolves `glib-sys` system dependency issues within the Nix development environment.

## Why

Enabling the `livekit` feature previously caused a build failure due to a missing `tokio-tungstenite` dependency. 

Additionally, building `livekit-webrtc` (specifically the underlying `glib-sys` crate) failed in the Nix environment because `pkg-config` could not locate the required `glib` development headers.

## How

* **`adk-realtime/Cargo.toml`:** Appended `dep:tokio-tungstenite` to the `livekit` feature array.
* **`devenv.nix`:** Added `pkgs.glib.dev` to the system packages and exported `PKG_CONFIG_PATH` (`"${pkgs.glib.dev}/lib/pkgconfig:$PKG_CONFIG_PATH"`) to ensure build scripts correctly resolve the C bindings.

## PR Checklist

### Quality Gates (all required)

- [ ] `devenv shell fmt` — code is formatted (Edition 2024)
- [ ] `devenv shell clippy` — zero warnings (-D warnings)
- [ ] `devenv shell test` — all non-ignored tests pass
- [ ] `devenv shell check` — fast workspace compilation check

### Code Quality

- [ ] New code has tests (unit, integration, or property tests as appropriate)
- [ ] Public APIs have rustdoc comments with `# Example` sections
- [ ] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [ ] No hardcoded secrets, API keys, or local paths

### Hygiene

- [ ] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [ ] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [ ] PR targets `main` branch

### Documentation (if applicable)

- [ ] CHANGELOG.md updated for user-facing changes
- [ ] README updated if crate capabilities changed
- [ ] Examples added or updated for new features