### PR TITLE
Validate empty artifact names in instruction template and add tests

### DIFF
--- a/adk-core/src/instruction_template.rs
+++ b/adk-core/src/instruction_template.rs
@@ -94,6 +94,12 @@ async fn replace_match(ctx: &dyn InvocationContext, content: &str) -> Result<Str
 
     // Handle artifact.{name} pattern
     if let Some(file_name) = var_name.strip_prefix("artifact.") {
+        if file_name.is_empty() {
+            return Err(AdkError::Agent(
+                "Invalid artifact name '': must include a file name after 'artifact.'".to_string(),
+            ));
+        }
+
         // Reject path traversal attempts in artifact names
         if file_name.contains("..") || file_name.contains('/') || file_name.contains('\\') {
             return Err(AdkError::Agent(format!(

--- a/adk-core/tests/instruction_template_tests.rs
+++ b/adk-core/tests/instruction_template_tests.rs
@@ -237,6 +237,34 @@ async fn test_no_artifacts_service_error() {
 }
 
 #[tokio::test]
+async fn test_empty_artifact_name_error() {
+    let ctx = MockContext::new().with_artifacts();
+    let template = "Content: {artifact.}";
+    let result = inject_session_state(&ctx, template).await;
+
+    match result {
+        Err(AdkError::Agent(msg)) => {
+            assert!(msg.contains("must include a file name after 'artifact.'"));
+        }
+        _ => panic!("Expected AdkError::Agent with empty artifact-name guidance"),
+    }
+}
+
+#[tokio::test]
+async fn test_empty_optional_artifact_name_error() {
+    let ctx = MockContext::new().with_artifacts();
+    let template = "Content: {artifact.?}";
+    let result = inject_session_state(&ctx, template).await;
+
+    match result {
+        Err(AdkError::Agent(msg)) => {
+            assert!(msg.contains("must include a file name after 'artifact.'"));
+        }
+        _ => panic!("Expected AdkError::Agent for optional empty artifact name"),
+    }
+}
+
+#[tokio::test]
 async fn test_complex_mix() {
     let ctx = MockContext::new().with_artifacts();
     let template = "{user_name} read '{artifact.welcome.txt}' (Theme: {user:pref?})";


### PR DESCRIPTION
### Motivation
- Prevent ambiguous or invalid `artifact.` placeholders (e.g. `{artifact.}`) from being treated as valid and provide a clear error message when no file name is supplied.

### Description
- Add an explicit check in `replace_match` to return `AdkError::Agent` when the `artifact.` prefix is followed by an empty name while keeping existing path traversal checks and artifact loading logic.
- Add tests `test_empty_artifact_name_error` and `test_empty_optional_artifact_name_error` to assert the new error behavior for both required and optional empty artifact placeholders.

### Testing
- Ran unit tests with `cargo test`, including the new artifact name tests and existing artifact injection tests, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69aad10a44948327961a82132f1f28d8)