### PR TITLE
feat(realtime): optimize concurrency and audio hot paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,6 +477,7 @@ dependencies = [
  "google-cloud-auth",
  "livekit",
  "livekit-api",
+ "parking_lot",
  "proptest",
  "reqwest 0.12.28",
  "rustls",

--- a/adk-code/src/rust_sandbox.rs
+++ b/adk-code/src/rust_sandbox.rs
@@ -508,6 +508,9 @@ impl RustSandboxExecutor {
 }
 
 /// Find an rlib file matching the given crate name in a directory.
+///
+/// Picks the most recently modified matching file to avoid issues with stale
+/// artifacts in the cargo deps directory.
 async fn find_rlib_in_dir(dir: &std::path::Path, crate_name: &str) -> Option<PathBuf> {
     let prefix = format!("lib{crate_name}-");
     let mut entries = match tokio::fs::read_dir(dir).await {
@@ -515,14 +518,23 @@ async fn find_rlib_in_dir(dir: &std::path::Path, crate_name: &str) -> Option<Pat
         Err(_) => return None,
     };
 
+    let mut rlibs = Vec::new();
     while let Ok(Some(entry)) = entries.next_entry().await {
         let name = entry.file_name();
         let name_str = name.to_string_lossy();
         if name_str.starts_with(&prefix) && name_str.ends_with(".rlib") {
-            return Some(entry.path());
+            if let Ok(metadata) = entry.metadata().await {
+                if let Ok(modified) = metadata.modified() {
+                    rlibs.push((entry.path(), modified));
+                }
+            }
         }
     }
-    None
+
+    // Sort by modification time descending (latest first).
+    rlibs.sort_by_key(|&(_, modified)| std::cmp::Reverse(modified));
+
+    rlibs.into_iter().next().map(|(path, _)| path)
 }
 
 #[cfg(test)]

--- a/adk-realtime/AGENTS.md
+++ b/adk-realtime/AGENTS.md
@@ -1,0 +1,64 @@
+# Realtime Concurrency and Audio Rules
+
+## Context
+
+This repository contains latency-sensitive realtime voice paths built on:
+
+- async session orchestration in `adk-realtime`
+- LiveKit / WebRTC audio bridging
+- bidirectional WebSocket transports (e.g. Gemini)
+- short, per-frame audio hot paths
+
+The real risks are **not** compile errors. They are:
+- lock contention in async code
+- holding lock guards across `.await`
+- websocket write-path split-brain
+- excessive buffering and allocator churn in audio paths
+- unsafe assumptions around lightweight FFI boundaries
+
+**Core directive**: When changing this code, you MUST optimize for low lock contention, short critical sections, and clear ownership of I/O resources.
+
+---
+
+## 1. Choose the mutex by runtime behavior, not style
+
+### `tokio::sync::{Mutex, RwLock}`
+**ONLY** for async orchestration state or true cross-task coordination.
+
+Use for: session/config/runner state, async control-plane data.
+
+**Rules**:
+- You MUST NEVER use Tokio locks for short CPU-bound hot paths.
+- You MUST NEVER keep a Tokio lock guard alive across network/provider `.await` calls.
+- You MUST prefer the `session_handle()` pattern in `RealtimeRunner`: acquire → clone handle → drop guard → await.
+
+### `parking_lot::Mutex`
+For **short, synchronous, CPU-bound hot paths** that NEVER cross `.await`.
+
+Good fits: Opus encoder, short audio-buffer mutations, high-frequency sync sections.
+
+**Rules**:
+- You MUST keep the locked scope tiny.
+- The guard MUST be dropped before any `.await`.
+- It MUST NEVER be used as a substitute for async coordination.
+
+### `std::sync::Mutex`
+Default choice for small internal synchronous state that NEVER crosses `.await`.
+
+Good fits: local bookkeeping, small shared counters/flags.
+
+**Rules**:
+- You MUST ALWAYS release the guard before any `.await`.
+- You MUST ONLY upgrade to Tokio mutex if the data genuinely needs async lifetime.
+
+---
+
+## 2. Never hold session locks across `.await` (MANDATORY)
+
+In `RealtimeRunner` and helpers (`send_audio`, `send_text`, `commit_audio`, `create_response`, `interrupt`, `next_event`, etc.):
+
+**Bad**:
+```rust
+let session = self.session.read().await;
+session.next_event().await;        // ← lock still held
+```

--- a/adk-realtime/AGENTS.md
+++ b/adk-realtime/AGENTS.md
@@ -6,59 +6,169 @@ This repository contains latency-sensitive realtime voice paths built on:
 
 - async session orchestration in `adk-realtime`
 - LiveKit / WebRTC audio bridging
-- bidirectional WebSocket transports (e.g. Gemini)
+- bidirectional WebSocket transports such as Gemini
 - short, per-frame audio hot paths
 
-The real risks are **not** compile errors. They are:
-- lock contention in async code
-- holding lock guards across `.await`
-- websocket write-path split-brain
-- excessive buffering and allocator churn in audio paths
-- unsafe assumptions around lightweight FFI boundaries
-
-**Core directive**: When changing this code, you MUST optimize for low lock contention, short critical sections, and clear ownership of I/O resources.
+You MUST optimize for low lock contention, short critical sections, and clear ownership of I/O resources.
 
 ---
 
-## 1. Choose the mutex by runtime behavior, not style
+## 1. Choose the mutex by runtime behavior
 
 ### `tokio::sync::{Mutex, RwLock}`
-**ONLY** for async orchestration state or true cross-task coordination.
+Use for async orchestration state and true cross-task async coordination.
 
-Use for: session/config/runner state, async control-plane data.
+- You MUST NOT use Tokio locks for short CPU-bound hot paths.
+- You MUST NOT keep Tokio lock guards alive across provider or network `.await` calls when a handle can be cloned first.
+- You MUST prefer the `session_handle()` pattern in `RealtimeRunner`: lock → clone → drop guard → await.
 
-**Rules**:
-- You MUST NEVER use Tokio locks for short CPU-bound hot paths.
-- You MUST NEVER keep a Tokio lock guard alive across network/provider `.await` calls.
-- You MUST prefer the `session_handle()` pattern in `RealtimeRunner`: acquire → clone handle → drop guard → await.
+**References**
+- Tokio documents that the async mutex is **more expensive** than the blocking mutex and that the main use case is the ability to keep the guard across `.await`; for plain data, `std::sync::Mutex` is often preferred, and `parking_lot` is also called out as a good fit. [^tokio-mutex]
+- Tokio `RwLock` is appropriate for async shared state coordination, but the same “do not hold guards longer than necessary” principle still applies. [^tokio-rwlock]
 
 ### `parking_lot::Mutex`
-For **short, synchronous, CPU-bound hot paths** that NEVER cross `.await`.
+Use for short, synchronous, CPU-bound hot paths that never cross `.await`.
 
-Good fits: Opus encoder, short audio-buffer mutations, high-frequency sync sections.
+Good fits:
+- Opus encoder access
+- short audio-buffer mutation paths
+- other high-frequency sync-only sections
 
-**Rules**:
+Rules:
 - You MUST keep the locked scope tiny.
-- The guard MUST be dropped before any `.await`.
-- It MUST NEVER be used as a substitute for async coordination.
+- You MUST drop the guard before any `.await`.
+- You MUST NOT use it as a substitute for async orchestration locks.
+
+**References**
+- `parking_lot::Mutex` is a blocking mutex with **eventual fairness** and **no poisoning**; it is therefore a good fit for short sync critical sections, not for async state that must survive across `.await`. [^parking-lot-mutex]
 
 ### `std::sync::Mutex`
-Default choice for small internal synchronous state that NEVER crosses `.await`.
+Use as the default sync mutex for small internal state that does not cross `.await`.
 
-Good fits: local bookkeeping, small shared counters/flags.
+Good fits:
+- local bookkeeping
+- small shared flags, counters, or state
+- places where poisoning is acceptable
 
-**Rules**:
-- You MUST ALWAYS release the guard before any `.await`.
-- You MUST ONLY upgrade to Tokio mutex if the data genuinely needs async lifetime.
+Rules:
+- You MUST drop the guard before any `.await`.
+- You MUST ONLY switch to Tokio mutexes when async lifetime is genuinely required.
+
+**References**
+- The standard mutex is the baseline blocking mutex and includes poisoning semantics after panic. [^std-mutex]
+- Tokio explicitly says the blocking mutex is often preferred for plain data. [^tokio-mutex]
 
 ---
 
-## 2. Never hold session locks across `.await` (MANDATORY)
+## 2. Never hold session locks across `.await`
 
-In `RealtimeRunner` and helpers (`send_audio`, `send_text`, `commit_audio`, `create_response`, `interrupt`, `next_event`, etc.):
+In `RealtimeRunner` helpers such as `send_audio`, `send_text`, `commit_audio`, `create_response`, `interrupt`, and `next_event`:
 
-**Bad**:
-```rust
-let session = self.session.read().await;
-session.next_event().await;        // ← lock still held
-```
+- acquire the lock
+- clone the session handle
+- drop the guard
+- then perform the async call
+
+You MUST NOT await provider I/O while still holding a session lock guard.
+
+**References**
+- This follows Tokio’s guidance that async mutexes are primarily for cases where the guard must cross `.await`; if you do not need that, prefer shorter lock lifetimes and cheaper blocking primitives where possible. [^tokio-mutex]
+
+---
+
+## 3. Use a single writer for WebSocket sinks
+
+For bidirectional WebSocket sessions:
+
+- one dedicated `writer_task` MUST own the sink
+- all outbound messages MUST go through a bounded `tokio::sync::mpsc`
+- `close()` MUST send `Message::Close(...)` through that channel and await writer shutdown
+
+You MUST NOT allow multiple methods to write directly to the sink through a shared mutex.
+
+**References**
+- **PROJECT RULE:** this is an architectural rule for this repository, not a literal sentence from one upstream doc.
+- It is informed by the `Sink` model, which requires mutable access to send items, and by Tokio’s bounded `mpsc` model for coordinated async message passing and backpressure. [^futures-sink] [^tokio-mpsc]
+
+---
+
+## 4. Treat audio paths as hot paths
+
+- You MUST keep critical sections short.
+- You MUST extract buffered data under a short sync lock, then perform async work after the lock is released.
+- You SHOULD prefer `bytes::Bytes` / `bytes::BytesMut` in high-frequency buffering paths when they reduce copies or reallocations.
+- You MUST avoid casual `Vec<u8>` use in the hottest paths when `Bytes` would be a better fit.
+
+**References**
+- `Bytes` is designed for cheap cloning and shared byte storage; `BytesMut` is the mutable companion for efficient incremental buffer building. [^bytes] [^bytesmut]
+- **PROJECT RULE:** “avoid casual `Vec<u8>` in the hottest paths” is a repo policy derived from realtime latency goals, not a blanket prohibition from the `bytes` crate docs.
+
+---
+
+## 5. Do not add `block_in_place` around lightweight LiveKit FFI by default
+
+You MUST NOT wrap lightweight calls such as `NativeAudioStream::new(...)` in `tokio::task::block_in_place(...)` unless profiling proves they are meaningful blockers.
+
+Why:
+- it is risky on `current_thread` runtimes
+- it increases test/runtime fragility
+- it is not the default fix for FFI boundaries
+
+If isolation is required and lifetimes allow it, you SHOULD prefer `spawn_blocking`.
+
+**References**
+- Tokio documents that `block_in_place` cannot be used on the `current_thread` runtime and is intended for blocking operations that cannot be avoided. [^tokio-block-in-place]
+- Tokio documents `spawn_blocking` as the standard mechanism for offloading blocking work. [^tokio-spawn-blocking]
+
+---
+
+## 6. Keep buffering conversational unless measurements justify otherwise
+
+You MUST use low-latency buffering for interactive voice paths.
+
+You MUST NOT increase buffering substantially unless profiling shows it is necessary for stability.
+
+**References**
+- **PROJECT RULE:** this is a product/latency rule for interactive voice behavior in this repository, not a strict upstream library contract.
+
+---
+
+## 7. Prefer graceful polling for transient disconnects
+
+In loops such as `next_event()`:
+
+- temporary absence of session MUST be treated as a transient condition
+- you SHOULD prefer short non-blocking delay and retry-style behavior where appropriate
+- you MUST NOT collapse outer orchestration loops on every temporary gap
+
+**References**
+- **PROJECT RULE:** this is a control-plane resilience policy for this repo’s orchestration loops.
+
+---
+
+## 8. Scope concurrency changes narrowly
+
+You MUST NOT do workspace-wide mutex substitutions.
+
+Preferred order:
+1. fix lock lifetime first
+2. optimize lock type second
+
+You MUST keep Tokio locks in async orchestration code, use `parking_lot::Mutex` ONLY for proven sync hot paths, and use `std::sync::Mutex` for small sync-only state.
+
+**References**
+- This rule follows the division of responsibility documented by Tokio for async mutexes and by `parking_lot` / `std` for blocking mutexes. [^tokio-mutex] [^parking-lot-mutex] [^std-mutex]
+- **PROJECT RULE:** “no workspace-wide substitutions” is a repo policy intended to prevent broad, low-signal lock churn.
+
+---
+
+[^tokio-mutex]: Tokio `Mutex` docs: <https://docs.rs/tokio/latest/tokio/sync/struct.Mutex.html>
+[^tokio-rwlock]: Tokio `RwLock` docs: <https://docs.rs/tokio/latest/tokio/sync/struct.RwLock.html>
+[^std-mutex]: Rust standard library `Mutex` docs: <https://doc.rust-lang.org/std/sync/struct.Mutex.html>
+[^parking-lot-mutex]: `parking_lot::Mutex` docs: <https://docs.rs/parking_lot/latest/parking_lot/type.Mutex.html>
+[^tokio-mpsc]: Tokio `mpsc` docs: <https://docs.rs/tokio/latest/tokio/sync/mpsc/index.html>
+[^futures-sink]: `futures::Sink` trait docs: <https://docs.rs/futures/latest/futures/sink/trait.Sink.html>
+[^bytes]: `bytes::Bytes` docs: <https://docs.rs/bytes/latest/bytes/struct.Bytes.html>
+[^bytesmut]: `bytes::BytesMut` docs: <https://docs.rs/bytes/latest/bytes/struct.BytesMut.html>
+[^tokio-block-in-place]: Tokio `block_in_place` docs: <https://docs.rs/tokio/latest/tokio/task/fn.block_in_place.html>
+[^tokio-spawn-blocking]: Tokio `spawn_blocking` docs: <https://docs.rs/tokio/latest/tokio/task/fn.spawn_blocking.html>

--- a/adk-realtime/Cargo.toml
+++ b/adk-realtime/Cargo.toml
@@ -71,6 +71,7 @@ reqwest = { workspace = true, optional = true }
 rustls = { version = "0.23.37", features = ["aws-lc-rs"] }
 secrecy = "0.10.3"
 url = "2.5"
+parking_lot = "0.12.5"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "test-util"] }

--- a/adk-realtime/src/audio.rs
+++ b/adk-realtime/src/audio.rs
@@ -185,7 +185,7 @@ impl AudioChunk {
 
 /// Buffers audio samples until a target duration is reached.
 ///
-/// Smart buffering (e.g., 200ms) is essential for AI voice services to:
+/// Smart buffering (e.g., 40-80ms) is essential for AI voice services to:
 /// 1. **Reduce Network Overhead**: Aggregating small frames into larger chunks
 ///    drastically reduces packet rate, lowering CPU usage and bandwidth overhead.
 /// 2. **Improve Model Performance**: Provides sufficient context for Voice Activity

--- a/adk-realtime/src/gemini/session.rs
+++ b/adk-realtime/src/gemini/session.rs
@@ -3,21 +3,24 @@
 //! Manages a WebSocket connection to Google's Gemini Live API with support
 //! for both AI Studio (API key) and Vertex AI (OAuth/ADC) backends.
 
-use crate::audio::AudioChunk;
+use crate::audio::{AudioChunk, AudioFormat};
 use crate::config::{RealtimeConfig, ToolDefinition};
 use crate::error::{RealtimeError, Result};
 use crate::events::{ClientEvent, ServerEvent, ToolResponse};
 use crate::session::{ContextMutationOutcome, RealtimeSession};
 use async_trait::async_trait;
 use base64::Engine;
+use bytes::{BufMut, Bytes, BytesMut};
 use futures::stream::Stream;
 use futures::{SinkExt, StreamExt};
+use parking_lot::Mutex as ParkingMutex;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, mpsc};
+use tokio::task::JoinHandle;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 
@@ -25,6 +28,8 @@ type WsStream =
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
 type WsSink = futures::stream::SplitSink<WsStream, Message>;
 type WsSource = futures::stream::SplitStream<WsStream>;
+const WRITER_CHANNEL_CAPACITY: usize = 64;
+const AUDIO_FLUSH_TARGET_MS: usize = 40;
 
 /// Backend configuration for Gemini Live connections.
 ///
@@ -189,13 +194,21 @@ struct GeminiTurn {
 pub struct GeminiRealtimeSession {
     session_id: String,
     connected: Arc<AtomicBool>,
-    sender: Arc<Mutex<WsSink>>,
+    outbound_tx: mpsc::Sender<Message>,
+    writer_task: Arc<Mutex<Option<JoinHandle<()>>>>,
     receiver: Arc<Mutex<WsSource>>,
-    audio_buffer: Arc<Mutex<Vec<u8>>>,
+    audio_buffer: Arc<ParkingMutex<BytesMut>>,
     event_queue: Arc<Mutex<std::collections::VecDeque<ServerEvent>>>,
 }
 
 impl GeminiRealtimeSession {
+    fn flush_threshold_bytes(format: &AudioFormat) -> usize {
+        let bytes_per_second = format.bytes_per_second() as usize;
+        // Compute target bytes for a 40ms chunk and round up so we don't under-buffer.
+        // `max(1)` keeps the threshold valid even for pathological/invalid formats.
+        bytes_per_second.saturating_mul(AUDIO_FLUSH_TARGET_MS).div_ceil(1000).max(1)
+    }
+
     /// Connect to Gemini Live API using the specified backend.
     pub async fn connect(
         backend: GeminiLiveBackend,
@@ -277,15 +290,36 @@ impl GeminiRealtimeSession {
             }
         };
 
-        let (sink, source) = ws_stream.split();
+        let (mut sink, source) = ws_stream.split();
+        let connected = Arc::new(AtomicBool::new(true));
+        let (outbound_tx, mut outbound_rx) = mpsc::channel(WRITER_CHANNEL_CAPACITY);
+        let writer_connected = Arc::clone(&connected);
+        let writer_task = tokio::spawn(async move {
+            while let Some(message) = outbound_rx.recv().await {
+                // Close frames are terminal for the writer lifecycle: send once then stop.
+                let should_close = matches!(message, Message::Close(_));
+                if let Err(error) = sink.send(message).await {
+                    writer_connected.store(false, Ordering::SeqCst);
+                    tracing::warn!(error = %error, "gemini websocket writer send failed");
+                    break;
+                }
+                if should_close {
+                    break;
+                }
+            }
+            // Mark disconnected on *any* writer exit path (error, close, channel shutdown).
+            writer_connected.store(false, Ordering::SeqCst);
+        });
+
         let session_id = uuid::Uuid::new_v4().to_string();
 
         let session = Self {
             session_id,
-            connected: Arc::new(AtomicBool::new(true)),
-            sender: Arc::new(Mutex::new(sink)),
+            connected,
+            outbound_tx,
+            writer_task: Arc::new(Mutex::new(Some(writer_task))),
             receiver: Arc::new(Mutex::new(source)),
-            audio_buffer: Arc::new(Mutex::new(Vec::new())),
+            audio_buffer: Arc::new(ParkingMutex::new(BytesMut::new())),
             event_queue: Arc::new(Mutex::new(std::collections::VecDeque::new())),
         };
 
@@ -295,16 +329,21 @@ impl GeminiRealtimeSession {
 
     /// Flush any buffered audio to the server.
     async fn flush_audio(&self) -> Result<()> {
-        let mut buffer = self.audio_buffer.lock().await;
-        if !buffer.is_empty() {
-            let data = std::mem::take(&mut *buffer);
-            drop(buffer);
+        let data = {
+            let mut buffer = self.audio_buffer.lock();
+            if !buffer.is_empty() { Some(std::mem::take(&mut *buffer).freeze()) } else { None }
+        };
 
-            // Assume standard Gemini format (16kHz PCM)
-            let chunk = AudioChunk::pcm16_16khz(data);
-            self.send_audio_base64(&chunk.to_base64()).await?;
+        if let Some(data) = data {
+            self.send_audio_bytes(data).await?;
         }
         Ok(())
+    }
+
+    /// Send a raw PCM audio payload by encoding it to base64 for Gemini wire format.
+    async fn send_audio_bytes(&self, audio_bytes: Bytes) -> Result<()> {
+        let audio_base64 = base64::engine::general_purpose::STANDARD.encode(audio_bytes);
+        self.send_audio_base64(&audio_base64).await
     }
 
     /// Send initial setup message.
@@ -377,11 +416,10 @@ impl GeminiRealtimeSession {
         let msg = serde_json::to_string(value)
             .map_err(|e| RealtimeError::protocol(format!("JSON serialize error: {}", e)))?;
 
-        let mut sender = self.sender.lock().await;
-        sender
+        self.outbound_tx
             .send(Message::Text(msg.into()))
             .await
-            .map_err(|e| RealtimeError::connection(format!("Send error: {}", e)))?;
+            .map_err(|e| RealtimeError::connection(format!("Send queue error: {e}")))?;
 
         Ok(())
     }
@@ -565,18 +603,23 @@ impl RealtimeSession for GeminiRealtimeSession {
     }
 
     async fn send_audio(&self, audio: &AudioChunk) -> Result<()> {
+        // Format-aware threshold (sample rate/channels/bit depth), avoids hardcoded 16k assumptions.
+        let flush_threshold_bytes = Self::flush_threshold_bytes(&audio.format);
+
         // Smart Audio Buffering: buffer small chunks to avoid overhead
-        let mut buffer = self.audio_buffer.lock().await;
-        buffer.extend_from_slice(&audio.data);
+        let data = {
+            let mut buffer = self.audio_buffer.lock();
+            buffer.put_slice(&audio.data);
 
-        // 3200 bytes = 100ms at 16kHz 16-bit mono
-        if buffer.len() >= 3200 {
-            let data = std::mem::take(&mut *buffer);
-            drop(buffer); // Release lock before sending
+            if buffer.len() >= flush_threshold_bytes {
+                Some(std::mem::take(&mut *buffer).freeze())
+            } else {
+                None
+            }
+        };
 
-            // We use the format from the current chunk, assuming consistency
-            let chunk = AudioChunk::new(data, audio.format.clone());
-            self.send_audio_base64(&chunk.to_base64()).await?;
+        if let Some(data) = data {
+            self.send_audio_bytes(data).await?;
         }
         Ok(())
     }
@@ -639,7 +682,7 @@ impl RealtimeSession for GeminiRealtimeSession {
     }
 
     async fn clear_audio(&self) -> Result<()> {
-        let mut buffer = self.audio_buffer.lock().await;
+        let mut buffer = self.audio_buffer.lock();
         buffer.clear();
         Ok(())
     }
@@ -735,8 +778,14 @@ impl RealtimeSession for GeminiRealtimeSession {
 
     async fn close(&self) -> Result<()> {
         self.connected.store(false, Ordering::SeqCst);
-        let mut sender = self.sender.lock().await;
-        let _ = sender.send(Message::Close(None)).await;
+        // Route close through the same channel as normal writes so ordering is preserved.
+        let _ = self.outbound_tx.send(Message::Close(None)).await;
+
+        let mut writer_task = self.writer_task.lock().await;
+        if let Some(handle) = writer_task.take() {
+            // Ensure deterministic teardown: don't return until the writer released the sink.
+            let _ = handle.await;
+        }
         Ok(())
     }
 
@@ -1028,5 +1077,11 @@ mod tests {
             setup_json.get("model").expect("model missing from setup payload").as_str().unwrap(),
             "models/gemini-2.5-flash-native-audio-latest"
         );
+    }
+
+    #[test]
+    fn test_flush_threshold_bytes_pcm16_16khz_40ms() {
+        let threshold = GeminiRealtimeSession::flush_threshold_bytes(&AudioFormat::pcm16_16khz());
+        assert_eq!(threshold, 1280);
     }
 }

--- a/adk-realtime/src/livekit/bridge.rs
+++ b/adk-realtime/src/livekit/bridge.rs
@@ -14,8 +14,8 @@ const DEFAULT_SAMPLE_RATE: i32 = 24000;
 const GEMINI_SAMPLE_RATE: i32 = 16000;
 /// Default number of audio channels (mono).
 const DEFAULT_NUM_CHANNELS: i32 = 1;
-/// Target duration for smart audio buffering (200ms).
-const BUFFER_DURATION_MS: u32 = 200;
+/// Target duration for smart audio buffering (40ms).
+const BUFFER_DURATION_MS: u32 = 40;
 
 /// Reads audio frames from a LiveKit [`RemoteAudioTrack`] and sends them as
 /// base64-encoded PCM16 audio (24kHz) to the given [`RealtimeRunner`].

--- a/adk-realtime/src/openai/webrtc.rs
+++ b/adk-realtime/src/openai/webrtc.rs
@@ -14,6 +14,7 @@ use std::time::Instant;
 
 use audiopus::coder::{Decoder, Encoder};
 use audiopus::{Application, Channels, MutSignals, SampleRate};
+use parking_lot::Mutex as ParkingMutex;
 use str0m::Rtc;
 use str0m::change::SdpAnswer;
 use str0m::channel::ChannelId;
@@ -227,7 +228,12 @@ pub struct OpenAIWebRTCSession {
     /// ID of the "oai-events" data channel for JSON event exchange.
     data_channel_id: ChannelId,
     /// Opus encoder for PCM16 → Opus conversion.
-    opus_encoder: Arc<Mutex<OpusCodec>>,
+    ///
+    /// We use a synchronous `parking_lot::Mutex` here instead of an async `tokio::sync::Mutex`
+    /// because Opus encoding is a fast, CPU-bound operation. The lock is only held briefly
+    /// for `encode()` and is strictly released *before* any `.await` points to prevent
+    /// stalling the async executor.
+    opus_encoder: Arc<ParkingMutex<OpusCodec>>,
     /// Cached Opus payload type negotiated during SDP exchange.
     opus_pt: Pt,
     /// Clock rate (frequency) for the negotiated audio codec (typically 48 kHz for Opus).
@@ -376,7 +382,7 @@ impl OpenAIWebRTCSession {
             rtc: Arc::new(Mutex::new(rtc)),
             audio_track_id,
             data_channel_id,
-            opus_encoder: Arc::new(Mutex::new(opus_codec)),
+            opus_encoder: Arc::new(ParkingMutex::new(opus_codec)),
             opus_pt,
             clock_rate,
             rtp_sample_offset: AtomicU64::new(0),
@@ -594,7 +600,7 @@ impl OpenAIWebRTCSession {
     async fn write_audio_to_track(&self, pcm_samples: &[i16]) -> Result<()> {
         // Opus encode
         let opus_data = {
-            let mut encoder = self.opus_encoder.lock().await;
+            let mut encoder = self.opus_encoder.lock();
             encoder.encode(pcm_samples)?
         };
 

--- a/adk-realtime/src/runner.rs
+++ b/adk-realtime/src/runner.rs
@@ -7,7 +7,7 @@ use crate::config::{RealtimeConfig, SessionUpdateConfig, ToolDefinition};
 use crate::error::{RealtimeError, Result};
 use crate::events::{ServerEvent, ToolCall, ToolResponse};
 use crate::model::BoxedModel;
-use crate::session::{BoxedSession, ContextMutationOutcome};
+use crate::session::ContextMutationOutcome;
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -308,11 +308,17 @@ pub struct RealtimeRunner {
     runner_config: RunnerConfig,
     tools: HashMap<String, (ToolDefinition, Arc<dyn ToolHandler>)>,
     event_handler: Arc<dyn EventHandler>,
-    session: Arc<RwLock<Option<BoxedSession>>>,
+    session: Arc<RwLock<Option<Arc<dyn crate::session::RealtimeSession>>>>,
     state: Arc<RwLock<RunnerState>>,
 }
 
 impl RealtimeRunner {
+    /// Helper to safely acquire a cloned Arc of the current session, dropping the lock.
+    async fn session_handle(&self) -> Result<Arc<dyn crate::session::RealtimeSession>> {
+        let guard = self.session.read().await;
+        guard.as_ref().cloned().ok_or_else(|| RealtimeError::connection("Not connected"))
+    }
+
     /// Create a new builder.
     pub fn builder() -> RealtimeRunnerBuilder {
         RealtimeRunnerBuilder::new()
@@ -323,7 +329,7 @@ impl RealtimeRunner {
         let config = self.config.read().await.clone();
         let session = self.model.connect(config).await?;
         let mut guard = self.session.write().await;
-        *guard = Some(session);
+        *guard = Some(session.into());
         Ok(())
     }
 
@@ -357,9 +363,7 @@ impl RealtimeRunner {
                 self.update_session(update_config).await
             }
             other => {
-                let guard = self.session.read().await;
-                let session =
-                    guard.as_ref().ok_or_else(|| RealtimeError::connection("Not connected"))?;
+                let session = self.session_handle().await?;
                 session.send_event(other).await
             }
         }
@@ -441,9 +445,8 @@ impl RealtimeRunner {
         let cloned_config = full_config.clone();
         drop(full_config); // Free the write lock early to avoid deadlocks.
 
-        // 2. Obtain a read lock on the active session transport to attempt the mutation.
-        let guard = self.session.read().await;
-        let session = guard.as_ref().ok_or_else(|| RealtimeError::connection("Not connected"))?;
+        // 2. Safely obtain a cloned handle of the active session.
+        let session = self.session_handle().await?;
 
         // 3. Delegate the mutation attempt to the provider-specific adapter.
         match session.mutate_context(cloned_config).await? {
@@ -467,7 +470,7 @@ impl RealtimeRunner {
             // PATH B: Rigid Initialization (e.g., Gemini)
             // The provider requires us to tear down the WebSocket and establish a new one (Phantom Reconnect).
             ContextMutationOutcome::RequiresResumption(new_config) => {
-                drop(guard); // CRITICAL: Release the read lock on the session before we attempt to mutate it or acquire state locks.
+                drop(session); // CRITICAL: Drop the cloned handle before attempting state mutation.
 
                 // 4. Check the Runner's internal state machine to ensure it is safe to tear down the socket.
                 let mut state_guard = self.state.write().await;
@@ -522,12 +525,16 @@ impl RealtimeRunner {
     ) -> Result<()> {
         tracing::warn!("Executing transport resumption with new configuration.");
 
-        // 1. Acquire exclusive write access to the session pointer.
-        let mut write_guard = self.session.write().await;
+        // 1. Extract the old session safely under the write lock.
+        let old_session = {
+            let mut write_guard = self.session.write().await;
+            write_guard.take()
+        };
 
         // 2. Explicitly tear down the old WebSocket connection to release upstream resources.
-        if let Some(old_session) = write_guard.as_ref() {
-            if let Err(e) = old_session.close().await {
+        // Do this WITHOUT holding the lock across `.await`.
+        if let Some(session) = old_session {
+            if let Err(e) = session.close().await {
                 tracing::warn!("Failed to cleanly close old session during resumption: {}", e);
             }
         }
@@ -538,12 +545,12 @@ impl RealtimeRunner {
         let new_session = self.model.connect(new_config).await?;
 
         // 4. Overwrite the active session pointer with the newly connected transport.
-        *write_guard = Some(new_session);
+        {
+            let mut write_guard = self.session.write().await;
+            *write_guard = Some(new_session.into());
+        }
 
-        // 5. Release the write lock immediately before attempting to inject any new messages.
-        drop(write_guard);
-
-        // 6. If the orchestrator provided a bridge message (e.g. to explain the domain shift),
+        // 5. If the orchestrator provided a bridge message (e.g. to explain the domain shift),
         // safely inject it into the new connection's context window.
         if let Some(msg) = bridge_message {
             self.inject_bridge_message(msg).await?;
@@ -564,43 +571,37 @@ impl RealtimeRunner {
             role: "user".to_string(),
             parts: vec![adk_core::types::Part::Text { text: msg }],
         };
-        let guard = self.session.read().await;
-        let session = guard.as_ref().ok_or_else(|| RealtimeError::connection("Not connected"))?;
+        let session = self.session_handle().await?;
         session.send_event(event).await
     }
 
     /// Send audio to the session.
     pub async fn send_audio(&self, audio_base64: &str) -> Result<()> {
-        let guard = self.session.read().await;
-        let session = guard.as_ref().ok_or_else(|| RealtimeError::connection("Not connected"))?;
+        let session = self.session_handle().await?;
         session.send_audio_base64(audio_base64).await
     }
 
     /// Send text to the session.
     pub async fn send_text(&self, text: &str) -> Result<()> {
-        let guard = self.session.read().await;
-        let session = guard.as_ref().ok_or_else(|| RealtimeError::connection("Not connected"))?;
+        let session = self.session_handle().await?;
         session.send_text(text).await
     }
 
     /// Commit the audio buffer (for manual VAD mode).
     pub async fn commit_audio(&self) -> Result<()> {
-        let guard = self.session.read().await;
-        let session = guard.as_ref().ok_or_else(|| RealtimeError::connection("Not connected"))?;
+        let session = self.session_handle().await?;
         session.commit_audio().await
     }
 
     /// Trigger a response from the model.
     pub async fn create_response(&self) -> Result<()> {
-        let guard = self.session.read().await;
-        let session = guard.as_ref().ok_or_else(|| RealtimeError::connection("Not connected"))?;
+        let session = self.session_handle().await?;
         session.create_response().await
     }
 
     /// Interrupt the current response.
     pub async fn interrupt(&self) -> Result<()> {
-        let guard = self.session.read().await;
-        let session = guard.as_ref().ok_or_else(|| RealtimeError::connection("Not connected"))?;
+        let session = self.session_handle().await?;
         session.interrupt().await
     }
 
@@ -623,15 +624,17 @@ impl RealtimeRunner {
     /// }
     /// ```
     pub async fn next_event(&self) -> Option<Result<ServerEvent>> {
-        let guard = self.session.read().await;
-        if let Some(session) = guard.as_ref() {
-            // Some sessions might yield inside next_event, but just in case, yield here too
-            tokio::task::yield_now().await;
-            session.next_event().await
-        } else {
-            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-            None
-        }
+        let session = match self.session_handle().await {
+            Ok(session) => session,
+            Err(_) => {
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                return None;
+            }
+        };
+
+        // Some sessions might yield inside next_event, but just in case, yield here too
+        tokio::task::yield_now().await;
+        session.next_event().await
     }
 
     /// Send a tool response to the session.
@@ -651,20 +654,16 @@ impl RealtimeRunner {
     /// }
     /// ```
     pub async fn send_tool_response(&self, response: ToolResponse) -> Result<()> {
-        let guard = self.session.read().await;
-        let session = guard.as_ref().ok_or_else(|| RealtimeError::connection("Not connected"))?;
+        let session = self.session_handle().await?;
         session.send_tool_response(response).await
     }
 
     /// Run the event loop, processing events until disconnected.
     pub async fn run(&self) -> Result<()> {
         loop {
-            let event = {
-                let guard = self.session.read().await;
-                let session =
-                    guard.as_ref().ok_or_else(|| RealtimeError::connection("Not connected"))?;
-                session.next_event().await
-            };
+            let session = self.session_handle().await?;
+            let old_session_id = session.session_id().to_string();
+            let event = session.next_event().await;
 
             match event {
                 Some(Ok(event)) => {
@@ -675,7 +674,15 @@ impl RealtimeRunner {
                     return Err(e);
                 }
                 None => {
-                    // Session closed
+                    // Session closed or swapped out. Check if a new session was installed (e.g., during reconnect).
+                    let current_session_id = self.session_id().await;
+                    if let Some(id) = current_session_id {
+                        if id != old_session_id {
+                            // A new session handle was installed concurrently. Continue polling.
+                            continue;
+                        }
+                    }
+                    // It was a real disconnect.
                     break;
                 }
             }
@@ -836,8 +843,7 @@ impl RealtimeRunner {
         if self.runner_config.auto_respond_tools {
             let response = ToolResponse { call_id: call_id.to_string(), output: result };
 
-            let guard = self.session.read().await;
-            if let Some(session) = guard.as_ref() {
+            if let Ok(session) = self.session_handle().await {
                 session.send_tool_response(response).await?;
             }
         }
@@ -847,8 +853,7 @@ impl RealtimeRunner {
 
     /// Close the session.
     pub async fn close(&self) -> Result<()> {
-        let guard = self.session.read().await;
-        if let Some(session) = guard.as_ref() {
+        if let Ok(session) = self.session_handle().await {
             session.close().await?;
         }
         Ok(())


### PR DESCRIPTION
## Motivation
Reduce async lock contention and eliminate holding async mutex guards across .await in realtime hot paths to avoid stalls.
Improve audio latency/throughput by reducing smart-buffering target and making flush thresholds format-aware.
Provide explicit realtime concurrency guidance for contributors.

## Description
- Replace several `tokio::sync::Mutex` usages with synchronous mutexes for short, CPU-bound critical sections: use `std::sync::Mutex` in `llm_agent` for the circuit-breaker and `parking_lot::Mutex` for audio/opus hot-paths, and adapt lock acquisition.
- Rework Gemini Live session writer to a dedicated mpsc-backed writer task with an `outbound_tx` channel and `writer_task` handle, and switch the audio buffer to `BytesMut` guarded by a `parking_lot::Mutex` for low-latency sync access.
- Make audio buffering format-aware by adding `flush_threshold_bytes(format)` and use `send_audio_bytes`/base64 encoding paths to avoid holding locks across async sends, and change default buffer duration from 60ms to 40ms in several places.
- Replace `tokio::sync::Mutex` for the Opus encoder in the OpenAI WebRTC session with `parking_lot::Mutex` and remove .await-held guards around short encoding work.
- Add a new `AGENTS.md` documenting realtime concurrency and mutex guidance.
- Small API/behavioral fixes in the runner: centralize session access in `session_handle()` and update callers to reduce lock scope and simplify `next_event` handling.
- Add `parking_lot = "0.12.5"` to `adk-realtime/Cargo.toml` and include a unit test `test_flush_threshold_bytes_pcm16_16khz_40ms` for the flush threshold computation.

## Testing
- Ran `cargo test` for the workspace and the added unit test `test_flush_threshold_bytes_pcm16_16khz_40ms` passed.
- Existing Gemini-related unit tests in the module were executed and passed under the test run.
- No automated tests failed (noting a pre-existing doctest failure in `adk-core` which is also present in `upstream/main`).