### PR TITLE
Fix the compilation failure in Windows environmentin adk-server 0.4.0

### DIFF
--- a/adk-server/src/rest/mod.rs
+++ b/adk-server/src/rest/mod.rs
@@ -392,7 +392,7 @@ pub async fn shutdown_signal() {
     };
 
     #[cfg(not(unix))]
-    let terminate = pending::<()>();
+    let terminate = std::future::pending::<()>();
 
     tokio::select! {
         _ = ctrl_c => {}


### PR DESCRIPTION
Fix the issue in `adk-server` crate version 0.4.0. The error clearly states that they need to import the `pending` function. The problem is in their code at line 395 where they use the `pending::<()>()` function without importing it.

``` compile log
Checking adk-server v0.4.0
error[E0425]: cannot find function `pending` in this scope
   --> C:\Users\Administrator\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\adk-server-0.4.0\src\rest\mod.rs:395:21
    |
395 |     let terminate = pending::<()>();
    |                     ^^^^^^^ not found in this scope
    |
help: consider importing one of these functions
    |
  4 + use std::future::pending;
    |
  4 + use futures::future::pending;
    |
  4 + use futures::stream::pending;
    |
  4 + use tokio_stream::pending;
    |

For more information about this error, try `rustc --explain E0425`.
error: could not compile `adk-server` (lib) due to 1 previous error
```