### PR TITLE
fix(gemini): convert tuple items to single schema, add default items for arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.4] - 2026-05-18
+
+### Fixed
+
+- **Gemini schema: array types require `items`**: Fixed "missing field" errors from Gemini API when array-typed properties had tuple validation `items` (JSON array). Instead of stripping `items` entirely (which left arrays without the required field), tuple `items` are now converted to a single schema using the first element. Arrays without any `items` field also get a default `{"type": "string"}` added.
+
 ## [0.8.3] - 2026-05-18
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "adk-acp"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "adk-core",
  "adk-runner",
@@ -62,7 +62,7 @@ dependencies = [
 
 [[package]]
 name = "adk-action"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "adk-core",
  "proptest",
@@ -74,7 +74,7 @@ dependencies = [
 
 [[package]]
 name = "adk-agent"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "adk-core",
  "adk-guardrail",
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "adk-anthropic"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "adk-audio"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "adk-core",
  "adk-realtime",
@@ -161,7 +161,7 @@ dependencies = [
 
 [[package]]
 name = "adk-auth"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "adk-core",
  "adk-server",
@@ -189,7 +189,7 @@ dependencies = [
 
 [[package]]
 name = "adk-awp"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "adk-core",
  "arc-swap",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "adk-browser"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "adk-cli"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "adk-agent",
  "adk-artifact",
@@ -266,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "adk-code"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "adk-core",
  "adk-sandbox",
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "adk-deploy"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -326,7 +326,7 @@ dependencies = [
 
 [[package]]
 name = "adk-eval"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "adk-core",
  "adk-model",
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -380,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "adk-graph"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "adk-action",
  "adk-core",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "adk-guardrail"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "adk-memory"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "adk-anthropic",
  "adk-core",
@@ -468,7 +468,7 @@ dependencies = [
 
 [[package]]
 name = "adk-payments"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "adk-artifact",
  "adk-auth",
@@ -497,7 +497,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rag"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "adk-realtime"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "adk-retry-reflect"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -582,7 +582,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "adk-acp",
  "adk-action",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "adk-sandbox"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -678,7 +678,7 @@ dependencies = [
 
 [[package]]
 name = "adk-server"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "a2a-protocol-types",
  "adk-agent",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "adk-core",
  "aes-gcm",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -777,7 +777,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "adk-code",
  "adk-core",
@@ -1880,7 +1880,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "awp-types"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "chrono",
  "proptest",
@@ -3342,7 +3342,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-adk"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "adk-deploy",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ strip = false
 opt-level = 2
 
 [workspace.package]
-version = "0.8.3"
+version = "0.8.4"
 edition = "2024"
 rust-version = "1.85.0"
 license = "Apache-2.0"
@@ -135,35 +135,35 @@ livekit = { version = "0.7.36", default-features = false, features = ["tokio", "
 livekit-api = { version = "0.4.18", default-features = false, features = ["signal-client-tokio", "services-tokio", "access-token"] }
 
 # ADK internal crates (use { workspace = true } in member crates)
-adk-core = { path = "adk-core", version = "0.8.3" }
-adk-rust-macros = { path = "adk-rust-macros", version = "0.8.3" }
-adk-agent = { path = "adk-agent", version = "0.8.3", default-features = false }
-adk-model = { path = "adk-model", version = "0.8.3", default-features = false }
-adk-tool = { path = "adk-tool", version = "0.8.3" }
-adk-runner = { path = "adk-runner", version = "0.8.3", default-features = false }
-adk-server = { path = "adk-server", version = "0.8.3" }
-adk-session = { path = "adk-session", version = "0.8.3" }
-adk-artifact = { path = "adk-artifact", version = "0.8.3" }
-adk-memory = { path = "adk-memory", version = "0.8.3" }
-adk-cli = { path = "adk-cli", version = "0.8.3", default-features = false }
-adk-realtime = { path = "adk-realtime", version = "0.8.3" }
-adk-graph = { path = "adk-graph", version = "0.8.3" }
-adk-browser = { path = "adk-browser", version = "0.8.3" }
-adk-eval = { path = "adk-eval", version = "0.8.3" }
-adk-telemetry = { path = "adk-telemetry", version = "0.8.3" }
-adk-guardrail = { path = "adk-guardrail", version = "0.8.3" }
-adk-auth = { path = "adk-auth", version = "0.8.3" }
-adk-plugin = { path = "adk-plugin", version = "0.8.3" }
-adk-skill = { path = "adk-skill", version = "0.8.3" }
-adk-gemini = { path = "adk-gemini", version = "0.8.3" }
-adk-code = { path = "adk-code", version = "0.8.3" }
-adk-sandbox = { path = "adk-sandbox", version = "0.8.3" }
-adk-rag = { path = "adk-rag", version = "0.8.3" }
-adk-audio = { path = "adk-audio", version = "0.8.3" }
-adk-deploy = { path = "adk-deploy", version = "0.8.3" }
-adk-payments = { path = "adk-payments", version = "0.8.3" }
-adk-action = { path = "adk-action", version = "0.8.3" }
-adk-anthropic = { path = "adk-anthropic", version = "0.8.3" }
-awp-types = { path = "awp-types", version = "0.8.3" }
-adk-awp = { path = "adk-awp", version = "0.8.3" }
-adk-acp = { path = "adk-acp", version = "0.8.3" }
+adk-core = { path = "adk-core", version = "0.8.4" }
+adk-rust-macros = { path = "adk-rust-macros", version = "0.8.4" }
+adk-agent = { path = "adk-agent", version = "0.8.4", default-features = false }
+adk-model = { path = "adk-model", version = "0.8.4", default-features = false }
+adk-tool = { path = "adk-tool", version = "0.8.4" }
+adk-runner = { path = "adk-runner", version = "0.8.4", default-features = false }
+adk-server = { path = "adk-server", version = "0.8.4" }
+adk-session = { path = "adk-session", version = "0.8.4" }
+adk-artifact = { path = "adk-artifact", version = "0.8.4" }
+adk-memory = { path = "adk-memory", version = "0.8.4" }
+adk-cli = { path = "adk-cli", version = "0.8.4", default-features = false }
+adk-realtime = { path = "adk-realtime", version = "0.8.4" }
+adk-graph = { path = "adk-graph", version = "0.8.4" }
+adk-browser = { path = "adk-browser", version = "0.8.4" }
+adk-eval = { path = "adk-eval", version = "0.8.4" }
+adk-telemetry = { path = "adk-telemetry", version = "0.8.4" }
+adk-guardrail = { path = "adk-guardrail", version = "0.8.4" }
+adk-auth = { path = "adk-auth", version = "0.8.4" }
+adk-plugin = { path = "adk-plugin", version = "0.8.4" }
+adk-skill = { path = "adk-skill", version = "0.8.4" }
+adk-gemini = { path = "adk-gemini", version = "0.8.4" }
+adk-code = { path = "adk-code", version = "0.8.4" }
+adk-sandbox = { path = "adk-sandbox", version = "0.8.4" }
+adk-rag = { path = "adk-rag", version = "0.8.4" }
+adk-audio = { path = "adk-audio", version = "0.8.4" }
+adk-deploy = { path = "adk-deploy", version = "0.8.4" }
+adk-payments = { path = "adk-payments", version = "0.8.4" }
+adk-action = { path = "adk-action", version = "0.8.4" }
+adk-anthropic = { path = "adk-anthropic", version = "0.8.4" }
+awp-types = { path = "awp-types", version = "0.8.4" }
+adk-awp = { path = "adk-awp", version = "0.8.4" }
+adk-acp = { path = "adk-acp", version = "0.8.4" }

--- a/adk-gemini/src/schema_adapter.rs
+++ b/adk-gemini/src/schema_adapter.rs
@@ -310,14 +310,28 @@ fn remove_unsupported_keywords(schema: &mut Value) {
         obj.remove(*keyword);
     }
 
-    // Remove `items` when:
-    // 1. The schema type is NOT "array" (items is meaningless on non-array types), OR
-    // 2. The schema IS "array" but `items` is a JSON array (tuple validation syntax) —
-    //    Gemini only supports single-schema items, not tuple validation.
+    // Handle `items`:
+    // 1. If type is NOT "array", remove items entirely (meaningless on non-array types).
+    // 2. If type IS "array" and items is a JSON array (tuple validation syntax),
+    //    convert to single schema using the first element. Gemini requires items
+    //    on array types but only supports a single schema, not tuple validation.
+    // 3. If type IS "array" and items is already an object, keep it (valid).
+    // 4. If type IS "array" and items is missing, add a default items schema.
     let is_array_type = obj.get("type").and_then(|t| t.as_str()).is_some_and(|t| t == "array");
-    let items_is_tuple = obj.get("items").is_some_and(|v| v.is_array());
-    if !is_array_type || items_is_tuple {
+    if !is_array_type {
         obj.remove("items");
+    } else if obj.get("items").is_some_and(|v| v.is_array()) {
+        // Convert tuple items [schema1, schema2, ...] → first schema as single items
+        let first_schema = obj
+            .get("items")
+            .and_then(|v| v.as_array())
+            .and_then(|arr| arr.first())
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!({"type": "string"}));
+        obj.insert("items".to_string(), first_schema);
+    } else if !obj.contains_key("items") {
+        // Gemini requires items on array types — add default if missing
+        obj.insert("items".to_string(), serde_json::json!({"type": "string"}));
     }
 
     // Recurse into properties
@@ -329,7 +343,7 @@ fn remove_unsupported_keywords(schema: &mut Value) {
         }
     }
 
-    // Recurse into items (only present if type is "array" with valid single-schema)
+    // Recurse into items (now guaranteed to be a single schema object if present)
     if let Some(items) = obj.get_mut("items")
         && items.is_object()
     {
@@ -373,14 +387,26 @@ fn remove_unsupported_keywords_vertex(schema: &mut Value) {
         obj.remove("additionalProperties");
     }
 
-    // Remove `items` when:
-    // 1. The schema type is NOT "array" (items is meaningless on non-array types), OR
-    // 2. The schema IS "array" but `items` is a JSON array (tuple validation syntax) —
-    //    Gemini only supports single-schema items, not tuple validation.
+    // Handle `items`:
+    // 1. If type is NOT "array", remove items entirely (meaningless on non-array types).
+    // 2. If type IS "array" and items is a JSON array (tuple validation syntax),
+    //    convert to single schema using the first element. Gemini requires items
+    //    on array types but only supports a single schema, not tuple validation.
+    // 3. If type IS "array" and items is already an object, keep it (valid).
+    // 4. If type IS "array" and items is missing, add a default items schema.
     let is_array_type = obj.get("type").and_then(|t| t.as_str()).is_some_and(|t| t == "array");
-    let items_is_tuple = obj.get("items").is_some_and(|v| v.is_array());
-    if !is_array_type || items_is_tuple {
+    if !is_array_type {
         obj.remove("items");
+    } else if obj.get("items").is_some_and(|v| v.is_array()) {
+        let first_schema = obj
+            .get("items")
+            .and_then(|v| v.as_array())
+            .and_then(|arr| arr.first())
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!({"type": "string"}));
+        obj.insert("items".to_string(), first_schema);
+    } else if !obj.contains_key("items") {
+        obj.insert("items".to_string(), serde_json::json!({"type": "string"}));
     }
 
     // Recurse into properties
@@ -392,7 +418,7 @@ fn remove_unsupported_keywords_vertex(schema: &mut Value) {
         }
     }
 
-    // Recurse into items (only present if type is "array" with valid single-schema)
+    // Recurse into items (now guaranteed to be a single schema object if present)
     if let Some(items) = obj.get_mut("items")
         && items.is_object()
     {
@@ -477,24 +503,25 @@ mod tests {
     }
 
     #[test]
-    fn test_removes_items_tuple_validation_on_array() {
+    fn test_converts_items_tuple_validation_to_single_schema() {
         // Gemini's proto doesn't support tuple validation (items as JSON array).
-        // This caused 400 errors: "Proto field is not repeating, cannot start list"
+        // Convert to single schema using first element so arrays still have items.
         let adapter = GeminiSchemaAdapter::new();
         let schema = json!({
             "type": "array",
             "items": [
-                { "type": "string" },
+                { "type": "number" },
                 { "type": "number" }
             ]
         });
         let result = adapter.normalize_schema(schema);
-        assert!(result.get("items").is_none(), "tuple validation items should be stripped");
+        // items should be converted to the first element schema, not removed
+        assert_eq!(result["items"], json!({"type": "number"}));
         assert_eq!(result["type"], "array");
     }
 
     #[test]
-    fn test_vertex_ai_removes_items_tuple_validation() {
+    fn test_vertex_ai_converts_items_tuple_validation() {
         let adapter = GeminiSchemaAdapter::vertex_ai();
         let schema = json!({
             "type": "array",
@@ -504,10 +531,8 @@ mod tests {
             ]
         });
         let result = adapter.normalize_schema(schema);
-        assert!(
-            result.get("items").is_none(),
-            "tuple validation items should be stripped on Vertex AI"
-        );
+        // Converts to first element schema
+        assert_eq!(result["items"], json!({"type": "integer"}));
     }
 
     #[test]

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,121 @@
+#!/bin/zsh
+# Publish all workspace crates to crates.io in correct dependency order.
+# Waits 10s after new publishes, 1s for skips.
+#
+# Dependency graph (verified May 2026):
+#   Tier 1: adk-core, awp-types (no internal deps)
+#   Tier 2: depends only on Tier 1
+#   Tier 3: depends on Tier 1-2
+#   Tier 4: depends on Tier 1-3
+#   Tier 5: depends on Tier 1-4
+#   Tier 6: depends on Tier 1-5
+#   Tier 7: depends on Tier 1-6
+#   Tier 8: depends on Tier 1-7
+#   Tier 9: umbrella (depends on everything)
+
+CRATES=(
+  # Tier 1: no internal deps
+  adk-core
+  awp-types
+
+  # Tier 2: depends on adk-core only (or awp-types)
+  adk-telemetry
+  adk-memory
+  adk-artifact
+  adk-plugin
+  adk-guardrail
+  adk-gemini
+  adk-anthropic
+  adk-rust-macros
+  adk-sandbox
+  adk-action
+  adk-acp
+  adk-deploy
+  adk-awp          # depends on awp-types + adk-core
+
+  # Tier 3: depends on Tier 2
+  adk-skill        # depends on adk-plugin
+  adk-code         # depends on adk-sandbox
+  adk-realtime     # depends on adk-gemini (optional)
+  adk-session      # depends on adk-core
+  adk-model        # depends on adk-gemini, adk-telemetry
+
+  # Tier 4: depends on Tier 3
+  adk-tool         # depends on adk-code (optional), adk-rust-macros, adk-telemetry
+  adk-browser      # depends on adk-core
+  adk-audio        # depends on adk-realtime (optional)
+
+  # Tier 5: depends on Tier 4
+  adk-agent        # depends on adk-tool (dev), adk-skill, adk-plugin, adk-telemetry
+  adk-graph        # depends on adk-action (optional)
+  adk-runner       # depends on adk-session, adk-artifact, adk-plugin, adk-skill
+
+  # Tier 6: depends on Tier 5
+  adk-eval         # depends on adk-runner, adk-model
+  adk-rag          # depends on adk-core
+  adk-server       # depends on adk-runner, adk-agent
+
+  # Tier 7: depends on Tier 6
+  adk-auth         # depends on adk-server (optional)
+  cargo-adk        # depends on adk-deploy
+
+  # Tier 8: depends on Tier 7
+  adk-cli          # depends on adk-server, adk-deploy
+  adk-payments     # depends on adk-auth
+
+  # Tier 9: umbrella — always last
+  adk-rust
+)
+
+echo "=== Publishing ADK-Rust ==="
+echo "Total crates: ${#CRATES[@]}"
+echo ""
+
+PUBLISHED=0
+SKIPPED=0
+FAILED=0
+FAILED_CRATES=()
+
+for crate in "${CRATES[@]}"; do
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "📦 [$((PUBLISHED + SKIPPED + FAILED + 1))/${#CRATES[@]}] Publishing: $crate"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+  OUTPUT=$(cargo publish -p "$crate" 2>&1)
+  STATUS=$?
+
+  echo "$OUTPUT"
+  echo ""
+
+  if echo "$OUTPUT" | grep -q "already exists\|already uploaded"; then
+    echo "⏭  Already published"
+    SKIPPED=$((SKIPPED + 1))
+    sleep 1
+  elif [ $STATUS -eq 0 ]; then
+    echo "✅ Published"
+    PUBLISHED=$((PUBLISHED + 1))
+    echo "⏳ Waiting 10s for indexing..."
+    sleep 10
+  else
+    echo "❌ FAILED (exit $STATUS)"
+    FAILED=$((FAILED + 1))
+    FAILED_CRATES+=("$crate")
+    sleep 2
+  fi
+
+  echo ""
+done
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "=== SUMMARY ==="
+echo "✅ Published: $PUBLISHED"
+echo "⏭  Skipped:   $SKIPPED"
+echo "❌ Failed:    $FAILED"
+if [ ${#FAILED_CRATES[@]} -gt 0 ]; then
+  echo ""
+  echo "Failed crates:"
+  for fc in "${FAILED_CRATES[@]}"; do
+    echo "  - $fc"
+  done
+fi
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
Fixes Gemini 'missing field' errors on array properties.

**Problem:** v0.8.3 stripped tuple-style `items` entirely, but Gemini requires `items` on all array types.

**Fix:** Convert tuple `items` (`[{type:number},{type:number}]`) to single schema using first element (`{type:number}`). Also adds default `{type:string}` items for arrays missing the field.

Bumps to v0.8.4.