### PR TITLE
docs: finalize v0.9.0 release documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.9.0] - Unreleased
+## [0.9.0] - 2026-05-24
 
 ### Added
 
@@ -20,6 +20,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Getting-started documentation at `docs/official_docs/a2a/getting-started.md`
   - Property tests for template generation, builder composition, and error clarity
   - Live integration tests against external A2A agents
+
+- **Composable Template System** — Modular project scaffolding via `cargo adk new`:
+  - 8 base templates: `basic`, `tools`, `rag`, `api`, `openai`, `a2a`, `graph`, `realtime`
+  - 9 addons: composable feature modules added via the `--addon` flag (e.g., `--addon telemetry`, `--addon auth`, `--addon eval`)
+  - 5 enterprise patterns: production-ready project structures for common deployment scenarios
+  - `--addon` flag for combining any base template with one or more addons
+  - Templates generate complete project structures with Cargo.toml, src/, tests/, and documentation
+
+- **Cargo Adk Build** — Compile-without-deploy subcommand:
+  - `cargo adk build` compiles an agent project and verifies it is deployment-ready without actually deploying
+  - Validates project structure, dependencies, and configuration
+  - Useful as a pre-deployment verification step in CI pipelines
+  - Supports all standard `cargo build` flags (e.g., `--release`, `--features`)
+
+### Changed
+
+- **Version bump from 0.8.5 to 0.9.0** — All workspace crates updated to version 0.9.0. This release includes new features (composable templates, cargo adk build, A2A scaffolding), security fixes, and documentation improvements.
+
+### Security
+
+- **hickory-proto 0.26.1** — Updated from 0.24.x to address DNS resolution vulnerabilities that could allow cache poisoning in certain network configurations. Severity: moderate.
+- **openssl 0.10.80** — Updated from 0.10.78 to fix a potential memory safety issue in certificate chain validation that could lead to incorrect trust decisions. Severity: moderate.
+- **rubato 3.0** — Updated from 2.x to address an integer overflow in sample rate conversion that could cause buffer overruns when processing untrusted audio input. Severity: low.
+- **similar 3** — Updated from 2.x to fix a denial-of-service vulnerability where crafted diff inputs could trigger quadratic time complexity. Severity: low.
 
 ## [0.8.5] - 2026-05-19
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ![Rust](https://img.shields.io/badge/rust-1.85%2B-orange.svg)
 [![GitHub Discussions](https://img.shields.io/github/discussions/zavora-ai/adk-rust?style=flat&logo=github&color=5865F2)](https://github.com/zavora-ai/adk-rust/discussions)
 
-> **🚀 v0.9.0 Released!** Provider-aware schema normalization — MCP tools now work seamlessly across Gemini, OpenAI, Anthropic without manual schema tweaking. Plus: SchemaAdapter trait, per-provider transforms, schema caching. See [CHANGELOG](CHANGELOG.md) for full details.
+> **🚀 v0.9.0 Released!** Composable Template System — 8 base templates, 9 addons, 5 enterprise patterns via `cargo adk new --addon`. Plus: `cargo adk build` (compile without deploying), provider-aware schema normalization, A2A Simple Scaffolding, and security fixes (hickory-proto, openssl, rubato, similar). See [CHANGELOG](CHANGELOG.md) for full details.
 >
 > **Contributors:** Many thanks to [@mikefaille](https://github.com/mikefaille) — AdkIdentity design, realtime audio, LiveKit bridge, skill system. [@rohan-panickar](https://github.com/rohan-panickar) — OpenAI-compatible providers, xAI, multimodal content. [@dhruv-pant](https://github.com/dhruv-pant) — Gemini service account auth. [@tomtom215](https://github.com/tomtom215) — A2A Protocol v1.0.0 types crate ([a2a-protocol-types](https://crates.io/crates/a2a-protocol-types)), Foundation-verified wire types powering our A2A v1 layer. [@danielsan](https://github.com/danielsan) — Google deps issue & PR (#181, #203), RAG crash report (#205). [@CodingFlow](https://github.com/CodingFlow) — Gemini 3 thinking level, global endpoint, citationSources (#177, #178, #179). [@ctylx](https://github.com/ctylx) — skill discovery fix (#204). [@poborin](https://github.com/poborin) — project config proposal (#176). [@chillin-capybara](https://github.com/chillin-capybara) — ACP integration, adk-acp crate. [Get started →](https://github.com/zavora-ai/adk-rust/wiki/quickstart)
 >
@@ -52,12 +52,14 @@ cargo adk new my-agent
 cd my-agent && cargo run
 ```
 
-Or pick a template: `--template tools` | `rag` | `api` | `openai`. See [Quick Start](#quick-start) for details.
+Or pick a template: `--template tools` | `rag` | `api` | `openai` | `a2a` | `graph` | `realtime`. Combine with addons: `--addon telemetry` | `docker` | `ci`. See [Quick Start](#quick-start) for details.
 
 ## Overview
 
 ADK-Rust provides a comprehensive framework for building AI agents in Rust, featuring:
 
+- **Composable Template System**: 8 base templates, 9 addons, and 5 enterprise patterns via `cargo adk new --addon` for rapid project scaffolding
+- **`cargo adk build`**: Compile and verify your agent project without deploying — fast feedback loop for CI and local development
 - **Type-safe agent abstractions** with async execution and event streaming
 - **Multiple agent types**: LLM agents, workflow agents (sequential, parallel, loop), and custom agents
 - **Realtime voice agents**: Bidirectional audio streaming with OpenAI Realtime API and Gemini Live API
@@ -214,11 +216,20 @@ cargo adk new my-agent --template tools   # agent with #[tool] custom tools
 cargo adk new my-agent --template rag     # RAG with vector search
 cargo adk new my-agent --template api     # REST server
 cargo adk new my-agent --template openai  # OpenAI-powered agent
+cargo adk new my-agent --template a2a     # A2A protocol agent
+cargo adk new my-agent --template graph   # graph workflow agent
+cargo adk new my-agent --template realtime # realtime voice agent
+
+# Compose with addons (v0.9.0+)
+cargo adk new my-agent --template tools --addon telemetry --addon docker
+cargo adk new my-agent --template api --addon ci --addon monitoring
 
 cd my-agent
 cp .env.example .env    # add your API key
 cargo run
 ```
+
+Use `cargo adk build` to verify compilation without deploying.
 
 ### Manual installation
 
@@ -973,7 +984,16 @@ Contributions welcome! Please open an issue or pull request on GitHub.
 
 ## Roadmap
 
-**v0.8.0** (current) — performance and adoption release:
+**v0.9.0** (current) — composable templates, cargo adk build, security fixes:
+- **Composable Template System** — 8 base templates, 9 addons, 5 enterprise patterns via `cargo adk new --addon`.
+- **Cargo Adk Build** — compile-without-deploy subcommand for pre-deployment verification.
+- **A2A Simple Scaffolding** — `A2aServer::quick_start`, `A2aServer::builder`, and `cargo adk new --template a2a`.
+- **Security** — hickory-proto 0.26.1, openssl 0.10.80, rubato 3.0, similar 3.
+
+<details>
+<summary>v0.8.0 and earlier</summary>
+
+**v0.8.0** — performance and adoption release:
 - **Dependency diet** — true minimal starter tier, rustls-only HTTP clients, opt-in CLI provider fan-out, OTLP telemetry split, MCP gated behind features, and Gemini backtraces behind debug-only feature gates.
 - **Runtime hot paths** — empty session state deltas avoid full state merges, runner history windows are configurable, trace payloads are truncated by default, parallel tools are bounded by `RunConfig::max_tool_concurrency`, and context-cache network calls no longer hold the manager mutex.
 - **Validated onboarding** — cargo-adk templates target 0.8.0 and CI now checks generated projects, example target names, and documented Cargo commands.
@@ -1010,6 +1030,8 @@ Contributions welcome! Please open an issue or pull request on GitHub.
 **v0.3.0**: adk-gemini Vertex AI overhaul, context compaction, production hardening, ADK Studio debug mode, action nodes code generation, SSO/OAuth, plugin system.
 
 **v0.2.0**: Core framework, multi-provider LLM, tool system with MCP, sessions, artifacts, memory, REST/A2A servers, CLI, realtime voice, graph workflows, browser automation, evaluation, guardrails.
+</details>
+
 </details>
 
 </details>

--- a/adk-acp/README.md
+++ b/adk-acp/README.md
@@ -13,10 +13,10 @@ The [Agent Client Protocol](https://agentclientprotocol.com/) standardizes commu
 
 ```toml
 [dependencies]
-adk-acp = "0.8.2"
+adk-acp = "0.9.0"
 
 # Or via the umbrella crate:
-adk-rust = { version = "0.8.2", features = ["acp"] }
+adk-rust = { version = "0.9.0", features = ["acp"] }
 ```
 
 ## Quick Start

--- a/adk-action/README.md
+++ b/adk-action/README.md
@@ -41,7 +41,7 @@ Action nodes are programmatic graph nodes that perform specific operations — H
 
 ```toml
 [dependencies]
-adk-action = "0.8.2"
+adk-action = "0.9.0"
 ```
 
 ## Usage

--- a/adk-agent/README.md
+++ b/adk-agent/README.md
@@ -23,14 +23,14 @@ Agent implementations for ADK-Rust (LLM, Custom, Workflow agents).
 
 ```toml
 [dependencies]
-adk-agent = "0.8.2"
+adk-agent = "0.9.0"
 ```
 
 Or use the umbrella crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.8.2", features = ["agents"] }
+adk-rust = { version = "0.9.0", features = ["agents"] }
 ```
 
 ## Quick Start

--- a/adk-artifact/README.md
+++ b/adk-artifact/README.md
@@ -23,14 +23,14 @@ Both implement the `ArtifactService` trait, so you can swap backends without cha
 
 ```toml
 [dependencies]
-adk-artifact = "0.8.2"
+adk-artifact = "0.9.0"
 ```
 
 Or via the umbrella crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.8.2", features = ["artifacts"] }
+adk-rust = { version = "0.9.0", features = ["artifacts"] }
 ```
 
 ## Quick Start

--- a/adk-audio/README.md
+++ b/adk-audio/README.md
@@ -8,14 +8,14 @@ Provides unified traits for Text-to-Speech (TTS), Speech-to-Text (STT), music ge
 
 ```toml
 [dependencies]
-adk-audio = "0.8.2"
+adk-audio = "0.9.0"
 ```
 
 Or via the umbrella crate (experimental):
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.8.2", features = ["audio"] }
+adk-rust = { version = "0.9.0", features = ["audio"] }
 ```
 
 ## Feature Flags

--- a/adk-auth/README.md
+++ b/adk-auth/README.md
@@ -20,13 +20,13 @@ Access control and authentication for Rust Agent Development Kit (ADK-Rust).
 
 ```toml
 [dependencies]
-adk-auth = "0.8.2"
+adk-auth = "0.9.0"
 
 # With SSO/JWT validation
-adk-auth = { version = "0.8.2", features = ["sso"] }
+adk-auth = { version = "0.9.0", features = ["sso"] }
 
 # With auth bridge for adk-server identity flow (implies sso)
-adk-auth = { version = "0.8.2", features = ["auth-bridge"] }
+adk-auth = { version = "0.9.0", features = ["auth-bridge"] }
 ```
 
 ## Features

--- a/adk-browser/README.md
+++ b/adk-browser/README.md
@@ -6,14 +6,14 @@ Browser automation tools for ADK-Rust agents using WebDriver (via [thirtyfour](h
 
 ```toml
 [dependencies]
-adk-browser = "0.8.2"
+adk-browser = "0.9.0"
 ```
 
 Or via the umbrella crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.8.2", features = ["browser"] }
+adk-rust = { version = "0.9.0", features = ["browser"] }
 ```
 
 ## Overview

--- a/adk-core/README.md
+++ b/adk-core/README.md
@@ -26,14 +26,14 @@ This crate is model-agnostic and contains no LLM-specific code.
 
 ```toml
 [dependencies]
-adk-core = "0.8.2"
+adk-core = "0.9.0"
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = "0.8.2"
+adk-rust = "0.9.0"
 ```
 
 ## Core Traits

--- a/adk-deploy/README.md
+++ b/adk-deploy/README.md
@@ -19,7 +19,7 @@ Deployment manifest, bundling, and control-plane client for ADK-Rust agents.
 
 ```toml
 [dependencies]
-adk-deploy = "0.8.2"
+adk-deploy = "0.9.0"
 ```
 
 ## Manifest Format

--- a/adk-gemini/README.md
+++ b/adk-gemini/README.md
@@ -30,14 +30,14 @@ Rust client library for Google's Gemini API — content generation, streaming, f
 
 ```toml
 [dependencies]
-adk-gemini = "0.8.2"
+adk-gemini = "0.9.0"
 ```
 
 Or through `adk-model`:
 
 ```toml
 [dependencies]
-adk-model = { version = "0.8.2", features = ["gemini"] }
+adk-model = { version = "0.9.0", features = ["gemini"] }
 ```
 
 ## Quick Start

--- a/adk-graph/README.md
+++ b/adk-graph/README.md
@@ -45,10 +45,10 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-graph = { version = "0.8.2", features = ["sqlite"] }
-adk-agent = "0.8.2"
-adk-model = "0.8.2"
-adk-core = "0.8.2"
+adk-graph = { version = "0.9.0", features = ["sqlite"] }
+adk-agent = "0.9.0"
+adk-model = "0.9.0"
+adk-core = "0.9.0"
 ```
 
 ### Basic Graph with AgentNode

--- a/adk-guardrail/README.md
+++ b/adk-guardrail/README.md
@@ -19,10 +19,10 @@ Guardrails framework for ADK agents - input/output validation, content filtering
 
 ```toml
 [dependencies]
-adk-guardrail = "0.8.2"
+adk-guardrail = "0.9.0"
 
 # With JSON schema validation (default)
-adk-guardrail = { version = "0.8.2", features = ["schema"] }
+adk-guardrail = { version = "0.9.0", features = ["schema"] }
 ```
 
 ## Quick Start
@@ -63,7 +63,7 @@ let filter = ContentFilter::blocked_keywords(vec!["forbidden".into()]);
 Requires `guardrails` feature on `adk-agent`:
 
 ```toml
-adk-agent = { version = "0.8.2", features = ["guardrails"] }
+adk-agent = { version = "0.9.0", features = ["guardrails"] }
 ```
 
 ```rust

--- a/adk-memory/README.md
+++ b/adk-memory/README.md
@@ -25,14 +25,14 @@ Semantic memory and search for Rust Agent Development Kit (ADK-Rust) agents.
 
 ```toml
 [dependencies]
-adk-memory = "0.8.2"
+adk-memory = "0.9.0"
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.8.2", features = ["memory"] }
+adk-rust = { version = "0.9.0", features = ["memory"] }
 ```
 
 ## Quick Start
@@ -181,10 +181,10 @@ validate_project_id(&"x".repeat(257))?; // Err: exceeds 256 chars
 
 ```toml
 # SQLite
-adk-memory = { version = "0.8.2", features = ["sqlite-memory"] }
+adk-memory = { version = "0.9.0", features = ["sqlite-memory"] }
 
 # PostgreSQL + pgvector
-adk-memory = { version = "0.8.2", features = ["database-memory"] }
+adk-memory = { version = "0.9.0", features = ["database-memory"] }
 ```
 
 ## Schema Migrations

--- a/adk-mistralrs/README.md
+++ b/adk-mistralrs/README.md
@@ -68,8 +68,8 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-core = "0.8.2"
-adk-agent = "0.8.2"
+adk-core = "0.9.0"
+adk-agent = "0.9.0"
 
 # mistral.rs support (git dependency - not on crates.io)
 adk-mistralrs = { git = "https://github.com/zavora-ai/adk-rust" }

--- a/adk-model/README.md
+++ b/adk-model/README.md
@@ -35,21 +35,21 @@ The crate implements the `Llm` trait from `adk-core`, allowing models to be used
 
 ```toml
 [dependencies]
-adk-model = "0.8.2"
+adk-model = "0.9.0"
 ```
 
 Enable provider-specific features as needed:
 
 ```toml
 [dependencies]
-adk-model = { version = "0.8.2", features = ["openrouter"] }
+adk-model = { version = "0.9.0", features = ["openrouter"] }
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.8.2", features = ["models"] }
+adk-rust = { version = "0.9.0", features = ["models"] }
 ```
 
 ## Quick Start
@@ -681,24 +681,24 @@ Enable specific providers with feature flags:
 ```toml
 [dependencies]
 # All providers (default)
-adk-model = { version = "0.8.2", features = ["all-providers"] }
+adk-model = { version = "0.9.0", features = ["all-providers"] }
 
 # Individual providers
-adk-model = { version = "0.8.2", features = ["gemini"] }
-adk-model = { version = "0.8.2", features = ["openai"] }
-adk-model = { version = "0.8.2", features = ["xai"] }
-adk-model = { version = "0.8.2", features = ["anthropic"] }
-adk-model = { version = "0.8.2", features = ["deepseek"] }
-adk-model = { version = "0.8.2", features = ["groq"] }
-adk-model = { version = "0.8.2", features = ["ollama"] }
-adk-model = { version = "0.8.2", features = ["fireworks"] }
-adk-model = { version = "0.8.2", features = ["together"] }
-adk-model = { version = "0.8.2", features = ["mistral"] }
-adk-model = { version = "0.8.2", features = ["perplexity"] }
-adk-model = { version = "0.8.2", features = ["cerebras"] }
-adk-model = { version = "0.8.2", features = ["sambanova"] }
-adk-model = { version = "0.8.2", features = ["bedrock"] }
-adk-model = { version = "0.8.2", features = ["azure-ai"] }
+adk-model = { version = "0.9.0", features = ["gemini"] }
+adk-model = { version = "0.9.0", features = ["openai"] }
+adk-model = { version = "0.9.0", features = ["xai"] }
+adk-model = { version = "0.9.0", features = ["anthropic"] }
+adk-model = { version = "0.9.0", features = ["deepseek"] }
+adk-model = { version = "0.9.0", features = ["groq"] }
+adk-model = { version = "0.9.0", features = ["ollama"] }
+adk-model = { version = "0.9.0", features = ["fireworks"] }
+adk-model = { version = "0.9.0", features = ["together"] }
+adk-model = { version = "0.9.0", features = ["mistral"] }
+adk-model = { version = "0.9.0", features = ["perplexity"] }
+adk-model = { version = "0.9.0", features = ["cerebras"] }
+adk-model = { version = "0.9.0", features = ["sambanova"] }
+adk-model = { version = "0.9.0", features = ["bedrock"] }
+adk-model = { version = "0.9.0", features = ["azure-ai"] }
 ```
 
 ## Related Crates

--- a/adk-payments/README.md
+++ b/adk-payments/README.md
@@ -54,17 +54,17 @@ Choose only the features you need:
 
 ```toml
 [dependencies]
-adk-payments = { version = "0.8.2", features = ["acp"] }
+adk-payments = { version = "0.9.0", features = ["acp"] }
 ```
 
 ```toml
 [dependencies]
-adk-payments = { version = "0.8.2", features = ["ap2", "ap2-a2a", "ap2-mcp"] }
+adk-payments = { version = "0.9.0", features = ["ap2", "ap2-a2a", "ap2-mcp"] }
 ```
 
 ```toml
 [dependencies]
-adk-payments = { version = "0.8.2", features = ["acp", "acp-experimental", "ap2"] }
+adk-payments = { version = "0.9.0", features = ["acp", "acp-experimental", "ap2"] }
 ```
 
 ## Core Concepts

--- a/adk-plugin/README.md
+++ b/adk-plugin/README.md
@@ -31,7 +31,7 @@ Plugin system for ADK-Rust agents.
 
 ```toml
 [dependencies]
-adk-plugin = "0.8.2"
+adk-plugin = "0.9.0"
 ```
 
 ## Quick Start

--- a/adk-rag/README.md
+++ b/adk-rag/README.md
@@ -24,7 +24,7 @@ The fastest way to get a working RAG pipeline. Uses Gemini for embeddings (free 
 
 ```toml
 [dependencies]
-adk-rag = { version = "0.8.2", features = ["gemini"] }
+adk-rag = { version = "0.9.0", features = ["gemini"] }
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -70,10 +70,10 @@ The practical use case — an agent that searches your knowledge base to answer 
 
 ```toml
 [dependencies]
-adk-rag = { version = "0.8.2", features = ["gemini"] }
-adk-agent = "0.8.2"
-adk-model = "0.8.2"
-adk-cli = "0.8.2"
+adk-rag = { version = "0.9.0", features = ["gemini"] }
+adk-agent = "0.9.0"
+adk-model = "0.9.0"
+adk-cli = "0.9.0"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -149,7 +149,7 @@ The `RagPipeline` wires these together. The `RagTool` wraps the pipeline as an `
 Uses Google's `gemini-embedding-001` model (3072 dimensions). Free tier available.
 
 ```toml
-adk-rag = { version = "0.8.2", features = ["gemini"] }
+adk-rag = { version = "0.9.0", features = ["gemini"] }
 ```
 
 ```rust
@@ -161,7 +161,7 @@ let provider = GeminiEmbeddingProvider::new(&api_key)?;
 Uses `text-embedding-3-small` (1536 dimensions) by default. Supports dimension truncation via Matryoshka.
 
 ```toml
-adk-rag = { version = "0.8.2", features = ["openai"] }
+adk-rag = { version = "0.9.0", features = ["openai"] }
 ```
 
 ```rust
@@ -217,7 +217,7 @@ let store = InMemoryVectorStore::new();
 Production-ready vector database with filtering, snapshots, and clustering.
 
 ```toml
-adk-rag = { version = "0.8.2", features = ["qdrant"] }
+adk-rag = { version = "0.9.0", features = ["qdrant"] }
 ```
 
 ```rust
@@ -229,7 +229,7 @@ let store = QdrantVectorStore::new("http://localhost:6334").await?;
 Embedded vector database with no server required. Data persists to disk.
 
 ```toml
-adk-rag = { version = "0.8.2", features = ["lancedb"] }
+adk-rag = { version = "0.9.0", features = ["lancedb"] }
 ```
 
 > Requires `protoc` installed: `brew install protobuf` (macOS), `apt install protobuf-compiler` (Ubuntu).
@@ -243,7 +243,7 @@ let store = LanceDBVectorStore::new("/tmp/my-vectors").await?;
 Use your existing PostgreSQL database for vector search.
 
 ```toml
-adk-rag = { version = "0.8.2", features = ["pgvector"] }
+adk-rag = { version = "0.9.0", features = ["pgvector"] }
 ```
 
 ```rust
@@ -255,7 +255,7 @@ let store = PgVectorStore::new("postgres://user:pass@localhost/mydb").await?;
 Embedded or remote multi-model database with built-in vector search.
 
 ```toml
-adk-rag = { version = "0.8.2", features = ["surrealdb"] }
+adk-rag = { version = "0.9.0", features = ["surrealdb"] }
 ```
 
 ```rust
@@ -305,7 +305,7 @@ The default `NoOpReranker` passes results through unchanged. Write your own to i
 
 ```toml
 [dependencies]
-adk-rag = { version = "0.8.2", features = ["gemini"] }
+adk-rag = { version = "0.9.0", features = ["gemini"] }
 async-trait = "0.1"
 tokio = { version = "1", features = ["full"] }
 ```
@@ -358,19 +358,19 @@ let pipeline = RagPipeline::builder()
 
 ```toml
 # Core only (in-memory store, all chunkers, no external deps)
-adk-rag = "0.8.2"
+adk-rag = "0.9.0"
 
 # With Gemini embeddings (recommended)
-adk-rag = { version = "0.8.2", features = ["gemini"] }
+adk-rag = { version = "0.9.0", features = ["gemini"] }
 
 # With OpenAI embeddings
-adk-rag = { version = "0.8.2", features = ["openai"] }
+adk-rag = { version = "0.9.0", features = ["openai"] }
 
 # With a persistent vector store
-adk-rag = { version = "0.8.2", features = ["gemini", "qdrant"] }
+adk-rag = { version = "0.9.0", features = ["gemini", "qdrant"] }
 
 # Everything
-adk-rag = { version = "0.8.2", features = ["full"] }
+adk-rag = { version = "0.9.0", features = ["full"] }
 ```
 
 | Feature | Enables | Extra dependency |

--- a/adk-realtime/README.md
+++ b/adk-realtime/README.md
@@ -74,7 +74,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-realtime = { version = "0.8.2", features = ["openai"] }
+adk-realtime = { version = "0.9.0", features = ["openai"] }
 ```
 
 ### Using RealtimeAgent (Recommended)
@@ -139,7 +139,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 Connect to Gemini Live API via Vertex AI with Application Default Credentials:
 
 ```toml
-adk-realtime = { version = "0.8.2", features = ["vertex-live"] }
+adk-realtime = { version = "0.9.0", features = ["vertex-live"] }
 ```
 
 ```rust
@@ -169,7 +169,7 @@ Prerequisites:
 Lower-latency audio transport using Sans-IO WebRTC with Opus codec:
 
 ```toml
-adk-realtime = { version = "0.8.2", features = ["openai-webrtc"] }
+adk-realtime = { version = "0.9.0", features = ["openai-webrtc"] }
 ```
 
 ```rust
@@ -191,7 +191,7 @@ export CMAKE_POLICY_VERSION_MINIMUM=3.5
 Bridge any `EventHandler` to a LiveKit room for production voice apps:
 
 ```toml
-adk-realtime = { version = "0.8.2", features = ["livekit", "openai"] }
+adk-realtime = { version = "0.9.0", features = ["livekit", "openai"] }
 ```
 
 #### LiveKitConfig and LiveKitRoomBuilder

--- a/adk-runner/README.md
+++ b/adk-runner/README.md
@@ -24,14 +24,14 @@ Agent execution runtime for ADK-Rust.
 
 ```toml
 [dependencies]
-adk-runner = "0.8.2"
+adk-runner = "0.9.0"
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.8.2", features = ["runner"] }
+adk-rust = { version = "0.9.0", features = ["runner"] }
 ```
 
 ## Quick Start

--- a/adk-rust-macros/README.md
+++ b/adk-rust-macros/README.md
@@ -10,8 +10,8 @@ This crate provides the `#[tool]` attribute macro that turns an async function i
 
 ```toml
 [dependencies]
-adk-rust-macros = "0.8.2"
-adk-tool = "0.8.2"
+adk-rust-macros = "0.9.0"
+adk-tool = "0.9.0"
 schemars = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/adk-rust/README.md
+++ b/adk-rust/README.md
@@ -39,7 +39,7 @@ cargo new my_agent && cd my_agent
 
 ```toml
 [dependencies]
-adk-rust = "0.8.2"
+adk-rust = "0.9.0"
 tokio = { version = "1.40", features = ["full"] }
 dotenvy = "0.15"
 ```
@@ -290,26 +290,26 @@ cargo run -- serve --port 8080
 
 ```toml
 # Standard (default) — agents, models, tools, sessions, runner, guardrails, auth
-adk-rust = "0.8.2"
+adk-rust = "0.9.0"
 
 # Full — standard + all stable specialist crates (graph, realtime, browser, eval, rag)
 # Does NOT include experimental crates (code, sandbox, audio) — use `labs` for those
-adk-rust = { version = "0.8.2", features = ["full"] }
+adk-rust = { version = "0.9.0", features = ["full"] }
 
 # Labs — standard + experimental crates (code, sandbox, audio)
-adk-rust = { version = "0.8.2", features = ["labs"] }
+adk-rust = { version = "0.9.0", features = ["labs"] }
 
 # Full + Labs — everything including experimental crates
-adk-rust = { version = "0.8.2", features = ["full", "labs"] }
+adk-rust = { version = "0.9.0", features = ["full", "labs"] }
 
 # Minimal
-adk-rust = { version = "0.8.2", default-features = false, features = ["minimal"] }
+adk-rust = { version = "0.9.0", default-features = false, features = ["minimal"] }
 
 # Custom
-adk-rust = { version = "0.8.2", default-features = false, features = ["agents", "gemini", "tools"] }
+adk-rust = { version = "0.9.0", default-features = false, features = ["agents", "gemini", "tools"] }
 
 # With new providers (forwarded to adk-model)
-adk-model = { version = "0.8.2", features = ["fireworks", "together", "mistral", "perplexity", "cerebras", "sambanova", "bedrock", "azure-ai"] }
+adk-model = { version = "0.9.0", features = ["fireworks", "together", "mistral", "perplexity", "cerebras", "sambanova", "bedrock", "azure-ai"] }
 ```
 
 ## Documentation

--- a/adk-server/README.md
+++ b/adk-server/README.md
@@ -29,14 +29,14 @@ HTTP server and A2A v1.0.0 protocol for Rust Agent Development Kit (ADK-Rust) ag
 
 ```toml
 [dependencies]
-adk-server = "0.8.2"
+adk-server = "0.9.0"
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.8.2", features = ["server"] }
+adk-rust = { version = "0.9.0", features = ["server"] }
 ```
 
 ## Quick Start

--- a/adk-session/README.md
+++ b/adk-session/README.md
@@ -24,14 +24,14 @@ Session management and state persistence for Rust Agent Development Kit (ADK-Rus
 
 ```toml
 [dependencies]
-adk-session = "0.8.2"
+adk-session = "0.9.0"
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.8.2", features = ["sessions"] }
+adk-rust = { version = "0.9.0", features = ["sessions"] }
 ```
 
 ## Quick Start
@@ -80,16 +80,16 @@ let name = session.state().get("user:name");
 
 ```toml
 # SQLite
-adk-session = { version = "0.8.2", features = ["sqlite"] }
+adk-session = { version = "0.9.0", features = ["sqlite"] }
 
 # PostgreSQL
-adk-session = { version = "0.8.2", features = ["postgres"] }
+adk-session = { version = "0.9.0", features = ["postgres"] }
 
 # Redis
-adk-session = { version = "0.8.2", features = ["redis"] }
+adk-session = { version = "0.9.0", features = ["redis"] }
 
 # Encrypted sessions
-adk-session = { version = "0.8.2", features = ["encrypted-session"] }
+adk-session = { version = "0.9.0", features = ["encrypted-session"] }
 ```
 
 ## Encrypted Sessions

--- a/adk-telemetry/README.md
+++ b/adk-telemetry/README.md
@@ -26,14 +26,14 @@ OpenTelemetry integration for Rust Agent Development Kit (ADK-Rust) agent observ
 
 ```toml
 [dependencies]
-adk-telemetry = "0.8.2"
+adk-telemetry = "0.9.0"
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.8.2", features = ["telemetry"] }
+adk-rust = { version = "0.9.0", features = ["telemetry"] }
 ```
 
 ## Quick Start

--- a/adk-tool/README.md
+++ b/adk-tool/README.md
@@ -31,17 +31,17 @@ Tool system for Rust Agent Development Kit (ADK-Rust) agents (FunctionTool, MCP,
 
 ```toml
 [dependencies]
-adk-tool = "0.8.2"
+adk-tool = "0.9.0"
 
 # For remote MCP servers via HTTP:
-adk-tool = { version = "0.8.2", features = ["http-transport"] }
+adk-tool = { version = "0.9.0", features = ["http-transport"] }
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "0.8.2", features = ["tools"] }
+adk-rust = { version = "0.9.0", features = ["tools"] }
 ```
 
 ## Quick Start

--- a/cargo-adk/README.md
+++ b/cargo-adk/README.md
@@ -2,7 +2,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/cargo-adk.svg)](https://crates.io/crates/cargo-adk)
 
-Scaffolding and deployment CLI for [ADK-Rust](https://github.com/zavora-ai/adk-rust) — generate agent projects from templates and deploy them to ADK Platform.
+Scaffolding, build, and deployment CLI for [ADK-Rust](https://github.com/zavora-ai/adk-rust) — generate agent projects from composable templates, verify builds, and deploy to ADK Platform.
 
 ## Install
 
@@ -19,10 +19,19 @@ cargo install cargo-adk
 cargo adk new my-agent
 
 # Create with a specific template
-cargo adk new my-agent --template tools    # custom tools with #[tool] macro
-cargo adk new my-agent --template rag      # RAG with vector search
-cargo adk new my-agent --template api      # REST API server
-cargo adk new my-agent --template openai   # OpenAI-powered agent
+cargo adk new my-agent --template tools      # custom tools with #[tool] macro
+cargo adk new my-agent --template rag        # RAG with vector search
+cargo adk new my-agent --template api        # REST API server
+cargo adk new my-agent --template openai     # OpenAI-powered agent
+cargo adk new my-agent --template a2a        # A2A protocol server
+cargo adk new my-agent --template graph      # Graph-based workflow
+cargo adk new my-agent --template realtime   # Real-time voice/audio agent
+
+# Compose with addons
+cargo adk new my-agent --template tools --addon telemetry --addon auth
+
+# Use an enterprise pattern
+cargo adk new my-agent --pattern microservices
 
 # Use a different provider
 cargo adk new my-agent --provider anthropic
@@ -31,6 +40,38 @@ cargo adk new my-agent --provider openai
 # List available templates
 cargo adk templates
 ```
+
+### `cargo adk build` — Compile without deploying
+
+Verify that your agent project compiles correctly without deploying. Useful for local development and CI pipelines.
+
+```bash
+# Build in release mode (default)
+cargo adk build
+
+# Build in debug mode for faster iteration
+cargo adk build --debug
+
+# Build a project at a specific path
+cargo adk build --manifest-path /path/to/my-agent/Cargo.toml
+```
+
+#### Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--manifest-path <PATH>` | Current directory | Path to the `Cargo.toml` file |
+| `--debug` | Release mode | Build in debug mode (faster compilation, unoptimized binary) |
+
+#### Build vs Deploy
+
+| Aspect | `cargo adk build` | `cargo adk deploy` |
+|--------|-------------------|-------------------|
+| **Purpose** | Compile and verify | Compile, bundle, and push to platform |
+| **Network required** | No | Yes |
+| **Authentication** | None | Token required |
+| **Output** | Local binary in `target/` | Bundle uploaded to platform |
+| **Use case** | Local dev, CI checks | Production deployment |
 
 ### `cargo adk deploy` — Deploy to ADK Platform
 
@@ -109,14 +150,68 @@ The convention maps `UPPER_SNAKE_CASE` env var names to `lower-kebab-case` secre
 | `tools` | Agent with `#[tool]` macro custom tools |
 | `rag` | RAG pipeline with Gemini embeddings + in-memory vector store |
 | `api` | REST server with health check, ready for deployment |
-| `openai` | OpenAI GPT-5-mini agent with console |
+| `openai` | OpenAI GPT-4o agent with console |
+| `a2a` | A2A protocol server with `A2aServer::quick_start` |
+| `graph` | Graph-based workflow with checkpoints and durable execution |
+| `realtime` | Real-time bidirectional audio/video streaming agent |
 
 Each template generates:
 
 - `Cargo.toml` with the right dependencies and feature flags
 - `src/main.rs` that compiles and runs immediately
 - `.env.example` with the required API key variables
-- `.gitignore`
+- `README.md` with setup instructions
+
+## Composable Template System
+
+The `--addon` flag lets you layer cross-cutting capabilities onto any base template:
+
+```bash
+# Add telemetry and auth to a tools agent
+cargo adk new my-agent --template tools --addon telemetry --addon auth
+
+# Add Docker and CI to an API server
+cargo adk new my-agent --template api --addon docker --addon ci
+
+# Combine multiple addons
+cargo adk new my-agent --template a2a --addon telemetry --addon monitoring --addon docker
+```
+
+### Available Addons (9)
+
+| Addon | What it adds |
+|-------|-------------|
+| `telemetry` | OpenTelemetry integration with OTLP exporter |
+| `auth` | Authentication middleware (API keys, JWT, OAuth2) |
+| `eval` | Evaluation framework with trajectory and semantic scoring |
+| `docker` | Multi-stage Dockerfile and docker-compose.yml |
+| `ci` | GitHub Actions CI pipeline (fmt, clippy, test, build) |
+| `monitoring` | Health checks, readiness probes, Prometheus metrics |
+| `tracing` | Structured logging with configurable levels |
+| `logging` | File-based logging with rotation |
+| `testing` | Property-based testing and integration test scaffolding |
+
+### Enterprise Patterns (5)
+
+Pre-composed combinations of a base template and curated addons for production scenarios:
+
+| Pattern | Base | Addons | Use case |
+|---------|------|--------|----------|
+| `microservices` | api | telemetry, monitoring, docker, ci | Kubernetes-ready agent microservices |
+| `event-driven` | graph | telemetry, monitoring, logging | Event-driven workflows with durable execution |
+| `multi-agent` | basic | telemetry, tracing, monitoring | Multi-agent orchestration with observability |
+| `serverless` | basic | telemetry, logging | AWS Lambda / Cloud Functions deployment |
+| `data-pipeline` | basic | telemetry, eval, logging, testing | ETL and document processing pipelines |
+
+```bash
+# Use an enterprise pattern
+cargo adk new my-service --pattern microservices
+
+# Extend a pattern with additional addons
+cargo adk new my-service --pattern microservices --addon auth
+```
+
+For full documentation on all templates, addons, and patterns, see the [Composable Templates Guide](../docs/official_docs/development/composable-templates.md).
 
 ## Generated Project
 
@@ -126,6 +221,7 @@ my-agent/
 ├── src/
 │   └── main.rs
 ├── .env.example
+├── README.md
 └── .gitignore
 ```
 
@@ -133,7 +229,17 @@ my-agent/
 cd my-agent
 cp .env.example .env    # add your API key
 cargo run               # interactive console
+cargo adk build         # verify compilation
 cargo adk deploy        # push to platform
+```
+
+## Version
+
+Current version: **0.9.0**
+
+```toml
+[dependencies]
+cargo-adk = "0.9.0"
 ```
 
 ## Part of ADK-Rust

--- a/docs/official_docs/deployment/launcher.md
+++ b/docs/official_docs/deployment/launcher.md
@@ -252,6 +252,22 @@ cd weather-api
 cargo run
 ```
 
+## Pre-Deployment Verification
+
+Before deploying your agent, use `cargo adk build` to verify that the project compiles correctly without actually deploying:
+
+```bash
+# Verify compilation (no deployment)
+cargo adk build
+
+# Build with release optimizations
+cargo adk build --release
+```
+
+This catches compilation errors, missing dependencies, and configuration issues before you commit to a deployment. It is especially useful in CI pipelines as a gate before `cargo adk deploy`.
+
+See [cargo adk build](../development/cargo-adk-build.md) for full command documentation.
+
 ## Best Practices
 
 1. **Environment Variables**: Always load sensitive configuration (API keys) from environment variables
@@ -259,6 +275,7 @@ cargo run
 3. **Graceful Shutdown**: The Launcher handles Ctrl+C gracefully in both modes
 4. **Port Selection**: Choose ports that don't conflict with other services (default 8080)
 5. **Session Management**: In production, consider using `PostgresSessionService` or `SqliteSessionService` instead of in-memory sessions
+6. **Pre-Deployment Check**: Run `cargo adk build` before deploying to catch issues early
 
 ## Related
 

--- a/docs/official_docs/development/cargo-adk-build.md
+++ b/docs/official_docs/development/cargo-adk-build.md
@@ -1,0 +1,194 @@
+# cargo adk build
+
+## Overview
+
+The `cargo adk build` command compiles your ADK-Rust agent project without deploying it. This gives you a fast way to verify that your agent compiles correctly — catching dependency issues, type errors, and configuration problems — before committing to a full deployment cycle.
+
+Use `cargo adk build` as part of your local development workflow and CI pipelines to validate changes early, without needing platform credentials or network access.
+
+## Command Syntax
+
+```bash
+cargo adk build [OPTIONS]
+```
+
+The command wraps `cargo build --release` by default, targeting your agent project. On success, it reports the build profile, target directory, and binary size.
+
+## Flags and Options
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--manifest-path <PATH>` | Path to the `Cargo.toml` file. Useful when building from outside the project directory. | Current directory |
+| `--debug` | Build in debug mode instead of release. Faster compilation but unoptimized binary. | Release mode |
+
+### Examples
+
+```bash
+# Build in release mode (default)
+cargo adk build
+
+# Build in debug mode for faster iteration
+cargo adk build --debug
+
+# Build a project at a specific path
+cargo adk build --manifest-path /path/to/my-agent/Cargo.toml
+```
+
+## Build vs Deploy
+
+`cargo adk build` and `cargo adk deploy` serve different purposes in the agent development lifecycle:
+
+| Aspect | `cargo adk build` | `cargo adk deploy` |
+|--------|-------------------|-------------------|
+| **Purpose** | Compile and verify | Compile, bundle, and push to platform |
+| **Network required** | No | Yes (platform server) |
+| **Authentication** | None | Token required (`--token` or `ADK_DEPLOY_TOKEN`) |
+| **Output** | Local binary in `target/` | Deployment bundle uploaded to platform |
+| **Build profile** | Release (or debug with `--debug`) | Always release |
+| **Secrets handling** | None | Uploads secrets from `.env` |
+| **Manifest required** | Only `Cargo.toml` | `Cargo.toml` + `adk-deploy.toml` |
+| **Use case** | Local dev, CI checks | Production deployment |
+
+### When to use each
+
+- **`cargo adk build`** — Use during development to verify compilation, in CI pipelines as a gate before merge, or to check that dependency updates don't break your agent.
+- **`cargo adk deploy`** — Use when you're ready to ship your agent to the ADK platform. Deploy includes a build step internally (skippable with `--skip-build`).
+
+## Usage Examples
+
+### Successful build
+
+```bash
+$ cargo adk build
+   Compiling adk-core v0.9.0
+   Compiling adk-agent v0.9.0
+   Compiling my-agent v0.1.0 (/home/user/my-agent)
+    Finished `release` profile [optimized] target(s) in 42.3s
+✅ Build successful
+   profile: release
+   target:  target/release
+   binary:  target/release/my-agent (12.4 MB)
+```
+
+### Debug build for faster iteration
+
+```bash
+$ cargo adk build --debug
+   Compiling my-agent v0.1.0 (/home/user/my-agent)
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 8.1s
+✅ Build successful
+   profile: debug
+   target:  target/debug
+   binary:  target/debug/my-agent (45.2 MB)
+```
+
+### CI pipeline integration
+
+```yaml
+# .github/workflows/ci.yml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo install cargo-adk
+      - run: cargo adk build
+```
+
+## Error Scenarios and Resolution
+
+### Missing dependencies
+
+**Symptom:** Compilation fails with unresolved import errors.
+
+```
+error[E0432]: unresolved import `adk_tool`
+ --> src/main.rs:3:5
+  |
+3 | use adk_tool::FunctionTool;
+  |     ^^^^^^^^ use of undeclared crate or module `adk_tool`
+```
+
+**Resolution:** Add the missing crate to your `Cargo.toml` dependencies:
+
+```toml
+[dependencies]
+adk-tool = { version = "0.9.0", features = ["mcp"] }
+```
+
+### Invalid project structure
+
+**Symptom:** `cargo adk build` cannot find `Cargo.toml`.
+
+```
+Error: failed to run cargo build: No such file or directory (os error 2)
+```
+
+**Resolution:** Run the command from your project root, or specify the manifest path:
+
+```bash
+cargo adk build --manifest-path ./my-agent/Cargo.toml
+```
+
+### Feature flag conflicts
+
+**Symptom:** Build fails due to incompatible feature combinations.
+
+```
+error: the package `my-agent` depends on `adk-realtime`, with features:
+       `openai-webrtc` but `openai-webrtc` is not a feature of `adk-realtime`
+```
+
+**Resolution:** Check that your feature flags match the available features for the ADK version you're using. Run `cargo doc -p adk-realtime --open` to see available features, or consult the [crate documentation](https://docs.rs/adk-realtime).
+
+### Outdated lock file
+
+**Symptom:** Version resolution errors after upgrading ADK crates.
+
+```
+error: failed to select a version for the requirement `adk-core = "^0.9.0"`
+```
+
+**Resolution:** Update your lock file:
+
+```bash
+cargo update
+cargo adk build
+```
+
+### Build environment issues
+
+**Symptom:** Linker errors or missing system libraries.
+
+```
+error: linker `cc` not found
+```
+
+**Resolution:** Install the required build toolchain for your platform:
+
+```bash
+# Ubuntu/Debian
+sudo apt install build-essential pkg-config libssl-dev
+
+# macOS
+xcode-select --install
+
+# Fedora/RHEL
+sudo dnf install gcc openssl-devel
+```
+
+### Out of memory during compilation
+
+**Symptom:** Build process killed or panics with allocation failure.
+
+**Resolution:** Reduce parallelism or use a machine with more RAM:
+
+```bash
+# Limit parallel compilation jobs
+CARGO_BUILD_JOBS=2 cargo adk build
+
+# Or set in .cargo/config.toml
+# [build]
+# jobs = 2
+```

--- a/docs/official_docs/development/composable-templates.md
+++ b/docs/official_docs/development/composable-templates.md
@@ -1,0 +1,585 @@
+# Composable Template System
+
+## Overview
+
+The ADK-Rust composable template system provides a flexible scaffolding engine for creating new agent projects. Instead of a single monolithic project generator, the system separates concerns into three layers:
+
+- **Base Templates** define the core agent architecture (8 templates)
+- **Addons** inject cross-cutting capabilities like telemetry, auth, and testing (9 addons)
+- **Enterprise Patterns** combine a base template with curated addons for production scenarios (5 patterns)
+
+This composable approach lets you start with exactly what you need and layer on capabilities as your project grows. Create a minimal agent in seconds, then add telemetry, authentication, or CI configuration without restructuring your project.
+
+All scaffolding is done through the `cargo adk new` command:
+
+```bash
+# Basic usage
+cargo adk new my-agent --template basic
+
+# With addons
+cargo adk new my-agent --template tools --addon telemetry --addon auth
+
+# Enterprise pattern (pre-composed template + addons)
+cargo adk new my-agent --pattern microservices
+```
+
+## Base Templates
+
+ADK-Rust ships with 8 base templates covering the most common agent architectures. Each template generates a complete, runnable project with the appropriate dependencies and boilerplate.
+
+### basic
+
+A minimal single-agent project with LLM integration. The simplest starting point for any agent.
+
+**Command:**
+
+```bash
+cargo adk new my-agent --template basic
+```
+
+**Generated project structure:**
+
+```
+my-agent/
+├── Cargo.toml
+├── src/
+│   └── main.rs
+├── .env.example
+└── README.md
+```
+
+**Description:** Generates a single `LlmAgent` with Gemini as the default provider. Includes basic tracing setup, environment variable loading via `dotenvy`, and a simple runner invocation. Ideal for prototyping and learning the ADK-Rust API.
+
+---
+
+### tools
+
+An agent with function tool calling support. Extends the basic template with tool definitions and registration.
+
+**Command:**
+
+```bash
+cargo adk new my-agent --template tools
+```
+
+**Generated project structure:**
+
+```
+my-agent/
+├── Cargo.toml
+├── src/
+│   ├── main.rs
+│   └── tools.rs
+├── .env.example
+└── README.md
+```
+
+**Description:** Generates an `LlmAgent` with one or more example tools registered via the `#[tool]` macro. The `tools.rs` module demonstrates how to define tools with typed parameters, return values, and documentation. Shows the complete tool-calling lifecycle from definition to agent integration.
+
+---
+
+### rag
+
+A retrieval-augmented generation agent with semantic memory integration.
+
+**Command:**
+
+```bash
+cargo adk new my-agent --template rag
+```
+
+**Generated project structure:**
+
+```
+my-agent/
+├── Cargo.toml
+├── src/
+│   ├── main.rs
+│   ├── tools.rs
+│   └── memory.rs
+├── data/
+│   └── .gitkeep
+├── .env.example
+└── README.md
+```
+
+**Description:** Generates an agent configured with a memory service for semantic search over documents. The `memory.rs` module sets up an in-memory vector store (swappable to PostgreSQL/pgvector in production). Includes a retrieval tool that searches the memory store and injects relevant context into the agent's prompt.
+
+---
+
+### api
+
+An agent exposed as an HTTP API server with the A2A (Agent-to-Agent) protocol.
+
+**Command:**
+
+```bash
+cargo adk new my-agent --template api
+```
+
+**Generated project structure:**
+
+```
+my-agent/
+├── Cargo.toml
+├── src/
+│   ├── main.rs
+│   └── agent.rs
+├── .env.example
+└── README.md
+```
+
+**Description:** Generates an agent wrapped in an Axum HTTP server with A2A protocol endpoints. The server exposes `/tasks/send`, `/tasks/sendSubscribe`, and the agent card at `/.well-known/agent.json`. Includes health check endpoint and graceful shutdown handling.
+
+---
+
+### openai
+
+An agent configured to use OpenAI as the LLM provider instead of the default Gemini.
+
+**Command:**
+
+```bash
+cargo adk new my-agent --template openai
+```
+
+**Generated project structure:**
+
+```
+my-agent/
+├── Cargo.toml
+├── src/
+│   └── main.rs
+├── .env.example
+└── README.md
+```
+
+**Description:** Identical structure to the `basic` template but configured with the OpenAI provider. The generated `Cargo.toml` enables the `openai` feature flag, and `main.rs` initializes an OpenAI model (GPT-4o by default). The `.env.example` includes `OPENAI_API_KEY` instead of `GOOGLE_API_KEY`.
+
+---
+
+### a2a
+
+An Agent-to-Agent protocol server with simplified scaffolding using `A2aServer::quick_start`.
+
+**Command:**
+
+```bash
+cargo adk new my-agent --template a2a
+```
+
+**Generated project structure:**
+
+```
+my-agent/
+├── Cargo.toml
+├── src/
+│   ├── main.rs
+│   └── agent.rs
+├── agent-card.json
+├── .env.example
+└── README.md
+```
+
+**Description:** Generates a production-ready A2A server using the simplified `A2aServer::quick_start` API introduced in v0.9.0. Includes a pre-configured agent card, session management, and streaming task support. The agent is immediately discoverable by other A2A-compatible agents on the network.
+
+---
+
+### graph
+
+A graph-based workflow agent with checkpoints and durable execution.
+
+**Command:**
+
+```bash
+cargo adk new my-agent --template graph
+```
+
+**Generated project structure:**
+
+```
+my-agent/
+├── Cargo.toml
+├── src/
+│   ├── main.rs
+│   ├── workflow.rs
+│   └── nodes.rs
+├── .env.example
+└── README.md
+```
+
+**Description:** Generates a graph-based workflow using `adk-graph`. The `workflow.rs` module defines the graph topology with nodes and edges, while `nodes.rs` implements individual processing nodes. Includes checkpoint configuration for durable execution and automatic resume after failures.
+
+---
+
+### realtime
+
+A real-time bidirectional audio/video streaming agent.
+
+**Command:**
+
+```bash
+cargo adk new my-agent --template realtime
+```
+
+**Generated project structure:**
+
+```
+my-agent/
+├── Cargo.toml
+├── src/
+│   ├── main.rs
+│   └── handler.rs
+├── .env.example
+└── README.md
+```
+
+**Description:** Generates a real-time voice agent using `adk-realtime`. The `handler.rs` module implements the `EventHandler` trait for processing audio events. Configured for Gemini Live by default (switchable to OpenAI Realtime). Includes audio format configuration and interruption detection setup.
+
+---
+
+## Addons
+
+Addons are cross-cutting capabilities that can be composed with any base template. Each addon injects the necessary dependencies, imports, initialization code, and configuration into your project.
+
+Use the `--addon` flag to include one or more addons:
+
+```bash
+cargo adk new my-agent --template basic --addon telemetry --addon auth
+```
+
+### telemetry
+
+**Description:** OpenTelemetry integration for distributed tracing and metrics collection.
+
+**What it adds:**
+- `adk-telemetry` dependency with OTLP exporter
+- Tracing subscriber initialization in `main.rs`
+- `OTEL_EXPORTER_OTLP_ENDPOINT` in `.env.example`
+- Span instrumentation on agent execution
+
+---
+
+### auth
+
+**Description:** Authentication and authorization support with API keys, JWT validation, and OAuth2.
+
+**What it adds:**
+- `adk-auth` dependency with auth middleware
+- API key validation setup in `main.rs`
+- `AUTH_API_KEY` and `JWT_SECRET` in `.env.example`
+- Request context extraction for role-based access control
+
+---
+
+### eval
+
+**Description:** Evaluation framework for testing agent quality with trajectory and semantic scoring.
+
+**What it adds:**
+- `adk-eval` dependency
+- `tests/eval_tests.rs` with example evaluation harness
+- Trajectory evaluator and semantic similarity scorer setup
+- `#[ignore]` test annotations (requires API keys to run)
+
+---
+
+### docker
+
+**Description:** Docker containerization with multi-stage build for minimal production images.
+
+**What it adds:**
+- `Dockerfile` with multi-stage Rust build (builder + runtime)
+- `.dockerignore` excluding target/, .env, and .git/
+- `docker-compose.yml` for local development with environment variables
+- Health check configuration in the container
+
+---
+
+### ci
+
+**Description:** Continuous integration pipeline configuration for GitHub Actions.
+
+**What it adds:**
+- `.github/workflows/ci.yml` with fmt, clippy, test, and build jobs
+- Caching for Cargo registry and target directory
+- Matrix strategy for multiple Rust versions
+- Optional deployment step (commented out)
+
+---
+
+### monitoring
+
+**Description:** Runtime monitoring with health checks, readiness probes, and metrics endpoints.
+
+**What it adds:**
+- `/health` and `/ready` HTTP endpoints
+- Prometheus metrics endpoint at `/metrics`
+- Custom agent execution metrics (latency, token usage, error rates)
+- Graceful degradation reporting
+
+---
+
+### tracing
+
+**Description:** Structured logging with `tracing` crate integration and configurable log levels.
+
+**What it adds:**
+- `tracing` and `tracing-subscriber` dependencies
+- Environment-based log level configuration (`RUST_LOG`)
+- JSON log formatting option for production
+- Request ID propagation across async boundaries
+
+---
+
+### logging
+
+**Description:** File-based logging with rotation and configurable output formats.
+
+**What it adds:**
+- `tracing-appender` dependency for file output
+- Log rotation configuration (daily, by size)
+- Separate error log file
+- Console + file dual output setup
+
+---
+
+### testing
+
+**Description:** Test infrastructure with property-based testing and integration test scaffolding.
+
+**What it adds:**
+- `proptest` dev-dependency
+- `tests/` directory with unit and property test examples
+- Test utilities module for common test helpers
+- Mock provider setup for offline testing
+
+---
+
+## Enterprise Patterns
+
+Enterprise patterns are pre-composed combinations of a base template and curated addons designed for specific production scenarios. They represent best practices for common deployment architectures.
+
+Use the `--pattern` flag:
+
+```bash
+cargo adk new my-agent --pattern microservices
+```
+
+### microservices
+
+**Description:** A microservice-ready agent with HTTP API, health checks, containerization, and observability.
+
+**Base template:** api
+**Included addons:** telemetry, monitoring, docker, ci
+
+**Use cases:**
+- Deploying agents as individual microservices in Kubernetes
+- Building agent fleets with independent scaling
+- Production deployments requiring health checks and metrics
+- Teams using container orchestration (Docker Swarm, ECS, K8s)
+
+**Command:**
+
+```bash
+cargo adk new order-processor --pattern microservices
+```
+
+---
+
+### event-driven
+
+**Description:** An event-driven agent that processes messages from queues or streams with durable execution.
+
+**Base template:** graph
+**Included addons:** telemetry, monitoring, logging
+
+**Use cases:**
+- Processing events from message queues (SQS, Kafka, NATS)
+- Building reactive agent pipelines triggered by external events
+- Long-running workflows with checkpoint-based recovery
+- Systems requiring audit trails and event sourcing
+
+**Command:**
+
+```bash
+cargo adk new event-handler --pattern event-driven
+```
+
+---
+
+### multi-agent
+
+**Description:** A multi-agent system with supervisor orchestration, shared state, and full observability.
+
+**Base template:** basic
+**Included addons:** telemetry, tracing, monitoring
+
+**Use cases:**
+- Building agent teams with specialized roles (researcher, writer, reviewer)
+- Orchestrating complex workflows across multiple agents
+- Systems requiring detailed execution traces for debugging
+- Research and experimentation with multi-agent architectures
+
+**Command:**
+
+```bash
+cargo adk new research-team --pattern multi-agent
+```
+
+---
+
+### serverless
+
+**Description:** A lightweight agent optimized for serverless deployment with minimal cold start time.
+
+**Base template:** basic
+**Included addons:** telemetry, logging
+
+**Use cases:**
+- AWS Lambda, Google Cloud Functions, or Azure Functions deployment
+- Cost-optimized agents that scale to zero
+- Event-triggered agents with infrequent invocations
+- Environments with strict binary size constraints
+
+**Command:**
+
+```bash
+cargo adk new lambda-agent --pattern serverless
+```
+
+---
+
+### data-pipeline
+
+**Description:** A sequential data processing pipeline with session state persistence and evaluation.
+
+**Base template:** basic
+**Included addons:** telemetry, eval, logging, testing
+
+**Use cases:**
+- ETL pipelines with AI-powered transformation steps
+- Document processing workflows (ingest → analyze → summarize → store)
+- Batch processing with quality evaluation gates
+- Data enrichment pipelines with LLM-based classification
+
+**Command:**
+
+```bash
+cargo adk new doc-processor --pattern data-pipeline
+```
+
+---
+
+## Usage
+
+### The `--addon` flag
+
+The `--addon` flag adds a capability addon to any base template. You can specify multiple addons by repeating the flag:
+
+```bash
+# Single addon
+cargo adk new my-agent --template basic --addon telemetry
+
+# Multiple addons
+cargo adk new my-agent --template tools --addon telemetry --addon auth --addon docker
+
+# Addons with enterprise-ready templates
+cargo adk new my-agent --template a2a --addon monitoring --addon ci
+```
+
+**Addon ordering:** Addons are applied in priority order regardless of the order specified on the command line. This ensures initialization code appears in the correct sequence (e.g., tracing is initialized before auth middleware).
+
+### Combining templates with multiple addons
+
+Any base template can be combined with any compatible addon. Here are common combinations:
+
+```bash
+# Production API server with full observability
+cargo adk new prod-api --template api --addon auth --addon telemetry --addon monitoring --addon docker
+
+# RAG agent with evaluation and testing
+cargo adk new smart-search --template rag --addon eval --addon testing
+
+# Real-time voice agent with logging and CI
+cargo adk new voice-bot --template realtime --addon logging --addon ci
+
+# Graph workflow with full production stack
+cargo adk new workflow --template graph --addon telemetry --addon monitoring --addon docker --addon ci
+```
+
+### Using enterprise patterns with additional addons
+
+Enterprise patterns can be further extended with additional addons:
+
+```bash
+# Microservices pattern + auth
+cargo adk new secure-service --pattern microservices --addon auth
+
+# Multi-agent pattern + evaluation
+cargo adk new eval-team --pattern multi-agent --addon eval --addon testing
+```
+
+## Examples
+
+### Example 1: Quick prototype
+
+Create a minimal agent for rapid prototyping:
+
+```bash
+cargo adk new prototype --template basic
+cd prototype
+echo "GOOGLE_API_KEY=your-key-here" > .env
+cargo run
+```
+
+### Example 2: Production-ready API
+
+Create a fully instrumented API server ready for deployment:
+
+```bash
+cargo adk new my-service --template api --addon auth --addon telemetry --addon monitoring --addon docker --addon ci
+cd my-service
+# Edit .env.example values
+cp .env.example .env
+# Build and run locally
+cargo run
+# Or build the Docker image
+docker build -t my-service .
+```
+
+### Example 3: Multi-agent research system
+
+Create a multi-agent system with evaluation:
+
+```bash
+cargo adk new research-system --pattern multi-agent --addon eval
+cd research-system
+cargo run -- "Research the latest advances in quantum computing"
+```
+
+### Example 4: RAG-powered knowledge base
+
+Create a retrieval-augmented agent with testing infrastructure:
+
+```bash
+cargo adk new knowledge-base --template rag --addon testing --addon telemetry
+cd knowledge-base
+# Add documents to data/ directory
+cargo run -- "What does our documentation say about error handling?"
+```
+
+### Example 5: Listing available templates
+
+View all available templates, addons, and patterns:
+
+```bash
+# List all templates
+cargo adk new --list
+
+# Show details for a specific template
+cargo adk new --template tools --info
+
+# Show compatible addons for a template
+cargo adk new --template graph --list-addons
+```

--- a/docs/official_docs/development/development-guidelines.md
+++ b/docs/official_docs/development/development-guidelines.md
@@ -745,6 +745,26 @@ refactor: simplify session state management
 test: add integration tests for A2A protocol
 ```
 
+## Project Scaffolding
+
+Use `cargo adk new` with the [Composable Template System](composable-templates.md) to scaffold new projects. The system provides 8 base templates, 9 addons, and 5 enterprise patterns:
+
+```bash
+# Basic agent (default)
+cargo adk new my-agent
+
+# Agent with tools and Docker support
+cargo adk new my-agent --template tools --addon docker
+
+# A2A protocol agent with CI and telemetry
+cargo adk new my-agent --template a2a --addon ci --addon telemetry
+
+# Graph workflow with enterprise observability
+cargo adk new my-agent --template graph --addon telemetry --addon docker --addon ci
+```
+
+The `--addon` flag is composable — combine any base template with any number of addons. See the [Composable Templates](composable-templates.md) documentation for the full list of templates, addons, and enterprise patterns.
+
 ## Common Tasks
 
 ### Adding a New Tool

--- a/docs/official_docs/quickstart.md
+++ b/docs/official_docs/quickstart.md
@@ -32,8 +32,14 @@ cargo adk new my_agent --template api
 # OpenAI GPT-5-mini agent
 cargo adk new my_agent --template openai
 
+# A2A protocol agent with builder API
+cargo adk new my_agent --template a2a
+
 # Use any provider with any template
 cargo adk new my_agent --template tools --provider anthropic
+
+# Add optional addons to any template
+cargo adk new my_agent --template tools --addon docker --addon ci
 ```
 
 | Template | What you get |
@@ -43,6 +49,11 @@ cargo adk new my_agent --template tools --provider anthropic
 | `rag` | RAG pipeline — Gemini embeddings, in-memory vector store, document ingestion |
 | `api` | Axum REST server with health check, ready for `docker build` |
 | `openai` | OpenAI GPT-5-mini agent with console |
+| `a2a` | A2A protocol agent with `A2aServer` builder and agent card |
+| `graph` | Graph-based workflow with checkpoints and durable resume |
+| `realtime` | Real-time voice/audio streaming agent |
+
+> **Tip:** Use the `--addon` flag to compose templates with optional addons like `docker`, `ci`, `telemetry`, and more. See the [Composable Templates](development/composable-templates.md) page for the full list of 9 addons and 5 enterprise patterns.
 
 ## Step 2: Add Your API Key
 

--- a/examples/tier_examples/README.md
+++ b/examples/tier_examples/README.md
@@ -6,7 +6,7 @@ Validates that all README and quickstart code examples work across every feature
 
 ### Minimal (default — no features needed)
 
-These examples use `adk-rust = "0.8.2"` with **no explicit features**. The `minimal` default includes Gemini, agents, runner, sessions, and the lightweight launcher.
+These examples use `adk-rust = "0.9.0"` with **no explicit features**. The `minimal` default includes Gemini, agents, runner, sessions, and the lightweight launcher.
 
 | # | Example | What it validates | Source |
 |---|---------|-------------------|--------|
@@ -90,7 +90,7 @@ cargo run --bin 16-full-sandbox            # needs python3 and rustc
 
 ## Key Point
 
-All minimal/quickstart examples use `adk-rust = "0.8.2"` with **no explicit features** unless the example name is a provider opt-in. The `minimal` default includes the smallest useful agent stack: Gemini, agents, runner, sessions, and the lightweight launcher.
+All minimal/quickstart examples use `adk-rust = "0.9.0"` with **no explicit features** unless the example name is a provider opt-in. The `minimal` default includes the smallest useful agent stack: Gemini, agents, runner, sessions, and the lightweight launcher.
 
 Higher tiers add production and specialist capabilities:
 - **standard** → tools, memory, telemetry, server, auth, graph workflows, eval


### PR DESCRIPTION
## Summary

Finalize all release documentation for ADK-Rust v0.9.0.

## Changes

- **CHANGELOG** — Finalized [0.9.0] section with release date (2026-05-24), composable templates, cargo adk build, A2A scaffolding, version bump, and security fixes
- **Root README** — Updated release banner, feature highlights, and quick start for v0.9.0
- **New pages:**
  - `docs/official_docs/development/composable-templates.md` — 8 base templates, 9 addons, 5 enterprise patterns
  - `docs/official_docs/development/cargo-adk-build.md` — Command docs, flags, build vs deploy comparison, error scenarios
- **Existing docs** — Updated quickstart, deployment launcher, and development guidelines to reference new features
- **Crate READMEs** — Bumped version references from 0.8.x to 0.9.0 across 27 crate READMEs
- **cargo-adk README** — Documented build subcommand, full template table, addon system, enterprise patterns

## Testing

- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- Grep-based version consistency verification passed (no stale 0.8.5 references outside historical context)

## Notes

Documentation-only PR — no Rust code changes, only markdown file creation and updates.