### PR TITLE
fix: adoption feedback follow-up — boxed telemetry layer + adapter lifetime fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Five adoption fixes reported by a real-world integrator (zavora-cli):
 
-- **SQLx lifetime fix** (`adk-memory`): `SqliteMemoryService` now clones the pool into a local variable before passing to `sqlx::query()`, resolving lifetime conflicts when called from `#[async_trait]` tool implementations.
+- **SQLx lifetime fix** (`adk-memory`): `SqliteMemoryService` now clones the pool into a local variable before passing to `sqlx::query()`, resolving lifetime conflicts when called from `#[async_trait]` tool implementations. `MemoryServiceAdapter` receives the same `inner.clone()` treatment so the fix applies at both the service and adapter levels.
 - **Tool context in callbacks** (`adk-core`, `adk-agent`, `adk-realtime`): `CallbackContext` gains `tool_name()` and `tool_input()` default methods. New `ToolCallbackContext` wrapper injects tool metadata at all before-tool and after-tool callback sites.
-- **Composable telemetry layer** (`adk-telemetry`): New `build_otlp_layer(service_name, endpoint)` returns a `tracing_subscriber::Layer` for composition into custom subscriber stacks without calling `.init()`.
+- **Composable telemetry layer** (`adk-telemetry`): New `build_otlp_layer<S>(service_name, endpoint)` returns a `Box<dyn Layer<S> + Send + Sync>` for composition into custom subscriber stacks without calling `.init()`. Uses a generic subscriber bound so the layer can be stored and composed across crate boundaries.
 - **Developer-friendly content filter** (`adk-guardrail`): `ContentFilter::harmful_content()` no longer blocks "hack" and "exploit". New `harmful_content_strict()` variant retains the full original keyword list.
 - **PluginBuilder documentation** (`adk-plugin`): Expanded rustdoc on `PluginBuilder` with end-to-end examples. Added Quick Start section showing both `PluginConfig` and `PluginBuilder` usage side by side.
 - **Showcase example** (`examples/crate_adoption_feedback`): Standalone example demonstrating all five fixes with a live LLM agent.

--- a/adk-memory/src/adapter.rs
+++ b/adk-memory/src/adapter.rs
@@ -47,8 +47,8 @@ impl MemoryServiceAdapter {
 #[async_trait]
 impl adk_core::Memory for MemoryServiceAdapter {
     async fn search(&self, query: &str) -> adk_core::Result<Vec<adk_core::MemoryEntry>> {
-        let resp = self
-            .inner
+        let inner = self.inner.clone();
+        let resp = inner
             .search(SearchRequest {
                 query: query.to_string(),
                 app_name: self.app_name.clone(),
@@ -66,19 +66,22 @@ impl adk_core::Memory for MemoryServiceAdapter {
     }
 
     async fn add(&self, entry: adk_core::MemoryEntry) -> adk_core::Result<()> {
+        let inner = self.inner.clone();
         let mem_entry = crate::MemoryEntry {
             content: entry.content,
             author: entry.author,
             timestamp: Utc::now(),
         };
-        self.inner.add_entry(&self.app_name, &self.user_id, mem_entry).await
+        inner.add_entry(&self.app_name, &self.user_id, mem_entry).await
     }
 
     async fn delete(&self, query: &str) -> adk_core::Result<u64> {
-        self.inner.delete_entries(&self.app_name, &self.user_id, query).await
+        let inner = self.inner.clone();
+        inner.delete_entries(&self.app_name, &self.user_id, query).await
     }
 
     async fn health_check(&self) -> adk_core::Result<()> {
-        self.inner.health_check().await
+        let inner = self.inner.clone();
+        inner.health_check().await
     }
 }

--- a/adk-telemetry/src/init.rs
+++ b/adk-telemetry/src/init.rs
@@ -153,9 +153,13 @@ pub fn init_with_otlp(service_name: &str, endpoint: &str) -> Result<(), Telemetr
 
 /// Build an OTLP tracing layer without initializing a global subscriber.
 ///
-/// Returns a [`tracing_subscriber::Layer`] that can be composed with any
-/// [`tracing_subscriber::Registry`] via `.with()`. Also configures the global
-/// OpenTelemetry tracer and meter providers.
+/// Returns a boxed [`tracing_subscriber::Layer`] that can be composed with any
+/// subscriber via `.with()`. Also configures the global OpenTelemetry tracer
+/// and meter providers.
+///
+/// The layer is returned as `Box<dyn Layer<S>>` rather than `impl Layer` so it
+/// can be stored, composed across crate boundaries, and used in `Layered<...>`
+/// chains without running into opaque-type limitations.
 ///
 /// Unlike [`init_with_otlp`], this function does **not** call `.init()` on a
 /// subscriber and does **not** use the `INIT` [`Once`] guard. The caller is
@@ -181,13 +185,16 @@ pub fn init_with_otlp(service_name: &str, endpoint: &str) -> Result<(), Telemetr
 ///     .with(tracing_subscriber::fmt::layer())
 ///     .init();
 /// ```
-pub fn build_otlp_layer(
+pub fn build_otlp_layer<S>(
     service_name: &str,
     endpoint: &str,
-) -> Result<
-    impl tracing_subscriber::Layer<tracing_subscriber::Registry> + Send + Sync,
-    TelemetryError,
-> {
+) -> Result<Box<dyn tracing_subscriber::Layer<S> + Send + Sync>, TelemetryError>
+where
+    S: tracing::Subscriber
+        + for<'span> tracing_subscriber::registry::LookupSpan<'span>
+        + Send
+        + Sync,
+{
     use opentelemetry::trace::TracerProvider;
     use opentelemetry_otlp::WithExportConfig;
     use tracing_opentelemetry::OpenTelemetryLayer;
@@ -226,7 +233,7 @@ pub fn build_otlp_layer(
 
     opentelemetry::global::set_meter_provider(meter_provider);
 
-    Ok(OpenTelemetryLayer::new(tracer))
+    Ok(Box::new(OpenTelemetryLayer::new(tracer)))
 }
 
 /// Shutdown telemetry and flush any pending spans.

--- a/examples/crate_adoption_feedback/src/main.rs
+++ b/examples/crate_adoption_feedback/src/main.rs
@@ -118,7 +118,7 @@ fn demo_composable_telemetry() {
 
     // Verify the function exists and returns an error for unreachable endpoint
     // (we can't actually connect without a collector running)
-    match adk_telemetry::build_otlp_layer("demo-service", "http://localhost:4317") {
+    match adk_telemetry::build_otlp_layer::<tracing_subscriber::Registry>("demo-service", "http://localhost:4317") {
         Ok(_layer) => {
             println!("  ✓ build_otlp_layer returned a composable layer");
             println!("  ✓ Layer can be used with tracing_subscriber::registry().with(layer)");


### PR DESCRIPTION
## Summary

Follow-up to #263 based on real-world integration feedback from zavora-cli.

### Changes

**1. `build_otlp_layer` returns `Box<dyn Layer<S>>`** (`adk-telemetry`)

The original `impl Layer<Registry>` return type can't be stored or composed across `Layered<...>` types. Changed to `Box<dyn Layer<S> + Send + Sync>` with a generic subscriber bound so callers can compose it freely.

**2. `MemoryServiceAdapter` clone fix** (`adk-memory`)

The SQLx pool clone in #263 only fixed `SqliteMemoryService`. The `MemoryServiceAdapter` (which bridges `MemoryService` to `adk_core::Memory`) had the same `async_trait` lifetime issue on `self.inner`. Now clones `self.inner` (an `Arc`) into a local in all four methods.

### Testing
- `cargo fmt --all` clean
- `cargo clippy -D warnings` clean on adk-telemetry, adk-memory
- 9/9 tests pass (adk-memory + adk-telemetry)
- Example runs successfully with live LLM

Ref #262