### PR TITLE
feat(anthropic): Claude Opus 4.7 support + 0.6.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2026-04-17
+
+### Added
+
+#### Text-Based Tool Call Parser (`adk-model`)
+
+Automatic detection and parsing of tool calls embedded in text responses from models that don't use native function calling. Enables tool use with open-weight models served via Ollama, vLLM, and other OpenAI-compatible endpoints.
+
+- **`parse_text_tool_calls()`** (`adk-model`): Parses text containing tool call markup into `Part::FunctionCall` items. Supports 7 model-family formats:
+  - **Qwen/Hermes**: `<tool_call>{"name":"...","arguments":{...}}</tool_call>`
+  - **Qwen-Coder**: `<tool_call><function=NAME>ARGS</function></tool_call>`
+  - **Llama**: `<|python_tag|>{"name":"...","parameters":{...}}`
+  - **Mistral Nemo**: `[TOOL_CALLS][{"name":"...","arguments":{...}}]`
+  - **DeepSeek**: JSON fences with `<｜tool▁call▁end｜>` (full-width Unicode delimiters)
+  - **Gemma 4**: `<|tool_call>call:NAME{...}<tool_call|>` (non-JSON custom escaping)
+  - **Action tags**: `<|action_start|>{"name":"...","arguments":{...}}<|action_end|>`
+- **`ToolCallBuffer`** (`adk-model`): Streaming token buffer that detects tool call prefixes mid-stream, accumulates tokens until the closing tag, then parses and emits `Part::FunctionCall`. Falls back to `Part::Text` on parse failure.
+- **`contains_tool_call_tag()`** (`adk-model`): Quick check for tool call markers in text without full parsing.
+- **OpenAI-compatible streaming integration**: `ToolCallBuffer` wired into the OpenAI-compatible streaming path, automatically converting text-embedded tool calls to native function calls during streaming.
+- **OpenAI non-streaming integration**: `parse_text_tool_calls()` applied to non-streaming responses from OpenAI-compatible endpoints.
+- **Ollama non-streaming integration**: `parse_text_tool_calls()` applied to Ollama text responses.
+- **Ollama streaming with tools**: Enabled streaming for Ollama tool-calling requests (previously forced non-streaming). Ollama's API now supports streaming with tool calls natively.
+- **22 unit tests** covering all 7 formats, mixed text+tool content, multiple tool calls, malformed input, and streaming buffer behavior.
+
+#### Ollama Qwen Example (`examples/ollama_qwen35/`)
+
+- Standalone example crate demonstrating three scenarios with Qwen 3.5 / Qwen3-Coder on Ollama:
+  1. **Thinking/reasoning**: Extended thinking with `<think>` blocks
+  2. **Native Ollama tool calling**: Ollama's built-in tool call API
+  3. **OpenAI-compat tool calling**: Text-based tool call parsing via the OpenAI-compatible endpoint
+- Model configurable via `OLLAMA_MODEL` env var (default: `qwen3.5`)
+- README documents all 7 supported text-based tool call formats
+
+### Fixed
+
+- **`cargo fmt` compliance** (`adk-model`): Fixed formatting in `tool_call_parser.rs` and module ordering in `lib.rs`.
+
+### Security
+
+- **thin-vec CVE fix**: Upgraded `thin-vec` 0.2.14 → 0.2.16 (use-after-free in `IntoIter::drop` when element drop panics).
+
 ## [0.6.0] - 2026-04-12
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,16 @@ Automatic detection and parsing of tool calls embedded in text responses from mo
 - Model configurable via `OLLAMA_MODEL` env var (default: `qwen3.5`)
 - README documents all 7 supported text-based tool call formats
 
+#### Claude Opus 4.7 Support (`adk-anthropic`, `adk-model`)
+
+Day-one support for Anthropic's Claude Opus 4.7 (released April 16, 2026):
+
+- **`KnownModel::ClaudeOpus47`** (`adk-anthropic`): New variant for `claude-opus-4-7` wire format with serde round-trip support.
+- **`EffortLevel::XHigh`** (`adk-anthropic`): New effort level between `High` and `Max` — recommended for coding and agentic workflows on Opus 4.7.
+- **`ModelPricing::OPUS_47`** (`adk-anthropic`): Pricing constant at $5/$25 per MTok (same as Opus 4.6).
+- **`Effort::XHigh`** (`adk-model`): New variant in the adk-model Anthropic config, mapped to `adk_anthropic::EffortLevel::XHigh`.
+- **Documentation updates**: ThinkingConfig, OutputConfig, and README updated to document Opus 4.7 breaking changes (adaptive thinking only, no `budget_tokens`/`temperature`/`top_p`, updated tokenizer).
+
 ### Fixed
 
 - **`cargo fmt` compliance** (`adk-model`): Fixed formatting in `tool_call_parser.rs` and module ordering in `lib.rs`.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ ADK supports multiple LLM providers with a unified API:
 | Gemini | `gemini-2.5-flash`, `gemini-2.5-pro`, `gemini-3-pro-preview`, `gemini-3-flash-preview` | (default) |
 | OpenAI | `gpt-5`, `gpt-5-mini`, `gpt-5-nano` | `openai` |
 | OpenAI Responses API | `gpt-4.1`, `o3`, `o4-mini` | `openai` |
-| Anthropic | `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-haiku-4-5` | `anthropic` |
+| Anthropic | `claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5` | `anthropic` |
 | DeepSeek | `deepseek-chat`, `deepseek-reasoner` | `deepseek` |
 | Groq | `meta-llama/llama-4-scout-17b-16e-instruct`, `llama-3.3-70b-versatile` | `groq` |
 | Ollama | `llama3.2:3b`, `qwen2.5:7b`, `mistral:7b` | `ollama` |

--- a/adk-anthropic/README.md
+++ b/adk-anthropic/README.md
@@ -10,9 +10,9 @@ This project is an **unofficial** community-maintained library. It is not affili
 ## Features
 
 - **Messages API** — non-streaming and SSE streaming with all content block types
-- **Adaptive thinking** — `ThinkingConfig::adaptive()` for Opus 4.6 / Sonnet 4.6
-- **Budget-based thinking** — `ThinkingConfig::enabled(budget)` for older models
-- **Effort parameter** — `OutputConfig::with_effort()` controlling response thoroughness
+- **Adaptive thinking** — `ThinkingConfig::adaptive()` for Opus 4.7 / Opus 4.6 / Sonnet 4.6
+- **Budget-based thinking** — `ThinkingConfig::enabled(budget)` for older models (rejected on Opus 4.7)
+- **Effort parameter** — `OutputConfig::with_effort()` with `low`, `medium`, `high`, `xhigh`, `max` levels
 - **Structured outputs** — JSON schema via `OutputConfig` / `OutputFormat`
 - **Tool calling** — custom function tools, server tools (web search, bash, text editor, code execution, memory)
 - **Prompt caching** — automatic (top-level `cache_control`) and explicit (block-level)
@@ -31,15 +31,25 @@ This project is an **unofficial** community-maintained library. It is not affili
 
 | Model | API ID | Generation |
 |-------|--------|------------|
-| Claude Opus 4.6 | `claude-opus-4-6` | Latest |
-| Claude Sonnet 4.6 | `claude-sonnet-4-6` | Latest |
-| Claude Haiku 4.5 | `claude-haiku-4-5` | Latest (fastest) |
+| Claude Opus 4.7 | `claude-opus-4-7` | Latest |
+| Claude Opus 4.6 | `claude-opus-4-6` | Current |
+| Claude Sonnet 4.6 | `claude-sonnet-4-6` | Current |
+| Claude Haiku 4.5 | `claude-haiku-4-5` | Current (fastest) |
 | Claude Opus 4.5 | `claude-opus-4-5` | Previous |
 | Claude Sonnet 4.5 | `claude-sonnet-4-5` | Previous |
-| Claude Sonnet 4 | `claude-sonnet-4-0` | Legacy |
-| Claude Opus 4 | `claude-opus-4-0` | Legacy |
+| Claude Sonnet 4 | `claude-sonnet-4-0` | Legacy (retiring June 2026) |
+| Claude Opus 4 | `claude-opus-4-0` | Legacy (retiring June 2026) |
 
 Any model string not matching a known variant deserializes as `Model::Custom(String)`.
+
+### Opus 4.7 Breaking Changes
+
+Opus 4.7 introduces API breaking changes versus Opus 4.6:
+
+- **Adaptive thinking only** — `thinking: {type: "enabled", budget_tokens: N}` returns 400. Use `ThinkingConfig::adaptive()`.
+- **No custom sampling** — `temperature` and `top_p` parameters are rejected.
+- **New `xhigh` effort level** — sits between `high` and `max`. Recommended for coding and agentic workflows.
+- **Updated tokenizer** — same text may produce 1.0–1.35× more tokens (especially code).
 
 ## Quick Start
 

--- a/adk-anthropic/src/pricing.rs
+++ b/adk-anthropic/src/pricing.rs
@@ -31,6 +31,14 @@ pub struct ModelPricing {
 }
 
 impl ModelPricing {
+    /// Claude Opus 4.7 — same pricing as Opus 4.6.
+    pub const OPUS_47: Self = Self {
+        input: 5.0,
+        cache_write_5m: 6.25,
+        cache_write_1h: 10.0,
+        cache_read: 0.50,
+        output: 25.0,
+    };
     /// Claude Opus 4.6
     pub const OPUS_46: Self = Self {
         input: 5.0,

--- a/adk-anthropic/src/types/effort_level.rs
+++ b/adk-anthropic/src/types/effort_level.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Serialize};
 /// Effort parameter controlling response thoroughness.
 /// Passed via `output_config.effort`. GA, no beta header required.
 ///
-/// Supported on Claude Opus 4.6, Sonnet 4.6, and Opus 4.5.
-/// `Max` is only available on Opus 4.6.
+/// Supported on Claude Opus 4.7, Opus 4.6, Sonnet 4.6, and Opus 4.5.
+/// `XHigh` is available on Opus 4.7+. `Max` is available on Opus 4.6+.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum EffortLevel {
@@ -14,7 +14,11 @@ pub enum EffortLevel {
     Medium,
     /// High capability (default). Same as omitting the parameter.
     High,
-    /// Absolute maximum capability. Opus 4.6 only.
+    /// Very deep reasoning. Opus 4.7+ recommended.
+    /// Sits between `High` and `Max` — deeper reasoning than `High`
+    /// without the full cost of `Max`.
+    XHigh,
+    /// Absolute maximum capability. Opus 4.6+ only.
     Max,
 }
 
@@ -27,11 +31,15 @@ mod tests {
         assert_eq!(serde_json::to_string(&EffortLevel::Low).unwrap(), r#""low""#);
         assert_eq!(serde_json::to_string(&EffortLevel::Medium).unwrap(), r#""medium""#);
         assert_eq!(serde_json::to_string(&EffortLevel::High).unwrap(), r#""high""#);
+        assert_eq!(serde_json::to_string(&EffortLevel::XHigh).unwrap(), r#""xhigh""#);
         assert_eq!(serde_json::to_string(&EffortLevel::Max).unwrap(), r#""max""#);
     }
 
     #[test]
     fn deserialization() {
+        let level: EffortLevel = serde_json::from_str(r#""xhigh""#).unwrap();
+        assert_eq!(level, EffortLevel::XHigh);
+
         let level: EffortLevel = serde_json::from_str(r#""max""#).unwrap();
         assert_eq!(level, EffortLevel::Max);
     }

--- a/adk-anthropic/src/types/model.rs
+++ b/adk-anthropic/src/types/model.rs
@@ -13,12 +13,17 @@ pub enum Model {
 
 /// Known Anthropic model versions.
 ///
-/// Covers the current generation (4.6), previous generation (4.5),
+/// Covers the current generation (4.7), previous generation (4.6/4.5),
 /// and legacy 4.0/4.1 models. Any string not matching a known variant
 /// deserialises into `Model::Custom`.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum KnownModel {
-    // 4.6 (latest)
+    // 4.7 (latest)
+    /// Claude Opus 4.7 — most capable GA model. Adaptive thinking only,
+    /// `budget_tokens`/`temperature`/`top_p` rejected. New `xhigh` effort level.
+    ClaudeOpus47,
+
+    // 4.6
     /// Claude Opus 4.6
     ClaudeOpus46,
     /// Claude Sonnet 4.6
@@ -55,6 +60,7 @@ impl KnownModel {
     /// Returns the wire-format string for this model.
     pub fn as_str(&self) -> &'static str {
         match self {
+            Self::ClaudeOpus47 => "claude-opus-4-7",
             Self::ClaudeOpus46 => "claude-opus-4-6",
             Self::ClaudeSonnet46 => "claude-sonnet-4-6",
             Self::ClaudeOpus45 => "claude-opus-4-5",
@@ -119,6 +125,7 @@ impl FromStr for KnownModel {
     type Err = ();
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
+            "claude-opus-4-7" => Ok(Self::ClaudeOpus47),
             "claude-opus-4-6" => Ok(Self::ClaudeOpus46),
             "claude-sonnet-4-6" => Ok(Self::ClaudeSonnet46),
             "claude-opus-4-5" => Ok(Self::ClaudeOpus45),
@@ -154,6 +161,7 @@ mod tests {
     #[test]
     fn current_models_roundtrip() {
         for (variant, wire) in [
+            (KnownModel::ClaudeOpus47, "claude-opus-4-7"),
             (KnownModel::ClaudeOpus46, "claude-opus-4-6"),
             (KnownModel::ClaudeSonnet46, "claude-sonnet-4-6"),
             (KnownModel::ClaudeHaiku45, "claude-haiku-4-5"),

--- a/adk-anthropic/src/types/output_config.rs
+++ b/adk-anthropic/src/types/output_config.rs
@@ -8,7 +8,7 @@ use crate::types::{EffortLevel, OutputFormat};
 /// response thoroughness. Maps to the API's `output_config` parameter.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct OutputConfig {
-    /// Effort level controlling response thoroughness (`low`, `medium`, `high`).
+    /// Effort level controlling response thoroughness (`low`, `medium`, `high`, `xhigh`, `max`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub effort: Option<EffortLevel>,
     /// The output format configuration.

--- a/adk-anthropic/src/types/thinking_config.rs
+++ b/adk-anthropic/src/types/thinking_config.rs
@@ -16,14 +16,15 @@ pub enum ThinkingDisplay {
 ///
 /// # Variants
 ///
-/// - `Enabled` — Budget-based thinking (legacy, deprecated on 4.6 models).
-/// - `Adaptive` — Adaptive thinking for Opus 4.6 / Sonnet 4.6.
+/// - `Enabled` — Budget-based thinking (legacy, deprecated on 4.6 models,
+///   **rejected on Opus 4.7**).
+/// - `Adaptive` — Adaptive thinking for Opus 4.7 / Opus 4.6 / Sonnet 4.6.
 ///   Pair with `output_config.effort` to control reasoning depth.
 /// - `Disabled` — Thinking disabled.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ThinkingConfig {
-    /// Budget-based thinking (deprecated on 4.6 models).
+    /// Budget-based thinking (deprecated on 4.6 models, **rejected on Opus 4.7**).
     Enabled {
         /// Token budget for thinking. Must be ≥1024 and less than `max_tokens`.
         budget_tokens: u32,
@@ -31,7 +32,7 @@ pub enum ThinkingConfig {
         #[serde(skip_serializing_if = "Option::is_none")]
         display: Option<ThinkingDisplay>,
     },
-    /// Adaptive thinking for Opus 4.6 / Sonnet 4.6.
+    /// Adaptive thinking for Opus 4.7 / Opus 4.6 / Sonnet 4.6.
     /// Use `output_config.effort` to control reasoning depth.
     Adaptive {
         /// Optional display control.

--- a/adk-model/src/anthropic/config.rs
+++ b/adk-model/src/anthropic/config.rs
@@ -7,13 +7,14 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ThinkingMode {
-    /// Budget-based thinking (legacy, deprecated on 4.6 models).
+    /// Budget-based thinking (legacy, deprecated on 4.6 models,
+    /// **rejected on Opus 4.7**).
     /// Requires `budget_tokens` < `max_tokens`.
     Enabled {
         /// Token budget for thinking (must be ≥ 1024).
         budget_tokens: u32,
     },
-    /// Adaptive thinking for Opus 4.6 / Sonnet 4.6.
+    /// Adaptive thinking for Opus 4.7 / Opus 4.6 / Sonnet 4.6.
     /// Claude decides when and how much to think.
     /// Control depth via `effort` on `AnthropicConfig`.
     Adaptive,
@@ -27,7 +28,9 @@ pub enum Effort {
     Low,
     Medium,
     High,
-    /// Opus 4.6 only.
+    /// Very deep reasoning. Opus 4.7+ recommended.
+    XHigh,
+    /// Opus 4.6+ only.
     Max,
 }
 
@@ -38,12 +41,17 @@ pub enum Effort {
 /// ```rust
 /// use adk_model::anthropic::{AnthropicConfig, ThinkingMode, Effort};
 ///
+/// // Opus 4.7 with adaptive thinking and xhigh effort (recommended)
+/// let config = AnthropicConfig::new("sk-ant-xxx", "claude-opus-4-7")
+///     .with_thinking_mode(ThinkingMode::Adaptive)
+///     .with_effort(Effort::XHigh);
+///
 /// // Adaptive thinking with medium effort (recommended for Sonnet 4.6)
 /// let config = AnthropicConfig::new("sk-ant-xxx", "claude-sonnet-4-6")
 ///     .with_thinking_mode(ThinkingMode::Adaptive)
 ///     .with_effort(Effort::Medium);
 ///
-/// // Budget-based thinking (legacy)
+/// // Budget-based thinking (legacy, rejected on Opus 4.7)
 /// let config = AnthropicConfig::new("sk-ant-xxx", "claude-sonnet-4-5")
 ///     .with_thinking_mode(ThinkingMode::Enabled { budget_tokens: 8192 });
 ///
@@ -55,7 +63,7 @@ pub enum Effort {
 pub struct AnthropicConfig {
     /// Anthropic API key.
     pub api_key: String,
-    /// Model name (e.g., `"claude-sonnet-4-6"`, `"claude-opus-4-6"`).
+    /// Model name (e.g., `"claude-opus-4-7"`, `"claude-sonnet-4-6"`).
     pub model: String,
     /// Maximum tokens to generate.
     #[serde(default = "default_max_tokens")]
@@ -81,7 +89,7 @@ pub struct AnthropicConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub effort: Option<Effort>,
 
-    /// Enable fast mode (Opus 4.6 only, beta).
+    /// Enable fast mode (Opus 4.6+ only, beta).
     /// Delivers up to 2.5× higher output tokens/sec at 6× pricing.
     #[serde(default)]
     pub fast_mode: bool,
@@ -190,7 +198,7 @@ impl AnthropicConfig {
         self
     }
 
-    /// Enable fast mode (Opus 4.6 only, beta).
+    /// Enable fast mode (Opus 4.6+ only, beta).
     pub fn with_fast_mode(mut self, enabled: bool) -> Self {
         self.fast_mode = enabled;
         self

--- a/adk-model/src/anthropic/convert.rs
+++ b/adk-model/src/anthropic/convert.rs
@@ -400,6 +400,7 @@ pub fn build_message_params(
             super::config::Effort::Low => adk_anthropic::EffortLevel::Low,
             super::config::Effort::Medium => adk_anthropic::EffortLevel::Medium,
             super::config::Effort::High => adk_anthropic::EffortLevel::High,
+            super::config::Effort::XHigh => adk_anthropic::EffortLevel::XHigh,
             super::config::Effort::Max => adk_anthropic::EffortLevel::Max,
         };
         params.output_config = Some(adk_anthropic::OutputConfig::with_effort(level));

--- a/adk-model/src/lib.rs
+++ b/adk-model/src/lib.rs
@@ -276,6 +276,7 @@ pub mod openai_compatible;
 pub mod openrouter;
 pub mod provider;
 pub mod retry;
+pub mod tool_call_parser;
 #[cfg(any(
     feature = "openai",
     feature = "ollama",
@@ -285,7 +286,6 @@ pub mod retry;
     feature = "azure-ai"
 ))]
 pub(crate) mod tool_result;
-pub mod tool_call_parser;
 pub mod usage_tracking;
 
 #[cfg(feature = "anthropic")]

--- a/adk-model/src/tool_call_parser.rs
+++ b/adk-model/src/tool_call_parser.rs
@@ -109,7 +109,10 @@ fn parse_qwen_format(text: &str, _parts: &mut Vec<Part>) -> Option<Vec<Part>> {
             result.push(part);
         } else {
             // Couldn't parse — keep as text
-            result.push(Part::Text { text: remaining[start..start + "<tool_call>".len() + end + "</tool_call>".len()].to_string() });
+            result.push(Part::Text {
+                text: remaining[start..start + "<tool_call>".len() + end + "</tool_call>".len()]
+                    .to_string(),
+            });
         }
 
         remaining = &after_open[end + "</tool_call>".len()..];
@@ -151,11 +154,8 @@ fn parse_json_tool_call(json_str: &str) -> Option<Part> {
     let value: serde_json::Value = serde_json::from_str(json_str).ok()?;
     let obj = value.as_object()?;
 
-    let name = obj
-        .get("name")
-        .or_else(|| obj.get("function"))
-        .and_then(|v| v.as_str())?
-        .to_string();
+    let name =
+        obj.get("name").or_else(|| obj.get("function")).and_then(|v| v.as_str())?.to_string();
 
     let args = obj
         .get("arguments")
@@ -455,11 +455,7 @@ impl ToolCallBuffer {
         // Otherwise emit as text
         let text = std::mem::take(&mut self.buffer);
         self.buffering = false;
-        if text.trim().is_empty() {
-            Vec::new()
-        } else {
-            vec![Part::Text { text }]
-        }
+        if text.trim().is_empty() { Vec::new() } else { vec![Part::Text { text }] }
     }
 
     fn starts_tool_call_prefix(&self) -> bool {
@@ -529,7 +525,8 @@ mod tests {
 
     #[test]
     fn test_qwen_json_format() {
-        let text = r#"<tool_call>{"name": "get_weather", "arguments": {"city": "Tokyo"}}</tool_call>"#;
+        let text =
+            r#"<tool_call>{"name": "get_weather", "arguments": {"city": "Tokyo"}}</tool_call>"#;
         let parts = parse_text_tool_calls(text).unwrap();
         assert_eq!(parts.len(), 1);
         match &parts[0] {
@@ -764,7 +761,8 @@ mod tests {
         let text = "I'll search for that.\n```json\n{\"name\": \"search\", \"arguments\": {\"q\": \"rust\"}}\n```\n<｜tool▁call▁end｜>";
         let parts = parse_text_tool_calls(text).unwrap();
         assert!(!parts.is_empty());
-        let has_fn_call = parts.iter().any(|p| matches!(p, Part::FunctionCall { name, .. } if name == "search"));
+        let has_fn_call =
+            parts.iter().any(|p| matches!(p, Part::FunctionCall { name, .. } if name == "search"));
         assert!(has_fn_call);
     }
 
@@ -816,7 +814,8 @@ mod tests {
         let text = "Let me look that up. <|action_start|>{\"name\": \"search\", \"arguments\": {}}<|action_end|> Done.";
         let parts = parse_text_tool_calls(text).unwrap();
         assert!(parts.len() >= 2); // text + function call (+ optional trailing text)
-        let has_fn_call = parts.iter().any(|p| matches!(p, Part::FunctionCall { name, .. } if name == "search"));
+        let has_fn_call =
+            parts.iter().any(|p| matches!(p, Part::FunctionCall { name, .. } if name == "search"));
         assert!(has_fn_call);
     }
 }

--- a/docs/official_docs/models/anthropic.md
+++ b/docs/official_docs/models/anthropic.md
@@ -17,13 +17,14 @@ The `adk-anthropic` crate is a dedicated Anthropic API client for ADK-Rust. It p
 
 | Model | API ID | Notes |
 |-------|--------|-------|
-| Claude Opus 4.6 | `claude-opus-4-6` | Most intelligent, 1M context, 128K output |
+| Claude Opus 4.7 | `claude-opus-4-7` | Most capable GA model, 1M context, 128K output, adaptive thinking only |
+| Claude Opus 4.6 | `claude-opus-4-6` | Previous flagship, 1M context, 128K output |
 | Claude Sonnet 4.6 | `claude-sonnet-4-6` | Best speed/intelligence balance, 1M context |
 | Claude Haiku 4.5 | `claude-haiku-4-5` | Fastest, 200K context |
 | Claude Opus 4.5 | `claude-opus-4-5` | Previous generation |
 | Claude Sonnet 4.5 | `claude-sonnet-4-5` | Previous generation |
-| Claude Sonnet 4 | `claude-sonnet-4-0` | Legacy |
-| Claude Opus 4 | `claude-opus-4-0` | Legacy |
+| Claude Sonnet 4 | `claude-sonnet-4-0` | Legacy (retiring June 2026) |
+| Claude Opus 4 | `claude-opus-4-0` | Legacy (retiring June 2026) |
 
 ## Setup
 
@@ -54,11 +55,19 @@ let model = AnthropicClient::new(AnthropicConfig::new(api_key, "claude-sonnet-4-
 
 ## Key Features
 
-### Adaptive Thinking (4.6 models)
+### Adaptive Thinking (4.6+ models)
+
+Opus 4.7 **only** supports adaptive thinking — `budget_tokens` is rejected.
 
 ```rust
 use adk_anthropic::{ThinkingConfig, OutputConfig, EffortLevel};
 
+// Opus 4.7: use xhigh effort (recommended for coding/agentic)
+let mut params = MessageCreateParams::simple("Solve this...", KnownModel::ClaudeOpus47)
+    .with_thinking(ThinkingConfig::adaptive());
+params.output_config = Some(OutputConfig::with_effort(EffortLevel::XHigh));
+
+// Sonnet 4.6: any effort level works
 let mut params = MessageCreateParams::simple("Solve this...", KnownModel::ClaudeSonnet46)
     .with_thinking(ThinkingConfig::adaptive());
 params.output_config = Some(OutputConfig::with_effort(EffortLevel::High));

--- a/docs/official_docs/models/providers.md
+++ b/docs/official_docs/models/providers.md
@@ -337,7 +337,8 @@ async fn main() -> anyhow::Result<()> {
 
 | Model | Description | Context |
 |-------|-------------|---------|
-| `claude-opus-4-6` | Most capable for complex autonomous tasks | 200K tokens |
+| `claude-opus-4-7` | Most capable GA model, adaptive thinking only | 1M tokens |
+| `claude-opus-4-6` | Previous flagship for complex autonomous tasks | 1M tokens |
 | `claude-sonnet-4-6` | Balanced intelligence and cost (recommended) | 1M tokens |
 | `claude-haiku-4-5-20251001` | Ultra-efficient for high-volume workloads | 200K tokens |
 | `claude-opus-4-20250514` | Hybrid model with extended thinking | 200K tokens |

--- a/docs/official_docs/quickstart.md
+++ b/docs/official_docs/quickstart.md
@@ -253,7 +253,7 @@ let model = OllamaModel::new(OllamaConfig::new("llama3.2"))?;
 |----------|---------------|--------------|
 | Gemini | `gemini-2.5-flash`, `gemini-2.5-pro`, `gemini-3-pro-preview` | (default) |
 | OpenAI | `gpt-5`, `gpt-5-mini`, `gpt-4.1` | `openai` |
-| Anthropic | `claude-sonnet-4-6`, `claude-opus-4-6`, `claude-haiku-4-5` | `anthropic` |
+| Anthropic | `claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5` | `anthropic` |
 | DeepSeek | `deepseek-chat`, `deepseek-reasoner` | `deepseek` |
 | Groq | `meta-llama/llama-4-scout-17b-16e-instruct`, `llama-3.3-70b-versatile` | `groq` |
 | Ollama | `llama3.2:3b`, `qwen2.5:7b`, `mistral:7b` | `ollama` |


### PR DESCRIPTION
Day-one support for Claude Opus 4.7 (released April 16, 2026) plus 0.6.1 patch changelog.

## Opus 4.7 Changes

### adk-anthropic
- `KnownModel::ClaudeOpus47` — `claude-opus-4-7` wire format with serde round-trip
- `EffortLevel::XHigh` — new effort level between `High` and `Max`
- `ModelPricing::OPUS_47` — $5/$25 per MTok (same as 4.6)
- `ThinkingConfig` docs updated: `budget_tokens` rejected on Opus 4.7

### adk-model
- `Effort::XHigh` variant added to Anthropic config
- Convert layer maps `XHigh` → `adk_anthropic::EffortLevel::XHigh`
- Config docs updated with Opus 4.7 examples

### Documentation
- README, official docs, providers.md, quickstart.md updated
- CHANGELOG 0.6.1 entry with tool call parser + Opus 4.7 + security fixes

## Opus 4.7 Breaking Changes (vs 4.6)
- Adaptive thinking only (`budget_tokens` returns 400)
- `temperature` and `top_p` parameters rejected
- Updated tokenizer (1.0–1.35× more tokens on code)
- New `xhigh` effort level (recommended for coding/agentic)

## Quality Gates
- `cargo fmt --all -- --check`: clean
- `cargo clippy -p adk-anthropic -p adk-model -- -D warnings`: zero warnings
- `cargo nextest run -p adk-anthropic --lib --tests`: 373/373 passed
- `cargo nextest run -p adk-model --lib --tests`: 65/65 passed