### PR TITLE
feat(awp): AwpStateBuilder, FileConsentService, and security dep fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### Agentic Web Protocol (`awp-types`, `adk-awp`)
+
+Two new workspace crates implementing the Agentic Web Protocol (AWP) — a protocol for making websites and services natively accessible to AI agents.
+
+- **awp-types**: Pure protocol types with zero `adk-*` dependencies. Includes `TrustLevel` (Anonymous/Known/Partner/Internal), `RequesterType` (Human/Agent), `AwpVersion` with compatibility checks, `AwpError` with HTTP status mapping, `AwpRequest`/`AwpResponse` envelopes, `A2aMessage`/`A2aMessageType`, `AwpDiscoveryDocument`, `CapabilityManifest` (JSON-LD), `BusinessContext` with full schema (business identity, brand voice, products, channels, payments, support, content, reviews, outreach), `PaymentIntent`/`PaymentIntentState`/`PaymentPolicy` for owner-policy-driven payments, `AwpMessageType` with 9 typed message categories for agent routing.
+- **adk-awp**: Full protocol implementation with axum 0.8. Includes `BusinessContextLoader` with hot-reload via ArcSwap, discovery document and capability manifest generation, requester type detection (human vs agent from headers), trust level assignment, `InMemoryRateLimiter` with per-trust-level sliding window (30/120/600/unlimited), `InMemoryConsentService` and `FileConsentService` (JSON file-backed for GDPR/KPA compliance), `InMemoryEventSubscriptionService` with HMAC-SHA256 webhook signing, `HealthStateMachine` (Healthy/Degrading/Degraded) with event emission, AWP version negotiation middleware, `awp_routes()` returning 7 Axum endpoints, `AwpStateBuilder` with sensible defaults.
+- **AWP Endpoints**: `GET /.well-known/awp.json` (discovery), `GET /awp/manifest` (JSON-LD capabilities), `GET /awp/health` (health state), `POST /awp/events/subscribe`, `GET /awp/events/subscriptions`, `DELETE /awp/events/subscriptions/{id}`, `POST /awp/a2a` (A2A messages).
+- **examples/awp_agent**: Standalone example with LLM agent serving AWP-compliant endpoints. Loads `business.toml`, derives agent instructions from business context, exercises all endpoints.
+- **docs/official_docs/deployment/awp.md**: Dedicated AWP documentation section covering architecture, quick start, all endpoints, trust levels, rate limiting, version negotiation, events, health, consent, message types, payment intents, and full `business.toml` schema reference.
+
+#### Video Avatar Providers (`adk-realtime`)
+
+- **adk-realtime**: Added `AvatarProvider` trait (object-safe, Send+Sync+Debug) with `start_session`, `stop_session`, `push_audio`, `is_active` methods.
+- **adk-realtime**: Added `HeyGenProvider` — REST API session management + LiveKit audio publishing. Feature flag: `heygen-avatar`.
+- **adk-realtime**: Added `DIDProvider` — REST API session management + WebRTC signaling. Feature flag: `did-avatar`.
+- **adk-realtime**: Wired avatar providers into `RealtimeAgent` event loop with session lifecycle, audio routing, keep-alive, and graceful degradation.
+- **adk-realtime**: HTTPS enforcement on all avatar provider API URLs (CodeQL fix).
+- **adk-realtime**: Feature flags: `heygen-avatar`, `did-avatar`, `video-avatar` (both).
+- **examples/video_avatar**: HeyGen and D-ID avatar provider examples.
+
+#### GeminiModel Thinking Config (`adk-model`)
+
+- **adk-model**: Added `with_thinking_config()` and `set_thinking_config()` to `GeminiModel`, matching OpenAI (`reasoning_effort`) and Anthropic (`thinking_mode`) patterns.
+- **adk-model**: Re-exported `ThinkingConfig` and `ThinkingLevel` from `adk_model::gemini`.
+
+### Changed
+
+- **adk-awp**: Upgraded from axum 0.7 to axum 0.8, aligning with adk-server, adk-auth, and adk-payments.
+
+### Security
+
+- **rustls-webpki**: Updated 0.103.10 → 0.103.13 (fixes DoS via panic on malformed CRL BIT STRING).
+- **openssl**: Updated 0.10.76 → 0.10.78 (fixes buffer overflow, unchecked callback length, incorrect bounds assertion, OOB read in PEM callback).
+- **rand**: Updated 0.8.5 → 0.8.6 (fixes unsound behavior with custom logger).
+
 #### Project-Scoped Memory (`adk-memory`, `adk-core`)
 
 Optional `project_id` dimension for memory isolation. Memories are now scoped by `(app_name, user_id, project_id?)` — global entries (no project) are visible everywhere, project entries are isolated to their project.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2345,7 +2345,7 @@ dependencies = [
  "http 0.2.12",
  "log",
  "oauth2",
- "rand 0.8.5",
+ "rand 0.8.6",
  "reqwest 0.11.27",
  "rustc_version",
  "serde",
@@ -2423,7 +2423,7 @@ dependencies = [
  "getrandom 0.2.17",
  "instant",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.8.6",
  "tokio",
 ]
 
@@ -2765,7 +2765,7 @@ dependencies = [
  "once_cell",
  "pollster",
  "portable-atomic",
- "rand 0.8.5",
+ "rand 0.8.6",
  "regress",
  "rustc-hash 2.1.1",
  "ryu-js",
@@ -3216,7 +3216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8144c22e24bbcf26ade86cb6501a0916c46b7e4787abdb0045a467eb1645a1d"
 dependencies = [
  "ambient-authority",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -5416,7 +5416,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5703,7 +5703,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6103,7 +6103,7 @@ dependencies = [
  "futures",
  "log",
  "parking_lot",
- "rand 0.8.5",
+ "rand 0.8.6",
  "redis-protocol",
  "semver",
  "socket2 0.5.10",
@@ -6574,8 +6574,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -6639,7 +6639,7 @@ dependencies = [
  "i_overlay",
  "log",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "robust",
  "rstar 0.12.2",
  "serde",
@@ -6763,7 +6763,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8388,7 +8388,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8558,7 +8558,7 @@ dependencies = [
  "p256",
  "p384",
  "pem",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "serde_json",
@@ -10051,7 +10051,7 @@ dependencies = [
  "noisy_float",
  "num-integer",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -10263,7 +10263,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10302,7 +10302,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -10438,7 +10438,7 @@ dependencies = [
  "chrono",
  "getrandom 0.2.17",
  "http 0.2.12",
- "rand 0.8.5",
+ "rand 0.8.6",
  "reqwest 0.11.27",
  "serde",
  "serde_json",
@@ -10789,9 +10789,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
@@ -10827,9 +10827,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
@@ -11351,7 +11351,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -11700,7 +11700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -11720,8 +11720,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -11755,7 +11755,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11768,7 +11768,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11999,7 +11999,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12078,9 +12078,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -12178,7 +12178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -13017,7 +13017,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rkyv",
  "serde",
  "serde_json",
@@ -13106,7 +13106,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13142,7 +13142,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -13214,11 +13214,11 @@ dependencies = [
  "rustls 0.23.37",
  "rustls-native-certs 0.8.3",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.13",
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13239,9 +13239,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -13518,7 +13518,7 @@ dependencies = [
  "hkdf",
  "num",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "sha2",
  "zbus",
@@ -13578,7 +13578,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13930,7 +13930,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -13942,7 +13942,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -14167,7 +14167,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "sha1",
@@ -14206,7 +14206,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2",
@@ -14579,7 +14579,7 @@ dependencies = [
  "pin-project-lite",
  "quick_cache",
  "radix_trie",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rayon",
  "reblessive",
  "regex",
@@ -14680,7 +14680,7 @@ dependencies = [
  "hex",
  "http 1.4.0",
  "papaya",
- "rand 0.8.5",
+ "rand 0.8.6",
  "regex",
  "rstest",
  "rust_decimal",
@@ -15075,7 +15075,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -15753,7 +15753,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.8.6",
  "slab",
  "tokio",
  "tokio-util",
@@ -15963,7 +15963,7 @@ dependencies = [
  "httparse",
  "log",
  "native-tls",
- "rand 0.8.5",
+ "rand 0.8.6",
  "sha1",
  "thiserror 1.0.69",
  "url",
@@ -15983,7 +15983,7 @@ dependencies = [
  "httparse",
  "log",
  "native-tls",
- "rand 0.8.5",
+ "rand 0.8.6",
  "sha1",
  "thiserror 1.0.69",
  "url",
@@ -16077,7 +16077,7 @@ dependencies = [
  "getrandom 0.2.17",
  "http-types",
  "pin-project",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "time",
@@ -17220,7 +17220,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -18160,7 +18160,7 @@ dependencies = [
  "hex",
  "nix 0.29.0",
  "ordered-stream",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_repr",
  "sha1",

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ![Rust](https://img.shields.io/badge/rust-1.85%2B-orange.svg)
 [![GitHub Discussions](https://img.shields.io/github/discussions/zavora-ai/adk-rust?style=flat&logo=github&color=5865F2)](https://github.com/zavora-ai/adk-rust/discussions)
 
-> **🚀 v0.7.0 Released!** Project-scoped memory isolation (6 backends), OS-level sandbox profiles (Seatbelt/bubblewrap/AppContainer), ServerBuilder API for custom controllers, graceful shutdown endpoint, Gemini 3.1 Flash-Lite support, 11 new v0.7.0 feature examples. See [CHANGELOG](CHANGELOG.md) for full details.
+> **🚀 v0.7.0 Released!** Agentic Web Protocol (AWP) implementation, video avatar providers (HeyGen, D-ID), project-scoped memory isolation (6 backends), OS-level sandbox profiles (Seatbelt/bubblewrap/AppContainer), ServerBuilder API for custom controllers, graceful shutdown endpoint, Gemini 3.1 Flash-Lite support, 11 new v0.7.0 feature examples. See [CHANGELOG](CHANGELOG.md) for full details.
 >
 > **Contributors:** Many thanks to [@mikefaille](https://github.com/mikefaille) — AdkIdentity design, realtime audio, LiveKit bridge, skill system. [@rohan-panickar](https://github.com/rohan-panickar) — OpenAI-compatible providers, xAI, multimodal content. [@dhruv-pant](https://github.com/dhruv-pant) — Gemini service account auth. [@tomtom215](https://github.com/tomtom215) — A2A Protocol v1.0.0 types crate ([a2a-protocol-types](https://crates.io/crates/a2a-protocol-types)), Foundation-verified wire types powering our A2A v1 layer. [@danielsan](https://github.com/danielsan) — Google deps issue & PR (#181, #203), RAG crash report (#205). [@CodingFlow](https://github.com/CodingFlow) — Gemini 3 thinking level, global endpoint, citationSources (#177, #178, #179). [@ctylx](https://github.com/ctylx) — skill discovery fix (#204). [@poborin](https://github.com/poborin) — project config proposal (#176). [Get started →](https://github.com/zavora-ai/adk-rust/wiki/quickstart)
 >
@@ -65,6 +65,7 @@ ADK-Rust provides a comprehensive framework for building AI agents in Rust, feat
 - **RAG pipeline**: Document chunking, vector embeddings, semantic search with 6 vector store backends
 - **Security**: Role-based access control, declarative scope-based tool security, SSO/OAuth, audit logging
 - **Agentic commerce**: ACP and AP2 payment orchestration with durable transaction journals and evidence-backed recall
+- **Agentic Web Protocol (AWP)**: Make websites agent-native with discovery, capability manifests, trust levels, rate limiting, consent, and health monitoring
 - **Production features**: Session management, artifact storage, memory systems with project-scoped isolation, REST/A2A APIs
 - **Developer experience**: Interactive CLI, 120+ working examples, comprehensive documentation
 
@@ -181,6 +182,8 @@ Built-in tools:
 | `adk-artifact` | Artifact storage system | File-based storage, MIME type handling, image/PDF/video support |
 | `adk-memory` | Long-term memory | Vector embeddings, semantic search, project-scoped isolation, 6 backends |
 | `adk-payments` | Agentic commerce orchestration | ACP/AP2 adapters, canonical transaction kernel, durable journals, evidence-backed payment flows |
+| `awp-types` | AWP protocol types | Trust levels, requester types, discovery documents, capability manifests, payment intents, typed A2A messages — zero `adk-*` deps |
+| `adk-awp` | Agentic Web Protocol implementation | Business context loading, discovery/manifest generation, rate limiting, consent, events, health state machine, AWP routes |
 | `adk-rag` | RAG pipeline | Document chunking, embeddings, vector search, reranking, 6 backends |
 | `adk-runner` | Agent execution runtime | Context management, event streaming, session lifecycle, callbacks |
 | `adk-server` | Production API servers | REST API, A2A v1.0.0 protocol (all 11 operations), middleware, health checks |
@@ -542,6 +545,43 @@ cargo run -p adk-realtime --example openai_webrtc --features openai-webrtc
 cargo run -p adk-realtime --example openai_session_update --features openai
 cargo run -p adk-realtime --example gemini_context_mutation --features gemini
 ```
+
+### Agentic Web Protocol (AWP)
+
+Make any website or service natively accessible to AI agents using the `awp-types` and `adk-awp` crates:
+
+```rust
+use adk_awp::{AwpState, BusinessContextLoader, awp_routes};
+
+// Load business context from TOML
+let loader = BusinessContextLoader::from_file("business.toml".as_ref())?;
+
+// Build AWP state with sensible defaults (rate limiting, consent, health, events)
+let state = AwpState::builder(loader.context_ref()).build();
+
+// Merge AWP routes into your Axum app — 7 endpoints, version negotiation included
+let app = axum::Router::new()
+    .merge(awp_routes(state))
+    .merge(your_custom_routes);
+```
+
+**AWP Endpoints**:
+- `GET /.well-known/awp.json` — Discovery document (entry point for agents)
+- `GET /awp/manifest` — JSON-LD capability manifest
+- `GET /awp/health` — Health state (Healthy/Degrading/Degraded)
+- `POST /awp/events/subscribe` — Webhook subscriptions with HMAC-SHA256 signing
+- `POST /awp/a2a` — Agent-to-agent message handling
+
+**Features**: Trust levels (Anonymous/Known/Partner/Internal), per-trust-level rate limiting, consent management (in-memory or file-backed), health state machine with event emission, version negotiation, business context hot-reload.
+
+**Run the AWP example**:
+```bash
+cd examples/awp_agent
+cp .env.example .env   # add your GOOGLE_API_KEY
+cargo run
+```
+
+See [AWP Documentation](docs/official_docs/deployment/awp.md) for the full guide.
 
 ### Graph-Based Workflows
 

--- a/adk-awp/Cargo.toml
+++ b/adk-awp/Cargo.toml
@@ -8,6 +8,11 @@ authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
 description = "Agentic Web Protocol (AWP) implementation for ADK-Rust"
+documentation = "https://docs.rs/adk-awp"
+readme = "README.md"
+keywords = ["awp", "agent", "adk", "protocol", "agentic"]
+categories = ["web-programming::http-server", "api-bindings"]
+include = ["src/**/*", "Cargo.toml", "README.md"]
 
 [dependencies]
 awp-types = { workspace = true }

--- a/adk-awp/README.md
+++ b/adk-awp/README.md
@@ -1,0 +1,218 @@
+# adk-awp
+
+Agentic Web Protocol (AWP) implementation for [ADK-Rust](https://github.com/zavora-ai/adk-rust).
+
+`adk-awp` provides the full AWP protocol implementation — route registration,
+middleware, rate limiting, consent, events, health monitoring, and business
+context management. Plug `awp_routes()` into any Axum app to make it
+AWP-compliant.
+
+## Overview
+
+Use `adk-awp` when you need to:
+
+- serve AWP discovery documents and capability manifests from a `business.toml`
+- apply per-trust-level rate limiting (Anonymous: 30/min, Known: 120/min, Partner: 600/min)
+- manage consent records with durable file-backed storage (GDPR/KPA compliance)
+- subscribe agents to events with HMAC-SHA256 webhook signing
+- monitor service health with a validated state machine (Healthy → Degrading → Degraded)
+- detect whether requests come from humans or AI agents
+- negotiate AWP protocol versions automatically
+
+## Quick Start
+
+### 1. Create a `business.toml`
+
+```toml
+site_name = "My Shop"
+site_description = "An online store powered by AWP"
+domain = "myshop.example.com"
+
+[brand_voice]
+tone = "friendly"
+greeting = "Welcome! How can I help?"
+
+[[capabilities]]
+name = "browse_products"
+description = "Browse the product catalog"
+endpoint = "/api/products"
+method = "GET"
+access_level = "anonymous"
+
+[[policies]]
+name = "privacy"
+description = "Minimal data collection."
+policy_type = "privacy"
+```
+
+### 2. Serve AWP routes
+
+```rust
+use adk_awp::{AwpState, BusinessContextLoader, awp_routes};
+
+let loader = BusinessContextLoader::from_file("business.toml".as_ref())?;
+let state = AwpState::builder(loader.context_ref()).build();
+
+let app = axum::Router::new()
+    .merge(awp_routes(state))
+    .merge(your_custom_routes);
+
+let listener = tokio::net::TcpListener::bind("0.0.0.0:3456").await?;
+axum::serve(listener, app).await?;
+```
+
+This registers all 7 AWP endpoints with version negotiation middleware.
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/.well-known/awp.json` | Discovery document |
+| GET | `/awp/manifest` | JSON-LD capability manifest |
+| GET | `/awp/health` | Health state |
+| POST | `/awp/events/subscribe` | Create webhook subscription |
+| GET | `/awp/events/subscriptions` | List subscriptions |
+| DELETE | `/awp/events/subscriptions/{id}` | Delete subscription |
+| POST | `/awp/a2a` | A2A message handler |
+
+## Components
+
+### AwpStateBuilder
+
+Build `AwpState` with sensible defaults — all services default to in-memory,
+health state machine auto-wired to event service:
+
+```rust
+use adk_awp::{AwpState, FileConsentService};
+use std::sync::Arc;
+
+let state = AwpState::builder(loader.context_ref())
+    .consent_service(Arc::new(FileConsentService::new("data/consent.json")?))
+    .build();
+```
+
+### BusinessContextLoader
+
+Parse and validate `business.toml` with hot-reload support:
+
+```rust
+use adk_awp::BusinessContextLoader;
+
+let loader = BusinessContextLoader::from_file("business.toml".as_ref())?;
+loader.watch("business.toml".into()).await?; // hot-reload every 5s
+let ctx = loader.load();
+println!("Site: {}", ctx.site_name);
+```
+
+### Rate Limiting
+
+Per-trust-level sliding window with configurable limits:
+
+| Trust Level | Default Limit |
+|-------------|--------------|
+| Anonymous | 30 req/min |
+| Known | 120 req/min |
+| Partner | 600 req/min |
+| Internal | Unlimited |
+
+```rust
+use adk_awp::{InMemoryRateLimiter, RateLimitConfig};
+use awp_types::TrustLevel;
+use std::collections::HashMap;
+use std::time::Duration;
+
+let mut limits = HashMap::new();
+limits.insert(TrustLevel::Anonymous, RateLimitConfig { max_requests: 10, window_secs: 60 });
+let limiter = InMemoryRateLimiter::with_config(limits, Duration::from_secs(60));
+```
+
+### Consent Service
+
+Two implementations:
+
+- **`InMemoryConsentService`** — ephemeral, for development
+- **`FileConsentService`** — JSON file-backed, for production (GDPR/KPA)
+
+```rust
+use adk_awp::FileConsentService;
+
+let consent = FileConsentService::new("data/consent.json")?;
+consent.capture_consent("visitor-123", "analytics").await?;
+assert!(consent.check_consent("visitor-123", "analytics").await?);
+consent.revoke_consent("visitor-123", "analytics").await?;
+```
+
+### Health State Machine
+
+Validated transitions with event emission:
+
+```
+Healthy → Degrading → Degraded → Healthy
+```
+
+Invalid transitions (e.g., Healthy → Degraded) return an error.
+
+### Event Subscriptions
+
+CRUD with HMAC-SHA256 webhook signing:
+
+```rust
+use adk_awp::{sign_payload, verify_signature};
+
+let sig = sign_payload(b"event payload", "webhook-secret");
+assert!(verify_signature(b"event payload", "webhook-secret", &sig));
+```
+
+### Requester Detection
+
+Detect human vs agent from HTTP headers:
+
+```rust
+use adk_awp::detect_requester_type;
+use axum::http::HeaderMap;
+
+let mut headers = HeaderMap::new();
+headers.insert("X-AWP-Channel", "agent".parse().unwrap());
+let requester = detect_requester_type(&headers);
+// RequesterType::Agent
+```
+
+## Feature Flags
+
+```toml
+[features]
+default = []
+webhook-delivery = ["dep:reqwest"]  # Enable real HTTP webhook delivery
+```
+
+## Testing
+
+```bash
+cargo test -p adk-awp                    # 124 tests
+cargo clippy -p adk-awp -- -D warnings  # zero warnings
+```
+
+## Example
+
+```bash
+cd examples/awp_agent
+cp .env.example .env   # add your GOOGLE_API_KEY
+cargo run
+```
+
+The example loads `business.toml`, creates an LLM agent with business context
+instructions, serves all AWP endpoints, and exercises each one.
+
+## Documentation
+
+See [AWP Documentation](https://github.com/zavora-ai/adk-rust/blob/main/docs/official_docs/deployment/awp.md) for the full guide.
+
+## Related Crates
+
+- [`awp-types`](https://crates.io/crates/awp-types) — Pure protocol types (zero `adk-*` deps)
+- [`adk-server`](https://crates.io/crates/adk-server) — HTTP server with A2A protocol
+- [`adk-core`](https://crates.io/crates/adk-core) — ADK foundational traits
+
+## License
+
+Apache-2.0

--- a/adk-awp/src/consent.rs
+++ b/adk-awp/src/consent.rs
@@ -1,9 +1,16 @@
 //! Consent capture, check, and revocation framework.
+//!
+//! Provides two implementations:
+//! - [`InMemoryConsentService`] — ephemeral, for development and testing
+//! - [`FileConsentService`] — JSON file-backed, for production (GDPR/KPA compliance)
+
+use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
 use awp_types::AwpError;
 use chrono::{DateTime, Utc};
 use dashmap::DashMap;
+use serde::{Deserialize, Serialize};
 
 /// Trait for managing user consent records.
 #[async_trait]
@@ -18,6 +25,10 @@ pub trait ConsentService: Send + Sync {
     async fn revoke_consent(&self, subject: &str, purpose: &str) -> Result<(), AwpError>;
 }
 
+// ---------------------------------------------------------------------------
+// In-memory implementation
+// ---------------------------------------------------------------------------
+
 /// A consent record with timestamp and revocation state.
 #[derive(Debug, Clone)]
 struct ConsentRecord {
@@ -29,6 +40,9 @@ struct ConsentRecord {
 ///
 /// Keys are `(subject, purpose)` tuples. Capturing consent on an already-
 /// captured pair re-activates it (clears the revoked flag).
+///
+/// Records are lost on process restart. Use [`FileConsentService`] for
+/// durable storage.
 pub struct InMemoryConsentService {
     records: DashMap<(String, String), ConsentRecord>,
 }
@@ -68,9 +82,151 @@ impl ConsentService for InMemoryConsentService {
     }
 }
 
+// ---------------------------------------------------------------------------
+// File-backed implementation
+// ---------------------------------------------------------------------------
+
+/// Serializable consent record for file persistence.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct FileConsentRecord {
+    subject: String,
+    purpose: String,
+    captured_at: DateTime<Utc>,
+    revoked: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    revoked_at: Option<DateTime<Utc>>,
+}
+
+/// Serializable consent store for JSON file persistence.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct FileConsentStore {
+    records: Vec<FileConsentRecord>,
+}
+
+/// JSON file-backed consent service for durable storage.
+///
+/// Persists consent records to a JSON file on every mutation (capture/revoke).
+/// Loads existing records from the file on construction. Safe for single-process
+/// deployments; for multi-process, use a database-backed implementation.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use adk_awp::FileConsentService;
+///
+/// let consent = FileConsentService::new("data/consent.json")?;
+/// consent.capture_consent("visitor-123", "analytics").await?;
+/// assert!(consent.check_consent("visitor-123", "analytics").await?);
+/// ```
+pub struct FileConsentService {
+    path: PathBuf,
+    records: DashMap<(String, String), FileConsentRecord>,
+}
+
+impl FileConsentService {
+    /// Create a new file-backed consent service.
+    ///
+    /// If the file exists, records are loaded from it. If it doesn't exist,
+    /// an empty store is created and the file is written on first mutation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AwpError::InternalError`] if the file exists but cannot be
+    /// read or parsed.
+    pub fn new(path: impl AsRef<Path>) -> Result<Self, AwpError> {
+        let path = path.as_ref().to_path_buf();
+        let records = DashMap::new();
+
+        if path.exists() {
+            let content = std::fs::read_to_string(&path).map_err(|e| {
+                AwpError::InternalError(format!(
+                    "failed to read consent file {}: {e}",
+                    path.display()
+                ))
+            })?;
+            let store: FileConsentStore = serde_json::from_str(&content).map_err(|e| {
+                AwpError::InternalError(format!(
+                    "failed to parse consent file {}: {e}",
+                    path.display()
+                ))
+            })?;
+            for record in store.records {
+                let key = (record.subject.clone(), record.purpose.clone());
+                records.insert(key, record);
+            }
+        }
+
+        Ok(Self { path, records })
+    }
+
+    /// Persist all records to the JSON file.
+    fn flush(&self) -> Result<(), AwpError> {
+        let records: Vec<FileConsentRecord> =
+            self.records.iter().map(|entry| entry.value().clone()).collect();
+        let store = FileConsentStore { records };
+        let json = serde_json::to_string_pretty(&store).map_err(|e| {
+            AwpError::InternalError(format!("failed to serialize consent records: {e}"))
+        })?;
+
+        // Create parent directories if needed
+        if let Some(parent) = self.path.parent() {
+            if !parent.exists() {
+                std::fs::create_dir_all(parent).map_err(|e| {
+                    AwpError::InternalError(format!(
+                        "failed to create consent directory {}: {e}",
+                        parent.display()
+                    ))
+                })?;
+            }
+        }
+
+        std::fs::write(&self.path, json).map_err(|e| {
+            AwpError::InternalError(format!(
+                "failed to write consent file {}: {e}",
+                self.path.display()
+            ))
+        })?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl ConsentService for FileConsentService {
+    async fn capture_consent(&self, subject: &str, purpose: &str) -> Result<(), AwpError> {
+        let key = (subject.to_string(), purpose.to_string());
+        self.records.insert(
+            key,
+            FileConsentRecord {
+                subject: subject.to_string(),
+                purpose: purpose.to_string(),
+                captured_at: Utc::now(),
+                revoked: false,
+                revoked_at: None,
+            },
+        );
+        self.flush()
+    }
+
+    async fn check_consent(&self, subject: &str, purpose: &str) -> Result<bool, AwpError> {
+        let key = (subject.to_string(), purpose.to_string());
+        Ok(self.records.get(&key).is_some_and(|r| !r.revoked))
+    }
+
+    async fn revoke_consent(&self, subject: &str, purpose: &str) -> Result<(), AwpError> {
+        let key = (subject.to_string(), purpose.to_string());
+        if let Some(mut entry) = self.records.get_mut(&key) {
+            entry.revoked = true;
+            entry.revoked_at = Some(Utc::now());
+        }
+        self.flush()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- InMemoryConsentService tests ---
 
     #[tokio::test]
     async fn test_capture_and_check() {
@@ -123,8 +279,132 @@ mod tests {
     #[tokio::test]
     async fn test_revoke_nonexistent_is_noop() {
         let svc = InMemoryConsentService::new();
-        // Should not error
         svc.revoke_consent("user1", "analytics").await.unwrap();
         assert!(!svc.check_consent("user1", "analytics").await.unwrap());
+    }
+
+    // --- FileConsentService tests ---
+
+    #[tokio::test]
+    async fn test_file_capture_and_check() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("consent.json");
+        let svc = FileConsentService::new(&path).unwrap();
+
+        svc.capture_consent("user1", "analytics").await.unwrap();
+        assert!(svc.check_consent("user1", "analytics").await.unwrap());
+
+        // File should exist
+        assert!(path.exists());
+    }
+
+    #[tokio::test]
+    async fn test_file_persistence_across_instances() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("consent.json");
+
+        // First instance: capture consent
+        {
+            let svc = FileConsentService::new(&path).unwrap();
+            svc.capture_consent("user1", "analytics").await.unwrap();
+            svc.capture_consent("user2", "marketing").await.unwrap();
+        }
+
+        // Second instance: records should be loaded from file
+        {
+            let svc = FileConsentService::new(&path).unwrap();
+            assert!(svc.check_consent("user1", "analytics").await.unwrap());
+            assert!(svc.check_consent("user2", "marketing").await.unwrap());
+            assert!(!svc.check_consent("user3", "analytics").await.unwrap());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_file_revoke_persists() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("consent.json");
+
+        {
+            let svc = FileConsentService::new(&path).unwrap();
+            svc.capture_consent("user1", "analytics").await.unwrap();
+            svc.revoke_consent("user1", "analytics").await.unwrap();
+        }
+
+        {
+            let svc = FileConsentService::new(&path).unwrap();
+            assert!(!svc.check_consent("user1", "analytics").await.unwrap());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_file_recapture_after_revoke_persists() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("consent.json");
+
+        {
+            let svc = FileConsentService::new(&path).unwrap();
+            svc.capture_consent("user1", "analytics").await.unwrap();
+            svc.revoke_consent("user1", "analytics").await.unwrap();
+            svc.capture_consent("user1", "analytics").await.unwrap();
+        }
+
+        {
+            let svc = FileConsentService::new(&path).unwrap();
+            assert!(svc.check_consent("user1", "analytics").await.unwrap());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_file_nonexistent_path_creates_on_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("subdir").join("consent.json");
+        assert!(!path.exists());
+
+        let svc = FileConsentService::new(&path).unwrap();
+        svc.capture_consent("user1", "analytics").await.unwrap();
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn test_file_invalid_json_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("consent.json");
+        std::fs::write(&path, "not valid json").unwrap();
+
+        let result = FileConsentService::new(&path);
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_file_check_without_capture_returns_false() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("consent.json");
+        let svc = FileConsentService::new(&path).unwrap();
+        assert!(!svc.check_consent("user1", "analytics").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_file_revoke_nonexistent_is_noop() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("consent.json");
+        let svc = FileConsentService::new(&path).unwrap();
+        svc.revoke_consent("user1", "analytics").await.unwrap();
+        assert!(!svc.check_consent("user1", "analytics").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_file_consent_json_structure() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("consent.json");
+        let svc = FileConsentService::new(&path).unwrap();
+        svc.capture_consent("user1", "analytics").await.unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert!(json["records"].is_array());
+        let record = &json["records"][0];
+        assert_eq!(record["subject"], "user1");
+        assert_eq!(record["purpose"], "analytics");
+        assert_eq!(record["revoked"], false);
     }
 }

--- a/adk-awp/src/lib.rs
+++ b/adk-awp/src/lib.rs
@@ -44,7 +44,7 @@ pub mod state;
 pub mod trust;
 
 pub use config::{AwpConfigError, business_context_to_toml};
-pub use consent::{ConsentService, InMemoryConsentService};
+pub use consent::{ConsentService, FileConsentService, InMemoryConsentService};
 pub use detect::detect_requester_type;
 pub use discovery::generate_discovery_document;
 pub use events::{
@@ -56,5 +56,5 @@ pub use loader::BusinessContextLoader;
 pub use manifest::build_manifest;
 pub use rate_limit::{InMemoryRateLimiter, RateLimitConfig, RateLimiter};
 pub use router::awp_routes;
-pub use state::AwpState;
+pub use state::{AwpState, AwpStateBuilder};
 pub use trust::{DefaultTrustAssigner, TrustLevelAssigner};

--- a/adk-awp/src/state.rs
+++ b/adk-awp/src/state.rs
@@ -5,11 +5,11 @@ use std::sync::Arc;
 use arc_swap::ArcSwap;
 use awp_types::BusinessContext;
 
-use crate::consent::ConsentService;
-use crate::events::EventSubscriptionService;
+use crate::consent::{ConsentService, InMemoryConsentService};
+use crate::events::{EventSubscriptionService, InMemoryEventSubscriptionService};
 use crate::health::HealthStateMachine;
-use crate::rate_limit::RateLimiter;
-use crate::trust::TrustLevelAssigner;
+use crate::rate_limit::{InMemoryRateLimiter, RateLimiter};
+use crate::trust::{DefaultTrustAssigner, TrustLevelAssigner};
 
 /// Shared state passed to all AWP route handlers via Axum's state extractor.
 #[derive(Clone)]
@@ -26,4 +26,164 @@ pub struct AwpState {
     pub health: Arc<HealthStateMachine>,
     /// Trust level assigner.
     pub trust_assigner: Arc<dyn TrustLevelAssigner>,
+}
+
+/// Builder for [`AwpState`] with sensible defaults.
+///
+/// Only `business_context` is required. All services default to their
+/// in-memory implementations. The builder wires `HealthStateMachine` to
+/// the event service automatically.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use adk_awp::AwpStateBuilder;
+/// use adk_awp::BusinessContextLoader;
+///
+/// let loader = BusinessContextLoader::from_file("business.toml".as_ref())?;
+/// let state = AwpStateBuilder::new(loader.context_ref()).build();
+/// ```
+pub struct AwpStateBuilder {
+    business_context: Arc<ArcSwap<BusinessContext>>,
+    rate_limiter: Option<Arc<dyn RateLimiter>>,
+    consent_service: Option<Arc<dyn ConsentService>>,
+    event_service: Option<Arc<dyn EventSubscriptionService>>,
+    trust_assigner: Option<Arc<dyn TrustLevelAssigner>>,
+}
+
+impl AwpStateBuilder {
+    /// Create a builder with the given business context.
+    pub fn new(business_context: Arc<ArcSwap<BusinessContext>>) -> Self {
+        Self {
+            business_context,
+            rate_limiter: None,
+            consent_service: None,
+            event_service: None,
+            trust_assigner: None,
+        }
+    }
+
+    /// Set a custom rate limiter. Defaults to [`InMemoryRateLimiter`].
+    pub fn rate_limiter(mut self, limiter: Arc<dyn RateLimiter>) -> Self {
+        self.rate_limiter = Some(limiter);
+        self
+    }
+
+    /// Set a custom consent service. Defaults to [`InMemoryConsentService`].
+    pub fn consent_service(mut self, service: Arc<dyn ConsentService>) -> Self {
+        self.consent_service = Some(service);
+        self
+    }
+
+    /// Set a custom event subscription service. Defaults to [`InMemoryEventSubscriptionService`].
+    ///
+    /// The health state machine is automatically wired to this service.
+    pub fn event_service(mut self, service: Arc<dyn EventSubscriptionService>) -> Self {
+        self.event_service = Some(service);
+        self
+    }
+
+    /// Set a custom trust level assigner. Defaults to [`DefaultTrustAssigner`].
+    pub fn trust_assigner(mut self, assigner: Arc<dyn TrustLevelAssigner>) -> Self {
+        self.trust_assigner = Some(assigner);
+        self
+    }
+
+    /// Build the [`AwpState`], wiring the health state machine to the event service.
+    pub fn build(self) -> AwpState {
+        let event_service =
+            self.event_service.unwrap_or_else(|| Arc::new(InMemoryEventSubscriptionService::new()));
+
+        AwpState {
+            business_context: self.business_context,
+            rate_limiter: self.rate_limiter.unwrap_or_else(|| Arc::new(InMemoryRateLimiter::new())),
+            consent_service: self
+                .consent_service
+                .unwrap_or_else(|| Arc::new(InMemoryConsentService::new())),
+            health: Arc::new(HealthStateMachine::new(event_service.clone())),
+            event_service,
+            trust_assigner: self.trust_assigner.unwrap_or_else(|| Arc::new(DefaultTrustAssigner)),
+        }
+    }
+}
+
+impl AwpState {
+    /// Create a builder for [`AwpState`].
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use adk_awp::AwpState;
+    /// use arc_swap::ArcSwap;
+    /// use std::sync::Arc;
+    ///
+    /// let ctx = Arc::new(ArcSwap::from_pointee(my_business_context));
+    /// let state = AwpState::builder(ctx).build();
+    /// ```
+    pub fn builder(business_context: Arc<ArcSwap<BusinessContext>>) -> AwpStateBuilder {
+        AwpStateBuilder::new(business_context)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use awp_types::BusinessContext;
+
+    fn test_context() -> Arc<ArcSwap<BusinessContext>> {
+        Arc::new(ArcSwap::from_pointee(BusinessContext::core("Test", "Test site", "example.com")))
+    }
+
+    #[test]
+    fn test_builder_defaults() {
+        let state = AwpState::builder(test_context()).build();
+        assert_eq!(state.business_context.load().site_name, "Test");
+    }
+
+    #[test]
+    fn test_builder_custom_rate_limiter() {
+        let limiter = Arc::new(InMemoryRateLimiter::new());
+        let state = AwpState::builder(test_context()).rate_limiter(limiter).build();
+        assert_eq!(state.business_context.load().site_name, "Test");
+    }
+
+    #[test]
+    fn test_builder_custom_consent() {
+        let consent = Arc::new(InMemoryConsentService::new());
+        let state = AwpState::builder(test_context()).consent_service(consent).build();
+        assert_eq!(state.business_context.load().site_name, "Test");
+    }
+
+    #[test]
+    fn test_builder_custom_events() {
+        let events = Arc::new(InMemoryEventSubscriptionService::new());
+        let state = AwpState::builder(test_context()).event_service(events).build();
+        assert_eq!(state.business_context.load().site_name, "Test");
+    }
+
+    #[test]
+    fn test_builder_custom_trust() {
+        let trust = Arc::new(DefaultTrustAssigner);
+        let state = AwpState::builder(test_context()).trust_assigner(trust).build();
+        assert_eq!(state.business_context.load().site_name, "Test");
+    }
+
+    #[tokio::test]
+    async fn test_builder_health_wired_to_events() {
+        let state = AwpState::builder(test_context()).build();
+        // Health should start as Healthy
+        let snap = state.health.snapshot().await;
+        assert_eq!(snap.state, crate::health::HealthState::Healthy);
+    }
+
+    #[test]
+    fn test_builder_all_custom() {
+        let state = AwpState::builder(test_context())
+            .rate_limiter(Arc::new(InMemoryRateLimiter::new()))
+            .consent_service(Arc::new(InMemoryConsentService::new()))
+            .event_service(Arc::new(InMemoryEventSubscriptionService::new()))
+            .trust_assigner(Arc::new(DefaultTrustAssigner))
+            .build();
+        assert_eq!(state.business_context.load().site_name, "Test");
+    }
 }

--- a/awp-types/Cargo.toml
+++ b/awp-types/Cargo.toml
@@ -8,6 +8,11 @@ authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
 description = "Shared protocol types for the Agentic Web Protocol (AWP)"
+documentation = "https://docs.rs/awp-types"
+readme = "README.md"
+keywords = ["awp", "agent", "protocol", "agentic", "web"]
+categories = ["web-programming", "data-structures"]
+include = ["src/**/*", "Cargo.toml", "README.md"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/awp-types/README.md
+++ b/awp-types/README.md
@@ -1,0 +1,117 @@
+# awp-types
+
+Shared protocol types for the [Agentic Web Protocol (AWP)](https://agenticwebprotocol.com).
+
+`awp-types` provides pure protocol types with **zero `adk-*` dependencies**, making it importable by any Rust project that needs to work with AWP messages — gateways, agents, CLI tools, or third-party integrations.
+
+## Overview
+
+Use `awp-types` when you need to:
+
+- parse or produce AWP discovery documents, capability manifests, or A2A messages
+- work with AWP trust levels, requester types, or error codes
+- define payment intents with owner-policy-driven lifecycle
+- route typed AWP messages between agents
+- share AWP types across crates without pulling in the full ADK tree
+
+## Types
+
+### Core Protocol
+
+| Type | Description |
+|------|-------------|
+| `AwpVersion` | Protocol version with `is_compatible()` and `CURRENT_VERSION` (1.0) |
+| `TrustLevel` | Anonymous < Known < Partner < Internal (ordered enum) |
+| `RequesterType` | Human or Agent |
+| `AwpError` | 8 error variants with HTTP status code mapping (400–503) |
+
+### Wire Types
+
+| Type | Description |
+|------|-------------|
+| `AwpRequest` | Protocol request envelope (id, trust_level, requester_type, version, payload) |
+| `AwpResponse` | Protocol response envelope (id, version, status, payload) |
+| `A2aMessage` | Generic agent-to-agent message |
+| `A2aMessageType` | Request, Response, Notification, Error |
+| `AwpTypedMessage` | AWP-specific typed message with `AwpMessageType` |
+| `AwpMessageType` | 9 domain-specific variants for agent routing |
+
+### Discovery & Capabilities
+
+| Type | Description |
+|------|-------------|
+| `AwpDiscoveryDocument` | `/.well-known/awp.json` payload |
+| `CapabilityManifest` | JSON-LD manifest with `@context` and `@type` |
+| `CapabilityEntry` | Single capability with name, endpoint, method, schemas |
+
+### Business Context
+
+| Type | Description |
+|------|-------------|
+| `BusinessContext` | Full site configuration parsed from `business.toml` |
+| `BusinessCapability` | Capability with access level |
+| `BusinessPolicy` | Operational policy |
+| `BusinessIdentity` | Country, languages, currency, timezone |
+| `BrandVoice` | Tone, greeting, escalation message |
+| `Product` | SKU, name, price, inventory, tags |
+| `ChannelConfig` | WhatsApp, email, website, SMS |
+| `PaymentConfig` | Providers, auto-approve thresholds |
+| `SupportConfig` | Escalation contacts, hours, SLA |
+| `ContentConfig` | Topics, auto-draft, publish delay |
+| `ReviewConfig` | Platforms, auto-respond threshold |
+| `OutreachConfig` | Follow-up delay, consent enforcement |
+
+### Payments
+
+| Type | Description |
+|------|-------------|
+| `PaymentIntent` | Owner-policy-driven payment with HMAC signature |
+| `PaymentIntentState` | Draft → PendingApproval → Approved → Executing → Settled/Rejected/Cancelled |
+| `PaymentPolicy` | Auto-approve/require-approval thresholds |
+| `PaymentPolicyDecision` | AutoApprove or RequireApproval |
+
+## Quick Start
+
+```toml
+[dependencies]
+awp-types = "0.7"
+```
+
+```rust
+use awp_types::{TrustLevel, AwpVersion, CURRENT_VERSION, BusinessContext};
+
+// Trust level ordering
+assert!(TrustLevel::Anonymous < TrustLevel::Known);
+assert!(TrustLevel::Known < TrustLevel::Partner);
+
+// Version compatibility
+let v = AwpVersion { major: 1, minor: 3 };
+assert!(CURRENT_VERSION.is_compatible(&v)); // same major
+
+// Business context from TOML
+let ctx = BusinessContext::core("My Site", "A description", "example.com");
+assert_eq!(ctx.site_name, "My Site");
+```
+
+## Serialization
+
+- All wire types use `#[serde(rename_all = "camelCase")]` for JSON
+- `BusinessContext` uses standard snake_case for TOML (`business.toml`)
+- All types implement `Serialize` and `Deserialize`
+
+## Design Principles
+
+1. **Zero `adk-*` dependencies** — only `serde`, `uuid`, `chrono`, `thiserror`
+2. **Backward-compatible** — all extended `BusinessContext` fields use `#[serde(default)]`
+3. **Type-safe** — ordered enums, exhaustive error variants, `Display` impls
+4. **Publishable** — suitable for crates.io (no git dependencies)
+
+## Related Crates
+
+- [`adk-awp`](https://crates.io/crates/adk-awp) — Full AWP implementation (routes, middleware, services)
+- [`adk-core`](https://crates.io/crates/adk-core) — ADK foundational traits
+- [`adk-server`](https://crates.io/crates/adk-server) — HTTP server with A2A protocol
+
+## License
+
+Apache-2.0


### PR DESCRIPTION
## What

Three changes that unblock adk-gateway integration and fix open Dependabot alerts.

### 1. AwpStateBuilder (gateway request #3)

Builder pattern for `AwpState` with sensible defaults. Consumers no longer need to manually wire `HealthStateMachine` to `EventSubscriptionService`.

```rust
// Before (fragile manual wiring):
let event_service = Arc::new(InMemoryEventSubscriptionService::new());
let state = AwpState {
    business_context: loader.context_ref(),
    rate_limiter: Arc::new(InMemoryRateLimiter::new()),
    consent_service: Arc::new(InMemoryConsentService::new()),
    event_service: event_service.clone(),
    health: Arc::new(HealthStateMachine::new(event_service)),
    trust_assigner: Arc::new(DefaultTrustAssigner),
};

// After:
let state = AwpState::builder(loader.context_ref()).build();
```

All services default to in-memory. Override any with `.rate_limiter()`, `.consent_service()`, `.event_service()`, `.trust_assigner()`.

### 2. FileConsentService (gateway request #4)

JSON file-backed persistent consent for GDPR/KPA compliance. `InMemoryConsentService` loses records on restart — `FileConsentService` persists to disk.

```rust
let consent = FileConsentService::new("data/consent.json")?;
consent.capture_consent("visitor-123", "analytics").await?;
// Survives restarts, tracks timestamps and revocation state
```

### 3. Security dependency updates

| Package | From | To | Severity | CVE |
|---------|------|----|----------|-----|
| rustls-webpki | 0.103.10 | 0.103.13 | High (x35) | DoS via panic on malformed CRL |
| openssl | 0.10.76 | 0.10.78 | High (x34x4) | Buffer overflow, unchecked callback, OOB read |
| rand | 0.8.5 | 0.8.6 | Low (x17) | Unsound with custom logger |

Remaining: `jsonwebtoken 9.3.1` (medium, 2 alerts) — pinned by `google-cloud-spanner 0.33` via `google-cloud-auth 0.17.2`. Requires upstream spanner release.

## Testing

- 124 unit + conformance + doc tests pass (up from 108)
- Zero clippy warnings
- Workspace compiles clean

## PR Checklist

- [x] `cargo fmt --all`
- [x] `cargo clippy -p adk-awp -- -D warnings`
- [x] `cargo test -p adk-awp` — 124 tests pass
- [x] `cargo check -p adk-core -p adk-awp -p awp-types -p adk-model -p adk-agent -p adk-runner`
- [x] No hardcoded secrets or local paths
- [x] Public APIs have rustdoc with examples