### PR TITLE
feat(acp): env var injection, session cancel, publish script

### DIFF
--- a/adk-acp/src/connection.rs
+++ b/adk-acp/src/connection.rs
@@ -30,6 +30,9 @@ pub struct AcpAgentConfig {
     /// Whether to auto-approve permission requests (YOLO mode).
     /// Used by `prompt_agent()`. For fine-grained control, use `prompt_agent_with_policy()`.
     pub auto_approve: bool,
+    /// Environment variables to inject when spawning the agent process.
+    /// These are merged with the current process environment (these take precedence).
+    pub env: std::collections::HashMap<String, String>,
 }
 
 impl AcpAgentConfig {
@@ -39,6 +42,7 @@ impl AcpAgentConfig {
             command: command.into(),
             working_dir: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
             auto_approve: true,
+            env: std::collections::HashMap::new(),
         }
     }
 
@@ -51,6 +55,23 @@ impl AcpAgentConfig {
     /// Set whether to auto-approve permission requests.
     pub fn auto_approve(mut self, approve: bool) -> Self {
         self.auto_approve = approve;
+        self
+    }
+
+    /// Add an environment variable to inject when spawning the agent.
+    pub fn env(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.env.insert(key.into(), value.into());
+        self
+    }
+
+    /// Set multiple environment variables at once.
+    pub fn envs(
+        mut self,
+        vars: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,
+    ) -> Self {
+        for (k, v) in vars {
+            self.env.insert(k.into(), v.into());
+        }
         self
     }
 }
@@ -95,7 +116,11 @@ pub async fn prompt_agent_with_policy(
 ) -> Result<String> {
     info!(command = %config.command, cwd = %config.working_dir.display(), "spawning ACP agent");
 
-    let agent = AcpAgent::from_str(&config.command).map_err(|e| {
+    // Build command with env vars prepended (SDK parses leading NAME=value as env vars
+    // and passes them to the child process via Command::env — no unsafe needed).
+    let command_with_env = build_command_with_env(&config.command, &config.env);
+
+    let agent = AcpAgent::from_str(&command_with_env).map_err(|e| {
         AcpError::InvalidConfig(format!("invalid command '{}': {e}", config.command))
     })?;
 
@@ -171,4 +196,21 @@ pub async fn prompt_agent_with_policy(
         .await;
 
     result.map_err(|e| AcpError::Protocol(e.to_string()))
+}
+
+/// Build a command string with environment variables prepended.
+///
+/// The ACP SDK's `AcpAgent::from_str` / `from_args` parses leading `NAME=value`
+/// tokens as environment variables and passes them to the child process via
+/// `Command::env()` — no unsafe `set_var` needed.
+pub(crate) fn build_command_with_env(
+    command: &str,
+    env: &std::collections::HashMap<String, String>,
+) -> String {
+    if env.is_empty() {
+        return command.to_string();
+    }
+    let mut parts: Vec<String> = env.iter().map(|(k, v)| format!("{k}={v}")).collect();
+    parts.push(command.to_string());
+    parts.join(" ")
 }

--- a/adk-acp/src/session.rs
+++ b/adk-acp/src/session.rs
@@ -83,12 +83,14 @@ struct SessionInner {
 
 enum SessionCommand {
     Prompt(String),
+    Cancel,
     Close,
 }
 
 enum SessionResult {
     Response(String),
     Error(String),
+    Cancelled,
     Closed,
 }
 
@@ -101,7 +103,10 @@ impl AcpSession {
     pub async fn start(config: AcpAgentConfig, policy: Arc<PermissionPolicy>) -> Result<Self> {
         info!(command = %config.command, cwd = %config.working_dir.display(), "starting persistent ACP session");
 
-        let agent = AcpAgent::from_str(&config.command).map_err(|e| {
+        let command_with_env =
+            crate::connection::build_command_with_env(&config.command, &config.env);
+
+        let agent = AcpAgent::from_str(&command_with_env).map_err(|e| {
             AcpError::InvalidConfig(format!("invalid command '{}': {e}", config.command))
         })?;
 
@@ -197,6 +202,10 @@ impl AcpSession {
                                             }
                                         }
                                     }
+                                    SessionCommand::Cancel => {
+                                        let _ = result_tx.send(SessionResult::Cancelled).await;
+                                        break;
+                                    }
                                     SessionCommand::Close => {
                                         let _ = result_tx.send(SessionResult::Closed).await;
                                         break;
@@ -259,6 +268,9 @@ impl AcpSession {
                 prompt_count: self.prompt_count,
             }),
             Some(SessionResult::Error(e)) => Err(AcpError::Protocol(e)),
+            Some(SessionResult::Cancelled) => {
+                Err(AcpError::ConnectionLost("prompt cancelled".into()))
+            }
             Some(SessionResult::Closed) => Err(AcpError::ConnectionLost("session closed".into())),
             None => Err(AcpError::ConnectionLost("agent process exited".into())),
         }
@@ -274,6 +286,27 @@ impl AcpSession {
                 "ACP session closed"
             );
         }
+        Ok(())
+    }
+
+    /// Cancel the currently running prompt.
+    ///
+    /// If the agent is processing a prompt, this terminates the session and
+    /// restarts it. The next call to [`prompt()`](Self::prompt) will work
+    /// on a fresh session context.
+    pub async fn cancel(&mut self) -> Result<()> {
+        if let Some(inner) = &self.inner {
+            info!("cancelling in-progress ACP prompt");
+            let _ = inner.prompt_tx.send(SessionCommand::Cancel).await;
+            // Drain the result channel
+            let mut rx = inner.result_rx.lock().await;
+            let _ = rx.recv().await;
+        }
+        // Close and restart
+        self.inner = None;
+        let mut new_session = AcpSession::start(self.config.clone(), self.policy.clone()).await?;
+        self.inner = new_session.inner.take();
+        info!("ACP session restarted after cancel");
         Ok(())
     }
 

--- a/adk-acp/src/streaming.rs
+++ b/adk-acp/src/streaming.rs
@@ -87,7 +87,9 @@ pub async fn stream_prompt(
 ) -> Result<OutputStream> {
     info!(command = %config.command, "starting streaming ACP prompt");
 
-    let agent = AcpAgent::from_str(&config.command).map_err(|e| {
+    let command_with_env = crate::connection::build_command_with_env(&config.command, &config.env);
+
+    let agent = AcpAgent::from_str(&command_with_env).map_err(|e| {
         AcpError::InvalidConfig(format!("invalid command '{}': {e}", config.command))
     })?;
 

--- a/examples/acp_kiro/Cargo.lock
+++ b/examples/acp_kiro/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
 
 [[package]]
 name = "adk-acp"
-version = "0.8.2"
+version = "0.8.4"
 dependencies = [
  "adk-core",
  "agent-client-protocol",
@@ -32,7 +32,7 @@ dependencies = [
 
 [[package]]
 name = "adk-agent"
-version = "0.8.2"
+version = "0.8.4"
 dependencies = [
  "adk-core",
  "adk-telemetry",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "0.8.2"
+version = "0.8.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -56,13 +56,15 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "adk-gemini"
-version = "0.8.2"
+version = "0.8.4"
 dependencies = [
+ "adk-core",
  "async-stream",
  "async-trait",
  "base64",
@@ -86,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "0.8.2"
+version = "0.8.4"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -105,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "0.8.2"
+version = "0.8.4"
 dependencies = [
  "adk-core",
  "adk-session",
@@ -122,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust"
-version = "0.8.2"
+version = "0.8.4"
 dependencies = [
  "adk-agent",
  "adk-core",
@@ -139,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "0.8.2"
+version = "0.8.4"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -152,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "0.8.2"
+version = "0.8.4"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/acp_kiro/Cargo.toml
+++ b/examples/acp_kiro/Cargo.toml
@@ -25,3 +25,7 @@ path = "src/direct.rs"
 [[bin]]
 name = "acp-kiro-session"
 path = "src/session.rs"
+
+[[bin]]
+name = "acp-kiro-env-cancel"
+path = "src/env_and_cancel.rs"

--- a/examples/acp_kiro/src/env_and_cancel.rs
+++ b/examples/acp_kiro/src/env_and_cancel.rs
@@ -1,0 +1,98 @@
+//! # ACP session with env vars and cancel
+//!
+//! Demonstrates the new `adk-acp` features:
+//! - **Environment variable injection**: Pass API keys and config to the agent process
+//! - **Session cancel**: Cancel an in-progress prompt and restart the session
+//!
+//! ## Run
+//!
+//! ```bash
+//! cargo run --bin acp-kiro-env-cancel
+//! ```
+
+use adk_acp::{AcpAgentConfig, AcpSession, PermissionPolicy};
+use std::sync::Arc;
+use tokio::time::{Duration, timeout};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    dotenvy::dotenv().ok();
+
+    println!("=== ADK-ACP: Env Vars + Cancel Demo ===\n");
+
+    // --- Feature 1: Environment variable injection ---
+    println!("─── Feature: Environment Variables ───");
+    println!("Passing env vars to the agent process (no unsafe set_var).\n");
+
+    let config = AcpAgentConfig::new("kiro-cli acp --trust-all-tools")
+        .working_dir(std::env::current_dir()?)
+        // These env vars are passed to the child process via Command::env()
+        .env("ADK_EXAMPLE_MODE", "true")
+        .env("ADK_EXAMPLE_NAME", "env-cancel-demo")
+        .envs([
+            ("CUSTOM_VAR_1", "hello"),
+            ("CUSTOM_VAR_2", "world"),
+        ]);
+
+    println!("Config created with {} env vars:", config.env.len());
+    for (k, v) in &config.env {
+        println!("  {k}={v}");
+    }
+    println!();
+
+    let policy = Arc::new(PermissionPolicy::AutoApprove);
+
+    println!("Starting session with env vars...");
+    let mut session = AcpSession::start(config, policy).await?;
+    println!("✅ Session started (env vars passed to child process)\n");
+
+    // Verify the agent can see the env vars
+    let r1 = session
+        .prompt("Print the value of the environment variable ADK_EXAMPLE_NAME. Just the value, nothing else.")
+        .await?;
+    println!("Agent sees ADK_EXAMPLE_NAME = {}", r1.text.trim());
+    println!("  (latency: {:?})\n", r1.duration);
+
+    // --- Feature 2: Cancel ---
+    println!("─── Feature: Session Cancel ───");
+    println!("Sending a long-running prompt, then cancelling after 3s.\n");
+
+    // Start a prompt that would take a while
+    let session_clone_prompt = "Write a detailed 500-word essay about the history of Rust programming language. Include dates, key contributors, and major milestones.";
+    println!("Sending long prompt: \"{}\"\n", &session_clone_prompt[..60]);
+
+    // Race: prompt vs timeout
+    let prompt_future = session.prompt(session_clone_prompt);
+    match timeout(Duration::from_secs(3), prompt_future).await {
+        Ok(Ok(result)) => {
+            // Agent responded within 3s (fast agent!)
+            println!("Agent responded in {:?} (faster than timeout)", result.duration);
+            println!("Response preview: {}...", &result.text[..result.text.len().min(100)]);
+        }
+        Ok(Err(e)) => {
+            println!("Prompt errored: {e}");
+        }
+        Err(_) => {
+            // Timed out — cancel the session
+            println!("⏱️  Timeout reached (3s). Cancelling...");
+            session.cancel().await?;
+            println!("✅ Session cancelled and restarted.\n");
+
+            // Verify session still works after cancel
+            println!("Verifying session works after cancel...");
+            let r2 = session.prompt("Say 'hello' and nothing else.").await?;
+            println!("Agent says: {}", r2.text.trim());
+            println!("✅ Session functional after cancel.");
+        }
+    }
+
+    // --- Summary ---
+    println!("\n📊 Session Summary:");
+    println!("   Prompts sent: {}", session.prompt_count());
+    println!("   Uptime: {:?}", session.uptime());
+    println!("   Active: {}", session.is_active());
+
+    session.close().await?;
+    println!("\n✅ Done.");
+    Ok(())
+}

--- a/publish.sh
+++ b/publish.sh
@@ -29,7 +29,6 @@ CRATES=(
   adk-rust-macros
   adk-sandbox
   adk-action
-  adk-acp
   adk-deploy
   adk-awp          # depends on awp-types + adk-core
 
@@ -57,6 +56,7 @@ CRATES=(
 
   # Tier 7: depends on Tier 6
   adk-auth         # depends on adk-server (optional)
+  adk-acp          # depends on adk-runner (optional server feature)
   cargo-adk        # depends on adk-deploy
 
   # Tier 8: depends on Tier 7


### PR DESCRIPTION
## What

Adds three gateway-requested features to `adk-acp`:

### 1. Environment variable injection
```rust
let config = AcpAgentConfig::new("claude-code")
    .env("ANTHROPIC_API_KEY", "sk-...")
    .envs([("KEY1", "val1"), ("KEY2", "val2")]);
```
Env vars are passed to the child process via the SDK's native `Command::env()` — no `unsafe set_var` needed.

### 2. Session cancel + auto-restart
```rust
session.cancel().await?;  // kills current, restarts fresh
session.prompt("next task").await?;  // works normally
```

### 3. Example: `acp-kiro-env-cancel`
Demonstrates both features against kiro-cli. Verified working.

### Also
- Updated `publish.sh` with correct dependency ordering (fixes adk-acp/adk-awp ordering from v0.8.3 publish)

## Testing
```bash
cargo run --manifest-path examples/acp_kiro/Cargo.toml --bin acp-kiro-env-cancel
```