### PR TITLE
fix(agent): consolidate streaming chunks in SequentialAgent/LoopAgent history

### DIFF
--- a/adk-agent/src/workflow/loop_agent.rs
+++ b/adk-agent/src/workflow/loop_agent.rs
@@ -146,7 +146,65 @@ impl HistoryTrackingSession {
 
     fn apply_event(&self, event: &Event) {
         if let Some(content) = &event.llm_response.content {
-            self.append_to_history(content.clone());
+            // Consolidate streaming chunks: if the last history entry has the
+            // same role, merge text into it instead of creating a new entry.
+            // This prevents N streaming chunks from becoming N separate Content
+            // entries that bloat context for subsequent agents.
+            let mut history = self.history.write().unwrap_or_else(|e| e.into_inner());
+
+            if event.llm_response.partial {
+                // Partial chunk — merge into last entry if same role
+                if let Some(last) = history.last_mut() {
+                    if last.role == content.role {
+                        for part in &content.parts {
+                            if let adk_core::Part::Text { text } = part {
+                                // Append text to the last Text part
+                                if let Some(adk_core::Part::Text { text: existing }) =
+                                    last.parts.last_mut()
+                                {
+                                    existing.push_str(text);
+                                } else {
+                                    last.parts.push(part.clone());
+                                }
+                            } else {
+                                last.parts.push(part.clone());
+                            }
+                        }
+                        return;
+                    }
+                }
+                // No matching last entry — start a new one
+                history.push(content.clone());
+            } else {
+                // Final event (partial=false) — append as-is.
+                // For non-streaming mode this carries the full content.
+                // For streaming mode the accumulated text is already in the
+                // last history entry from partial merges above, so the final
+                // chunk (which may carry the last fragment or be empty) is
+                // merged if same role, or appended if different.
+                if let Some(last) = history.last_mut() {
+                    if last.role == content.role && !content.parts.is_empty() {
+                        // Merge any remaining text from the final chunk
+                        for part in &content.parts {
+                            if let adk_core::Part::Text { text } = part {
+                                if let Some(adk_core::Part::Text { text: existing }) =
+                                    last.parts.last_mut()
+                                {
+                                    existing.push_str(text);
+                                } else {
+                                    last.parts.push(part.clone());
+                                }
+                            } else {
+                                last.parts.push(part.clone());
+                            }
+                        }
+                    } else if !content.parts.is_empty() {
+                        history.push(content.clone());
+                    }
+                } else {
+                    history.push(content.clone());
+                }
+            }
         }
         self.state.apply_delta(&event.actions.state_delta);
     }


### PR DESCRIPTION
## What

Fixes context bloat when streaming agents run inside `SequentialAgent` or `LoopAgent`. Streaming chunks from Agent A are now merged into a single `Content` entry instead of creating N separate entries that bloat the context for Agent B.

## The Bug

When Agent A streams a response (e.g., a 3KB plan), each streaming chunk becomes a separate `Content` entry in `HistoryTrackingSession`:

```
{role: "model", parts: [{text: "Here is the plan"}]}
{role: "model", parts: [{text: " to build the LBO"}]}
{role: "model", parts: [{text: " model.\n\n### File"}]}
... 77 more entries
```

When Agent B starts, it sees all 80+ entries. Every LLM call sends the full history, causing:
- Context bloat filling small context windows
- Degrading latency as payload grows
- Eventual hangs or token limit errors

## The Fix

`HistoryTrackingSession::apply_event()` now merges consecutive same-role streaming chunks:

- **Partial chunks** (`partial: true`): text is concatenated into the last same-role `Content` entry
- **Final events** (`partial: false`): merged if same role, appended if different role
- **Non-text parts** (tool calls, thinking): always appended as-is

**Before**: 80 streaming chunks → 80 `Content` entries
**After**: 80 streaming chunks → 1 `Content` entry with full concatenated text

## Why LoopAgent

`SequentialAgent` is a thin wrapper around `LoopAgent(max_iterations=1)`. The history tracking lives in `LoopAgent`, so the fix there covers both.

## Testing

- 69 adk-agent tests pass
- 101 adk-runner tests pass
- Zero clippy warnings

## PR Checklist

- [x] `cargo fmt --all`
- [x] `cargo clippy -p adk-agent -p adk-runner -- -D warnings`
- [x] `cargo test -p adk-agent` — 69 tests pass
- [x] `cargo test -p adk-runner` — 101 tests pass
- [x] No unrelated changes