### PR TITLE
docs: bump all version references to 0.6.0

### DIFF
--- a/adk-action/README.md
+++ b/adk-action/README.md
@@ -41,7 +41,7 @@ Action nodes are programmatic graph nodes that perform specific operations — H
 
 ```toml
 [dependencies]
-adk-action = "0.5.0"
+adk-action = "0.6.0"
 ```
 
 ## Usage

--- a/adk-agent/README.md
+++ b/adk-agent/README.md
@@ -23,14 +23,14 @@ Agent implementations for ADK-Rust (LLM, Custom, Workflow agents).
 
 ```toml
 [dependencies]
-adk-agent = "0.5.0"
+adk-agent = "0.6.0"
 ```
 
 Or use the umbrella crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.5.0", features = ["agents"] }
+adk-rust = { version = "0.6.0", features = ["agents"] }
 ```
 
 ## Quick Start

--- a/adk-artifact/README.md
+++ b/adk-artifact/README.md
@@ -23,14 +23,14 @@ Both implement the `ArtifactService` trait, so you can swap backends without cha
 
 ```toml
 [dependencies]
-adk-artifact = "0.5.0"
+adk-artifact = "0.6.0"
 ```
 
 Or via the umbrella crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.5.0", features = ["artifacts"] }
+adk-rust = { version = "0.6.0", features = ["artifacts"] }
 ```
 
 ## Quick Start

--- a/adk-audio/README.md
+++ b/adk-audio/README.md
@@ -8,14 +8,14 @@ Provides unified traits for Text-to-Speech (TTS), Speech-to-Text (STT), music ge
 
 ```toml
 [dependencies]
-adk-audio = "0.5.0"
+adk-audio = "0.6.0"
 ```
 
 Or via the umbrella crate (experimental):
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.5.0", features = ["audio"] }
+adk-rust = { version = "0.6.0", features = ["audio"] }
 ```
 
 ## Feature Flags

--- a/adk-auth/README.md
+++ b/adk-auth/README.md
@@ -20,13 +20,13 @@ Access control and authentication for Rust Agent Development Kit (ADK-Rust).
 
 ```toml
 [dependencies]
-adk-auth = "0.5.0"
+adk-auth = "0.6.0"
 
 # With SSO/JWT validation
-adk-auth = { version = "0.5.0", features = ["sso"] }
+adk-auth = { version = "0.6.0", features = ["sso"] }
 
 # With auth bridge for adk-server identity flow (implies sso)
-adk-auth = { version = "0.5.0", features = ["auth-bridge"] }
+adk-auth = { version = "0.6.0", features = ["auth-bridge"] }
 ```
 
 ## Features

--- a/adk-auth/src/sso/mod.rs
+++ b/adk-auth/src/sso/mod.rs
@@ -8,7 +8,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-auth = { version = "0.5.0", features = ["sso"] }
+//! adk-auth = { version = "0.6.0", features = ["sso"] }
 //! ```
 //!
 //! # Quick Start

--- a/adk-browser/README.md
+++ b/adk-browser/README.md
@@ -6,14 +6,14 @@ Browser automation tools for ADK-Rust agents using WebDriver (via [thirtyfour](h
 
 ```toml
 [dependencies]
-adk-browser = "0.5.0"
+adk-browser = "0.6.0"
 ```
 
 Or via the umbrella crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.5.0", features = ["browser"] }
+adk-rust = { version = "0.6.0", features = ["browser"] }
 ```
 
 ## Overview

--- a/adk-core/README.md
+++ b/adk-core/README.md
@@ -25,14 +25,14 @@ This crate is model-agnostic and contains no LLM-specific code.
 
 ```toml
 [dependencies]
-adk-core = "0.5.0"
+adk-core = "0.6.0"
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = "0.5.0"
+adk-rust = "0.6.0"
 ```
 
 ## Core Traits

--- a/adk-deploy/README.md
+++ b/adk-deploy/README.md
@@ -19,7 +19,7 @@ Deployment manifest, bundling, and control-plane client for ADK-Rust agents.
 
 ```toml
 [dependencies]
-adk-deploy = "0.5.0"
+adk-deploy = "0.6.0"
 ```
 
 ## Manifest Format

--- a/adk-gemini/README.md
+++ b/adk-gemini/README.md
@@ -30,14 +30,14 @@ Rust client library for Google's Gemini API — content generation, streaming, f
 
 ```toml
 [dependencies]
-adk-gemini = "0.5.0"
+adk-gemini = "0.6.0"
 ```
 
 Or through `adk-model`:
 
 ```toml
 [dependencies]
-adk-model = { version = "0.5.0", features = ["gemini"] }
+adk-model = { version = "0.6.0", features = ["gemini"] }
 ```
 
 ## Quick Start

--- a/adk-graph/README.md
+++ b/adk-graph/README.md
@@ -45,10 +45,10 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-graph = { version = "0.5.0", features = ["sqlite"] }
-adk-agent = "0.5.0"
-adk-model = "0.5.0"
-adk-core = "0.5.0"
+adk-graph = { version = "0.6.0", features = ["sqlite"] }
+adk-agent = "0.6.0"
+adk-model = "0.6.0"
+adk-core = "0.6.0"
 ```
 
 ### Basic Graph with AgentNode

--- a/adk-guardrail/README.md
+++ b/adk-guardrail/README.md
@@ -19,10 +19,10 @@ Guardrails framework for ADK agents - input/output validation, content filtering
 
 ```toml
 [dependencies]
-adk-guardrail = "0.5.0"
+adk-guardrail = "0.6.0"
 
 # With JSON schema validation (default)
-adk-guardrail = { version = "0.5.0", features = ["schema"] }
+adk-guardrail = { version = "0.6.0", features = ["schema"] }
 ```
 
 ## Quick Start
@@ -63,7 +63,7 @@ let filter = ContentFilter::blocked_keywords(vec!["forbidden".into()]);
 Requires `guardrails` feature on `adk-agent`:
 
 ```toml
-adk-agent = { version = "0.5.0", features = ["guardrails"] }
+adk-agent = { version = "0.6.0", features = ["guardrails"] }
 ```
 
 ```rust

--- a/adk-memory/README.md
+++ b/adk-memory/README.md
@@ -24,14 +24,14 @@ Semantic memory and search for Rust Agent Development Kit (ADK-Rust) agents.
 
 ```toml
 [dependencies]
-adk-memory = "0.5.0"
+adk-memory = "0.6.0"
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.5.0", features = ["memory"] }
+adk-rust = { version = "0.6.0", features = ["memory"] }
 ```
 
 ## Quick Start
@@ -76,10 +76,10 @@ for memory in response.memories {
 
 ```toml
 # SQLite
-adk-memory = { version = "0.5.0", features = ["sqlite-memory"] }
+adk-memory = { version = "0.6.0", features = ["sqlite-memory"] }
 
 # PostgreSQL + pgvector
-adk-memory = { version = "0.5.0", features = ["database-memory"] }
+adk-memory = { version = "0.6.0", features = ["database-memory"] }
 ```
 
 ## Schema Migrations

--- a/adk-mistralrs/Cargo.toml
+++ b/adk-mistralrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adk-mistralrs"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.85.0"
 license = "MIT"

--- a/adk-mistralrs/README.md
+++ b/adk-mistralrs/README.md
@@ -66,8 +66,8 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-core = "0.5.0"
-adk-agent = "0.5.0"
+adk-core = "0.6.0"
+adk-agent = "0.6.0"
 
 # mistral.rs support (git dependency - not on crates.io)
 adk-mistralrs = { git = "https://github.com/zavora-ai/adk-rust" }

--- a/adk-model/README.md
+++ b/adk-model/README.md
@@ -35,21 +35,21 @@ The crate implements the `Llm` trait from `adk-core`, allowing models to be used
 
 ```toml
 [dependencies]
-adk-model = "0.5.0"
+adk-model = "0.6.0"
 ```
 
 Enable provider-specific features as needed:
 
 ```toml
 [dependencies]
-adk-model = { version = "0.5.0", features = ["openrouter"] }
+adk-model = { version = "0.6.0", features = ["openrouter"] }
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.5.0", features = ["models"] }
+adk-rust = { version = "0.6.0", features = ["models"] }
 ```
 
 ## Quick Start
@@ -681,24 +681,24 @@ Enable specific providers with feature flags:
 ```toml
 [dependencies]
 # All providers (default)
-adk-model = { version = "0.5.0", features = ["all-providers"] }
+adk-model = { version = "0.6.0", features = ["all-providers"] }
 
 # Individual providers
-adk-model = { version = "0.5.0", features = ["gemini"] }
-adk-model = { version = "0.5.0", features = ["openai"] }
-adk-model = { version = "0.5.0", features = ["xai"] }
-adk-model = { version = "0.5.0", features = ["anthropic"] }
-adk-model = { version = "0.5.0", features = ["deepseek"] }
-adk-model = { version = "0.5.0", features = ["groq"] }
-adk-model = { version = "0.5.0", features = ["ollama"] }
-adk-model = { version = "0.5.0", features = ["fireworks"] }
-adk-model = { version = "0.5.0", features = ["together"] }
-adk-model = { version = "0.5.0", features = ["mistral"] }
-adk-model = { version = "0.5.0", features = ["perplexity"] }
-adk-model = { version = "0.5.0", features = ["cerebras"] }
-adk-model = { version = "0.5.0", features = ["sambanova"] }
-adk-model = { version = "0.5.0", features = ["bedrock"] }
-adk-model = { version = "0.5.0", features = ["azure-ai"] }
+adk-model = { version = "0.6.0", features = ["gemini"] }
+adk-model = { version = "0.6.0", features = ["openai"] }
+adk-model = { version = "0.6.0", features = ["xai"] }
+adk-model = { version = "0.6.0", features = ["anthropic"] }
+adk-model = { version = "0.6.0", features = ["deepseek"] }
+adk-model = { version = "0.6.0", features = ["groq"] }
+adk-model = { version = "0.6.0", features = ["ollama"] }
+adk-model = { version = "0.6.0", features = ["fireworks"] }
+adk-model = { version = "0.6.0", features = ["together"] }
+adk-model = { version = "0.6.0", features = ["mistral"] }
+adk-model = { version = "0.6.0", features = ["perplexity"] }
+adk-model = { version = "0.6.0", features = ["cerebras"] }
+adk-model = { version = "0.6.0", features = ["sambanova"] }
+adk-model = { version = "0.6.0", features = ["bedrock"] }
+adk-model = { version = "0.6.0", features = ["azure-ai"] }
 ```
 
 ## Related Crates

--- a/adk-payments/README.md
+++ b/adk-payments/README.md
@@ -54,17 +54,17 @@ Choose only the features you need:
 
 ```toml
 [dependencies]
-adk-payments = { version = "0.5.0", features = ["acp"] }
+adk-payments = { version = "0.6.0", features = ["acp"] }
 ```
 
 ```toml
 [dependencies]
-adk-payments = { version = "0.5.0", features = ["ap2", "ap2-a2a", "ap2-mcp"] }
+adk-payments = { version = "0.6.0", features = ["ap2", "ap2-a2a", "ap2-mcp"] }
 ```
 
 ```toml
 [dependencies]
-adk-payments = { version = "0.5.0", features = ["acp", "acp-experimental", "ap2"] }
+adk-payments = { version = "0.6.0", features = ["acp", "acp-experimental", "ap2"] }
 ```
 
 ## Core Concepts

--- a/adk-plugin/README.md
+++ b/adk-plugin/README.md
@@ -23,7 +23,7 @@ Plugin system for ADK-Rust agents.
 
 ```toml
 [dependencies]
-adk-plugin = "0.5.0"
+adk-plugin = "0.6.0"
 ```
 
 ## Quick Start

--- a/adk-rag/README.md
+++ b/adk-rag/README.md
@@ -24,7 +24,7 @@ The fastest way to get a working RAG pipeline. Uses Gemini for embeddings (free 
 
 ```toml
 [dependencies]
-adk-rag = { version = "0.5.0", features = ["gemini"] }
+adk-rag = { version = "0.6.0", features = ["gemini"] }
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -70,10 +70,10 @@ The practical use case — an agent that searches your knowledge base to answer 
 
 ```toml
 [dependencies]
-adk-rag = { version = "0.5.0", features = ["gemini"] }
-adk-agent = "0.5.0"
-adk-model = "0.5.0"
-adk-cli = "0.5.0"
+adk-rag = { version = "0.6.0", features = ["gemini"] }
+adk-agent = "0.6.0"
+adk-model = "0.6.0"
+adk-cli = "0.6.0"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -149,7 +149,7 @@ The `RagPipeline` wires these together. The `RagTool` wraps the pipeline as an `
 Uses Google's `gemini-embedding-001` model (3072 dimensions). Free tier available.
 
 ```toml
-adk-rag = { version = "0.5.0", features = ["gemini"] }
+adk-rag = { version = "0.6.0", features = ["gemini"] }
 ```
 
 ```rust
@@ -161,7 +161,7 @@ let provider = GeminiEmbeddingProvider::new(&api_key)?;
 Uses `text-embedding-3-small` (1536 dimensions) by default. Supports dimension truncation via Matryoshka.
 
 ```toml
-adk-rag = { version = "0.5.0", features = ["openai"] }
+adk-rag = { version = "0.6.0", features = ["openai"] }
 ```
 
 ```rust
@@ -217,7 +217,7 @@ let store = InMemoryVectorStore::new();
 Production-ready vector database with filtering, snapshots, and clustering.
 
 ```toml
-adk-rag = { version = "0.5.0", features = ["qdrant"] }
+adk-rag = { version = "0.6.0", features = ["qdrant"] }
 ```
 
 ```rust
@@ -229,7 +229,7 @@ let store = QdrantVectorStore::new("http://localhost:6334").await?;
 Embedded vector database with no server required. Data persists to disk.
 
 ```toml
-adk-rag = { version = "0.5.0", features = ["lancedb"] }
+adk-rag = { version = "0.6.0", features = ["lancedb"] }
 ```
 
 > Requires `protoc` installed: `brew install protobuf` (macOS), `apt install protobuf-compiler` (Ubuntu).
@@ -243,7 +243,7 @@ let store = LanceDBVectorStore::new("/tmp/my-vectors").await?;
 Use your existing PostgreSQL database for vector search.
 
 ```toml
-adk-rag = { version = "0.5.0", features = ["pgvector"] }
+adk-rag = { version = "0.6.0", features = ["pgvector"] }
 ```
 
 ```rust
@@ -255,7 +255,7 @@ let store = PgVectorStore::new("postgres://user:pass@localhost/mydb").await?;
 Embedded or remote multi-model database with built-in vector search.
 
 ```toml
-adk-rag = { version = "0.5.0", features = ["surrealdb"] }
+adk-rag = { version = "0.6.0", features = ["surrealdb"] }
 ```
 
 ```rust
@@ -305,7 +305,7 @@ The default `NoOpReranker` passes results through unchanged. Write your own to i
 
 ```toml
 [dependencies]
-adk-rag = { version = "0.5.0", features = ["gemini"] }
+adk-rag = { version = "0.6.0", features = ["gemini"] }
 async-trait = "0.1"
 tokio = { version = "1", features = ["full"] }
 ```
@@ -358,19 +358,19 @@ let pipeline = RagPipeline::builder()
 
 ```toml
 # Core only (in-memory store, all chunkers, no external deps)
-adk-rag = "0.5.0"
+adk-rag = "0.6.0"
 
 # With Gemini embeddings (recommended)
-adk-rag = { version = "0.5.0", features = ["gemini"] }
+adk-rag = { version = "0.6.0", features = ["gemini"] }
 
 # With OpenAI embeddings
-adk-rag = { version = "0.5.0", features = ["openai"] }
+adk-rag = { version = "0.6.0", features = ["openai"] }
 
 # With a persistent vector store
-adk-rag = { version = "0.5.0", features = ["gemini", "qdrant"] }
+adk-rag = { version = "0.6.0", features = ["gemini", "qdrant"] }
 
 # Everything
-adk-rag = { version = "0.5.0", features = ["full"] }
+adk-rag = { version = "0.6.0", features = ["full"] }
 ```
 
 | Feature | Enables | Extra dependency |

--- a/adk-realtime/README.md
+++ b/adk-realtime/README.md
@@ -74,7 +74,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-realtime = { version = "0.5.0", features = ["openai"] }
+adk-realtime = { version = "0.6.0", features = ["openai"] }
 ```
 
 ### Using RealtimeAgent (Recommended)
@@ -139,7 +139,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 Connect to Gemini Live API via Vertex AI with Application Default Credentials:
 
 ```toml
-adk-realtime = { version = "0.5.0", features = ["vertex-live"] }
+adk-realtime = { version = "0.6.0", features = ["vertex-live"] }
 ```
 
 ```rust
@@ -169,7 +169,7 @@ Prerequisites:
 Lower-latency audio transport using Sans-IO WebRTC with Opus codec:
 
 ```toml
-adk-realtime = { version = "0.5.0", features = ["openai-webrtc"] }
+adk-realtime = { version = "0.6.0", features = ["openai-webrtc"] }
 ```
 
 ```rust
@@ -191,7 +191,7 @@ export CMAKE_POLICY_VERSION_MINIMUM=3.5
 Bridge any `EventHandler` to a LiveKit room for production voice apps:
 
 ```toml
-adk-realtime = { version = "0.5.0", features = ["livekit", "openai"] }
+adk-realtime = { version = "0.6.0", features = ["livekit", "openai"] }
 ```
 
 #### LiveKitConfig and LiveKitRoomBuilder

--- a/adk-runner/README.md
+++ b/adk-runner/README.md
@@ -24,14 +24,14 @@ Agent execution runtime for ADK-Rust.
 
 ```toml
 [dependencies]
-adk-runner = "0.5.0"
+adk-runner = "0.6.0"
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.5.0", features = ["runner"] }
+adk-rust = { version = "0.6.0", features = ["runner"] }
 ```
 
 ## Quick Start

--- a/adk-rust-macros/README.md
+++ b/adk-rust-macros/README.md
@@ -10,8 +10,8 @@ This crate provides the `#[tool]` attribute macro that turns an async function i
 
 ```toml
 [dependencies]
-adk-rust-macros = "0.5.0"
-adk-tool = "0.5.0"
+adk-rust-macros = "0.6.0"
+adk-tool = "0.6.0"
 schemars = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/adk-rust/README.md
+++ b/adk-rust/README.md
@@ -39,7 +39,7 @@ cargo new my_agent && cd my_agent
 
 ```toml
 [dependencies]
-adk-rust = "0.5.0"
+adk-rust = "0.6.0"
 tokio = { version = "1.40", features = ["full"] }
 dotenvy = "0.15"
 ```
@@ -290,26 +290,26 @@ cargo run -- serve --port 8080
 
 ```toml
 # Standard (default) — agents, models, tools, sessions, runner, guardrails, auth
-adk-rust = "0.5.0"
+adk-rust = "0.6.0"
 
 # Full — standard + all stable specialist crates (graph, realtime, browser, eval, rag)
 # Does NOT include experimental crates (code, sandbox, audio) — use `labs` for those
-adk-rust = { version = "0.5.0", features = ["full"] }
+adk-rust = { version = "0.6.0", features = ["full"] }
 
 # Labs — standard + experimental crates (code, sandbox, audio)
-adk-rust = { version = "0.5.0", features = ["labs"] }
+adk-rust = { version = "0.6.0", features = ["labs"] }
 
 # Full + Labs — everything including experimental crates
-adk-rust = { version = "0.5.0", features = ["full", "labs"] }
+adk-rust = { version = "0.6.0", features = ["full", "labs"] }
 
 # Minimal
-adk-rust = { version = "0.5.0", default-features = false, features = ["minimal"] }
+adk-rust = { version = "0.6.0", default-features = false, features = ["minimal"] }
 
 # Custom
-adk-rust = { version = "0.5.0", default-features = false, features = ["agents", "gemini", "tools"] }
+adk-rust = { version = "0.6.0", default-features = false, features = ["agents", "gemini", "tools"] }
 
 # With new providers (forwarded to adk-model)
-adk-model = { version = "0.5.0", features = ["fireworks", "together", "mistral", "perplexity", "cerebras", "sambanova", "bedrock", "azure-ai"] }
+adk-model = { version = "0.6.0", features = ["fireworks", "together", "mistral", "perplexity", "cerebras", "sambanova", "bedrock", "azure-ai"] }
 ```
 
 ## Documentation

--- a/adk-rust/src/lib.rs
+++ b/adk-rust/src/lib.rs
@@ -40,7 +40,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-rust = "0.5.0"
+//! adk-rust = "0.6.0"
 //! tokio = { version = "1.40", features = ["full"] }
 //! dotenvy = "0.15"  # For loading .env files
 //! ```
@@ -49,23 +49,23 @@
 //!
 //! ```toml
 //! # Standard (default) — agents, models, tools, sessions, runner, guardrails, auth
-//! adk-rust = "0.5.0"
+//! adk-rust = "0.6.0"
 //!
 //! # Full — standard + all stable specialist crates (graph, realtime, browser, eval, rag)
 //! # Does NOT include experimental crates (code, sandbox, audio) — use `labs` for those
-//! adk-rust = { version = "0.5.0", features = ["full"] }
+//! adk-rust = { version = "0.6.0", features = ["full"] }
 //!
 //! # Labs — standard + experimental crates (code, sandbox, audio)
-//! adk-rust = { version = "0.5.0", features = ["labs"] }
+//! adk-rust = { version = "0.6.0", features = ["labs"] }
 //!
 //! # Full + Labs — everything including experimental crates
-//! adk-rust = { version = "0.5.0", features = ["full", "labs"] }
+//! adk-rust = { version = "0.6.0", features = ["full", "labs"] }
 //!
 //! # Minimal — just agents + Gemini + runner (fastest build)
-//! adk-rust = { version = "0.5.0", default-features = false, features = ["minimal"] }
+//! adk-rust = { version = "0.6.0", default-features = false, features = ["minimal"] }
 //!
 //! # Custom — pick exactly what you need
-//! adk-rust = { version = "0.5.0", default-features = false, features = [
+//! adk-rust = { version = "0.6.0", default-features = false, features = [
 //!     "agents", "gemini", "tools", "sessions", "openai", "openrouter"
 //! ] }
 //! ```

--- a/adk-session/README.md
+++ b/adk-session/README.md
@@ -24,14 +24,14 @@ Session management and state persistence for Rust Agent Development Kit (ADK-Rus
 
 ```toml
 [dependencies]
-adk-session = "0.5.0"
+adk-session = "0.6.0"
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.5.0", features = ["sessions"] }
+adk-rust = { version = "0.6.0", features = ["sessions"] }
 ```
 
 ## Quick Start
@@ -80,16 +80,16 @@ let name = session.state().get("user:name");
 
 ```toml
 # SQLite
-adk-session = { version = "0.5.0", features = ["sqlite"] }
+adk-session = { version = "0.6.0", features = ["sqlite"] }
 
 # PostgreSQL
-adk-session = { version = "0.5.0", features = ["postgres"] }
+adk-session = { version = "0.6.0", features = ["postgres"] }
 
 # Redis
-adk-session = { version = "0.5.0", features = ["redis"] }
+adk-session = { version = "0.6.0", features = ["redis"] }
 
 # Encrypted sessions
-adk-session = { version = "0.5.0", features = ["encrypted-session"] }
+adk-session = { version = "0.6.0", features = ["encrypted-session"] }
 ```
 
 ## Encrypted Sessions

--- a/adk-telemetry/README.md
+++ b/adk-telemetry/README.md
@@ -19,14 +19,14 @@ OpenTelemetry integration for Rust Agent Development Kit (ADK-Rust) agent observ
 
 ```toml
 [dependencies]
-adk-telemetry = "0.5.0"
+adk-telemetry = "0.6.0"
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.5.0", features = ["telemetry"] }
+adk-rust = { version = "0.6.0", features = ["telemetry"] }
 ```
 
 ## Quick Start

--- a/adk-tool/README.md
+++ b/adk-tool/README.md
@@ -28,17 +28,17 @@ Tool system for Rust Agent Development Kit (ADK-Rust) agents (FunctionTool, MCP,
 
 ```toml
 [dependencies]
-adk-tool = "0.5.0"
+adk-tool = "0.6.0"
 
 # For remote MCP servers via HTTP:
-adk-tool = { version = "0.5.0", features = ["http-transport"] }
+adk-tool = { version = "0.6.0", features = ["http-transport"] }
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.5.0", features = ["tools"] }
+adk-rust = { version = "0.6.0", features = ["tools"] }
 ```
 
 ## Quick Start

--- a/docs/official_docs/agents/graph-agents.md
+++ b/docs/official_docs/agents/graph-agents.md
@@ -115,10 +115,10 @@ Add dependencies to `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-graph = { version = "0.5.0", features = ["sqlite"] }
-adk-agent = "0.5.0"
-adk-model = "0.5.0"
-adk-core = "0.5.0"
+adk-graph = { version = "0.6.0", features = ["sqlite"] }
+adk-agent = "0.6.0"
+adk-model = "0.6.0"
+adk-core = "0.6.0"
 tokio = { version = "1", features = ["full"] }
 dotenvy = "0.15"
 serde_json = "1.0"

--- a/docs/official_docs/agents/llm-agent.md
+++ b/docs/official_docs/agents/llm-agent.md
@@ -15,7 +15,7 @@ Add dependencies to `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-rust = "0.5.0"
+adk-rust = "0.6.0"
 tokio = { version = "1.40", features = ["full"] }
 dotenvy = "0.15"
 serde_json = "1.0"
@@ -297,7 +297,7 @@ Add dependencies to `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.5.0", features = ["tools"] }
+adk-rust = { version = "0.6.0", features = ["tools"] }
 tokio = { version = "1.40", features = ["full"] }
 dotenvy = "0.15"
 serde_json = "1.0"

--- a/docs/official_docs/agents/multi-agent.md
+++ b/docs/official_docs/agents/multi-agent.md
@@ -45,7 +45,7 @@ Add dependencies to `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.5.0", features = ["agents", "models", "cli"] }
+adk-rust = { version = "0.6.0", features = ["agents", "models", "cli"] }
 tokio = { version = "1", features = ["full"] }
 dotenvy = "0.15"
 ```

--- a/docs/official_docs/agents/realtime-agents.md
+++ b/docs/official_docs/agents/realtime-agents.md
@@ -44,16 +44,16 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-realtime = { version = "0.5.0", features = ["openai"] }
+adk-realtime = { version = "0.6.0", features = ["openai"] }
 
 # For Vertex AI Live (Google Cloud with ADC auth)
-# adk-realtime = { version = "0.5.0", features = ["vertex-live"] }
+# adk-realtime = { version = "0.6.0", features = ["vertex-live"] }
 
 # For LiveKit WebRTC bridge
-# adk-realtime = { version = "0.5.0", features = ["livekit"] }
+# adk-realtime = { version = "0.6.0", features = ["livekit"] }
 
 # For all transports (except WebRTC which needs cmake)
-# adk-realtime = { version = "0.5.0", features = ["full"] }
+# adk-realtime = { version = "0.6.0", features = ["full"] }
 ```
 
 ### Basic Usage

--- a/docs/official_docs/agents/workflow-agents.md
+++ b/docs/official_docs/agents/workflow-agents.md
@@ -15,7 +15,7 @@ Add dependencies to `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-rust = "0.5.0"
+adk-rust = "0.6.0"
 tokio = { version = "1.40", features = ["full"] }
 dotenvy = "0.15"
 ```

--- a/docs/official_docs/core/runner.md
+++ b/docs/official_docs/core/runner.md
@@ -16,7 +16,7 @@ The `Runner` manages the complete lifecycle of agent execution:
 
 ```toml
 [dependencies]
-adk-runner = "0.5.0"
+adk-runner = "0.6.0"
 ```
 
 ## RunnerConfig

--- a/docs/official_docs/introduction.md
+++ b/docs/official_docs/introduction.md
@@ -2,7 +2,7 @@
 
 Agent Development Kit (ADK) is a flexible and modular framework for developing and deploying AI agents. While optimized for Gemini and the Google ecosystem, ADK is model-agnostic, deployment-agnostic, and built for compatibility with other frameworks. ADK was designed to make agent development feel more like software development, making it easier for developers to create, deploy, and orchestrate agentic architectures that range from simple tasks to complex workflows.
 
-> **Note:** ADK-Rust v0.5.0 requires Rust 1.85.0 or higher
+> **Note:** ADK-Rust v0.6.0 requires Rust 1.85.0 or higher
 
 ## Installation
 
@@ -16,7 +16,7 @@ Or add it to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-rust = "0.5.0"
+adk-rust = "0.6.0"
 tokio = { version = "1.40", features = ["full"] }
 ```
 
@@ -161,23 +161,23 @@ ADK-Rust uses Cargo features for modularity. Three presets control which crates 
 
 ```toml
 # Standard (default) — agents, models, tools, sessions, runner, guardrails, auth
-adk-rust = "0.5.0"
+adk-rust = "0.6.0"
 
 # Full — standard + all stable specialist crates (graph, realtime, browser, eval, rag)
 # Does NOT include experimental crates — use `labs` for those
-adk-rust = { version = "0.5.0", features = ["full"] }
+adk-rust = { version = "0.6.0", features = ["full"] }
 
 # Labs — standard + experimental crates (code, sandbox, audio)
-adk-rust = { version = "0.5.0", features = ["labs"] }
+adk-rust = { version = "0.6.0", features = ["labs"] }
 
 # Full + Labs — everything including experimental crates
-adk-rust = { version = "0.5.0", features = ["full", "labs"] }
+adk-rust = { version = "0.6.0", features = ["full", "labs"] }
 
 # Minimal: Only agents + Gemini + runner
-adk-rust = { version = "0.5.0", default-features = false, features = ["minimal"] }
+adk-rust = { version = "0.6.0", default-features = false, features = ["minimal"] }
 
 # Custom: Pick what you need
-adk-rust = { version = "0.5.0", default-features = false, features = ["agents", "gemini", "tools"] }
+adk-rust = { version = "0.6.0", default-features = false, features = ["agents", "gemini", "tools"] }
 ```
 
 Available features:

--- a/docs/official_docs/models/ollama.md
+++ b/docs/official_docs/models/ollama.md
@@ -97,7 +97,7 @@ ollama pull codellama:13b     # Code generation
 
 ```toml
 [dependencies]
-adk-model = { version = "0.5.0", features = ["ollama"] }
+adk-model = { version = "0.6.0", features = ["ollama"] }
 ```
 
 ---
@@ -157,7 +157,7 @@ async fn main() -> anyhow::Result<()> {
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.5.0", features = ["cli", "ollama"] }
+adk-rust = { version = "0.6.0", features = ["cli", "ollama"] }
 tokio = { version = "1", features = ["full"] }
 dotenvy = "0.15"
 anyhow = "1.0"

--- a/docs/official_docs/models/openai-responses.md
+++ b/docs/official_docs/models/openai-responses.md
@@ -53,14 +53,14 @@ Use `OpenAIResponsesClient` when you need reasoning models with summaries, built
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.5.0", features = ["openai"] }
+adk-rust = { version = "0.6.0", features = ["openai"] }
 ```
 
 Or with `adk-model` directly:
 
 ```toml
 [dependencies]
-adk-model = { version = "0.5.0", features = ["openai"] }
+adk-model = { version = "0.6.0", features = ["openai"] }
 ```
 
 Set your API key:

--- a/docs/official_docs/models/providers.md
+++ b/docs/official_docs/models/providers.md
@@ -41,14 +41,14 @@ Add the providers you need to your `Cargo.toml`:
 ```toml
 [dependencies]
 # Pick one or more providers:
-adk-model = { version = "0.5.0", features = ["gemini"] }        # Google Gemini (default)
-adk-model = { version = "0.5.0", features = ["openai"] }        # OpenAI GPT-5
-adk-model = { version = "0.5.0", features = ["anthropic"] }     # Anthropic Claude
-adk-model = { version = "0.5.0", features = ["deepseek"] }      # DeepSeek
-adk-model = { version = "0.5.0", features = ["groq"] }          # Groq (ultra-fast)
+adk-model = { version = "0.6.0", features = ["gemini"] }        # Google Gemini (default)
+adk-model = { version = "0.6.0", features = ["openai"] }        # OpenAI GPT-5
+adk-model = { version = "0.6.0", features = ["anthropic"] }     # Anthropic Claude
+adk-model = { version = "0.6.0", features = ["deepseek"] }      # DeepSeek
+adk-model = { version = "0.6.0", features = ["groq"] }          # Groq (ultra-fast)
 
 # Or all cloud providers at once:
-adk-model = { version = "0.5.0", features = ["all-providers"] }
+adk-model = { version = "0.6.0", features = ["all-providers"] }
 ```
 
 ## Step 2: Set Your API Key

--- a/docs/official_docs/quickstart.md
+++ b/docs/official_docs/quickstart.md
@@ -135,7 +135,7 @@ The fastest way to add tools is the `#[tool]` macro. Add `adk-tool` to your depe
 
 ```toml
 [dependencies]
-adk-tool = "0.5.0"
+adk-tool = "0.6.0"
 schemars = "0.8"
 serde = { version = "1", features = ["derive"] }
 ```
@@ -206,7 +206,7 @@ Enable providers via feature flags:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.5.0", features = ["openai"] }
+adk-rust = { version = "0.6.0", features = ["openai"] }
 ```
 
 Or scaffold with a provider: `cargo adk new my-agent --provider openai`

--- a/docs/official_docs/security/access-control.md
+++ b/docs/official_docs/security/access-control.md
@@ -126,10 +126,10 @@ sso.check_token(token, &permission).await?;
 
 ```toml
 [dependencies]
-adk-auth = "0.5.0"
+adk-auth = "0.6.0"
 
 # For SSO/OAuth support
-adk-auth = { version = "0.5.0", features = ["sso"] }
+adk-auth = { version = "0.6.0", features = ["sso"] }
 ```
 
 ## Core Components

--- a/docs/official_docs/security/guardrails.md
+++ b/docs/official_docs/security/guardrails.md
@@ -15,10 +15,10 @@ Guardrails validate and transform agent inputs and outputs to ensure safety, com
 
 ```toml
 [dependencies]
-adk-guardrail = "0.5.0"
+adk-guardrail = "0.6.0"
 
 # For JSON schema validation
-adk-guardrail = { version = "0.5.0", features = ["schema"] }
+adk-guardrail = { version = "0.6.0", features = ["schema"] }
 ```
 
 ## Core Concepts

--- a/docs/official_docs/security/memory.md
+++ b/docs/official_docs/security/memory.md
@@ -10,7 +10,7 @@ The memory system provides persistent, searchable storage for agent conversation
 
 ```toml
 [dependencies]
-adk-memory = "0.5.0"
+adk-memory = "0.6.0"
 ```
 
 ## Core Concepts

--- a/docs/official_docs/sessions/sessions.md
+++ b/docs/official_docs/sessions/sessions.md
@@ -198,7 +198,7 @@ async fn main() -> anyhow::Result<()> {
 
 > **Note**: The `SqliteSessionService` requires the `sqlite` feature flag:
 > ```toml
-> adk-session = { version = "0.5.0", features = ["sqlite"] }
+> adk-session = { version = "0.6.0", features = ["sqlite"] }
 > ```
 
 ### PostgresSessionService
@@ -231,7 +231,7 @@ async fn main() -> anyhow::Result<()> {
 
 > **Note**: Requires the `postgres` feature flag:
 > ```toml
-> adk-session = { version = "0.5.0", features = ["postgres"] }
+> adk-session = { version = "0.6.0", features = ["postgres"] }
 > ```
 
 ### MongoSessionService
@@ -276,7 +276,7 @@ async fn main() -> anyhow::Result<()> {
 
 > **Note**: Requires the `mongodb` feature flag:
 > ```toml
-> adk-session = { version = "0.5.0", features = ["mongodb"] }
+> adk-session = { version = "0.6.0", features = ["mongodb"] }
 > ```
 
 #### MongoDB deployment modes
@@ -330,7 +330,7 @@ async fn main() -> anyhow::Result<()> {
 
 > **Note**: Requires the `neo4j` feature flag:
 > ```toml
-> adk-session = { version = "0.5.0", features = ["neo4j"] }
+> adk-session = { version = "0.6.0", features = ["neo4j"] }
 > ```
 
 ### RedisSessionService
@@ -346,7 +346,7 @@ let session_service = RedisSessionService::new(config).await?;
 
 > **Note**: Requires the `redis` feature flag:
 > ```toml
-> adk-session = { version = "0.5.0", features = ["redis"] }
+> adk-session = { version = "0.6.0", features = ["redis"] }
 > ```
 
 ## Schema Migrations
@@ -358,7 +358,7 @@ All database-backed session services (SQLite, PostgreSQL, MongoDB, Neo4j) includ
 Wrap any `SessionService` with `EncryptedSession` to encrypt session state at rest using AES-256-GCM. Requires the `encrypted-session` feature flag.
 
 ```toml
-adk-session = { version = "0.5.0", features = ["encrypted-session"] }
+adk-session = { version = "0.6.0", features = ["encrypted-session"] }
 ```
 
 #### Basic Usage

--- a/docs/official_docs/studio/studio.md
+++ b/docs/official_docs/studio/studio.md
@@ -356,13 +356,13 @@ The generated `Cargo.toml` automatically includes the correct `adk-model` featur
 
 ```toml
 # Only Gemini
-adk-model = { version = "0.5.0", default-features = false, features = ["gemini"] }
+adk-model = { version = "0.6.0", default-features = false, features = ["gemini"] }
 
 # Mixed providers (e.g., Gemini + Anthropic)
-adk-model = { version = "0.5.0", default-features = false, features = ["gemini", "anthropic"] }
+adk-model = { version = "0.6.0", default-features = false, features = ["gemini", "anthropic"] }
 
 # Ollama only (no API key needed)
-adk-model = { version = "0.5.0", default-features = false, features = ["ollama"] }
+adk-model = { version = "0.6.0", default-features = false, features = ["ollama"] }
 ```
 
 ### Generated Code with Action Nodes

--- a/docs/official_docs/tools/browser-tools.md
+++ b/docs/official_docs/tools/browser-tools.md
@@ -19,9 +19,9 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-browser = "0.5.0"
-adk-agent = "0.5.0"
-adk-model = "0.5.0"
+adk-browser = "0.6.0"
+adk-agent = "0.6.0"
+adk-model = "0.6.0"
 ```
 
 ### Prerequisites

--- a/docs/official_docs/tools/rag.md
+++ b/docs/official_docs/tools/rag.md
@@ -29,10 +29,10 @@ This means your agent can answer questions about product docs, company policies,
 ```toml
 [dependencies]
 # Core only (in-memory store, all chunkers, no external deps)
-adk-rag = "0.5.0"
+adk-rag = "0.6.0"
 
 # With Gemini embeddings (recommended for getting started)
-adk-rag = { version = "0.5.0", features = ["gemini"] }
+adk-rag = { version = "0.6.0", features = ["gemini"] }
 ```
 
 ---
@@ -353,13 +353,13 @@ Only pull the dependencies you need:
 
 ```toml
 # Just core
-adk-rag = "0.5.0"
+adk-rag = "0.6.0"
 
 # With Gemini embeddings
-adk-rag = { version = "0.5.0", features = ["gemini"] }
+adk-rag = { version = "0.6.0", features = ["gemini"] }
 
 # Everything
-adk-rag = { version = "0.5.0", features = ["full"] }
+adk-rag = { version = "0.6.0", features = ["full"] }
 ```
 
 > **Note:** The `lancedb` feature requires `protoc` installed. Install with `brew install protobuf` (macOS) or `apt install protobuf-compiler` (Ubuntu).

--- a/docs/official_docs/tools/ui-tools.md
+++ b/docs/official_docs/tools/ui-tools.md
@@ -114,11 +114,11 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.5.0", features = ["ui"] }
+adk-rust = { version = "0.6.0", features = ["ui"] }
 # Or use individual crates:
-adk-ui = "0.5.0"
-adk-agent = "0.5.0"
-adk-model = "0.5.0"
+adk-ui = "0.6.0"
+adk-agent = "0.6.0"
+adk-model = "0.6.0"
 ```
 
 ### Basic Usage

--- a/docs/roadmap/realtime-streaming.md
+++ b/docs/roadmap/realtime-streaming.md
@@ -89,7 +89,7 @@ adk-realtime/
 
 ```toml
 [dependencies]
-adk-model = { version = "0.5.0", features = ["realtime"] }
+adk-model = { version = "0.6.0", features = ["realtime"] }
 ```
 
 ---


### PR DESCRIPTION
Sweep all crate READMEs, official docs, lib.rs doc comments, and source doc comments from 0.5.0 to 0.6.0.

**Scope**: 47 files across 27 crates + docs directory.

**What changed**:
- All `adk-*` crate READMEs: dependency examples updated
- `adk-rust/src/lib.rs`: rustdoc install snippets
- `adk-auth/src/sso/mod.rs`: doc comment
- `adk-mistralrs/Cargo.toml`: package version
- `docs/official_docs/`: all guides (agents, models, tools, sessions, security, etc.)
- `docs/roadmap/realtime-streaming.md`

**Not changed** (intentionally):
- `CHANGELOG.md` historical entries
- `#[deprecated(since = "0.5.0")]` markers
- Mock test data containing version strings
- `AGENTS.md` "Convenience APIs (0.5.0+)" header (means "since 0.5.0")