### PR TITLE
fix: clippy warnings for publish readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@
 
 **Listen to ADK-Rust explain itself.** This podcast episode was generated entirely by ADK-Rust using Gemini 3.1 Flash TTS — two AI hosts, natural voices, zero manual editing.
 
-🔊 **[Listen to Episode 1 (WAV)](docs/podcast/adk-rust-episode-1.wav)** · 2 min 21 sec · Hosts: James (Fenrir) & Ada (Kore)
+<audio controls src="https://github.com/zavora-ai/adk-rust/raw/main/docs/podcast/adk-rust-episode-1.wav">
+  Your browser does not support the audio element. <a href="docs/podcast/adk-rust-episode-1.wav">Download Episode 1 (WAV)</a>
+</audio>
+
+*2 min 21 sec · Hosts: James (Fenrir) & Ada (Kore)*
 
 > *"This episode was created using the Gemini 3.1 Flash TTS model through adk-audio. Two speakers, natural voices, all from a Rust script."* — James, in the episode
 

--- a/adk-agent/tests/shared_state_integration_tests.rs
+++ b/adk-agent/tests/shared_state_integration_tests.rs
@@ -359,7 +359,7 @@ async fn test_fresh_state_per_run() {
                 let mut event = Event::new(&invocation_id);
                 event.author = "write-count".to_string();
                 event.llm_response.content = Some(
-                    Content::new("model").with_text(&format!("{count}")),
+                    Content::new("model").with_text(format!("{count}")),
                 );
                 yield Ok(event);
             };

--- a/adk-audio/src/providers/stt/gemini.rs
+++ b/adk-audio/src/providers/stt/gemini.rs
@@ -124,7 +124,7 @@ impl SttProvider for GeminiStt {
 
         let resp = self
             .client
-            .post(&self.url())
+            .post(self.url())
             .header("x-goog-api-key", &self.api_key)
             .json(&body)
             .send()

--- a/adk-gemini/src/models.rs
+++ b/adk-gemini/src/models.rs
@@ -561,8 +561,8 @@ mod tests {
     #[test]
     fn test_content_function_response_multimodal_parts_nested() {
         use super::super::tools::FunctionResponsePart;
-        let blobs = vec![Blob::new("image/png", "img1"), Blob::new("image/jpeg", "img2")];
-        let files = vec![FileDataRef {
+        let blobs = [Blob::new("image/png", "img1"), Blob::new("image/jpeg", "img2")];
+        let files = [FileDataRef {
             mime_type: "application/pdf".to_string(),
             file_uri: "gs://b/f.pdf".to_string(),
         }];

--- a/adk-gemini/tests/multimodal_fn_response_tests.rs
+++ b/adk-gemini/tests/multimodal_fn_response_tests.rs
@@ -71,24 +71,24 @@ proptest! {
             prop_assert_eq!(function_response.parts.len(), n + m);
 
             // First N are InlineData (order preserved)
-            for i in 0..n {
-                match &function_response.parts[i] {
+            for (actual, expected) in function_response.parts[..n].iter().zip(inline_data.iter()) {
+                match actual {
                     FunctionResponsePart::InlineData { inline_data: blob } => {
-                        prop_assert_eq!(&blob.mime_type, &inline_data[i].mime_type);
-                        prop_assert_eq!(&blob.data, &inline_data[i].data);
+                        prop_assert_eq!(&blob.mime_type, &expected.mime_type);
+                        prop_assert_eq!(&blob.data, &expected.data);
                     }
-                    other => prop_assert!(false, "expected InlineData at {}, got {:?}", i, other),
+                    other => prop_assert!(false, "expected InlineData, got {:?}", other),
                 }
             }
 
             // Next M are FileData (order preserved)
-            for j in 0..m {
-                match &function_response.parts[n + j] {
+            for (actual, expected) in function_response.parts[n..].iter().zip(file_data.iter()) {
+                match actual {
                     FunctionResponsePart::FileData { file_data: fdr } => {
-                        prop_assert_eq!(&fdr.mime_type, &file_data[j].mime_type);
-                        prop_assert_eq!(&fdr.file_uri, &file_data[j].file_uri);
+                        prop_assert_eq!(&fdr.mime_type, &expected.mime_type);
+                        prop_assert_eq!(&fdr.file_uri, &expected.file_uri);
                     }
-                    other => prop_assert!(false, "expected FileData at {}, got {:?}", n + j, other),
+                    other => prop_assert!(false, "expected FileData, got {:?}", other),
                 }
             }
         }

--- a/adk-model/tests/multimodal_conversion_tests.rs
+++ b/adk-model/tests/multimodal_conversion_tests.rs
@@ -90,25 +90,25 @@ proptest! {
         prop_assert_eq!(gemini_fr.parts.len(), k + l);
 
         // Verify inline data parts: base64-decoded matches original bytes
-        for i in 0..k {
-            match &gemini_fr.parts[i] {
+        for (actual, expected) in gemini_fr.parts[..k].iter().zip(inline_data.iter()) {
+            match actual {
                 adk_gemini::FunctionResponsePart::InlineData { inline_data: blob } => {
-                    prop_assert_eq!(&blob.mime_type, &inline_data[i].mime_type);
+                    prop_assert_eq!(&blob.mime_type, &expected.mime_type);
                     let decoded = BASE64_STANDARD.decode(&blob.data).unwrap();
-                    prop_assert_eq!(&decoded, &inline_data[i].data);
+                    prop_assert_eq!(&decoded, &expected.data);
                 }
-                other => prop_assert!(false, "expected InlineData at {}, got {:?}", i, other),
+                other => prop_assert!(false, "expected InlineData, got {:?}", other),
             }
         }
 
         // Verify file data parts: MIME type and URI preserved
-        for j in 0..l {
-            match &gemini_fr.parts[k + j] {
+        for (actual, expected) in gemini_fr.parts[k..].iter().zip(file_data.iter()) {
+            match actual {
                 adk_gemini::FunctionResponsePart::FileData { file_data: fdr } => {
-                    prop_assert_eq!(&fdr.mime_type, &file_data[j].mime_type);
-                    prop_assert_eq!(&fdr.file_uri, &file_data[j].file_uri);
+                    prop_assert_eq!(&fdr.mime_type, &expected.mime_type);
+                    prop_assert_eq!(&fdr.file_uri, &expected.file_uri);
                 }
-                other => prop_assert!(false, "expected FileData at {}, got {:?}", k + j, other),
+                other => prop_assert!(false, "expected FileData, got {:?}", other),
             }
         }
     }


### PR DESCRIPTION
Resolve all clippy warnings across the workspace for publish readiness.

**Fixes:**
- `adk-audio`: remove needless borrow in GeminiStt
- `adk-gemini`: use zip iterators in property tests, array literals in unit tests
- `adk-model`: use zip iterators in property tests
- `adk-agent`: remove needless borrow in shared_state integration test

**Quality gates (all pass):**
- `cargo fmt --all -- --check`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: zero warnings
- `cargo nextest run --workspace`: 1938 passed, 0 failed, 77 skipped