### PR TITLE
feat(gemini): Gemini 3 function calling compliance — VALIDATED mode, allowed_function_names, call id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,15 @@ Thread-safe key-value store for parallel agent coordination:
 
 - **Tool authorization guide** (`docs/official_docs/security/tool-authorization.md`): `ToolConfirmationPolicy` (HITL), `BeforeToolCallback`, RBAC, graph interrupts with CLI and web server examples.
 
+#### Gemini 3 Function Calling Compliance (`adk-gemini`, `adk-model`)
+
+Four additions bringing `adk-gemini` to full compliance with the Gemini function calling specification:
+
+- **`VALIDATED` function calling mode** (`adk-gemini`): New `FunctionCallingMode::Validated` variant for schema validation without forced calling (Gemini 3 series).
+- **`allowed_function_names`** (`adk-gemini`): `FunctionCallingConfig` now supports restricting which functions the model may call when mode is `Any`.
+- **Function call `id` field** (`adk-gemini`): `FunctionCall` struct now includes an optional `id` field for Gemini 3 series models that return unique identifiers per call.
+- **`id` propagation** (`adk-model`): Gemini conversion layer propagates function call `id` between `adk-core` and `adk-gemini` types in both directions.
+
 #### Crate Adoption Feedback (GitHub issue #262)
 
 Five adoption fixes reported by a real-world integrator (zavora-cli):

--- a/adk-gemini/Cargo.toml
+++ b/adk-gemini/Cargo.toml
@@ -107,6 +107,10 @@ name = "files_lifecycle"
 path = "examples/files_lifecycle.rs"
 
 [[example]]
+name = "gemini3_function_calling"
+path = "examples/gemini3_function_calling.rs"
+
+[[example]]
 name = "gemini_pro_example"
 path = "examples/gemini_pro_example.rs"
 

--- a/adk-gemini/examples/gemini3_function_calling.rs
+++ b/adk-gemini/examples/gemini3_function_calling.rs
@@ -1,0 +1,270 @@
+//! Gemini 3 Function Calling Features
+//!
+//! Demonstrates the Gemini 3 series function calling enhancements:
+//! - `VALIDATED` mode: schema validation without forced calling
+//! - `allowed_function_names`: restrict which functions the model may call
+//! - Function call `id` field: unique identifier per call for correlation
+//!
+//! Run: `cargo run -p adk-gemini --example gemini3_function_calling`
+//! Requires: `GEMINI_API_KEY` environment variable
+
+use adk_gemini::{
+    Content, FunctionCallingMode, FunctionDeclaration, Gemini, GenerationConfig, Message, Part,
+    Role,
+};
+use display_error_chain::DisplayErrorChain;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::env;
+use std::process::ExitCode;
+use tracing::info;
+
+// ── Tool parameter types ──────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+struct WeatherParams {
+    /// City name, e.g. "Tokyo"
+    location: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+struct StockParams {
+    /// Stock ticker symbol, e.g. "GOOG"
+    symbol: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+struct NewsParams {
+    /// Topic to search for
+    topic: String,
+    /// Maximum number of results
+    max_results: Option<u32>,
+}
+
+// ── Simulated tool execution ──────────────────────────────────────────
+
+fn execute_weather(params: &WeatherParams) -> serde_json::Value {
+    serde_json::json!({
+        "temperature": 24,
+        "unit": "celsius",
+        "condition": "partly cloudy",
+        "location": params.location
+    })
+}
+
+fn execute_stock(params: &StockParams) -> serde_json::Value {
+    serde_json::json!({
+        "symbol": params.symbol,
+        "price": 182.45,
+        "currency": "USD",
+        "change": "+1.23%"
+    })
+}
+
+fn execute_news(params: &NewsParams) -> serde_json::Value {
+    serde_json::json!({
+        "articles": [
+            {"title": format!("Latest on {}", params.topic), "source": "Reuters"},
+            {"title": format!("{} update", params.topic), "source": "AP News"},
+        ]
+    })
+}
+
+// ── Main ──────────────────────────────────────────────────────────────
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match run().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error = %chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY not set");
+    let client = Gemini::new(api_key)?;
+
+    // Define three tools
+    let weather_fn =
+        FunctionDeclaration::new("get_weather", "Get current weather for a city", None)
+            .with_parameters::<WeatherParams>();
+
+    let stock_fn =
+        FunctionDeclaration::new("get_stock_price", "Get current stock price by ticker", None)
+            .with_parameters::<StockParams>();
+
+    let news_fn =
+        FunctionDeclaration::new("search_news", "Search recent news articles by topic", None)
+            .with_parameters::<NewsParams>();
+
+    // ── Demo 1: VALIDATED mode ────────────────────────────────────────
+    // The model validates calls against the schema but is not forced to call.
+    // It may respond with text if it can answer directly.
+    info!("── Demo 1: VALIDATED mode ──");
+    info!("asking a question the model can answer without tools...");
+
+    let response = client
+        .generate_content()
+        .with_system_prompt("You are a helpful assistant with access to tools. Only use tools when you need real-time data.")
+        .with_user_message("What is the capital of France?")
+        .with_function(weather_fn.clone())
+        .with_function(stock_fn.clone())
+        .with_function_calling_mode(FunctionCallingMode::Validated)
+        .with_generation_config(GenerationConfig {
+            temperature: Some(0.1),
+            max_output_tokens: Some(200),
+            ..Default::default()
+        })
+        .execute()
+        .await?;
+
+    let calls = response.function_calls();
+    if calls.is_empty() {
+        info!(
+            text = response.text(),
+            "model answered directly (no tool call) — VALIDATED mode allows this"
+        );
+    } else {
+        info!(count = calls.len(), "model chose to call tools anyway");
+    }
+
+    // ── Demo 2: allowed_function_names ────────────────────────────────
+    // Restrict the model to only call get_weather, even though all three tools are declared.
+    info!("\n── Demo 2: allowed_function_names ──");
+    info!("three tools declared, but only get_weather is allowed...");
+
+    let response = client
+        .generate_content()
+        .with_system_prompt("You are a helpful assistant.")
+        .with_user_message("What's the weather in Berlin and what's the latest tech news?")
+        .with_function(weather_fn.clone())
+        .with_function(stock_fn.clone())
+        .with_function(news_fn.clone())
+        .with_function_calling_mode_restricted(
+            FunctionCallingMode::Any,
+            vec!["get_weather".to_string()],
+        )
+        .with_generation_config(GenerationConfig {
+            temperature: Some(0.1),
+            max_output_tokens: Some(200),
+            ..Default::default()
+        })
+        .execute()
+        .await?;
+
+    for call in response.function_calls() {
+        info!(
+            name = call.name,
+            id = ?call.id,
+            args = %call.args,
+            "function call received — should only be get_weather"
+        );
+        assert_eq!(
+            call.name, "get_weather",
+            "model should only call get_weather due to allowed_function_names"
+        );
+    }
+
+    // ── Demo 3: Function call id + multi-turn ─────────────────────────
+    // Gemini 3 returns an `id` on each function call for correlation.
+    info!("\n── Demo 3: Function call id + parallel calls ──");
+    info!("asking for weather, stock price, AND news to trigger parallel calls...");
+
+    let response = client
+        .generate_content()
+        .with_system_prompt("You are a helpful assistant. When asked about multiple things, call all relevant tools.")
+        .with_user_message("What's the weather in Tokyo, what's Google's stock price, and what's the latest AI news?")
+        .with_function(weather_fn.clone())
+        .with_function(stock_fn.clone())
+        .with_function(news_fn.clone())
+        .with_function_calling_mode(FunctionCallingMode::Any)
+        .with_generation_config(GenerationConfig {
+            temperature: Some(0.1),
+            max_output_tokens: Some(500),
+            ..Default::default()
+        })
+        .execute()
+        .await?;
+
+    let calls = response.function_calls();
+    info!(count = calls.len(), "function calls received");
+
+    // Log each call with its id
+    for call in &calls {
+        info!(
+            name = call.name,
+            id = ?call.id,
+            args = %call.args,
+            "call details"
+        );
+    }
+
+    // Execute each tool and build function responses
+    let mut response_parts = Vec::new();
+    let mut call_parts = Vec::new();
+
+    for call in &calls {
+        // Preserve the function call part (with id) for the model turn
+        call_parts
+            .push(Part::FunctionCall { function_call: (*call).clone(), thought_signature: None });
+
+        // Execute the tool
+        let result = match call.name.as_str() {
+            "get_weather" => {
+                let params: WeatherParams = serde_json::from_value(call.args.clone())?;
+                execute_weather(&params)
+            }
+            "get_stock_price" => {
+                let params: StockParams = serde_json::from_value(call.args.clone())?;
+                execute_stock(&params)
+            }
+            "search_news" => {
+                let params: NewsParams = serde_json::from_value(call.args.clone())?;
+                execute_news(&params)
+            }
+            other => serde_json::json!({"error": format!("unknown function: {other}")}),
+        };
+
+        info!(name = call.name, id = ?call.id, result = %result, "tool executed");
+
+        response_parts.push(Part::FunctionResponse {
+            function_response: adk_gemini::FunctionResponse::new(&call.name, result),
+            thought_signature: None,
+        });
+    }
+
+    // Build the multi-turn conversation with all function responses in one turn
+    let model_content = Content { parts: Some(call_parts), role: Some(Role::Model) };
+    let fn_content = Content { parts: Some(response_parts), role: Some(Role::User) };
+
+    let final_response = client
+        .generate_content()
+        .with_system_prompt("You are a helpful assistant.")
+        .with_user_message("What's the weather in Tokyo, what's Google's stock price, and what's the latest AI news?")
+        .with_message(Message { content: model_content, role: Role::Model })
+        .with_message(Message { content: fn_content, role: Role::User })
+        .with_generation_config(GenerationConfig {
+            temperature: Some(0.7),
+            max_output_tokens: Some(500),
+            ..Default::default()
+        })
+        .execute()
+        .await?;
+
+    info!(response = final_response.text(), "final response with both tool results");
+
+    info!("\n✅ all demos completed successfully");
+    Ok(())
+}

--- a/adk-gemini/src/generation/builder.rs
+++ b/adk-gemini/src/generation/builder.rs
@@ -231,7 +231,22 @@ impl ContentBuilder {
     /// Sets the function calling mode for the request.
     pub fn with_function_calling_mode(mut self, mode: FunctionCallingMode) -> Self {
         self.tool_config.get_or_insert_with(Default::default).function_calling_config =
-            Some(FunctionCallingConfig { mode });
+            Some(FunctionCallingConfig { mode, allowed_function_names: None });
+        self
+    }
+
+    /// Sets the function calling mode with allowed function names.
+    ///
+    /// When mode is `Any`, the model will only call functions whose names are in the list.
+    pub fn with_function_calling_mode_restricted(
+        mut self,
+        mode: FunctionCallingMode,
+        allowed_function_names: Vec<String>,
+    ) -> Self {
+        let names =
+            if allowed_function_names.is_empty() { None } else { Some(allowed_function_names) };
+        self.tool_config.get_or_insert_with(Default::default).function_calling_config =
+            Some(FunctionCallingConfig { mode, allowed_function_names: names });
         self
     }
 

--- a/adk-gemini/src/tools/model.rs
+++ b/adk-gemini/src/tools/model.rs
@@ -201,6 +201,12 @@ pub struct FunctionCall {
     pub name: String,
     /// The arguments for the function
     pub args: serde_json::Value,
+    /// Unique identifier for this function call (Gemini 3 series).
+    ///
+    /// Gemini 3 models return an `id` on each function call to correlate with
+    /// the corresponding `FunctionResponse`. Earlier models may omit this field.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub id: Option<String>,
     /// The thought signature for the function call (Gemini 2.5 series only).
     ///
     /// Gemini expects this at the enclosing `Part::FunctionCall` level, not inside the
@@ -230,7 +236,7 @@ pub enum FunctionCallError {
 impl FunctionCall {
     /// Create a new function call
     pub fn new(name: impl Into<String>, args: serde_json::Value) -> Self {
-        Self { name: name.into(), args, thought_signature: None }
+        Self { name: name.into(), args, id: None, thought_signature: None }
     }
 
     /// Create a new function call with thought signature
@@ -239,7 +245,12 @@ impl FunctionCall {
         args: serde_json::Value,
         thought_signature: impl Into<String>,
     ) -> Self {
-        Self { name: name.into(), args, thought_signature: Some(thought_signature.into()) }
+        Self {
+            name: name.into(),
+            args,
+            id: None,
+            thought_signature: Some(thought_signature.into()),
+        }
     }
 
     /// Get a parameter from the arguments
@@ -322,18 +333,26 @@ pub struct ToolConfig {
 pub struct FunctionCallingConfig {
     /// The mode for function calling
     pub mode: FunctionCallingMode,
+    /// Restricts which functions the model may call.
+    /// Only applicable when mode is `Any`. The model will only call functions
+    /// whose names are in this list.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed_function_names: Option<Vec<String>>,
 }
 
 /// Mode for function calling
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum FunctionCallingMode {
-    /// The model may use function calling
+    /// The model decides whether to call functions (default behavior)
     Auto,
-    /// The model must use function calling
+    /// The model must call one of the provided functions
     Any,
-    /// The model must not use function calling
+    /// The model must not call any functions
     None,
+    /// The model validates function calls against the schema but does not force calling.
+    /// Available in Gemini 3 series models.
+    Validated,
 }
 
 #[cfg(test)]
@@ -365,5 +384,72 @@ mod tests {
 
         let json = serde_json::to_value(&config).unwrap();
         assert!(json.get("includeServerSideToolInvocations").is_none());
+    }
+
+    #[test]
+    fn function_calling_mode_validated_serde_round_trip() {
+        let config = FunctionCallingConfig {
+            mode: FunctionCallingMode::Validated,
+            allowed_function_names: None,
+        };
+        let json = serde_json::to_value(&config).unwrap();
+        assert_eq!(json["mode"], "VALIDATED");
+        let deserialized: FunctionCallingConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(deserialized.mode, FunctionCallingMode::Validated);
+    }
+
+    #[test]
+    fn function_calling_config_with_allowed_names() {
+        let config = FunctionCallingConfig {
+            mode: FunctionCallingMode::Any,
+            allowed_function_names: Some(vec!["get_weather".to_string(), "search".to_string()]),
+        };
+        let json = serde_json::to_value(&config).unwrap();
+        assert_eq!(json["mode"], "ANY");
+        assert_eq!(json["allowed_function_names"], serde_json::json!(["get_weather", "search"]));
+
+        let deserialized: FunctionCallingConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(deserialized, config);
+    }
+
+    #[test]
+    fn function_calling_config_omits_none_allowed_names() {
+        let config =
+            FunctionCallingConfig { mode: FunctionCallingMode::Auto, allowed_function_names: None };
+        let json = serde_json::to_value(&config).unwrap();
+        assert!(json.get("allowed_function_names").is_none());
+    }
+
+    #[test]
+    fn function_call_with_id_serde_round_trip() {
+        let call = FunctionCall {
+            name: "get_weather".to_string(),
+            args: serde_json::json!({"city": "Tokyo"}),
+            id: Some("fc_001".to_string()),
+            thought_signature: None,
+        };
+        let json = serde_json::to_value(&call).unwrap();
+        assert_eq!(json["id"], "fc_001");
+
+        let deserialized: FunctionCall = serde_json::from_value(json).unwrap();
+        assert_eq!(deserialized.id, Some("fc_001".to_string()));
+    }
+
+    #[test]
+    fn function_call_without_id_omits_field() {
+        let call = FunctionCall::new("get_weather", serde_json::json!({"city": "Tokyo"}));
+        let json = serde_json::to_value(&call).unwrap();
+        assert!(json.get("id").is_none());
+    }
+
+    #[test]
+    fn function_call_deserializes_without_id() {
+        let json = serde_json::json!({
+            "name": "get_weather",
+            "args": {"city": "Tokyo"}
+        });
+        let call: FunctionCall = serde_json::from_value(json).unwrap();
+        assert_eq!(call.id, None);
+        assert_eq!(call.name, "get_weather");
     }
 }

--- a/adk-model/src/gemini/client.rs
+++ b/adk-model/src/gemini/client.rs
@@ -212,7 +212,7 @@ impl GeminiModel {
                         converted_parts.push(Part::FunctionCall {
                             name: function_call.name.clone(),
                             args: function_call.args.clone(),
-                            id: None,
+                            id: function_call.id.clone(),
                             thought_signature: thought_signature.clone(),
                         });
                     }
@@ -544,11 +544,12 @@ impl GeminiModel {
                                     thought_signature: signature.clone(),
                                 });
                             }
-                            Part::FunctionCall { name, args, thought_signature, .. } => {
+                            Part::FunctionCall { name, args, thought_signature, id } => {
                                 gemini_parts.push(adk_gemini::Part::FunctionCall {
                                     function_call: adk_gemini::FunctionCall {
                                         name: name.clone(),
                                         args: args.clone(),
+                                        id: id.clone(),
                                         thought_signature: None,
                                     },
                                     thought_signature: thought_signature.clone(),


### PR DESCRIPTION
## Summary

Four additions bringing `adk-gemini` to full compliance with the Gemini function calling specification, plus an LLM-driven example that validates all features end-to-end.

## Changes

### `adk-gemini`

- **`FunctionCallingMode::Validated`** — New mode for schema validation without forced calling (Gemini 3 series). The model validates function calls against the schema but may respond with text if it can answer directly.
- **`FunctionCallingConfig.allowed_function_names`** — Restricts which functions the model may call when mode is `Any`. Builder method `with_function_calling_mode_restricted()` added.
- **`FunctionCall.id`** — Optional unique identifier per call (Gemini 3 series models return this for correlation). Backward-compatible: omitted from JSON when `None`.
- **6 new unit tests** for serde round-trips on all new fields.

### `adk-model`

- **`id` propagation** — Gemini conversion layer propagates function call `id` between `adk-core` and `adk-gemini` types in both directions.

### Example: `gemini3_function_calling`

LLM-driven example validated against real Gemini 2.5 Flash API:

1. **VALIDATED mode** — Model answers "The capital of France is Paris" directly without tool calls
2. **allowed_function_names** — Three tools declared, model restricted to only `get_weather`
3. **Parallel function calls** — Three simultaneous calls (weather, stock, news) with multi-turn completion

## Test Results

- `adk-gemini`: 71/71 tests pass (6 new)
- `adk-model`: 38/38 tests pass
- Clippy clean, no warnings
- Example validated end-to-end against Gemini API

## Audit Context

These gaps were identified during an audit of `adk-gemini` against the [Gemini function calling documentation](https://ai.google.dev/gemini-api/docs/function-calling). The remaining gap (multimodal function responses — images/PDFs in tool results) is a larger design change deferred to a separate PR.