### PR TITLE
feat(tiers): add OpenAI and Anthropic to standard tier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Restructured the `adk-rust` umbrella crate feature tiers to reduce default build
 | Tier | What's included | Use case |
 |------|----------------|----------|
 | `minimal` (default) | agents, models, gemini, runner, sessions | Fast Gemini starter agents |
-| `standard` | minimal + skills, graph, auth, server, eval, guardrail, plugin, artifacts, tools, memory, telemetry | Production deployment without CLI/provider fan-out |
+| `standard` | minimal + openai, anthropic, tools, memory, telemetry, skills, graph, auth, server, eval, guardrail, plugin, artifacts | Production deployment |
 | `enterprise` | standard + realtime, browser, rag, payments, awp | Full-featured production |
 | `audio` | adk-audio (STT/TTS/desktop) | Voice agents (composable add-on) |
 | `code` | adk-code + adk-sandbox | Code execution (composable add-on) |

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ adk-rust = "0.8.0"  # Minimal (default): Gemini + agent runtime + sessions
 | Tier | Includes | Use case |
 |------|----------|----------|
 | `minimal` (default) | Gemini provider, agents, runner, sessions | Fast starter agents |
-| `standard` | minimal + tools, memory, telemetry, server, auth, graph, eval, guardrail, plugins, artifacts, skills | Production deployment without CLI overhead |
+| `standard` | minimal + OpenAI, Anthropic, tools, memory, telemetry, server, auth, graph, eval, guardrail, plugins, artifacts, skills | Production deployment |
 | `enterprise` | standard + realtime, browser, RAG, payments, AWP | Full-featured production |
 | `full` | enterprise + audio, code execution, sandbox | Everything |
 

--- a/adk-rust/Cargo.toml
+++ b/adk-rust/Cargo.toml
@@ -30,6 +30,9 @@ minimal = [
 # Standard — production deployment with server, auth, graph workflows, and evaluation.
 standard = [
     "minimal",
+    "openai",
+    "anthropic",
+    "anthropic-client",
     "skills",
     "graph",
     "auth",


### PR DESCRIPTION
Production deployments typically need multi-provider support. This adds `openai`, `anthropic`, and `anthropic-client` to the `standard` feature tier.

**Before:** Users needed `features = ["standard", "openai", "anthropic"]` for multi-provider production.
**After:** `features = ["standard"]` includes all three major providers.

The `minimal` tier remains Gemini-only for fast starter builds.

**Changes:**
- `adk-rust/Cargo.toml`: Added openai, anthropic, anthropic-client to standard tier
- `CHANGELOG.md`: Updated tier table
- `README.md`: Updated tier table