### PR TITLE
feat: make Google Cloud dependencies optional via feature flag (#181)

### DIFF
--- a/adk-gemini/Cargo.toml
+++ b/adk-gemini/Cargo.toml
@@ -22,9 +22,9 @@ license = "Apache-2.0"
 repository = "https://github.com/zavora-ai/adk-rust"
 
 [features]
-default = ["studio"]
+default = ["studio", "vertex"]
 studio = []
-vertex = []
+vertex = ["dep:google-cloud-aiplatform-v1", "dep:google-cloud-auth", "dep:google-cloud-gax"]
 
 [lib]
 name = "adk_gemini"
@@ -224,15 +224,18 @@ version = "^0.3"
 version = "1.7.0"
 features = ["prediction-service", "default-rustls-provider"]
 default-features = false
+optional = true
 
 [dependencies.google-cloud-auth]
 version = "1.4.0"
 default-features = false
 features = ["default-rustls-provider"]
+optional = true
 
 [dependencies.google-cloud-gax]
 version = "1.7.0"
 default-features = false
+optional = true
 
 [dependencies.mime]
 version = "0.3"

--- a/adk-gemini/README.md
+++ b/adk-gemini/README.md
@@ -32,6 +32,20 @@ Rust client library for Google's Gemini API — content generation, streaming, f
 adk-gemini = "0.3.2"
 ```
 
+### Feature Flags
+
+By default, both AI Studio and Vertex AI backends are enabled. You can disable Vertex AI support to reduce compilation time and dependencies:
+
+```toml
+[dependencies]
+# AI Studio only (faster compilation, no Google Cloud dependencies)
+adk-gemini = { version = "0.3.2", default-features = false, features = ["studio"] }
+```
+
+Available features:
+- `studio` (default) — AI Studio REST API backend
+- `vertex` (default) — Vertex AI backend with Google Cloud dependencies
+
 Or through `adk-model`:
 
 ```toml

--- a/adk-gemini/src/backend/mod.rs
+++ b/adk-gemini/src/backend/mod.rs
@@ -7,6 +7,7 @@
 //! Inspired by [PR #74](https://github.com/zavora-ai/adk-rust/pull/74) by @mikefaille.
 
 pub mod studio;
+#[cfg(feature = "vertex")]
 pub mod vertex;
 
 use crate::{

--- a/adk-gemini/src/client.rs
+++ b/adk-gemini/src/client.rs
@@ -14,7 +14,9 @@ use crate::{
 };
 use eventsource_stream::EventStreamError;
 use futures::Stream;
+#[cfg(feature = "vertex")]
 use google_cloud_aiplatform_v1::client::PredictionService;
+#[cfg(feature = "vertex")]
 use google_cloud_auth::credentials::{self, Credentials};
 use mime::Mime;
 use reqwest::{ClientBuilder, header::InvalidHeaderValue};
@@ -298,63 +300,77 @@ pub enum Error {
     },
 
     #[snafu(display("failed to build google cloud credentials"))]
+    #[cfg(feature = "vertex")]
     GoogleCloudAuth {
         source: google_cloud_auth::build_errors::Error,
     },
 
     #[snafu(display("failed to obtain google cloud auth headers"))]
+    #[cfg(feature = "vertex")]
     GoogleCloudCredentialHeaders {
         source: google_cloud_auth::errors::CredentialsError,
     },
 
     #[snafu(display("google cloud credentials returned NotModified without cached headers"))]
+    #[cfg(feature = "vertex")]
     GoogleCloudCredentialHeadersUnavailable,
 
     #[snafu(display("failed to parse google cloud credentials JSON"))]
+    #[cfg(feature = "vertex")]
     GoogleCloudCredentialParse {
         source: serde_json::Error,
     },
 
     #[snafu(display("failed to build google cloud vertex client"))]
+    #[cfg(feature = "vertex")]
     GoogleCloudClientBuild {
         source: google_cloud_gax::client_builder::Error,
     },
 
     #[snafu(display("failed to send google cloud vertex request"))]
+    #[cfg(feature = "vertex")]
     GoogleCloudRequest {
         source: google_cloud_aiplatform_v1::Error,
     },
 
     #[snafu(display("failed to serialize google cloud request"))]
+    #[cfg(feature = "vertex")]
     GoogleCloudRequestSerialize {
         source: serde_json::Error,
     },
 
     #[snafu(display("failed to deserialize google cloud request"))]
+    #[cfg(feature = "vertex")]
     GoogleCloudRequestDeserialize {
         source: serde_json::Error,
     },
 
     #[snafu(display("failed to serialize google cloud response"))]
+    #[cfg(feature = "vertex")]
     GoogleCloudResponseSerialize {
         source: serde_json::Error,
     },
 
     #[snafu(display("failed to deserialize google cloud response"))]
+    #[cfg(feature = "vertex")]
     GoogleCloudResponseDeserialize {
         source: serde_json::Error,
     },
 
     #[snafu(display("google cloud request payload is not an object"))]
+    #[cfg(feature = "vertex")]
     GoogleCloudRequestNotObject,
 
     #[snafu(display("google cloud configuration is required for this authentication mode"))]
+    #[cfg(feature = "vertex")]
     MissingGoogleCloudConfig,
 
     #[snafu(display("google cloud authentication is required for this configuration"))]
+    #[cfg(feature = "vertex")]
     MissingGoogleCloudAuth,
 
     #[snafu(display("service account JSON is missing required field 'project_id'"))]
+    #[cfg(feature = "vertex")]
     MissingGoogleCloudProjectId,
 
     #[snafu(display("api key is required for this configuration"))]
@@ -410,6 +426,7 @@ impl GeminiClient {
     }
 
     /// Create a client backed by Vertex AI.
+    #[cfg(feature = "vertex")]
     fn with_vertex(model: Model, vertex: backend::vertex::VertexBackend) -> Self {
         Self { model, backend: Box::new(vertex) }
     }
@@ -615,12 +632,14 @@ impl GeminiClient {
 // Auth helpers & builder infrastructure
 // ══════════════════════════════════════════════════════════════════════
 
+#[cfg(feature = "vertex")]
 #[derive(Debug, Clone)]
 enum GoogleCloudAuth {
     ApiKey(String),
     Credentials(Credentials),
 }
 
+#[cfg(feature = "vertex")]
 impl GoogleCloudAuth {
     fn credentials(&self) -> Result<Credentials, Error> {
         match self {
@@ -632,18 +651,21 @@ impl GoogleCloudAuth {
     }
 }
 
+#[cfg(feature = "vertex")]
 #[derive(Debug, Clone)]
 struct GoogleCloudConfig {
     project_id: String,
     location: String,
 }
 
+#[cfg(feature = "vertex")]
 impl GoogleCloudConfig {
     fn endpoint(&self) -> String {
         format!("https://{}-aiplatform.googleapis.com", self.location)
     }
 }
 
+#[cfg(feature = "vertex")]
 fn extract_service_account_project_id(service_account_json: &str) -> Result<String, Error> {
     let value: serde_json::Value =
         serde_json::from_str(service_account_json).context(GoogleCloudCredentialParseSnafu)?;
@@ -658,6 +680,7 @@ fn extract_service_account_project_id(service_account_json: &str) -> Result<Stri
     Ok(project_id.to_string())
 }
 
+#[cfg(feature = "vertex")]
 fn build_vertex_prediction_service(
     endpoint: String,
     credentials: Credentials,
@@ -711,8 +734,10 @@ pub struct GeminiBuilder {
     model: Model,
     client_builder: ClientBuilder,
     base_url: Url,
+    #[cfg(feature = "vertex")]
     google_cloud: Option<GoogleCloudConfig>,
     api_key: Option<String>,
+    #[cfg(feature = "vertex")]
     google_cloud_auth: Option<GoogleCloudAuth>,
 }
 
@@ -722,8 +747,10 @@ impl GeminiBuilder {
             model: Model::default(),
             client_builder: ClientBuilder::default(),
             base_url: DEFAULT_BASE_URL.clone(),
+            #[cfg(feature = "vertex")]
             google_cloud: None,
             api_key: Some(key.into()),
+            #[cfg(feature = "vertex")]
             google_cloud_auth: None,
         }
     }
@@ -740,11 +767,15 @@ impl GeminiBuilder {
 
     pub fn with_base_url(mut self, base_url: Url) -> Self {
         self.base_url = base_url;
-        self.google_cloud = None;
-        self.google_cloud_auth = None;
+        #[cfg(feature = "vertex")]
+        {
+            self.google_cloud = None;
+            self.google_cloud_auth = None;
+        }
         self
     }
 
+    #[cfg(feature = "vertex")]
     pub fn with_service_account_json(mut self, service_account_json: &str) -> Result<Self, Error> {
         let value =
             serde_json::from_str(service_account_json).context(GoogleCloudCredentialParseSnafu)?;
@@ -755,6 +786,7 @@ impl GeminiBuilder {
         Ok(self)
     }
 
+    #[cfg(feature = "vertex")]
     pub fn with_google_cloud<P: Into<String>, L: Into<String>>(
         mut self,
         project_id: P,
@@ -765,6 +797,7 @@ impl GeminiBuilder {
         self
     }
 
+    #[cfg(feature = "vertex")]
     pub fn with_google_cloud_adc(mut self) -> Result<Self, Error> {
         let credentials = google_cloud_auth::credentials::Builder::default()
             .build()
@@ -773,6 +806,7 @@ impl GeminiBuilder {
         Ok(self)
     }
 
+    #[cfg(feature = "vertex")]
     pub fn with_google_cloud_wif_json(mut self, wif_json: &str) -> Result<Self, Error> {
         let value = serde_json::from_str(wif_json).context(GoogleCloudCredentialParseSnafu)?;
         let credentials = google_cloud_auth::credentials::external_account::Builder::new(value)
@@ -784,34 +818,38 @@ impl GeminiBuilder {
 
     /// Builds the `Gemini` client.
     pub fn build(self) -> Result<Gemini, Error> {
-        if self.google_cloud.is_none() && self.google_cloud_auth.is_some() {
-            return MissingGoogleCloudConfigSnafu.fail();
-        }
+        #[cfg(feature = "vertex")]
+        {
+            if self.google_cloud.is_none() && self.google_cloud_auth.is_some() {
+                return MissingGoogleCloudConfigSnafu.fail();
+            }
 
-        // ── Vertex AI path ──────────────────────────────────────────────
-        if let Some(config) = &self.google_cloud {
-            let model =
-                Model::Custom(self.model.vertex_model_path(&config.project_id, &config.location));
-            let google_cloud_auth = match self.google_cloud_auth {
-                Some(auth) => auth,
-                None => match self.api_key {
-                    Some(api_key) if !api_key.is_empty() => GoogleCloudAuth::ApiKey(api_key),
-                    _ => return MissingGoogleCloudAuthSnafu.fail(),
-                },
-            };
-            let credentials = google_cloud_auth.credentials()?;
-            let endpoint = config.endpoint();
-            let prediction =
-                build_vertex_prediction_service(endpoint.clone(), credentials.clone())?;
+            // ── Vertex AI path ──────────────────────────────────────────────
+            if let Some(config) = &self.google_cloud {
+                let model = Model::Custom(
+                    self.model.vertex_model_path(&config.project_id, &config.location),
+                );
+                let google_cloud_auth = match self.google_cloud_auth {
+                    Some(auth) => auth,
+                    None => match self.api_key {
+                        Some(api_key) if !api_key.is_empty() => GoogleCloudAuth::ApiKey(api_key),
+                        _ => return MissingGoogleCloudAuthSnafu.fail(),
+                    },
+                };
+                let credentials = google_cloud_auth.credentials()?;
+                let endpoint = config.endpoint();
+                let prediction =
+                    build_vertex_prediction_service(endpoint.clone(), credentials.clone())?;
 
-            let vertex = backend::vertex::VertexBackend::new(
-                model.clone(),
-                prediction,
-                credentials,
-                endpoint,
-            );
+                let vertex = backend::vertex::VertexBackend::new(
+                    model.clone(),
+                    prediction,
+                    credentials,
+                    endpoint,
+                );
 
-            return Ok(Gemini { client: Arc::new(GeminiClient::with_vertex(model, vertex)) });
+                return Ok(Gemini { client: Arc::new(GeminiClient::with_vertex(model, vertex)) });
+            }
         }
 
         // ── AI Studio REST path ─────────────────────────────────────────
@@ -870,6 +908,7 @@ impl Gemini {
     }
 
     /// Create a new client using Vertex AI (Google Cloud) endpoints.
+    #[cfg(feature = "vertex")]
     pub fn with_google_cloud<K: AsRef<str>, P: AsRef<str>, L: AsRef<str>>(
         api_key: K,
         project_id: P,
@@ -879,6 +918,7 @@ impl Gemini {
     }
 
     /// Create a new client using Vertex AI (Google Cloud) endpoints and a specific model.
+    #[cfg(feature = "vertex")]
     pub fn with_google_cloud_model<K: AsRef<str>, P: AsRef<str>, L: AsRef<str>, M: Into<Model>>(
         api_key: K,
         project_id: P,
@@ -892,6 +932,7 @@ impl Gemini {
     }
 
     /// Create a new client using Vertex AI (Google Cloud) endpoints with Application Default Credentials (ADC).
+    #[cfg(feature = "vertex")]
     pub fn with_google_cloud_adc<P: AsRef<str>, L: AsRef<str>>(
         project_id: P,
         location: L,
@@ -900,6 +941,7 @@ impl Gemini {
     }
 
     /// Create a new client using Vertex AI (Google Cloud) endpoints and a specific model with ADC.
+    #[cfg(feature = "vertex")]
     pub fn with_google_cloud_adc_model<P: AsRef<str>, L: AsRef<str>, M: Into<Model>>(
         project_id: P,
         location: L,
@@ -913,6 +955,7 @@ impl Gemini {
     }
 
     /// Create a new client using Vertex AI (Google Cloud) endpoints and Workload Identity Federation JSON.
+    #[cfg(feature = "vertex")]
     pub fn with_google_cloud_wif_json<P: AsRef<str>, L: AsRef<str>, M: Into<Model>>(
         wif_json: &str,
         project_id: P,
@@ -927,11 +970,13 @@ impl Gemini {
     }
 
     /// Create a new client using a service account JSON key.
+    #[cfg(feature = "vertex")]
     pub fn with_service_account_json(service_account_json: &str) -> Result<Self, Error> {
         Self::with_service_account_json_model(service_account_json, Model::default())
     }
 
     /// Create a new client using a service account JSON key and a specific model.
+    #[cfg(feature = "vertex")]
     pub fn with_service_account_json_model<M: Into<Model>>(
         service_account_json: &str,
         model: M,
@@ -945,6 +990,7 @@ impl Gemini {
     }
 
     /// Create a new client using Vertex AI (Google Cloud) endpoints and a service account JSON key.
+    #[cfg(feature = "vertex")]
     pub fn with_google_cloud_service_account_json<M: Into<Model>>(
         service_account_json: &str,
         project_id: &str,

--- a/adk-model/Cargo.toml
+++ b/adk-model/Cargo.toml
@@ -37,6 +37,7 @@ aws-smithy-types = { version = "1", optional = true }
 [features]
 default = ["gemini"]
 gemini = ["dep:adk-gemini"]
+gemini-vertex = ["gemini", "adk-gemini/vertex"]
 openai = ["dep:async-openai"]
 xai = ["openai"]
 anthropic = ["dep:claudius"]
@@ -51,7 +52,7 @@ cerebras = ["openai"]
 sambanova = ["openai"]
 bedrock = ["dep:aws-sdk-bedrockruntime", "dep:aws-config", "dep:aws-smithy-types"]
 azure-ai = ["dep:reqwest"]
-all-providers = ["gemini", "openai", "xai", "anthropic", "deepseek", "ollama", "groq", "fireworks", "together", "mistral", "perplexity", "cerebras", "sambanova", "bedrock", "azure-ai"]
+all-providers = ["gemini", "gemini-vertex", "openai", "xai", "anthropic", "deepseek", "ollama", "groq", "fireworks", "together", "mistral", "perplexity", "cerebras", "sambanova", "bedrock", "azure-ai"]
 
 [dev-dependencies]
 proptest = "1.5"

--- a/adk-model/src/gemini/client.rs
+++ b/adk-model/src/gemini/client.rs
@@ -24,6 +24,7 @@ impl GeminiModel {
         Ok(Self { client, model_name, retry_config: RetryConfig::default() })
     }
 
+    #[cfg(feature = "gemini-vertex")]
     pub fn new_google_cloud(
         api_key: impl Into<String>,
         project_id: impl AsRef<str>,
@@ -42,6 +43,7 @@ impl GeminiModel {
         Ok(Self { client, model_name, retry_config: RetryConfig::default() })
     }
 
+    #[cfg(feature = "gemini-vertex")]
     pub fn new_google_cloud_service_account(
         service_account_json: &str,
         project_id: impl AsRef<str>,
@@ -60,6 +62,7 @@ impl GeminiModel {
         Ok(Self { client, model_name, retry_config: RetryConfig::default() })
     }
 
+    #[cfg(feature = "gemini-vertex")]
     pub fn new_google_cloud_adc(
         project_id: impl AsRef<str>,
         location: impl AsRef<str>,
@@ -76,6 +79,7 @@ impl GeminiModel {
         Ok(Self { client, model_name, retry_config: RetryConfig::default() })
     }
 
+    #[cfg(feature = "gemini-vertex")]
     pub fn new_google_cloud_wif(
         wif_json: &str,
         project_id: impl AsRef<str>,


### PR DESCRIPTION
## What

make Google Cloud dependencies optional via 'vertex' feature flag

## Why

Fixes #181 

## How

- Add 'vertex' feature flag to adk-gemini (enabled by default for backward compatibility)
- Make google-cloud-* dependencies optional in adk-gemini
- Add feature gates to Vertex AI code in client.rs, backend/vertex.rs, and backend/mod.rs
- Add 'gemini-vertex' feature to adk-model for Google Cloud methods
- Update documentation with feature flag information
- Resolves #181 by allowing projects to opt-out of Google Cloud dependencies

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [ ] New code has tests (unit, integration, or property tests as appropriate)
- [ ] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [ ] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [ ] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed
- [ ] Examples added or updated for new features 