### PR TITLE
chore: upgrade thin-vec 0.2.16 (CVE fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14124,9 +14124,9 @@ dependencies = [
 
 [[package]]
 name = "thin-vec"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144f754d318415ac792f9d69fc87abbbfc043ce2ef041c60f16ad828f638717d"
+checksum = "259cdf8ed4e4aca6f1e9d011e10bd53f524a2d0637d7b28450f6c64ac298c4c6"
 
 [[package]]
 name = "thirtyfour"


### PR DESCRIPTION
Upgrade `thin-vec` from 0.2.14 to 0.2.16 in the workspace lockfile.

Fixes Dependabot alert for use-after-free and double free in `IntoIter::drop` when element drop panics (thin-vec #144).

This is a transitive dependency — no published crate metadata is affected, only the repo lockfile.