### PR TITLE
chore: release v0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.3] - 2026-05-18
+
+### Fixed
+
+- **Gemini schema `items` tuple validation error**: Fixed 400 errors from Gemini API when MCP tools declared `items` using JSON array syntax (tuple validation). Gemini's Schema proto only supports `items` as a single schema object for array element types. Tuple validation syntax (`items: [{...}, {...}]`) is now stripped.
+
+- **Comprehensive unsupported keyword stripping**: Expanded the Gemini schema adapter's unsupported keywords list from 7 to 32 entries based on the official Gemini API documentation. The Schema proto only supports `type`, `description`, `enum`, `items`, `properties`, `required`, `nullable`, and `format` (limited values). All other JSON Schema keywords are now stripped, including:
+  - Numeric constraints: `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`
+  - String constraints: `minLength`, `maxLength`, `pattern`
+  - Array constraints: `minItems`, `maxItems`, `uniqueItems`, `contains`, `prefixItems`
+  - Object constraints: `minProperties`, `maxProperties`, `dependentRequired`, `dependentSchemas`
+  - Annotations: `title`, `default`, `deprecated`, `examples`, `readOnly`, `writeOnly`
+  - Content: `contentMediaType`, `contentEncoding`
+  - Meta: `$id`
+
 ## [0.8.2] - 2026-05-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "adk-acp"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "adk-core",
  "adk-runner",
@@ -62,7 +62,7 @@ dependencies = [
 
 [[package]]
 name = "adk-action"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "adk-core",
  "proptest",
@@ -74,7 +74,7 @@ dependencies = [
 
 [[package]]
 name = "adk-agent"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "adk-core",
  "adk-guardrail",
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "adk-anthropic"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "adk-audio"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "adk-core",
  "adk-realtime",
@@ -161,7 +161,7 @@ dependencies = [
 
 [[package]]
 name = "adk-auth"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "adk-core",
  "adk-server",
@@ -189,7 +189,7 @@ dependencies = [
 
 [[package]]
 name = "adk-awp"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "adk-core",
  "arc-swap",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "adk-browser"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "adk-cli"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "adk-agent",
  "adk-artifact",
@@ -266,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "adk-code"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "adk-core",
  "adk-sandbox",
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "adk-deploy"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -326,7 +326,7 @@ dependencies = [
 
 [[package]]
 name = "adk-eval"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "adk-core",
  "adk-model",
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -380,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "adk-graph"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "adk-action",
  "adk-core",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "adk-guardrail"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "adk-memory"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "adk-anthropic",
  "adk-core",
@@ -468,7 +468,7 @@ dependencies = [
 
 [[package]]
 name = "adk-payments"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "adk-artifact",
  "adk-auth",
@@ -497,7 +497,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rag"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "adk-realtime"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "adk-retry-reflect"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -582,7 +582,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "adk-acp",
  "adk-action",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "adk-sandbox"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -678,7 +678,7 @@ dependencies = [
 
 [[package]]
 name = "adk-server"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "a2a-protocol-types",
  "adk-agent",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "adk-core",
  "aes-gcm",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -777,7 +777,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "adk-code",
  "adk-core",
@@ -1880,7 +1880,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "awp-types"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "chrono",
  "proptest",
@@ -3342,7 +3342,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-adk"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "adk-deploy",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ strip = false
 opt-level = 2
 
 [workspace.package]
-version = "0.8.2"
+version = "0.8.3"
 edition = "2024"
 rust-version = "1.85.0"
 license = "Apache-2.0"
@@ -135,35 +135,35 @@ livekit = { version = "0.7.36", default-features = false, features = ["tokio", "
 livekit-api = { version = "0.4.18", default-features = false, features = ["signal-client-tokio", "services-tokio", "access-token"] }
 
 # ADK internal crates (use { workspace = true } in member crates)
-adk-core = { path = "adk-core", version = "0.8.2" }
-adk-rust-macros = { path = "adk-rust-macros", version = "0.8.2" }
-adk-agent = { path = "adk-agent", version = "0.8.2", default-features = false }
-adk-model = { path = "adk-model", version = "0.8.2", default-features = false }
-adk-tool = { path = "adk-tool", version = "0.8.2" }
-adk-runner = { path = "adk-runner", version = "0.8.2", default-features = false }
-adk-server = { path = "adk-server", version = "0.8.2" }
-adk-session = { path = "adk-session", version = "0.8.2" }
-adk-artifact = { path = "adk-artifact", version = "0.8.2" }
-adk-memory = { path = "adk-memory", version = "0.8.2" }
-adk-cli = { path = "adk-cli", version = "0.8.2", default-features = false }
-adk-realtime = { path = "adk-realtime", version = "0.8.2" }
-adk-graph = { path = "adk-graph", version = "0.8.2" }
-adk-browser = { path = "adk-browser", version = "0.8.2" }
-adk-eval = { path = "adk-eval", version = "0.8.2" }
-adk-telemetry = { path = "adk-telemetry", version = "0.8.2" }
-adk-guardrail = { path = "adk-guardrail", version = "0.8.2" }
-adk-auth = { path = "adk-auth", version = "0.8.2" }
-adk-plugin = { path = "adk-plugin", version = "0.8.2" }
-adk-skill = { path = "adk-skill", version = "0.8.2" }
-adk-gemini = { path = "adk-gemini", version = "0.8.2" }
-adk-code = { path = "adk-code", version = "0.8.2" }
-adk-sandbox = { path = "adk-sandbox", version = "0.8.2" }
-adk-rag = { path = "adk-rag", version = "0.8.2" }
-adk-audio = { path = "adk-audio", version = "0.8.2" }
-adk-deploy = { path = "adk-deploy", version = "0.8.2" }
-adk-payments = { path = "adk-payments", version = "0.8.2" }
-adk-action = { path = "adk-action", version = "0.8.2" }
-adk-anthropic = { path = "adk-anthropic", version = "0.8.2" }
-awp-types = { path = "awp-types", version = "0.8.2" }
-adk-awp = { path = "adk-awp", version = "0.8.2" }
-adk-acp = { path = "adk-acp", version = "0.8.2" }
+adk-core = { path = "adk-core", version = "0.8.3" }
+adk-rust-macros = { path = "adk-rust-macros", version = "0.8.3" }
+adk-agent = { path = "adk-agent", version = "0.8.3", default-features = false }
+adk-model = { path = "adk-model", version = "0.8.3", default-features = false }
+adk-tool = { path = "adk-tool", version = "0.8.3" }
+adk-runner = { path = "adk-runner", version = "0.8.3", default-features = false }
+adk-server = { path = "adk-server", version = "0.8.3" }
+adk-session = { path = "adk-session", version = "0.8.3" }
+adk-artifact = { path = "adk-artifact", version = "0.8.3" }
+adk-memory = { path = "adk-memory", version = "0.8.3" }
+adk-cli = { path = "adk-cli", version = "0.8.3", default-features = false }
+adk-realtime = { path = "adk-realtime", version = "0.8.3" }
+adk-graph = { path = "adk-graph", version = "0.8.3" }
+adk-browser = { path = "adk-browser", version = "0.8.3" }
+adk-eval = { path = "adk-eval", version = "0.8.3" }
+adk-telemetry = { path = "adk-telemetry", version = "0.8.3" }
+adk-guardrail = { path = "adk-guardrail", version = "0.8.3" }
+adk-auth = { path = "adk-auth", version = "0.8.3" }
+adk-plugin = { path = "adk-plugin", version = "0.8.3" }
+adk-skill = { path = "adk-skill", version = "0.8.3" }
+adk-gemini = { path = "adk-gemini", version = "0.8.3" }
+adk-code = { path = "adk-code", version = "0.8.3" }
+adk-sandbox = { path = "adk-sandbox", version = "0.8.3" }
+adk-rag = { path = "adk-rag", version = "0.8.3" }
+adk-audio = { path = "adk-audio", version = "0.8.3" }
+adk-deploy = { path = "adk-deploy", version = "0.8.3" }
+adk-payments = { path = "adk-payments", version = "0.8.3" }
+adk-action = { path = "adk-action", version = "0.8.3" }
+adk-anthropic = { path = "adk-anthropic", version = "0.8.3" }
+awp-types = { path = "awp-types", version = "0.8.3" }
+adk-awp = { path = "adk-awp", version = "0.8.3" }
+adk-acp = { path = "adk-acp", version = "0.8.3" }


### PR DESCRIPTION
## Release v0.8.3

### Fixed

- **Gemini schema `items` tuple validation error**: Fixed 400 errors from Gemini API when MCP tools declared `items` using JSON array syntax (tuple validation).

- **Comprehensive unsupported keyword stripping**: Expanded the Gemini schema adapter's unsupported keywords list from 7 to 32 entries based on official Gemini API documentation. Previously keywords like `minimum`, `maxLength`, `pattern`, `title`, `default` etc. were not stripped and could cause proto parse errors.

### Changes

- Version bump: 0.8.2 → 0.8.3
- CHANGELOG updated