### PR TITLE
docs: update adk-telemetry and adk-server READMEs for v0.8.2

### DIFF
--- a/adk-server/README.md
+++ b/adk-server/README.md
@@ -18,6 +18,12 @@ HTTP server and A2A v1.0.0 protocol for Rust Agent Development Kit (ADK-Rust) ag
 - **Auth Bridge** - Flow authenticated identity from HTTP headers into agent execution
 - **Artifacts** - Binary artifact storage and retrieval per session
 - **Debug/Tracing** - Trace inspection and graph visualization endpoints
+- **YAML Agent Config** (feature: `yaml-agent`) - Declarative agent definitions with:
+  - `AgentConfigLoader` — load agents from YAML files
+  - `HotReloadWatcher` — filesystem watching with debounce
+  - Environment variable interpolation (`${VAR}` and `${VAR:-default}`)
+  - Plugin, session, and memory backend configuration in YAML
+  - Round-trip serialization (`serialize_definition()`)
 
 ## Installation
 

--- a/adk-telemetry/README.md
+++ b/adk-telemetry/README.md
@@ -14,6 +14,13 @@ OpenTelemetry integration for Rust Agent Development Kit (ADK-Rust) agent observ
 - **Logging** - Structured logging with tracing-subscriber
 - **Metrics** - Performance metrics export via OTLP (tonic 0.12 / gRPC)
 - **Span Context** - Propagation across agent boundaries
+- **GenAI Semantic Conventions** (v0.8.2) - Full OTel GenAI semconv v1.41.0 compliance:
+  - `GenAiSpanBuilder` — fluent API for model call spans with `gen_ai.*` attributes
+  - `GenAiResponseRecorder` — records response model, finish reasons, token usage
+  - `GenAiProvider` / `GenAiOperation` enums for all supported providers
+  - `map_finish_reason()` — provider-specific finish reason mapping
+  - `ContentEventEmitter` — opt-in prompt/completion capture
+  - Feature: `genai-semconv` (enabled by default)
 
 ## Installation
 


### PR DESCRIPTION
Updates crate READMEs for the two crates that were missing v0.8.2 feature documentation:

- **adk-telemetry**: Added GenAI Semantic Conventions section (genai-semconv feature, GenAiSpanBuilder, GenAiResponseRecorder, etc.)
- **adk-server**: Added YAML Agent Config section (yaml-agent feature, env interpolation, hot reload, plugins/session/memory config)

Pre-publish cleanup for v0.8.2 release.