### PR TITLE
docs: document LiveKit typestate builder, OpenAI protocol handler, ne…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### Realtime — LiveKit Typestate Builder, OpenAI Protocol Centralization ([@mikefaille](https://github.com/mikefaille))
+
+- **`LiveKitConfig`** (`adk-realtime`): Secure LiveKit configuration with `secrecy::SecretString` for API keys. URL validation and empty-credential rejection at construction time.
+- **`LiveKitRoomBuilder`** (`adk-realtime`): Typestate builder for LiveKit room connections. `identity` is required at compile time. Supports optional audio track setup, room name, and custom video grants.
+- **`LiveKitError`** (`adk-realtime`): Dedicated error type for LiveKit operations (config, token generation, connection).
+- **`OpenAIProtocolHandler<T>`** (`adk-realtime`): Generic protocol handler wrapping any `OpenAITransportLink` transport. Implements `RealtimeSession` for both WebSocket and WebRTC.
+- **`OpenAITransportLink` trait** (`adk-realtime`): Transport abstraction for OpenAI Realtime API. Default implementations for audio encoding and session configuration. WebRTC overrides for direct media track access.
+- **Centralized OpenAI protocol** (`adk-realtime`): Shared `convert_config_to_openai()` and `translate_client_message()` functions used by both WebSocket and WebRTC transports.
+- **New examples**: `debug_gemini`, `debug_livekit_auth`, `livekit_gemini_bridge`.
+
 #### Developer Ergonomics — Parallel Dispatch, Builder, Tool Metadata, Macro Attributes
 
 - **`ToolExecutionStrategy`** (`adk-core`): New enum with `Sequential` (default), `Parallel`, and `Auto` variants controlling how multiple tool calls from a single LLM response are dispatched.

--- a/adk-realtime/README.md
+++ b/adk-realtime/README.md
@@ -194,6 +194,30 @@ Bridge any `EventHandler` to a LiveKit room for production voice apps:
 adk-realtime = { version = "0.5.0", features = ["livekit", "openai"] }
 ```
 
+#### LiveKitConfig and LiveKitRoomBuilder
+
+Use the typestate builder for secure room connections. Credentials are stored with `secrecy::SecretString` and redacted in Debug output:
+
+```rust
+use adk_realtime::livekit::{LiveKitConfig, LiveKitRoomBuilder};
+
+let config = LiveKitConfig::new(
+    "wss://your-server.livekit.cloud",
+    std::env::var("LIVEKIT_API_KEY")?,
+    std::env::var("LIVEKIT_API_SECRET")?,
+)?;
+
+let bundle = LiveKitRoomBuilder::new(config)
+    .identity("my-agent")           // required — enables connect()
+    .name("Voice Agent")            // optional display name
+    .room_name("session-room-123")  // optional — auto-generated if omitted
+    .with_audio(24_000, 1)          // publish a local audio track
+    .connect()
+    .await?;
+```
+
+#### Bridging Audio
+
 ```rust
 use adk_realtime::livekit::{LiveKitEventHandler, bridge_input};
 

--- a/docs/official_docs/agents/realtime-agents.md
+++ b/docs/official_docs/agents/realtime-agents.md
@@ -449,6 +449,61 @@ while let Some(event) = session.next_event().await {
 | `full` | `openai` + `gemini` + `vertex-live` + `livekit` | All transports except WebRTC |
 | `full-webrtc` | `full` + `openai-webrtc` | Everything (requires cmake) |
 
+## LiveKit WebRTC Bridge
+
+For production voice applications, the LiveKit bridge routes audio through a LiveKit server for scalable, multi-participant scenarios.
+
+### LiveKitConfig
+
+Securely configure LiveKit credentials. API keys and secrets are stored using `secrecy::SecretString` and redacted in Debug output:
+
+```rust
+use adk_realtime::livekit::{LiveKitConfig, LiveKitRoomBuilder};
+
+let config = LiveKitConfig::new(
+    "wss://your-server.livekit.cloud",
+    std::env::var("LIVEKIT_API_KEY")?,
+    std::env::var("LIVEKIT_API_SECRET")?,
+)?;
+```
+
+`LiveKitConfig::new()` validates the URL format and rejects empty credentials at construction time.
+
+### LiveKitRoomBuilder
+
+A typestate builder for connecting to LiveKit rooms. The `identity` field is required at compile time — `connect()` is only available after it's set:
+
+```rust
+let bundle = LiveKitRoomBuilder::new(config)
+    .identity("my-agent")           // required — enables connect()
+    .name("Voice Agent")            // optional display name
+    .room_name("session-room-123")  // optional — auto-generated if omitted
+    .auto_subscribe(true)           // subscribe to remote tracks
+    .with_audio(24_000, 1)          // publish a local audio track (sample rate, channels)
+    .connect()
+    .await?;
+
+// The bundle contains everything you need
+let room = bundle.room;
+let mut events = bundle.events;
+let audio_source = bundle.audio_source;  // for publishing audio
+let audio_track = bundle.audio_track;
+```
+
+### Bridging Audio
+
+Use the bridge utilities to connect LiveKit audio to a `RealtimeRunner`:
+
+```rust
+use adk_realtime::livekit::{LiveKitEventHandler, bridge_input};
+
+// Wrap your event handler to publish model audio to LiveKit
+let lk_handler = LiveKitEventHandler::new(inner_handler, audio_source, 24000, 1);
+
+// Bridge participant audio from LiveKit into the RealtimeRunner
+tokio::spawn(bridge_input(remote_track, runner));
+```
+
 ## Examples
 
 Run the included examples:
@@ -466,6 +521,11 @@ cargo run -p adk-realtime --example vertex_live_tools --features vertex-live
 
 # LiveKit Bridge (requires LiveKit server)
 cargo run -p adk-realtime --example livekit_bridge --features livekit,openai
+cargo run -p adk-realtime --example livekit_gemini_bridge --features livekit,gemini
+
+# Debug utilities
+cargo run -p adk-realtime --example debug_gemini --features gemini
+cargo run -p adk-realtime --example debug_livekit_auth --features livekit
 
 # OpenAI WebRTC (requires cmake)
 cargo run -p adk-realtime --example openai_webrtc --features openai-webrtc


### PR DESCRIPTION
…w examples

- realtime-agents.md: LiveKitConfig, LiveKitRoomBuilder, bridging audio section
- adk-realtime/README.md: LiveKit builder quick start with secure config
- CHANGELOG.md: entry for mikefaille's LiveKit/OpenAI protocol contribution

## What

Brief description of the change.

## Why

Link to the issue this addresses: Fixes #___

## How

Summary of the approach taken.

## PR Checklist

### Quality Gates (all required)

- [ ] `devenv shell fmt` — code is formatted (Edition 2024)
- [ ] `devenv shell clippy` — zero warnings (-D warnings)
- [ ] `devenv shell test` — all non-ignored tests pass
- [ ] `devenv shell check` — fast workspace compilation check

### Code Quality

- [ ] New code has tests (unit, integration, or property tests as appropriate)
- [ ] Public APIs have rustdoc comments with `# Example` sections
- [ ] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [ ] No hardcoded secrets, API keys, or local paths

### Hygiene

- [ ] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [ ] No unrelated changes mixed in (formatting, refactoring, other features)
- [ ] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [ ] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [ ] PR targets `main` branch

### Documentation (if applicable)

- [ ] CHANGELOG.md updated for user-facing changes
- [ ] README updated if crate capabilities changed
- [ ] Examples added or updated for new features
