### PR TITLE
fix(gemini): handle includeServerSideToolInvocations across AI Studio…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,8 +91,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+#### adk-gemini
+- Fixed Gemini 3 built-in tools (Google Search, URL Context) causing truncated responses (#224). `ContentBuilder::build()` now auto-sets `includeServerSideToolInvocations: true` when server-side tools are present, enabling Gemini 3 to return `toolCall`/`toolResponse` parts on AI Studio instead of silently truncating.
+- Fixed Vertex AI 400 error when `includeServerSideToolInvocations` was sent. Vertex AI rejects this field — it handles built-in tools natively. Both the Vertex backend and the Studio backend (when `with_base_url` points at `aiplatform.googleapis.com`) now strip the field before sending.
+
 #### adk-model
 - Fixed `test_server_tool_response_round_trip_as_openai_items` test — JSON fixture had `outcome` fields flattened instead of nested, causing deserialization mismatch with `async-openai` 0.33 structs.
+- Fixed Anthropic system prompt tests (`test_heuristic_skipped_when_explicit_system_exists`, `test_instruction_rerouting_to_system`, `test_multiple_system_entries_concatenated`) that expected `SystemPrompt::String` but received `SystemPrompt::Blocks` after `prompt_caching` default changed to `true`.
+- Fixed `prop_default_config_backward_compatible` property test asserting `prompt_caching` should be `false` — updated to match the actual default of `true`.
 - Removed unused `OutputStatus` import in `responses_convert.rs`.
 - Replaced `drain(..).collect()` with `std::mem::take()` in Anthropic streaming client per clippy `drain_collect` lint.
 

--- a/adk-gemini/src/backend/studio.rs
+++ b/adk-gemini/src/backend/studio.rs
@@ -63,6 +63,10 @@ pub struct StudioBackend {
     pub(crate) http_client: Client,
     pub(crate) base_url: Url,
     pub(crate) model: Model,
+    /// Whether the base URL points to Vertex AI (`aiplatform.googleapis.com`).
+    /// When true, `includeServerSideToolInvocations` is stripped from requests
+    /// because Vertex AI rejects it with `INVALID_ARGUMENT`.
+    pub(crate) is_vertex_url: bool,
 }
 
 impl StudioBackend {
@@ -78,12 +82,19 @@ impl StudioBackend {
             .build()
             .expect("all parameters must be valid");
 
-        Ok(Self { http_client, base_url, model })
+        let is_vertex_url = Self::detect_vertex_url(&base_url);
+        Ok(Self { http_client, base_url, model, is_vertex_url })
     }
 
     /// Create with a custom `reqwest::Client` (e.g. for proxy support).
     pub fn with_client(http_client: Client, model: Model, base_url: Url) -> Self {
-        Self { http_client, base_url, model }
+        let is_vertex_url = Self::detect_vertex_url(&base_url);
+        Self { http_client, base_url, model, is_vertex_url }
+    }
+
+    /// Returns `true` if the URL points to a Vertex AI endpoint.
+    fn detect_vertex_url(url: &Url) -> bool {
+        url.host_str().is_some_and(|h| h.ends_with("aiplatform.googleapis.com"))
     }
 
     // ── URL helpers ─────────────────────────────────────────────────────
@@ -195,16 +206,22 @@ impl GeminiBackend for StudioBackend {
 
     async fn generate_content(
         &self,
-        request: GenerateContentRequest,
+        mut request: GenerateContentRequest,
     ) -> Result<GenerationResponse, Error> {
+        if self.is_vertex_url {
+            request.strip_vertex_unsupported_fields();
+        }
         let url = self.build_url("generateContent")?;
         self.post_json(url, &request).await
     }
 
     async fn generate_content_stream(
         &self,
-        request: GenerateContentRequest,
+        mut request: GenerateContentRequest,
     ) -> Result<BackendStream<GenerationResponse>, Error> {
+        if self.is_vertex_url {
+            request.strip_vertex_unsupported_fields();
+        }
         let mut url = self.build_url("streamGenerateContent")?;
         url.query_pairs_mut().append_pair("alt", "sse");
 
@@ -444,5 +461,52 @@ impl GeminiBackend for StudioBackend {
             if name.starts_with("models/") { name.to_string() } else { format!("models/{name}") };
         let url = self.build_url_with_suffix(&qualified)?;
         self.get_json(url).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_vertex_url_regional() {
+        let url = Url::parse("https://us-central1-aiplatform.googleapis.com/v1/publishers/google/")
+            .unwrap();
+        assert!(StudioBackend::detect_vertex_url(&url));
+    }
+
+    #[test]
+    fn detect_vertex_url_global() {
+        let url = Url::parse(
+            "https://aiplatform.googleapis.com/v1/publishers/google/models/gemini-3-flash-preview",
+        )
+        .unwrap();
+        assert!(StudioBackend::detect_vertex_url(&url));
+    }
+
+    #[test]
+    fn detect_vertex_url_with_project() {
+        let url = Url::parse(
+            "https://us-central1-aiplatform.googleapis.com/v1/projects/my-project/locations/us-central1/publishers/google/"
+        ).unwrap();
+        assert!(StudioBackend::detect_vertex_url(&url));
+    }
+
+    #[test]
+    fn detect_studio_url() {
+        let url = Url::parse("https://generativelanguage.googleapis.com/v1beta/").unwrap();
+        assert!(!StudioBackend::detect_vertex_url(&url));
+    }
+
+    #[test]
+    fn detect_studio_v1_url() {
+        let url = Url::parse("https://generativelanguage.googleapis.com/v1/").unwrap();
+        assert!(!StudioBackend::detect_vertex_url(&url));
+    }
+
+    #[test]
+    fn detect_custom_url() {
+        let url = Url::parse("https://my-proxy.example.com/gemini/").unwrap();
+        assert!(!StudioBackend::detect_vertex_url(&url));
     }
 }

--- a/adk-gemini/src/backend/vertex.rs
+++ b/adk-gemini/src/backend/vertex.rs
@@ -84,6 +84,17 @@ impl VertexBackend {
             || normalized.contains("stream error")
     }
 
+    /// Strip fields from the request that Vertex AI doesn't support.
+    ///
+    /// The `includeServerSideToolInvocations` field is only supported by the
+    /// AI Studio REST API (generativelanguage.googleapis.com). Vertex AI
+    /// (aiplatform.googleapis.com) rejects it with `INVALID_ARGUMENT`.
+    fn strip_unsupported_fields(request: &mut GenerateContentRequest) {
+        if let Some(ref mut tc) = request.tool_config {
+            tc.include_server_side_tool_invocations = None;
+        }
+    }
+
     /// Non-streaming generate via REST (fallback when gRPC has transport issues).
     async fn generate_content_rest(
         &self,
@@ -122,6 +133,10 @@ impl GeminiBackend for VertexBackend {
         &self,
         request: GenerateContentRequest,
     ) -> Result<GenerationResponse, Error> {
+        // Strip fields unsupported by Vertex AI before sending.
+        let mut request = request;
+        Self::strip_unsupported_fields(&mut request);
+
         // Try gRPC first, fall back to REST on transport errors.
         let rest_request = request.clone();
         let mut request_value =
@@ -158,6 +173,10 @@ impl GeminiBackend for VertexBackend {
         &self,
         request: GenerateContentRequest,
     ) -> Result<BackendStream<GenerationResponse>, Error> {
+        // Strip fields unsupported by Vertex AI before sending.
+        let mut request = request;
+        Self::strip_unsupported_fields(&mut request);
+
         // Vertex AI REST supports streamGenerateContent with SSE, same as AI Studio.
         let url = Url::parse(&format!(
             "{}/v1/{}:streamGenerateContent?alt=sse",

--- a/adk-gemini/src/generation/builder.rs
+++ b/adk-gemini/src/generation/builder.rs
@@ -332,13 +332,30 @@ impl ContentBuilder {
     }
 
     /// Builds the `GenerateContentRequest`.
+    ///
+    /// When server-side tools (Google Search, URL Context, etc.) are present,
+    /// `includeServerSideToolInvocations` is automatically set in the `ToolConfig`
+    /// so Gemini 3 returns `toolCall`/`toolResponse` parts instead of silently
+    /// truncating the response.
     pub fn build(self) -> GenerateContentRequest {
+        let mut tool_config = self.tool_config;
+
+        // Auto-set includeServerSideToolInvocations when server-side tools are present
+        if let Some(tools) = &self.tools {
+            let has_server_side = tools.iter().any(|t| t.is_server_side());
+            if has_server_side {
+                tool_config
+                    .get_or_insert_with(Default::default)
+                    .include_server_side_tool_invocations = Some(true);
+            }
+        }
+
         GenerateContentRequest {
             contents: self.contents,
             generation_config: self.generation_config,
             safety_settings: None,
             tools: self.tools,
-            tool_config: self.tool_config,
+            tool_config,
             system_instruction: self.system_instruction,
             cached_content: self.cached_content,
         }

--- a/adk-gemini/src/generation/model.rs
+++ b/adk-gemini/src/generation/model.rs
@@ -544,6 +544,25 @@ pub struct GenerateContentRequest {
     pub cached_content: Option<String>,
 }
 
+impl GenerateContentRequest {
+    /// Strips fields that Vertex AI does not support.
+    ///
+    /// The Vertex AI surface (`aiplatform.googleapis.com`) rejects
+    /// `includeServerSideToolInvocations` with a 400 error. Vertex AI handles
+    /// built-in tools (Google Search, URL Context, etc.) natively without
+    /// needing this flag. This method clears the flag so the request can be
+    /// sent to Vertex AI without modification.
+    ///
+    /// AI Studio (`generativelanguage.googleapis.com`) requires the flag for
+    /// Gemini 3 models to return `toolCall`/`toolResponse` parts instead of
+    /// silently truncating the response.
+    pub fn strip_vertex_unsupported_fields(&mut self) {
+        if let Some(tc) = &mut self.tool_config {
+            tc.include_server_side_tool_invocations = None;
+        }
+    }
+}
+
 /// Native thinking level for Gemini 3 models.
 ///
 /// Controls the amount of reasoning effort the model applies. This is the

--- a/adk-gemini/src/tools/model.rs
+++ b/adk-gemini/src/tools/model.rs
@@ -101,6 +101,16 @@ impl Tool {
     pub fn mcp_server(config: Value) -> Self {
         Self::McpServer { mcp_server: config }
     }
+
+    /// Returns `true` if this tool is a server-side built-in tool (e.g., Google Search,
+    /// URL Context, Google Maps, Code Execution) that Gemini 3 executes internally.
+    ///
+    /// When server-side tools are present, `includeServerSideToolInvocations` should be
+    /// set in the `ToolConfig` so Gemini 3 returns `toolCall`/`toolResponse` parts instead
+    /// of silently truncating the response.
+    pub fn is_server_side(&self) -> bool {
+        !matches!(self, Self::Function { .. })
+    }
 }
 
 /// Defines the function behavior

--- a/adk-model/src/anthropic/client.rs
+++ b/adk-model/src/anthropic/client.rs
@@ -783,7 +783,12 @@ mod tests {
                 assert!(s.contains("You are a coding assistant."));
                 assert!(s.contains("Always respond in Rust."));
             }
-            SystemPrompt::Blocks(_) => panic!("Expected string system prompt"),
+            SystemPrompt::Blocks(blocks) => {
+                let text: String =
+                    blocks.iter().map(|b| b.block.text.as_str()).collect::<Vec<_>>().join("\n");
+                assert!(text.contains("You are a coding assistant."));
+                assert!(text.contains("Always respond in Rust."));
+            }
         }
         // Messages should start with the assistant message
         assert_eq!(params.messages.len(), 2);
@@ -821,7 +826,11 @@ mod tests {
             SystemPrompt::String(s) => {
                 assert_eq!(s, "First system instruction.\nSecond system instruction.");
             }
-            SystemPrompt::Blocks(_) => panic!("Expected string system prompt"),
+            SystemPrompt::Blocks(blocks) => {
+                let text: String =
+                    blocks.iter().map(|b| b.block.text.as_str()).collect::<Vec<_>>().join("");
+                assert_eq!(text, "First system instruction.\nSecond system instruction.");
+            }
         }
     }
 
@@ -875,7 +884,11 @@ mod tests {
         // System should only contain the explicit system content
         match &params.system.unwrap() {
             SystemPrompt::String(s) => assert_eq!(s, "Explicit system."),
-            SystemPrompt::Blocks(_) => panic!("Expected string system prompt"),
+            SystemPrompt::Blocks(blocks) => {
+                let text: String =
+                    blocks.iter().map(|b| b.block.text.as_str()).collect::<Vec<_>>().join("");
+                assert_eq!(text, "Explicit system.");
+            }
         }
         // The user message should remain in messages (not re-routed)
         assert_eq!(params.messages.len(), 2);

--- a/adk-model/src/gemini/client.rs
+++ b/adk-model/src/gemini/client.rs
@@ -392,7 +392,7 @@ impl GeminiModel {
             gemini_tools.push(adk_gemini::Tool::with_functions(function_declarations));
         }
 
-        if has_provider_native_tools && has_function_declarations {
+        if has_provider_native_tools {
             tool_config_json.insert(
                 "includeServerSideToolInvocations".to_string(),
                 serde_json::Value::Bool(true),
@@ -839,6 +839,54 @@ mod native_tool_tests {
 
         assert_eq!(gemini_tools.len(), 2);
         assert_eq!(tool_config.include_server_side_tool_invocations, Some(true));
+    }
+
+    #[test]
+    fn test_build_gemini_tools_sets_flag_for_builtin_only() {
+        let mut tools = std::collections::HashMap::new();
+        tools.insert(
+            "google_search".to_string(),
+            serde_json::json!({
+                "x-adk-gemini-tool": {
+                    "google_search": {}
+                }
+            }),
+        );
+
+        let (_gemini_tools, tool_config) =
+            GeminiModel::build_gemini_tools(&tools).expect("tool conversion should succeed");
+
+        assert_eq!(
+            tool_config.include_server_side_tool_invocations,
+            Some(true),
+            "includeServerSideToolInvocations should be set even with only built-in tools"
+        );
+    }
+
+    #[test]
+    fn test_build_gemini_tools_no_flag_for_function_only() {
+        let mut tools = std::collections::HashMap::new();
+        tools.insert(
+            "lookup_weather".to_string(),
+            serde_json::json!({
+                "name": "lookup_weather",
+                "description": "lookup weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "city": { "type": "string" }
+                    }
+                }
+            }),
+        );
+
+        let (_gemini_tools, tool_config) =
+            GeminiModel::build_gemini_tools(&tools).expect("tool conversion should succeed");
+
+        assert_eq!(
+            tool_config.include_server_side_tool_invocations, None,
+            "includeServerSideToolInvocations should NOT be set for function-only tools"
+        );
     }
 
     #[test]

--- a/adk-model/tests/anthropic_config_tests.rs
+++ b/adk-model/tests/anthropic_config_tests.rs
@@ -75,7 +75,7 @@ proptest! {
     /// **Feature: anthropic-deep-integration, Property 15: Backward compatibility**
     /// *For any* LlmRequest, building API parameters with a default AnthropicConfig
     /// (no optional features enabled) SHALL produce a config with no `thinking`
-    /// parameter, no `cache_control` on any block, prompt_caching false,
+    /// parameter, prompt_caching true (enabled by default for cost/latency savings),
     /// empty beta_features, and no api_version override.
     /// **Validates: Requirements 13.3**
     #[test]
@@ -87,7 +87,7 @@ proptest! {
             .with_max_tokens(max_tokens);
 
         // All new fields must be at their disabled/empty defaults
-        prop_assert!(!config.prompt_caching, "prompt_caching should be false by default");
+        prop_assert!(config.prompt_caching, "prompt_caching should be true by default");
         prop_assert!(config.thinking.is_none(), "thinking should be None by default");
         prop_assert!(config.beta_features.is_empty(), "beta_features should be empty by default");
         prop_assert!(config.api_version.is_none(), "api_version should be None by default");

--- a/adk-model/tests/builtin_tool_flag_property_tests.rs
+++ b/adk-model/tests/builtin_tool_flag_property_tests.rs
@@ -1,12 +1,21 @@
 //! Property-based tests for the `include_server_side_tool_invocations` flag on `ToolConfig`.
 //!
-//! **Property 1: Bug Condition — Server-Side Tool Invocation Flag Not Set**
+//! **Property 1: Server-Side Tool Invocation Flag Set for Mixed Tools**
 //!
 //! When built-in tools (`google_search` or `url_context`) are present alongside user-defined
 //! function tools, the `ToolConfig` sent to the Gemini API SHALL have
 //! `includeServerSideToolInvocations: true` in its JSON representation.
 //!
-//! **Validates: Requirements 1.1, 2.1**
+//! **Property 2: No Flag Without Built-in Tools**
+//!
+//! When only user-defined function tools are present, the flag SHALL NOT be set.
+//!
+//! **Property 3: Flag Set for Built-in Tools Only**
+//!
+//! When only built-in tools are present (no function tools), the flag SHALL still be set
+//! so Gemini 3 returns `toolCall`/`toolResponse` parts instead of truncating.
+//!
+//! **Validates: Requirements 1.1, 2.1, 3.1, 3.2, 3.3**
 
 use proptest::prelude::*;
 
@@ -43,14 +52,24 @@ fn arb_mixed_tool_list() -> impl Strategy<Value = Vec<String>> {
         .prop_shuffle()
 }
 
-/// Simulate the tool config building logic from `GeminiModel::generate_content_internal()`.
+/// Strategy that generates a tool list containing ONLY built-in tool names.
+fn arb_builtin_only_tool_list() -> impl Strategy<Value = Vec<String>> {
+    prop::collection::vec(arb_builtin_tool_name(), 1..=3)
+}
+
+/// Strategy that generates a tool list containing ONLY user-defined function tool names
+/// (no built-in tools like `google_search` or `url_context`).
+fn arb_user_only_tool_list() -> impl Strategy<Value = Vec<String>> {
+    prop::collection::vec(arb_user_tool_name(), 1..=8)
+}
+
+/// Simulate the tool config building logic from `GeminiModel::build_gemini_tools()`.
 ///
-/// This mirrors lines ~510-540 of `adk-model/src/gemini/client.rs`:
+/// This mirrors the logic in `adk-model/src/gemini/client.rs`:
 /// 1. Iterate through tool names
-/// 2. Detect `google_search` / `url_context` and set flags
+/// 2. Detect `google_search` / `url_context` as provider-native tools
 /// 3. Build function declarations for non-builtin tools
-/// 4. Create `Tool::with_functions(...)` and `Tool::google_search()` / `Tool::url_context()`
-/// 5. Build a `ToolConfig` (currently only has `function_calling_config`)
+/// 4. Set `includeServerSideToolInvocations` when ANY provider-native tools are present
 ///
 /// Returns the serialized JSON of the `ToolConfig` that would be sent to the API.
 fn build_tool_config_json(tool_names: &[String]) -> serde_json::Value {
@@ -67,14 +86,12 @@ fn build_tool_config_json(tool_names: &[String]) -> serde_json::Value {
                 has_url_context = true;
             }
             _ => {
-                // Build a minimal FunctionDeclaration the same way the real code does
                 let func_decl = adk_gemini::FunctionDeclaration::new(name, "test tool", None);
                 function_declarations.push(func_decl);
             }
         }
     }
 
-    // Build the tools list the same way generate_content_internal does
     let mut _tools = Vec::new();
     let has_function_declarations = !function_declarations.is_empty();
     if has_function_declarations {
@@ -87,38 +104,33 @@ fn build_tool_config_json(tool_names: &[String]) -> serde_json::Value {
         _tools.push(adk_gemini::Tool::url_context());
     }
 
-    // Build the ToolConfig the same way generate_content_internal does.
-    // When BOTH built-in tools AND function tools are present, set the flag.
+    let has_provider_native_tools = has_google_search || has_url_context;
+
+    // Set the flag whenever provider-native tools are present (not just when mixed)
     let mut tool_config = adk_gemini::ToolConfig::default();
-    if (has_google_search || has_url_context) && has_function_declarations {
+    if has_provider_native_tools {
         tool_config.include_server_side_tool_invocations = Some(true);
     }
 
-    // Serialize to JSON to inspect what would be sent on the wire
     serde_json::to_value(&tool_config).expect("ToolConfig should serialize to JSON")
 }
 
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(100))]
 
-    /// **Feature: gemini3-builtin-tool-fix, Property 1: Bug Condition**
+    /// **Feature: gemini3-builtin-tool-fix, Property 1: Mixed Tools**
     ///
-    /// *For any* tool list containing at least one built-in tool (`google_search` or
-    /// `url_context`) alongside at least one user-defined function tool, the `ToolConfig`
-    /// SHALL serialize to JSON containing `"includeServerSideToolInvocations": true`.
+    /// *For any* tool list containing at least one built-in tool alongside at least one
+    /// user-defined function tool, the `ToolConfig` SHALL contain
+    /// `"includeServerSideToolInvocations": true`.
     ///
     /// **Validates: Requirements 1.1, 2.1**
-    ///
-    /// This test is EXPECTED TO FAIL on unfixed code because the `ToolConfig` struct
-    /// does not have an `include_server_side_tool_invocations` field, so the serialized
-    /// JSON will never contain the key.
     #[test]
-    fn prop_bug_condition_server_side_tool_invocation_flag(
+    fn prop_flag_set_for_mixed_tools(
         tool_names in arb_mixed_tool_list()
     ) {
         let tool_config_json = build_tool_config_json(&tool_names);
 
-        // The JSON representation of ToolConfig should contain the flag
         let has_flag = tool_config_json
             .get("includeServerSideToolInvocations")
             .and_then(|v| v.as_bool())
@@ -132,42 +144,53 @@ proptest! {
             serde_json::to_string_pretty(&tool_config_json).unwrap()
         );
     }
-}
 
-/// Strategy that generates a tool list containing ONLY user-defined function tool names
-/// (no built-in tools like `google_search` or `url_context`).
-fn arb_user_only_tool_list() -> impl Strategy<Value = Vec<String>> {
-    prop::collection::vec(arb_user_tool_name(), 1..=8)
-}
-
-proptest! {
-    #![proptest_config(ProptestConfig::with_cases(100))]
-
-    /// **Feature: gemini3-builtin-tool-fix, Property 2: Preservation**
+    /// **Feature: gemini3-builtin-tool-fix, Property 2: No Flag Without Built-in Tools**
     ///
     /// *For any* tool list containing only user-defined function tools (no built-in tools),
-    /// the `ToolConfig` SHALL NOT have `includeServerSideToolInvocations` set in its JSON
-    /// representation, preserving identical request construction to current behavior.
+    /// the `ToolConfig` SHALL NOT have `includeServerSideToolInvocations` set.
     ///
     /// **Validates: Requirements 3.1, 3.2, 3.3**
-    ///
-    /// This test should PASS on unfixed code because the `ToolConfig` struct does not have
-    /// the `include_server_side_tool_invocations` field at all, so the key is never present.
-    /// After the fix, this test should STILL PASS because the field should only be set when
-    /// built-in tools are present alongside function tools.
     #[test]
-    fn prop_preservation_no_flag_without_builtin_tools(
+    fn prop_no_flag_without_builtin_tools(
         tool_names in arb_user_only_tool_list()
     ) {
         let tool_config_json = build_tool_config_json(&tool_names);
 
-        // The JSON representation of ToolConfig should NOT contain the flag
         let has_flag = tool_config_json.get("includeServerSideToolInvocations").is_some();
 
         prop_assert!(
             !has_flag,
             "ToolConfig JSON for user-only tool list {:?} should NOT contain \
              'includeServerSideToolInvocations', but got: {}",
+            tool_names,
+            serde_json::to_string_pretty(&tool_config_json).unwrap()
+        );
+    }
+
+    /// **Feature: gemini3-builtin-tool-fix, Property 3: Flag Set for Built-in Only**
+    ///
+    /// *For any* tool list containing only built-in tools (no function tools),
+    /// the `ToolConfig` SHALL contain `"includeServerSideToolInvocations": true`.
+    /// This is the key fix for issue #224 — Gemini 3 truncates responses when
+    /// built-in tools are present without the flag, even without function tools.
+    ///
+    /// **Validates: Requirements 1.1, 2.1**
+    #[test]
+    fn prop_flag_set_for_builtin_only_tools(
+        tool_names in arb_builtin_only_tool_list()
+    ) {
+        let tool_config_json = build_tool_config_json(&tool_names);
+
+        let has_flag = tool_config_json
+            .get("includeServerSideToolInvocations")
+            .and_then(|v| v.as_bool())
+            == Some(true);
+
+        prop_assert!(
+            has_flag,
+            "ToolConfig JSON for builtin-only tool list {:?} should contain \
+             '\"includeServerSideToolInvocations\": true', but got: {}",
             tool_names,
             serde_json::to_string_pretty(&tool_config_json).unwrap()
         );


### PR DESCRIPTION
… and Vertex AI (#224)

Gemini 3 with built-in tools (google_search, url_context) requires includeServerSideToolInvocations in the ToolConfig for AI Studio to return toolCall/toolResponse parts instead of silently truncating. However, Vertex AI rejects this field with INVALID_ARGUMENT.

Changes:
- ContentBuilder::build() auto-sets the flag when server-side tools present
- Tool::is_server_side() detects built-in tools (non-function tools)
- GenerateContentRequest::strip_vertex_unsupported_fields() strips the flag
- Studio backend detects Vertex AI URLs and strips before sending
- Vertex backend strips before gRPC/REST dispatch (already present)
- adk-model build_gemini_tools() sets flag for builtin-only tools

Also fixes pre-existing Anthropic test failures where prompt_caching default changed to true but tests still expected SystemPrompt::String.

Fixes #224

## What

Brief description of the change.

## Why

Link to the issue this addresses: Fixes #___

## How

Summary of the approach taken.

## PR Checklist

### Quality Gates (all required)

- [ ] `devenv shell fmt` — code is formatted (Edition 2024)
- [ ] `devenv shell clippy` — zero warnings (-D warnings)
- [ ] `devenv shell test` — all non-ignored tests pass
- [ ] `devenv shell check` — fast workspace compilation check

### Code Quality

- [ ] New code has tests (unit, integration, or property tests as appropriate)
- [ ] Public APIs have rustdoc comments with `# Example` sections
- [ ] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [ ] No hardcoded secrets, API keys, or local paths

### Hygiene

- [ ] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [ ] No unrelated changes mixed in (formatting, refactoring, other features)
- [ ] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [ ] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [ ] PR targets `main` branch

### Documentation (if applicable)

- [ ] CHANGELOG.md updated for user-facing changes
- [ ] README updated if crate capabilities changed
- [ ] Examples added or updated for new features
