### PR TITLE
feat(a2a): add non-streaming support to RemoteA2aAgent

### DIFF
--- a/adk-server/src/a2a/remote_agent.rs
+++ b/adk-server/src/a2a/remote_agent.rs
@@ -1,4 +1,6 @@
-use crate::a2a::{A2aClient, Part as A2aPart, Role, UpdateEvent};
+use crate::a2a::{
+    A2aClient, Part as A2aPart, Role, TaskArtifactUpdateEvent, TaskStatusUpdateEvent, UpdateEvent,
+};
 use adk_core::{Agent, Content, Event, EventStream, InvocationContext, Part, Result};
 use async_trait::async_trait;
 use std::sync::Arc;
@@ -13,6 +15,9 @@ pub struct RemoteA2aConfig {
     /// Base URL of the remote agent (e.g., "http://localhost:8080")
     /// The agent card will be fetched from {base_url}/.well-known/agent.json
     pub agent_url: String,
+    /// Whether to use streaming for communication.
+    /// If `None`, the agent uses streaming if the remote agent supports it.
+    pub streaming: Option<bool>,
 }
 
 /// An agent that communicates with a remote A2A agent
@@ -48,6 +53,7 @@ impl Agent for RemoteA2aAgent {
         let url = self.config.agent_url.clone();
         let invocation_id = ctx.invocation_id().to_string();
         let agent_name = self.config.name.clone();
+        let config_streaming = self.config.streaming;
 
         // Get user content from context
         let user_content = get_user_content_from_context(ctx.as_ref());
@@ -62,29 +68,57 @@ impl Agent for RemoteA2aAgent {
                 }
             };
 
+            // Determine if we should use streaming
+            let use_streaming = config_streaming.unwrap_or(client.agent_card().capabilities.streaming);
+
             // Build message from user content
             let message = build_a2a_message(user_content);
 
-            // Send streaming message
-            match client.send_streaming_message(message).await {
-                Ok(mut event_stream) => {
-                    use futures::StreamExt;
-                    while let Some(result) = event_stream.next().await {
-                        match result {
-                            Ok(update_event) => {
-                                if let Some(event) = convert_update_event(&invocation_id, &agent_name, update_event) {
-                                    yield Ok(event);
+            if use_streaming {
+                // Send streaming message
+                match client.send_streaming_message(message).await {
+                    Ok(mut event_stream) => {
+                        use futures::StreamExt;
+                        while let Some(result) = event_stream.next().await {
+                            match result {
+                                Ok(update_event) => {
+                                    if let Some(event) = convert_update_event(&invocation_id, &agent_name, update_event) {
+                                        yield Ok(event);
+                                    }
                                 }
-                            }
-                            Err(e) => {
-                                yield Ok(create_error_event(&invocation_id, &agent_name, &e.to_string()));
-                                return;
+                                Err(e) => {
+                                    yield Ok(create_error_event(&invocation_id, &agent_name, &e.to_string()));
+                                    return;
+                                }
                             }
                         }
                     }
+                    Err(e) => {
+                        yield Ok(create_error_event(&invocation_id, &agent_name, &e.to_string()));
+                    }
                 }
-                Err(e) => {
-                    yield Ok(create_error_event(&invocation_id, &agent_name, &e.to_string()));
+            } else {
+                // Send non-streaming message
+                match client.send_message(message).await {
+                    Ok(rpc_response) => {
+                        if let Some(result) = rpc_response.result {
+                            match serde_json::from_value::<crate::a2a::Task>(result) {
+                                Ok(task) => {
+                                    for event in convert_task_to_events(&invocation_id, &agent_name, task) {
+                                        yield Ok(event);
+                                    }
+                                }
+                                Err(e) => {
+                                    yield Ok(create_error_event(&invocation_id, &agent_name, &format!("failed to parse response: {e}")));
+                                }
+                            }
+                        } else if let Some(error) = rpc_response.error {
+                            yield Ok(create_error_event(&invocation_id, &agent_name, &format!("RPC error: {} ({})", error.message, error.code)));
+                        }
+                    }
+                    Err(e) => {
+                        yield Ok(create_error_event(&invocation_id, &agent_name, &e.to_string()));
+                    }
                 }
             }
         };
@@ -98,11 +132,12 @@ pub struct RemoteA2aAgentBuilder {
     name: String,
     description: String,
     agent_url: Option<String>,
+    streaming: Option<bool>,
 }
 
 impl RemoteA2aAgentBuilder {
     pub fn new(name: impl Into<String>) -> Self {
-        Self { name: name.into(), description: String::new(), agent_url: None }
+        Self { name: name.into(), description: String::new(), agent_url: None, streaming: None }
     }
 
     pub fn description(mut self, description: impl Into<String>) -> Self {
@@ -115,6 +150,12 @@ impl RemoteA2aAgentBuilder {
         self
     }
 
+    /// Set whether to use streaming. If not set, auto-detects from agent capabilities.
+    pub fn streaming(mut self, streaming: bool) -> Self {
+        self.streaming = Some(streaming);
+        self
+    }
+
     pub fn build(self) -> Result<RemoteA2aAgent> {
         let agent_url = self
             .agent_url
@@ -124,6 +165,7 @@ impl RemoteA2aAgentBuilder {
             name: self.name,
             description: self.description,
             agent_url,
+            streaming: self.streaming,
         }))
     }
 }
@@ -203,6 +245,68 @@ fn create_error_event(invocation_id: &str, agent_name: &str, error: &str) -> Eve
     event
 }
 
+/// Converts a non-streaming A2A Task response into a sequence of ADK Events.
+fn convert_task_to_events(
+    invocation_id: &str,
+    agent_name: &str,
+    task: crate::a2a::Task,
+) -> Vec<Event> {
+    let mut events = Vec::new();
+
+    // 1. Yield events for artifacts
+    if let Some(artifacts) = task.artifacts {
+        for artifact in artifacts {
+            let update = UpdateEvent::TaskArtifactUpdate(TaskArtifactUpdateEvent {
+                task_id: task.id.clone(),
+                context_id: task.context_id.clone(),
+                artifact,
+                append: false,
+                last_chunk: true,
+            });
+            if let Some(event) = convert_update_event(invocation_id, agent_name, update) {
+                events.push(event);
+            }
+        }
+    }
+
+    // 2. Yield events for history (agent messages)
+    if let Some(history) = task.history {
+        for msg in history {
+            if msg.role == Role::Agent {
+                let parts: Vec<Part> = msg
+                    .parts
+                    .iter()
+                    .filter_map(|p| match p {
+                        A2aPart::Text { text, .. } => Some(Part::Text { text: text.clone() }),
+                        _ => None,
+                    })
+                    .collect();
+
+                if !parts.is_empty() {
+                    let mut event = Event::new(invocation_id.to_string());
+                    event.author = agent_name.to_string();
+                    event.llm_response.content = Some(Content { role: "model".to_string(), parts });
+                    event.llm_response.turn_complete = false;
+                    events.push(event);
+                }
+            }
+        }
+    }
+
+    // 3. Yield final status event
+    let update = UpdateEvent::TaskStatusUpdate(TaskStatusUpdateEvent {
+        task_id: task.id,
+        context_id: task.context_id,
+        status: task.status,
+        final_update: true,
+    });
+    if let Some(event) = convert_update_event(invocation_id, agent_name, update) {
+        events.push(event);
+    }
+
+    events
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -223,6 +327,112 @@ mod tests {
     fn test_builder_missing_url() {
         let result = RemoteA2aAgent::builder("test").build();
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_builder_streaming_option() {
+        let agent = RemoteA2aAgent::builder("test")
+            .agent_url("http://localhost:8080")
+            .streaming(true)
+            .build()
+            .unwrap();
+
+        assert_eq!(agent.config.streaming, Some(true));
+    }
+
+    #[test]
+    fn test_builder_streaming_default_is_none() {
+        let agent =
+            RemoteA2aAgent::builder("test").agent_url("http://localhost:8080").build().unwrap();
+
+        assert_eq!(agent.config.streaming, None);
+    }
+
+    #[test]
+    fn test_convert_task_to_events_with_artifacts_and_history() {
+        use crate::a2a::{Artifact, Message, Task, TaskState, TaskStatus};
+
+        let task = Task {
+            id: "task-123".to_string(),
+            context_id: Some("ctx-456".to_string()),
+            status: TaskStatus { state: TaskState::Completed, message: Some("Done".to_string()) },
+            artifacts: Some(vec![Artifact {
+                artifact_id: "art-1".to_string(),
+                name: Some("result".to_string()),
+                description: None,
+                parts: vec![A2aPart::text("artifact content".to_string())],
+                metadata: None,
+                extensions: None,
+            }]),
+            history: Some(vec![
+                Message::builder()
+                    .role(Role::Agent)
+                    .parts(vec![A2aPart::text("Hello from agent".to_string())])
+                    .build(),
+            ]),
+        };
+
+        let events = convert_task_to_events("inv-1", "remote-agent", task);
+
+        // Should have 3 events: artifact, history message, final status
+        assert_eq!(events.len(), 3);
+
+        // Artifact event
+        assert_eq!(events[0].author, "remote-agent");
+        let content = events[0].llm_response.content.as_ref().unwrap();
+        assert_eq!(content.parts[0], Part::Text { text: "artifact content".to_string() });
+
+        // History event
+        assert_eq!(events[1].author, "remote-agent");
+        let content = events[1].llm_response.content.as_ref().unwrap();
+        assert_eq!(content.parts[0], Part::Text { text: "Hello from agent".to_string() });
+        assert!(!events[1].llm_response.turn_complete);
+
+        // Final status event
+        assert_eq!(events[2].author, "remote-agent");
+        assert!(events[2].llm_response.turn_complete);
+    }
+
+    #[test]
+    fn test_convert_task_to_events_empty_task() {
+        use crate::a2a::{Task, TaskState, TaskStatus};
+
+        let task = Task {
+            id: "task-empty".to_string(),
+            context_id: None,
+            status: TaskStatus { state: TaskState::Completed, message: None },
+            artifacts: None,
+            history: None,
+        };
+
+        let events = convert_task_to_events("inv-1", "agent", task);
+
+        // A completed task with no message and no artifacts produces no events
+        // because convert_update_event only emits for final_update with a message
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn test_convert_task_to_events_status_with_message() {
+        use crate::a2a::{Task, TaskState, TaskStatus};
+
+        let task = Task {
+            id: "task-msg".to_string(),
+            context_id: None,
+            status: TaskStatus {
+                state: TaskState::Completed,
+                message: Some("All done".to_string()),
+            },
+            artifacts: None,
+            history: None,
+        };
+
+        let events = convert_task_to_events("inv-1", "agent", task);
+
+        assert_eq!(events.len(), 1);
+        assert!(events[0].llm_response.turn_complete);
+        let content = events[0].llm_response.content.as_ref().unwrap();
+        assert_eq!(content.parts[0], Part::Text { text: "All done".to_string() });
     }
 }
 
@@ -253,6 +463,9 @@ pub mod v1_remote {
         pub description: String,
         /// The v1.0.0 agent card describing the remote agent.
         pub agent_card: AgentCard,
+        /// Whether to use streaming for communication.
+        /// If `None`, auto-detects from the agent card capabilities.
+        pub streaming: Option<bool>,
     }
 
     /// An agent that communicates with a remote A2A v1.0.0 agent.
@@ -298,6 +511,7 @@ pub mod v1_remote {
             let card = self.config.agent_card.clone();
             let invocation_id = ctx.invocation_id().to_string();
             let agent_name = self.config.name.clone();
+            let config_streaming = self.config.streaming;
 
             // Get user content from context
             let user_content = extract_user_text(ctx.as_ref());
@@ -319,60 +533,132 @@ pub mod v1_remote {
                 // Build a card with the selected interface for the client
                 let client = A2aV1Client::new(card.clone());
 
+                // Determine if we should use streaming
+                let use_streaming = config_streaming.unwrap_or(card.capabilities.streaming.unwrap_or(false));
+
                 // Build a v1 Message from user content
                 let message = build_v1_message(user_content);
 
-                // Send streaming message and process the SSE response
-                match client.send_streaming_message(message).await {
-                    Ok(response) => {
-                        use futures::StreamExt;
+                if use_streaming {
+                    // Send streaming message and process the SSE response
+                    match client.send_streaming_message(message).await {
+                        Ok(response) => {
+                            use futures::StreamExt;
 
-                        let mut bytes_stream = response.bytes_stream();
-                        let mut buffer = String::new();
+                            let mut bytes_stream = response.bytes_stream();
+                            let mut buffer = String::new();
 
-                        while let Some(chunk_result) = bytes_stream.next().await {
-                            let chunk = match chunk_result {
-                                Ok(c) => c,
-                                Err(e) => {
-                                    yield Ok(create_v1_error_event(
-                                        &invocation_id,
-                                        &agent_name,
-                                        &format!("stream error: {e}"),
-                                    ));
-                                    break;
-                                }
-                            };
-
-                            buffer.push_str(&String::from_utf8_lossy(&chunk));
-
-                            // Process complete SSE events (delimited by \n\n)
-                            while let Some(event_end) = buffer.find("\n\n") {
-                                let event_data = buffer[..event_end].to_string();
-                                buffer = buffer[event_end + 2..].to_string();
-
-                                if let Some(data) = parse_sse_data_line(&event_data) {
-                                    if data.is_empty() {
-                                        continue;
+                            while let Some(chunk_result) = bytes_stream.next().await {
+                                let chunk = match chunk_result {
+                                    Ok(c) => c,
+                                    Err(e) => {
+                                        yield Ok(create_v1_error_event(
+                                            &invocation_id,
+                                            &agent_name,
+                                            &format!("stream error: {e}"),
+                                        ));
+                                        break;
                                     }
+                                };
 
-                                    // Parse as StreamResponse (may be wrapped in JSON-RPC or direct)
-                                    if let Some(event) = parse_stream_response(
-                                        &data,
-                                        &invocation_id,
-                                        &agent_name,
-                                    ) {
-                                        yield Ok(event);
+                                buffer.push_str(&String::from_utf8_lossy(&chunk));
+
+                                // Process complete SSE events (delimited by \n\n)
+                                while let Some(event_end) = buffer.find("\n\n") {
+                                    let event_data = buffer[..event_end].to_string();
+                                    buffer = buffer[event_end + 2..].to_string();
+
+                                    if let Some(data) = parse_sse_data_line(&event_data) {
+                                        if data.is_empty() {
+                                            continue;
+                                        }
+
+                                        // Parse as StreamResponse (may be wrapped in JSON-RPC or direct)
+                                        if let Some(event) = parse_stream_response(
+                                            &data,
+                                            &invocation_id,
+                                            &agent_name,
+                                        ) {
+                                            yield Ok(event);
+                                        }
                                     }
                                 }
                             }
                         }
+                        Err(e) => {
+                            yield Ok(create_v1_error_event(
+                                &invocation_id,
+                                &agent_name,
+                                &format!("failed to send streaming message: {e}"),
+                            ));
+                        }
                     }
-                    Err(e) => {
-                        yield Ok(create_v1_error_event(
-                            &invocation_id,
-                            &agent_name,
-                            &format!("failed to send streaming message: {e}"),
-                        ));
+                } else {
+                    // Send non-streaming message
+                    match client.send_message(message).await {
+                        Ok(task) => {
+                            // Yield events for artifacts
+                            if let Some(artifacts) = task.artifacts {
+                                for artifact in artifacts {
+                                    let resp = a2a_protocol_types::events::StreamResponse::ArtifactUpdate(
+                                        a2a_protocol_types::events::TaskArtifactUpdateEvent {
+                                            task_id: task.id.clone(),
+                                            context_id: task.context_id.clone(),
+                                            artifact,
+                                            append: Some(false),
+                                            last_chunk: Some(true),
+                                            metadata: None,
+                                        }
+                                    );
+                                    if let Some(event) = convert_stream_response(&resp, &invocation_id, &agent_name) {
+                                        yield Ok(event);
+                                    }
+                                }
+                            }
+
+                            // Yield events for history (agent messages)
+                            if let Some(history) = task.history {
+                                for msg in history {
+                                    if msg.role == a2a_protocol_types::MessageRole::Agent {
+                                        use a2a_protocol_types::PartContent;
+                                        let text_parts: Vec<Part> = msg.parts.iter().filter_map(|p| {
+                                            match &p.content {
+                                                PartContent::Text(text) => Some(Part::Text { text: text.clone() }),
+                                                _ => None,
+                                            }
+                                        }).collect();
+
+                                        if !text_parts.is_empty() {
+                                            let mut event = Event::new(invocation_id.clone());
+                                            event.author = agent_name.clone();
+                                            event.llm_response.content = Some(Content { role: "model".to_string(), parts: text_parts });
+                                            event.llm_response.turn_complete = false;
+                                            yield Ok(event);
+                                        }
+                                    }
+                                }
+                            }
+
+                            // Yield final status event
+                            let resp = a2a_protocol_types::events::StreamResponse::StatusUpdate(
+                                a2a_protocol_types::events::TaskStatusUpdateEvent {
+                                    task_id: task.id,
+                                    context_id: task.context_id,
+                                    status: task.status,
+                                    metadata: None,
+                                }
+                            );
+                            if let Some(event) = convert_stream_response(&resp, &invocation_id, &agent_name) {
+                                yield Ok(event);
+                            }
+                        }
+                        Err(e) => {
+                            yield Ok(create_v1_error_event(
+                                &invocation_id,
+                                &agent_name,
+                                &format!("failed to send message: {e}"),
+                            ));
+                        }
                     }
                 }
 


### PR DESCRIPTION
## What

Add non-streaming communication support to `RemoteA2aAgent` and `RemoteA2aV1Agent`. Not all A2A agents support streaming — this allows graceful fallback to request/response.

## Why

Closes #343 — supersedes the PR from @lsas-okazaki with proper implementation, test coverage, and preserved error-case tests.

## How

- Added `streaming: Option<bool>` to `RemoteA2aConfig` and `RemoteA2aV1Config`
- Added `.streaming(bool)` builder method
- When `streaming = Some(false)` or the remote agent's capabilities don't support streaming, uses `send_message()` instead of `send_streaming_message()`
- Converts the `Task` response into the same event sequence (artifacts → history → status) that streaming would produce
- Auto-detects from agent card capabilities when not explicitly set

## Tests (7 passing)

- `test_builder` — existing builder test
- `test_builder_missing_url` — preserved error case
- `test_builder_streaming_option` — explicit streaming setting
- `test_builder_streaming_default_is_none` — auto-detect default
- `test_convert_task_to_events_with_artifacts_and_history` — full task conversion
- `test_convert_task_to_events_empty_task` — edge case (no artifacts/history/message)
- `test_convert_task_to_events_status_with_message` — status message extraction

## Quality Gates

- `cargo fmt` — clean
- `cargo clippy -p adk-server -- -D warnings` — clean
- `cargo test -p adk-server -- remote` — 7 passed, 0 failed