### PR TITLE
fix: UTF-8 boundary panics and CJK search failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,11 +4,11 @@ Rust Agent Development Kit — a modular workspace of publishable crates for bui
 
 ## Dev environment
 
-- Rust 1.85.0+, edition 2024. Use `make setup` or `devenv shell` to bootstrap.
+- Rust 1.96.0+, edition 2024. Use `make setup` or `devenv shell` to bootstrap.
 - `sccache` is the compilation cache. Set `RUSTC_WRAPPER=sccache` in your shell profile.
 - On Linux, `wild` is the linker (configured in `.cargo/config.toml`). macOS uses the default linker.
 - Copy `.env.example` to `.env` for API keys. Never commit `.env` files or secrets.
-- `adk-mistralrs` is a workspace member but requires Rust 1.88+ (mistralrs 0.8.1 dependency). GPU features (`cuda`, `metal`) are opt-in.
+- `adk-mistralrs` is a workspace member using workspace version inheritance. GPU features (`cuda`, `metal`) are opt-in.
 - `CMAKE_POLICY_VERSION_MINIMUM=3.5` is needed for cmake 4.x compatibility (audiopus).
 - **Performance**: `.cargo/config.toml` sets `incremental = false` globally for `sccache` compatibility, but `Cargo.toml` `[profile.dev]` overrides this with `incremental = true` for local dev builds. CI uses the `ci` profile where the config.toml setting applies.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   All `adk-*` crates move from 0.9.x to 0.10.0 in lockstep.
 - **adk-mistralrs: Now a workspace member.** Previously excluded due to git
   dependencies; now included since mistral.rs published to crates.io.
-  `rust-version` bumped to 1.88.0 (required by mistralrs 0.8.1).
+  Uses workspace `rust-version` (1.96.0).
 - **adk-core: `LlmResponse` and `LlmRequest` gained public fields.** These structs
   are not `#[non_exhaustive]` and are constructed with struct literals downstream,
   so the additions below are breaking changes for external code that builds them
@@ -1619,7 +1619,7 @@ let toolset = McpHttpClientBuilder::new("https://api.githubcopilot.com/mcp/")
 
 ### Changed
 - All ADK crates bumped to version 0.2.0
-- Rust edition updated to 2024, requires Rust 1.85+
+- Rust edition updated to 2024, requires Rust 1.96+
 
 ## [0.1.9] - 2026-01-03
 
@@ -1719,7 +1719,7 @@ let toolset = McpHttpClientBuilder::new("https://api.githubcopilot.com/mcp/")
 - **Host flag**: `--host` flag for backend and studio management scripts
 
 ### 🔥 Breaking Changes
-- **Rust 2024 Edition**: All crates now use `edition = "2024"` (requires Rust 1.85+)
+- **Rust 2024 Edition**: All crates now use `edition = "2024"` (requires Rust 1.96+)
 - **Workspace Restructure**: `vendor/gemini-rust` → `adk-gemini`
   - Import paths change from `gemini_rust::*` to `adk_gemini::*`
   - Standardized workspace dependencies for consistency

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ cargo nextest run --workspace
 
 ### Prerequisites
 
-- Rust 1.85.0+ (edition 2024)
+- Rust 1.96.0+ (edition 2024)
 - For browser examples: Chrome/Chromium
 - For `openai-webrtc` feature: cmake (audiopus builds Opus from source)
 - For mistral.rs: see [adk-mistralrs section](#adk-mistralrs)
@@ -348,7 +348,7 @@ If your change is purely internal refactoring with no behavior change, existing 
 
 ### Rust Conventions
 
-- Edition 2024, MSRV 1.85.0
+- Edition 2024, MSRV 1.96.0
 - `thiserror` for library error types
 - `async-trait` for async trait methods
 - `Arc<T>` for shared ownership across async boundaries

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ opt-level = 2
 [workspace.package]
 version = "0.10.0"
 edition = "2024"
-rust-version = "1.85.0"
+rust-version = "1.96.0"
 license = "Apache-2.0"
 authors = ["James Karanja Maina <james.karanja@zavora.ai>"]
 homepage = "https://www.zavora.ai"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![docs.rs](https://docs.rs/adk-rust/badge.svg)](https://docs.rs/adk-rust)
 [![Wiki](https://img.shields.io/badge/docs-Wiki-blue)](https://github.com/zavora-ai/adk-rust/wiki)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-![Rust](https://img.shields.io/badge/rust-1.85%2B-orange.svg)
+![Rust](https://img.shields.io/badge/rust-1.96%2B-orange.svg)
 [![GitHub Discussions](https://img.shields.io/github/discussions/zavora-ai/adk-rust?style=flat&logo=github&color=5865F2)](https://github.com/zavora-ai/adk-rust/discussions)
 
 > **🚀 v0.9.2 Released!** Composable Template System — 8 base templates, 9 addons, 5 enterprise patterns via `cargo adk new --addon`. Plus: `cargo adk build` (compile without deploying), provider-aware schema normalization, A2A Simple Scaffolding, and security fixes (hickory-proto, openssl, rubato, similar). See [CHANGELOG](CHANGELOG.md) for full details.
@@ -233,7 +233,7 @@ Use `cargo adk build` to verify compilation without deploying.
 
 ### Manual installation
 
-Requires Rust 1.85 or later (Rust 2024 edition). Add to your `Cargo.toml`:
+Requires Rust 1.96 or later (Rust 2024 edition). Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]

--- a/adk-anthropic/examples/citations.rs
+++ b/adk-anthropic/examples/citations.rs
@@ -173,5 +173,13 @@ fn print_cited_response(content: &[ContentBlock]) {
 }
 
 fn truncate(s: &str, max: usize) -> String {
-    if s.len() <= max { s.to_string() } else { format!("{}…", &s[..max]) }
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        let mut end = max;
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}…", &s[..end])
+    }
 }

--- a/adk-gemini/examples/simple_thought_signature.rs
+++ b/adk-gemini/examples/simple_thought_signature.rs
@@ -72,9 +72,13 @@ async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
         );
 
         if let Some(signature) = thought_signature {
+            let mut end = 50.min(signature.len());
+            while end > 0 && !signature.is_char_boundary(end) {
+                end -= 1;
+            }
             info!(
                 signature_length = signature.len(),
-                preview = &signature[..50.min(signature.len())],
+                preview = &signature[..end],
                 "thought signature present"
             );
         } else {

--- a/adk-gemini/examples/text_thought_signature_example.rs
+++ b/adk-gemini/examples/text_thought_signature_example.rs
@@ -143,7 +143,11 @@ fn do_main() -> Result<(), Box<dyn std::error::Error>> {
                 );
 
                 if let Some(sig) = thought_signature {
-                    info!(signature_preview = &sig[..10.min(sig.len())], "preserve signature");
+                    let mut end = 10.min(sig.len());
+                    while end > 0 && !sig.is_char_boundary(end) {
+                        end -= 1;
+                    }
+                    info!(signature_preview = &sig[..end], "preserve signature");
                 }
             }
         }

--- a/adk-memory/src/postgres.rs
+++ b/adk-memory/src/postgres.rs
@@ -428,7 +428,7 @@ impl MemoryService for PostgresMemoryService {
                     INSERT INTO memory_entries
                         (app_name, user_id, session_id, content, author, timestamp, embedding, search_text, project_id)
                     VALUES
-                        ($1, $2, $3, $4, $5, $6, $7, to_tsvector('english', $8), $9)
+                        ($1, $2, $3, $4, $5, $6, $7, to_tsvector('simple', $8), $9)
                     "#,
                 )
                 .bind(app_name)
@@ -449,7 +449,7 @@ impl MemoryService for PostgresMemoryService {
                     INSERT INTO memory_entries
                         (app_name, user_id, session_id, content, author, timestamp, search_text, project_id)
                     VALUES
-                        ($1, $2, $3, $4, $5, $6, to_tsvector('english', $7), $8)
+                        ($1, $2, $3, $4, $5, $6, to_tsvector('simple', $7), $8)
                     "#,
                 )
                 .bind(app_name)
@@ -583,10 +583,10 @@ impl MemoryService for PostgresMemoryService {
                 None => {
                     sqlx::query(
                         r#"
-                        SELECT content, author, timestamp, ts_rank(search_text, plainto_tsquery('english', $3)) AS rank_score
+                        SELECT content, author, timestamp, ts_rank(search_text, plainto_tsquery('simple', $3)) AS rank_score
                         FROM memory_entries
                         WHERE app_name = $1 AND user_id = $2
-                          AND search_text @@ plainto_tsquery('english', $3)
+                          AND search_text @@ plainto_tsquery('simple', $3)
                           AND project_id IS NULL
                         ORDER BY rank_score DESC
                         LIMIT $4
@@ -603,10 +603,10 @@ impl MemoryService for PostgresMemoryService {
                 Some(pid) => {
                     sqlx::query(
                         r#"
-                        SELECT content, author, timestamp, ts_rank(search_text, plainto_tsquery('english', $3)) AS rank_score
+                        SELECT content, author, timestamp, ts_rank(search_text, plainto_tsquery('simple', $3)) AS rank_score
                         FROM memory_entries
                         WHERE app_name = $1 AND user_id = $2
-                          AND search_text @@ plainto_tsquery('english', $3)
+                          AND search_text @@ plainto_tsquery('simple', $3)
                           AND (project_id IS NULL OR project_id = $5)
                         ORDER BY rank_score DESC
                         LIMIT $4
@@ -685,7 +685,7 @@ impl MemoryService for PostgresMemoryService {
             r#"
             DELETE FROM memory_entries
             WHERE app_name = $1 AND user_id = $2
-              AND search_text @@ plainto_tsquery('english', $3)
+              AND search_text @@ plainto_tsquery('simple', $3)
               AND project_id IS NULL
             "#,
         )
@@ -741,7 +741,7 @@ impl MemoryService for PostgresMemoryService {
                     INSERT INTO memory_entries
                         (app_name, user_id, session_id, content, author, timestamp, embedding, search_text, project_id)
                     VALUES
-                        ($1, $2, $3, $4, $5, $6, $7, to_tsvector('english', $8), $9)
+                        ($1, $2, $3, $4, $5, $6, $7, to_tsvector('simple', $8), $9)
                     "#,
                 )
                 .bind(app_name)
@@ -762,7 +762,7 @@ impl MemoryService for PostgresMemoryService {
                     INSERT INTO memory_entries
                         (app_name, user_id, session_id, content, author, timestamp, search_text, project_id)
                     VALUES
-                        ($1, $2, $3, $4, $5, $6, to_tsvector('english', $7), $8)
+                        ($1, $2, $3, $4, $5, $6, to_tsvector('simple', $7), $8)
                     "#,
                 )
                 .bind(app_name)
@@ -812,7 +812,7 @@ impl MemoryService for PostgresMemoryService {
                 INSERT INTO memory_entries
                     (app_name, user_id, session_id, content, author, timestamp, embedding, search_text, project_id)
                 VALUES
-                    ($1, $2, $3, $4, $5, $6, $7, to_tsvector('english', $8), $9)
+                    ($1, $2, $3, $4, $5, $6, $7, to_tsvector('simple', $8), $9)
                 "#,
             )
             .bind(app_name)
@@ -833,7 +833,7 @@ impl MemoryService for PostgresMemoryService {
                 INSERT INTO memory_entries
                     (app_name, user_id, session_id, content, author, timestamp, search_text, project_id)
                 VALUES
-                    ($1, $2, $3, $4, $5, $6, to_tsvector('english', $7), $8)
+                    ($1, $2, $3, $4, $5, $6, to_tsvector('simple', $7), $8)
                 "#,
             )
             .bind(app_name)
@@ -866,7 +866,7 @@ impl MemoryService for PostgresMemoryService {
             r#"
             DELETE FROM memory_entries
             WHERE app_name = $1 AND user_id = $2
-              AND search_text @@ plainto_tsquery('english', $3)
+              AND search_text @@ plainto_tsquery('simple', $3)
               AND project_id = $4
             "#,
         )

--- a/adk-memory/src/text.rs
+++ b/adk-memory/src/text.rs
@@ -19,9 +19,80 @@ pub fn extract_text(content: &adk_core::Content) -> String {
         .join(" ")
 }
 
+/// Returns `true` if the character is in a CJK Unified Ideographs block.
+fn is_cjk_char(c: char) -> bool {
+    matches!(c,
+        '\u{4e00}'..='\u{9fff}'   // CJK Unified Ideographs
+        | '\u{3400}'..='\u{4dbf}' // CJK Unified Ideographs Extension A
+        | '\u{f900}'..='\u{faff}' // CJK Compatibility Ideographs
+        | '\u{2e80}'..='\u{2eff}' // CJK Radicals Supplement
+        | '\u{3000}'..='\u{303f}' // CJK Symbols and Punctuation
+        | '\u{3040}'..='\u{309f}' // Hiragana
+        | '\u{30a0}'..='\u{30ff}' // Katakana
+        | '\u{ac00}'..='\u{d7af}' // Hangul Syllables
+    )
+}
+
 /// Tokenize text into a set of lowercase words for keyword matching.
+///
+/// For whitespace-separated languages (English, etc.), splits on whitespace.
+/// For CJK text (Chinese, Japanese, Korean) which has no word-separating
+/// whitespace, generates character-level unigrams and bigrams to enable
+/// substring matching.
 pub fn extract_words(text: &str) -> HashSet<String> {
-    text.split_whitespace().filter(|s| !s.is_empty()).map(|s| s.to_lowercase()).collect()
+    let mut words = HashSet::new();
+
+    for token in text.split_whitespace() {
+        if token.is_empty() {
+            continue;
+        }
+        let lower = token.to_lowercase();
+
+        // Check if this token contains CJK characters
+        let has_cjk = lower.chars().any(is_cjk_char);
+
+        if has_cjk {
+            // For CJK tokens, generate character unigrams and bigrams
+            // This enables partial matching: "编程" matches within "用户喜欢用Rust编程"
+            let chars: Vec<char> = lower.chars().collect();
+            for c in &chars {
+                if is_cjk_char(*c) {
+                    words.insert(c.to_string());
+                }
+            }
+            for window in chars.windows(2) {
+                if window.iter().any(|c| is_cjk_char(*c)) {
+                    let bigram: String = window.iter().collect();
+                    words.insert(bigram);
+                }
+            }
+            // Also insert the full token for exact matches
+            words.insert(lower);
+        } else {
+            words.insert(lower);
+        }
+    }
+
+    // Handle text with no whitespace at all (pure CJK string)
+    if !text.contains(char::is_whitespace) && text.chars().any(is_cjk_char) {
+        let lower = text.to_lowercase();
+        let chars: Vec<char> = lower.chars().collect();
+        for c in &chars {
+            if is_cjk_char(*c) {
+                words.insert(c.to_string());
+            }
+        }
+        for window in chars.windows(2) {
+            if window.iter().any(|c| is_cjk_char(*c)) {
+                let bigram: String = window.iter().collect();
+                words.insert(bigram);
+            }
+        }
+        // Also add the full string
+        words.insert(lower);
+    }
+
+    words
 }
 
 /// Extract and tokenize all text from a [`Content`](adk_core::Content) into word set.
@@ -33,4 +104,63 @@ pub fn extract_words_from_content(content: &adk_core::Content) -> HashSet<String
         }
     }
     words
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_words_english() {
+        let words = extract_words("Hello World foo bar");
+        assert!(words.contains("hello"));
+        assert!(words.contains("world"));
+        assert!(words.contains("foo"));
+        assert!(words.contains("bar"));
+    }
+
+    #[test]
+    fn test_extract_words_cjk_bigram_matching() {
+        // "用户喜欢用Rust编程" should produce bigrams that include "编程"
+        let stored = extract_words("用户喜欢用Rust编程");
+        let query = extract_words("编程");
+
+        // The query "编程" should match because it's a bigram in the stored text
+        let matches: HashSet<_> = stored.intersection(&query).collect();
+        assert!(
+            !matches.is_empty(),
+            "CJK search should find matches. Stored: {stored:?}, Query: {query:?}"
+        );
+    }
+
+    #[test]
+    fn test_extract_words_cjk_single_char() {
+        let stored = extract_words("今天天气很好");
+        let query = extract_words("天气");
+
+        let matches: HashSet<_> = stored.intersection(&query).collect();
+        assert!(
+            !matches.is_empty(),
+            "CJK bigram '天气' should match. Stored: {stored:?}, Query: {query:?}"
+        );
+    }
+
+    #[test]
+    fn test_extract_words_mixed_cjk_english() {
+        let words = extract_words("Hello 你好 World");
+        assert!(words.contains("hello"));
+        assert!(words.contains("world"));
+        assert!(words.contains("你"));
+        assert!(words.contains("好"));
+        assert!(words.contains("你好"));
+    }
+
+    #[test]
+    fn test_extract_words_japanese() {
+        let stored = extract_words("東京タワー");
+        let query = extract_words("東京");
+
+        let matches: HashSet<_> = stored.intersection(&query).collect();
+        assert!(!matches.is_empty(), "Japanese bigram should match");
+    }
 }

--- a/adk-mistralrs/Cargo.toml
+++ b/adk-mistralrs/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "adk-mistralrs"
-version = "0.10.0"
-edition = "2024"
-rust-version = "1.88.0"
-license = "MIT"
-authors = ["James Karanja Maina <james.karanja@zavora.ai>"]
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
 description = "mistral.rs integration for ADK-Rust - native local LLM inference with Gemma 4, Qwen 3.5, Voxtral, and 50+ model architectures"
-repository = "https://github.com/zavora-ai/adk-rust"
+repository.workspace = true
 readme = "README.md"
 keywords = ["ai", "agent", "adk", "mistral", "llm", "local-inference"]
 categories = ["api-bindings", "asynchronous"]

--- a/adk-model/examples/gemini_thinking.rs
+++ b/adk-model/examples/gemini_thinking.rs
@@ -57,7 +57,11 @@ async fn run_model(label: &str, model: &GeminiModel) {
                                 match part {
                                     Part::Thinking { thinking, .. } => {
                                         let preview = if thinking.len() > 120 {
-                                            format!("{}...", &thinking[..120])
+                                            let mut end = 120;
+                                            while end > 0 && !thinking.is_char_boundary(end) {
+                                                end -= 1;
+                                            }
+                                            format!("{}...", &thinking[..end])
                                         } else {
                                             thinking.clone()
                                         };

--- a/adk-model/examples/openrouter/chat_support.rs
+++ b/adk-model/examples/openrouter/chat_support.rs
@@ -62,5 +62,13 @@ fn trim_for_display(text: &str) -> String {
     const MAX_LEN: usize = 200;
 
     let compact = text.split_whitespace().collect::<Vec<_>>().join(" ");
-    if compact.len() <= MAX_LEN { compact } else { format!("{}...", &compact[..MAX_LEN]) }
+    if compact.len() <= MAX_LEN {
+        compact
+    } else {
+        let mut end = MAX_LEN;
+        while end > 0 && !compact.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}...", &compact[..end])
+    }
 }

--- a/adk-model/examples/openrouter/llm_support.rs
+++ b/adk-model/examples/openrouter/llm_support.rs
@@ -80,5 +80,13 @@ fn trim_for_display(text: &str) -> String {
     const MAX_LEN: usize = 200;
 
     let compact = text.split_whitespace().collect::<Vec<_>>().join(" ");
-    if compact.len() <= MAX_LEN { compact } else { format!("{}...", &compact[..MAX_LEN]) }
+    if compact.len() <= MAX_LEN {
+        compact
+    } else {
+        let mut end = MAX_LEN;
+        while end > 0 && !compact.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}...", &compact[..end])
+    }
 }

--- a/adk-model/examples/openrouter/responses_support.rs
+++ b/adk-model/examples/openrouter/responses_support.rs
@@ -49,5 +49,13 @@ fn trim_for_display(text: &str) -> String {
     const MAX_LEN: usize = 200;
 
     let compact = text.split_whitespace().collect::<Vec<_>>().join(" ");
-    if compact.len() <= MAX_LEN { compact } else { format!("{}...", &compact[..MAX_LEN]) }
+    if compact.len() <= MAX_LEN {
+        compact
+    } else {
+        let mut end = MAX_LEN;
+        while end > 0 && !compact.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}...", &compact[..end])
+    }
 }

--- a/adk-realtime/examples/debug_livekit_auth.rs
+++ b/adk-realtime/examples/debug_livekit_auth.rs
@@ -35,8 +35,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let token = token_builder.to_jwt()?;
     println!("Generated Token length: {}", token.len());
-    println!("Token start: {}...", &token[..10]);
-    println!("Token end: ...{}", &token[token.len() - 10..]);
+    println!("Token start: {}...", {
+        let mut e = 10.min(token.len());
+        while e > 0 && !token.is_char_boundary(e) {
+            e -= 1;
+        }
+        &token[..e]
+    });
+    println!("Token end: ...{}", {
+        let start = token.len().saturating_sub(10);
+        let mut s = start;
+        while s < token.len() && !token.is_char_boundary(s) {
+            s += 1;
+        }
+        &token[s..]
+    });
 
     // 2. Attempt Connection
     println!("Connecting to LiveKit room...");

--- a/adk-session/src/vertex.rs
+++ b/adk-session/src/vertex.rs
@@ -935,12 +935,52 @@ fn truncate_for_error(value: &str) -> String {
     if value.len() <= MAX_LEN {
         return value.to_string();
     }
-    format!("{}...", &value[..MAX_LEN])
+    let mut end = MAX_LEN;
+    while end > 0 && !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}...", &value[..end])
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_truncate_for_error_ascii() {
+        let short = "hello";
+        assert_eq!(truncate_for_error(short), "hello");
+
+        let long = "a".repeat(600);
+        let result = truncate_for_error(&long);
+        assert!(result.ends_with("..."));
+        assert!(result.len() <= 515); // 512 + "..."
+    }
+
+    #[test]
+    fn test_truncate_for_error_multibyte_no_panic() {
+        // Chinese characters are 3 bytes each in UTF-8
+        // 200 repetitions of "你好" = 1200 bytes, byte 512 is NOT a char boundary
+        let value = "你好".repeat(200);
+        assert_eq!(value.len(), 1200);
+        assert!(!value.is_char_boundary(512)); // confirms the bug condition
+
+        // This must NOT panic
+        let result = truncate_for_error(&value);
+        assert!(result.ends_with("..."));
+        assert!(result.is_char_boundary(result.len())); // valid UTF-8
+    }
+
+    #[test]
+    fn test_truncate_for_error_emoji() {
+        // Emoji are 4 bytes each
+        let value = "🎉".repeat(200); // 800 bytes
+        let result = truncate_for_error(&value);
+        assert!(result.ends_with("..."));
+        // Should truncate to a valid char boundary
+        let without_dots = &result[..result.len() - 3];
+        assert!(without_dots.is_char_boundary(without_dots.len()));
+    }
 
     #[test]
     fn test_extract_reasoning_engine_id_from_resource_name() {

--- a/docs/official_docs/a2a/getting-started.md
+++ b/docs/official_docs/a2a/getting-started.md
@@ -4,7 +4,7 @@ Create and run an A2A (Agent-to-Agent) protocol agent in under 5 minutes.
 
 ## Prerequisites
 
-- Rust 1.85.0 or later (`rustup update stable`)
+- Rust 1.96.0 or later (`rustup update stable`)
 - `cargo-adk` installed (`cargo install cargo-adk`)
 - A Google API key ([get one here](https://aistudio.google.com/app/apikey))
 

--- a/docs/official_docs/development/development-guidelines.md
+++ b/docs/official_docs/development/development-guidelines.md
@@ -18,7 +18,7 @@ This document provides comprehensive guidelines for developers contributing to A
 
 ### Prerequisites
 
-- **Rust**: 1.85.0 or higher (edition 2024, check with `rustc --version`)
+- **Rust**: 1.96.0 or higher (edition 2024, check with `rustc --version`)
 - **Cargo**: Latest stable
 - **Git**: For version control
 - **sccache** (recommended): Compilation cache that cuts rebuild times by ~70%

--- a/docs/official_docs/introduction.md
+++ b/docs/official_docs/introduction.md
@@ -2,7 +2,7 @@
 
 Agent Development Kit (ADK) is a flexible and modular framework for developing and deploying AI agents. While optimized for Gemini and the Google ecosystem, ADK is model-agnostic, deployment-agnostic, and built for compatibility with other frameworks. ADK was designed to make agent development feel more like software development, making it easier for developers to create, deploy, and orchestrate agentic architectures that range from simple tasks to complex workflows.
 
-> **Note:** ADK-Rust v0.8.0 requires Rust 1.85.0 or higher.
+> **Note:** ADK-Rust v0.8.0 requires Rust 1.96.0 or higher.
 
 ## Installation
 

--- a/docs/official_docs/quickstart.md
+++ b/docs/official_docs/quickstart.md
@@ -4,7 +4,7 @@ Create your first AI agent in under 5 minutes.
 
 ## Prerequisites
 
-- Rust 1.85.0 or later (`rustup update stable`)
+- Rust 1.96.0 or later (`rustup update stable`)
 - A Google API key ([get one here](https://aistudio.google.com/app/apikey))
 
 ## Step 1: Scaffold Your Project

--- a/examples/a2a_interceptors/README.md
+++ b/examples/a2a_interceptors/README.md
@@ -15,7 +15,7 @@ Demonstrates ADK-Rust's A2A (Agent-to-Agent) interceptor chain for request proce
 
 ## Prerequisites
 
-- **Rust 1.85+** (edition 2024)
+- **Rust 1.96+** (edition 2024)
 - **`GOOGLE_API_KEY`** environment variable set with a valid Gemini API key
 
 Set up your environment:

--- a/examples/acp_kiro/Cargo.lock
+++ b/examples/acp_kiro/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
 
 [[package]]
 name = "adk-acp"
-version = "0.8.5"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "agent-client-protocol",
@@ -32,7 +32,7 @@ dependencies = [
 
 [[package]]
 name = "adk-agent"
-version = "0.8.5"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "adk-telemetry",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "0.8.5"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -62,7 +62,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "0.8.5"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "0.8.5"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "0.8.5"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "adk-session",
@@ -116,6 +116,7 @@ dependencies = [
  "futures",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
  "tokio-util",
  "tracing",
@@ -124,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust"
-version = "0.8.5"
+version = "0.10.0"
 dependencies = [
  "adk-agent",
  "adk-core",
@@ -141,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "0.8.5"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -154,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "0.8.5"
+version = "0.10.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/acp_kiro/src/delegate.rs
+++ b/examples/acp_kiro/src/delegate.rs
@@ -18,15 +18,15 @@
 //! ```
 
 use adk_acp::{AcpAgentTool, PermissionDecision, PermissionPolicy, UsageTracker};
-use adk_rust::prelude::*;
 use adk_rust::Launcher;
+use adk_rust::prelude::*;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
 
-    let api_key = std::env::var("GOOGLE_API_KEY")
-        .map_err(|_| anyhow::anyhow!("GOOGLE_API_KEY not set"))?;
+    let api_key =
+        std::env::var("GOOGLE_API_KEY").map_err(|_| anyhow::anyhow!("GOOGLE_API_KEY not set"))?;
 
     let model = GeminiModel::new(&api_key, "gemini-2.5-flash")?;
 
@@ -89,10 +89,7 @@ async fn main() -> anyhow::Result<()> {
         println!("   Total chars received: {}", stats.total_response_chars);
         println!("   Total time: {:?}", stats.total_duration);
         if stats.total_calls > 0 {
-            println!(
-                "   Avg latency: {:?}",
-                stats.total_duration / stats.total_calls as u32
-            );
+            println!("   Avg latency: {:?}", stats.total_duration / stats.total_calls as u32);
         }
     }
 

--- a/examples/acp_kiro/src/direct.rs
+++ b/examples/acp_kiro/src/direct.rs
@@ -20,8 +20,8 @@ use std::time::Instant;
 async fn main() -> anyhow::Result<()> {
     println!("=== ADK-ACP: Direct connection to Kiro CLI ===\n");
 
-    let config = AcpAgentConfig::new("kiro-cli acp --trust-all-tools")
-        .working_dir(std::env::current_dir()?);
+    let config =
+        AcpAgentConfig::new("kiro-cli acp --trust-all-tools").working_dir(std::env::current_dir()?);
 
     let prompt = "What files are in the current directory? List the first 5.";
     println!("Prompt: \"{prompt}\"\n");

--- a/examples/acp_kiro/src/env_and_cancel.rs
+++ b/examples/acp_kiro/src/env_and_cancel.rs
@@ -29,10 +29,7 @@ async fn main() -> anyhow::Result<()> {
         // These env vars are passed to the child process via Command::env()
         .env("ADK_EXAMPLE_MODE", "true")
         .env("ADK_EXAMPLE_NAME", "env-cancel-demo")
-        .envs([
-            ("CUSTOM_VAR_1", "hello"),
-            ("CUSTOM_VAR_2", "world"),
-        ]);
+        .envs([("CUSTOM_VAR_1", "hello"), ("CUSTOM_VAR_2", "world")]);
 
     println!("Config created with {} env vars:", config.env.len());
     for (k, v) in &config.env {
@@ -59,7 +56,16 @@ async fn main() -> anyhow::Result<()> {
 
     // Start a prompt that would take a while
     let session_clone_prompt = "Write a detailed 500-word essay about the history of Rust programming language. Include dates, key contributors, and major milestones.";
-    println!("Sending long prompt: \"{}\"\n", &session_clone_prompt[..60]);
+    println!("Sending long prompt: \"{}...\"\n", {
+        let end = {
+            let mut e = 60.min(session_clone_prompt.len());
+            while e > 0 && !session_clone_prompt.is_char_boundary(e) {
+                e -= 1;
+            }
+            e
+        };
+        &session_clone_prompt[..end]
+    });
 
     // Race: prompt vs timeout
     let prompt_future = session.prompt(session_clone_prompt);

--- a/examples/acp_kiro/src/session.rs
+++ b/examples/acp_kiro/src/session.rs
@@ -17,8 +17,8 @@ use std::sync::Arc;
 async fn main() -> anyhow::Result<()> {
     println!("=== ADK-ACP: Persistent Session with Kiro CLI ===\n");
 
-    let config = AcpAgentConfig::new("kiro-cli acp --trust-all-tools")
-        .working_dir(std::env::current_dir()?);
+    let config =
+        AcpAgentConfig::new("kiro-cli acp --trust-all-tools").working_dir(std::env::current_dir()?);
 
     let policy = Arc::new(PermissionPolicy::AutoApprove);
 
@@ -36,9 +36,8 @@ async fn main() -> anyhow::Result<()> {
 
     // Second prompt — uses context from first
     println!("─── Prompt 2: Use established context ───");
-    let r2 = session
-        .prompt("Which of those files handles error types? Answer in one sentence.")
-        .await?;
+    let r2 =
+        session.prompt("Which of those files handles error types? Answer in one sentence.").await?;
     println!("{}", r2.text);
     println!("  (latency: {:?}, prompt #{})\n", r2.duration, r2.prompt_count);
 

--- a/examples/agent_registry/README.md
+++ b/examples/agent_registry/README.md
@@ -14,7 +14,7 @@ Demonstrates the Agent Registry REST API from ADK-Rust v0.8.0 for registering, d
 
 ## Prerequisites
 
-- Rust 1.85+
+- Rust 1.96+
 - No LLM provider or API keys required
 
 ## Environment Variables

--- a/examples/awp_agent/Cargo.lock
+++ b/examples/awp_agent/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "adk-awp"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "arc-swap",
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -97,7 +97,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -174,7 +174,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "awp-types"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "chrono",
  "serde",

--- a/examples/awp_agent/src/main.rs
+++ b/examples/awp_agent/src/main.rs
@@ -94,20 +94,17 @@ async fn ask_agent(State(state): State<AppState>, Json(body): Json<AskRequest>) 
     }
 
     // Run the agent
-    let mut event_stream = match state
-        .runner
-        .run_str("visitor", &session_id_str, user_content)
-        .await
-    {
-        Ok(s) => s,
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({"error": format!("runner error: {e}")})),
-            )
-                .into_response();
-        }
-    };
+    let mut event_stream =
+        match state.runner.run_str("visitor", &session_id_str, user_content).await {
+            Ok(s) => s,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"error": format!("runner error: {e}")})),
+                )
+                    .into_response();
+            }
+        };
 
     // Collect the final agent response
     let mut response_text = String::new();
@@ -168,10 +165,7 @@ async fn main() -> anyhow::Result<()> {
     let business_toml = Path::new(env!("CARGO_MANIFEST_DIR")).join("business.toml");
     let loader = BusinessContextLoader::from_file(&business_toml)?;
     let ctx = loader.load();
-    println!(
-        "📋 Loaded business context: {} ({})",
-        ctx.site_name, ctx.domain
-    );
+    println!("📋 Loaded business context: {} ({})", ctx.site_name, ctx.domain);
     println!(
         "   {} capabilities, {} policies, {} products\n",
         ctx.capabilities.len(),
@@ -195,16 +189,8 @@ async fn main() -> anyhow::Result<()> {
          Keep answers concise and helpful.",
         site = ctx.site_name,
         desc = ctx.site_description,
-        tone = ctx
-            .brand_voice
-            .as_ref()
-            .and_then(|b| b.tone.as_deref())
-            .unwrap_or("professional"),
-        greeting = ctx
-            .brand_voice
-            .as_ref()
-            .and_then(|b| b.greeting.as_deref())
-            .unwrap_or("Hello!"),
+        tone = ctx.brand_voice.as_ref().and_then(|b| b.tone.as_deref()).unwrap_or("professional"),
+        greeting = ctx.brand_voice.as_ref().and_then(|b| b.greeting.as_deref()).unwrap_or("Hello!"),
         products = ctx
             .products
             .iter()
@@ -248,10 +234,7 @@ async fn main() -> anyhow::Result<()> {
             .build()?,
     );
 
-    let app_state = AppState {
-        runner,
-        session_service,
-    };
+    let app_state = AppState { runner, session_service };
 
     // --- Step 4: Build AWP state with all protocol services ---
     let event_service = Arc::new(InMemoryEventSubscriptionService::new());
@@ -273,9 +256,7 @@ async fn main() -> anyhow::Result<()> {
         .route("/api/products", get(list_products))
         .with_state(app_state);
 
-    let app = axum::Router::new()
-        .merge(awp_routes(awp_state))
-        .merge(custom_routes);
+    let app = axum::Router::new().merge(awp_routes(awp_state)).merge(custom_routes);
 
     // --- Step 6: Start the server ---
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
@@ -292,10 +273,7 @@ async fn main() -> anyhow::Result<()> {
 
     // 7a. Discovery document
     println!("── AWP Discovery ──────────────────────────────");
-    let resp = client
-        .get(format!("{base}/.well-known/awp.json"))
-        .send()
-        .await?;
+    let resp = client.get(format!("{base}/.well-known/awp.json")).send().await?;
     println!("GET /.well-known/awp.json → {}", resp.status());
     let doc: serde_json::Value = resp.json().await?;
     println!("  siteName: {}", doc["siteName"]);
@@ -309,10 +287,7 @@ async fn main() -> anyhow::Result<()> {
     let manifest: serde_json::Value = resp.json().await?;
     println!("  @context: {}", manifest["@context"]);
     println!("  @type: {}", manifest["@type"]);
-    let caps = manifest["capabilities"]
-        .as_array()
-        .map(|a| a.len())
-        .unwrap_or(0);
+    let caps = manifest["capabilities"].as_array().map(|a| a.len()).unwrap_or(0);
     println!("  capabilities: {caps}\n");
 
     // 7c. Health endpoint
@@ -329,10 +304,7 @@ async fn main() -> anyhow::Result<()> {
         .header("AWP-Version", "1.1")
         .send()
         .await?;
-    println!(
-        "GET with AWP-Version: 1.1 → {} (compatible)",
-        resp.status()
-    );
+    println!("GET with AWP-Version: 1.1 → {} (compatible)", resp.status());
     let _ = resp.text().await;
 
     let resp = client
@@ -340,10 +312,7 @@ async fn main() -> anyhow::Result<()> {
         .header("AWP-Version", "2.0")
         .send()
         .await?;
-    println!(
-        "GET with AWP-Version: 2.0 → {} (incompatible)\n",
-        resp.status()
-    );
+    println!("GET with AWP-Version: 2.0 → {} (incompatible)\n", resp.status());
     let _ = resp.text().await;
 
     // 7e. Event subscription
@@ -354,25 +323,15 @@ async fn main() -> anyhow::Result<()> {
         "eventTypes": ["health.changed"],
         "secret": "test-secret-key"
     });
-    let resp = client
-        .post(format!("{base}/awp/events/subscribe"))
-        .json(&sub_body)
-        .send()
-        .await?;
+    let resp = client.post(format!("{base}/awp/events/subscribe")).json(&sub_body).send().await?;
     println!("POST /awp/events/subscribe → {}", resp.status());
     let sub_resp: serde_json::Value = resp.json().await?;
     println!("  subscription id: {}", sub_resp["id"]);
 
-    let resp = client
-        .get(format!("{base}/awp/events/subscriptions"))
-        .send()
-        .await?;
+    let resp = client.get(format!("{base}/awp/events/subscriptions")).send().await?;
     println!("GET /awp/events/subscriptions → {}", resp.status());
     let subs: serde_json::Value = resp.json().await?;
-    println!(
-        "  count: {}\n",
-        subs.as_array().map(|a| a.len()).unwrap_or(0)
-    );
+    println!("  count: {}\n", subs.as_array().map(|a| a.len()).unwrap_or(0));
 
     // 7f. A2A message
     println!("── AWP A2A ────────────────────────────────────");
@@ -383,11 +342,7 @@ async fn main() -> anyhow::Result<()> {
         "messageType": "request",
         "payload": {"query": "What products do you sell?"}
     });
-    let resp = client
-        .post(format!("{base}/awp/a2a"))
-        .json(&a2a_body)
-        .send()
-        .await?;
+    let resp = client.post(format!("{base}/awp/a2a")).json(&a2a_body).send().await?;
     println!("POST /awp/a2a → {}", resp.status());
     let a2a_resp: serde_json::Value = resp.json().await?;
     println!("  status: {}\n", a2a_resp["status"]);
@@ -404,18 +359,17 @@ async fn main() -> anyhow::Result<()> {
 
     // 7h. Ask the LLM agent
     println!("── LLM Agent ──────────────────────────────────");
-    let ask_body =
-        serde_json::json!({"question": "What is your most popular product and how much does it cost?"});
-    let resp = client
-        .post(format!("{base}/ask"))
-        .json(&ask_body)
-        .send()
-        .await?;
+    let ask_body = serde_json::json!({"question": "What is your most popular product and how much does it cost?"});
+    let resp = client.post(format!("{base}/ask")).json(&ask_body).send().await?;
     println!("POST /ask → {}", resp.status());
     let answer: serde_json::Value = resp.json().await?;
     let answer_text = answer["answer"].as_str().unwrap_or("(no answer)");
     let display = if answer_text.len() > 300 {
-        format!("{}...", &answer_text[..300])
+        let mut end = 300;
+        while end > 0 && !answer_text.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}...", &answer_text[..end])
     } else {
         answer_text.to_string()
     };

--- a/examples/bigquery_toolset/README.md
+++ b/examples/bigquery_toolset/README.md
@@ -14,7 +14,7 @@ lists datasets, inspects table schemas, and executes SQL queries via the BigQuer
 
 ## Prerequisites
 
-- Rust 1.85+
+- Rust 1.96+
 - `GOOGLE_API_KEY` for the Gemini LLM provider
 - (Optional) A Google Cloud project with BigQuery enabled for live mode
 - (Optional) Application Default Credentials configured via `gcloud auth application-default login`

--- a/examples/context_compaction/README.md
+++ b/examples/context_compaction/README.md
@@ -12,7 +12,7 @@ Demonstrates ADK-Rust's automatic context window management, showing how to hand
 
 ## Prerequisites
 
-- **Rust 1.85+** (edition 2024)
+- **Rust 1.96+** (edition 2024)
 - **`GOOGLE_API_KEY`** environment variable set with a valid Gemini API key
 
 Set up your environment:

--- a/examples/crate_adoption_feedback/Cargo.lock
+++ b/examples/crate_adoption_feedback/Cargo.lock
@@ -3,8 +3,18 @@
 version = 4
 
 [[package]]
+name = "a2a-protocol-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4fe91cf2436cef079cf2f00bb208344d63a5a8030fc77c96812b304404e8b"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "adk-agent"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "adk-guardrail",
@@ -20,8 +30,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "adk-anthropic"
+version = "0.10.0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures",
+ "hex",
+ "hmac",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "adk-artifact"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -31,35 +61,38 @@ dependencies = [
 
 [[package]]
 name = "adk-auth"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "async-trait",
  "chrono",
+ "hex",
  "serde",
  "serde_json",
- "thiserror",
+ "sha2",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "adk-core"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "chrono",
  "futures",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "adk-eval"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "adk-model",
@@ -70,15 +103,16 @@ dependencies = [
  "futures",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "adk-gemini"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
+ "adk-core",
  "async-stream",
  "async-trait",
  "base64",
@@ -102,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "adk-graph"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -111,7 +145,7 @@ dependencies = [
  "futures",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "uuid",
@@ -119,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "adk-guardrail"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -128,13 +162,13 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "adk-memory"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -147,17 +181,20 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
+ "adk-anthropic",
  "adk-core",
  "adk-gemini",
  "adk-telemetry",
  "anyhow",
+ "async-openai",
  "async-stream",
  "async-trait",
  "base64",
  "chrono",
  "futures",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
@@ -166,7 +203,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -176,7 +213,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -188,6 +225,7 @@ dependencies = [
  "futures",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
@@ -196,9 +234,10 @@ dependencies = [
 
 [[package]]
 name = "adk-rust"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "adk-agent",
+ "adk-anthropic",
  "adk-artifact",
  "adk-auth",
  "adk-core",
@@ -224,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -233,8 +272,9 @@ dependencies = [
 
 [[package]]
 name = "adk-server"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
+ "a2a-protocol-types",
  "adk-agent",
  "adk-artifact",
  "adk-core",
@@ -253,7 +293,7 @@ dependencies = [
  "rust-embed",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -265,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -278,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -286,18 +326,18 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2",
- "thiserror",
+ "thiserror 2.0.18",
  "walkdir",
 ]
 
 [[package]]
 name = "adk-telemetry"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -305,7 +345,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",
@@ -365,6 +405,46 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "async-openai"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc48c3deb4ad9a2ee8c8e364c79eb0f74e69e17ed7e883d55988b90ea44fe986"
+dependencies = [
+ "async-openai-macros",
+ "backoff",
+ "base64",
+ "bytes",
+ "derive_builder",
+ "eventsource-stream",
+ "futures",
+ "getrandom 0.3.4",
+ "rand 0.9.4",
+ "reqwest",
+ "reqwest-eventsource",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "async-openai-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81872a8e595e8ceceab71c6ba1f9078e313b452a1e31934e6763ef5d308705e4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "async-stream"
@@ -482,6 +562,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.17",
+ "instant",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "tokio",
 ]
 
 [[package]]
@@ -701,6 +795,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,6 +854,37 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
 ]
 
 [[package]]
@@ -995,6 +1155,12 @@ name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -1386,6 +1552,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1416,6 +1588,15 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1772,7 +1953,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -1802,7 +1983,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "reqwest",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tonic",
  "tracing",
@@ -1833,7 +2014,7 @@ dependencies = [
  "opentelemetry",
  "percent-encoding",
  "rand 0.9.4",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
 ]
@@ -2027,7 +2208,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -2048,7 +2229,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2278,6 +2459,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest-eventsource"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "632c55746dbb44275691640e7b40c907c16a2dc1a5842aa98aaec90da6ec6bde"
+dependencies = [
+ "eventsource-stream",
+ "futures-core",
+ "futures-timer",
+ "mime",
+ "nom",
+ "pin-project-lite",
+ "reqwest",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2458,6 +2655,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "serde",
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"
@@ -2741,7 +2948,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2824,7 +3031,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "whoami",
 ]
@@ -2862,7 +3069,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "whoami",
 ]
@@ -2887,7 +3094,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "url",
 ]
@@ -2908,6 +3115,12 @@ dependencies = [
  "unicode-normalization",
  "unicode-properties",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
@@ -2969,11 +3182,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/examples/crate_adoption_feedback/src/main.rs
+++ b/examples/crate_adoption_feedback/src/main.rs
@@ -97,7 +97,15 @@ fn make_tool_audit_callback() -> BeforeToolCallback {
                     .tool_input()
                     .map(|v| {
                         let s = v.to_string();
-                        if s.len() > 80 { format!("{}...", &s[..80]) } else { s }
+                        if s.len() > 80 {
+                            let mut end = 80;
+                            while end > 0 && !s.is_char_boundary(end) {
+                                end -= 1;
+                            }
+                            format!("{}...", &s[..end])
+                        } else {
+                            s
+                        }
                     })
                     .unwrap_or_default();
                 println!("  [audit] tool={name} input={input_preview}");
@@ -119,7 +127,10 @@ fn demo_composable_telemetry() {
 
     // Verify the function exists and returns an error for unreachable endpoint
     // (we can't actually connect without a collector running)
-    match adk_telemetry::build_otlp_layer::<tracing_subscriber::Registry>("demo-service", "http://localhost:4317") {
+    match adk_telemetry::build_otlp_layer::<tracing_subscriber::Registry>(
+        "demo-service",
+        "http://localhost:4317",
+    ) {
         Ok(_layer) => {
             println!("  ✓ build_otlp_layer returned a composable layer");
             println!("  ✓ Layer can be used with tracing_subscriber::registry().with(layer)");

--- a/examples/deferred_nodes/Cargo.lock
+++ b/examples/deferred_nodes/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "0.8.5"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "0.8.5"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "0.8.5"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "adk-graph"
-version = "0.8.5"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "0.8.5"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -97,7 +97,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "0.8.5"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "0.8.5"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "0.8.5"
+version = "0.10.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/deferred_nodes/src/main.rs
+++ b/examples/deferred_nodes/src/main.rs
@@ -88,10 +88,7 @@ pub struct FanInTracker {
 impl FanInTracker {
     /// Create a new tracker expecting results from the given paths.
     pub fn new(expected_paths: Vec<String>) -> Self {
-        Self {
-            expected_paths,
-            received: HashMap::new(),
-        }
+        Self { expected_paths, received: HashMap::new() }
     }
 
     /// Record a result from an upstream path.
@@ -101,20 +98,18 @@ impl FanInTracker {
 
     /// Check if all expected paths have reported results.
     pub fn is_complete(&self) -> bool {
-        self.expected_paths
-            .iter()
-            .all(|p| self.received.contains_key(p))
+        self.expected_paths.iter().all(|p| self.received.contains_key(p))
     }
 
     /// Apply the configured merge strategy to produce the final merged output.
     pub fn merge(&self, strategy: &MergeStrategy) -> serde_json::Value {
         match strategy {
             MergeStrategy::Collect => {
-                let values: Vec<serde_json::Value> =
-                    self.expected_paths
-                        .iter()
-                        .filter_map(|p| self.received.get(p).cloned())
-                        .collect();
+                let values: Vec<serde_json::Value> = self
+                    .expected_paths
+                    .iter()
+                    .filter_map(|p| self.received.get(p).cloned())
+                    .collect();
                 serde_json::Value::Array(values)
             }
             MergeStrategy::MergeMap => {
@@ -314,8 +309,7 @@ async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
     tracing_subscriber::fmt()
         .with_env_filter(
-            EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| EnvFilter::new("info")),
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
         )
         .init();
 
@@ -361,8 +355,10 @@ async fn main() -> anyhow::Result<()> {
     println!("  ✓ All {} paths completed in {:?}", collect_paths.len(), collect_elapsed);
     println!("  ✓ Completed paths: {:?}", collect_paths);
     println!("  ✓ Merge strategy: {}", collect_config.merge_strategy);
-    println!("  → Result type: Array with {} elements", 
-        collect_result.as_array().map_or(0, |a| a.len()));
+    println!(
+        "  → Result type: Array with {} elements",
+        collect_result.as_array().map_or(0, |a| a.len())
+    );
 
     if let Some(arr) = collect_result.as_array() {
         for (i, item) in arr.iter().enumerate() {
@@ -380,10 +376,8 @@ async fn main() -> anyhow::Result<()> {
     println!("\n--- Step 3: MergeStrategy::MergeMap ---\n");
     println!("  → Merging upstream state maps into a single map");
 
-    let merge_config = DeferredNodeConfig {
-        merge_strategy: MergeStrategy::MergeMap,
-        fan_in_timeout: None,
-    };
+    let merge_config =
+        DeferredNodeConfig { merge_strategy: MergeStrategy::MergeMap, fan_in_timeout: None };
 
     let branch_delays = vec![
         ("history", Duration::from_millis(500)),
@@ -400,11 +394,16 @@ async fn main() -> anyhow::Result<()> {
     if let Some(obj) = merge_result.as_object() {
         println!("  → Result type: Object with {} keys", obj.len());
         for key in obj.keys() {
-            let value_preview = obj.get(key)
+            let value_preview = obj
+                .get(key)
                 .map(|v| {
                     let s = v.to_string();
                     if s.len() > 60 {
-                        format!("{}...", &s[..60])
+                        let mut end = 60;
+                        while end > 0 && !s.is_char_boundary(end) {
+                            end -= 1;
+                        }
+                        format!("{}...", &s[..end])
                     } else {
                         s
                     }
@@ -441,8 +440,10 @@ async fn main() -> anyhow::Result<()> {
 
     println!("  ✓ Deferred node completed in {:?}", timeout_elapsed);
     println!("  ✓ Paths that completed before timeout: {:?}", timeout_paths);
-    println!("  → Partial result: Array with {} elements (out of 3 expected)",
-        timeout_result.as_array().map_or(0, |a| a.len()));
+    println!(
+        "  → Partial result: Array with {} elements (out of 3 expected)",
+        timeout_result.as_array().map_or(0, |a| a.len())
+    );
 
     if let Some(arr) = timeout_result.as_array() {
         for (i, item) in arr.iter().enumerate() {
@@ -455,11 +456,8 @@ async fn main() -> anyhow::Result<()> {
 
     // Check which paths were missed
     let all_expected = ["history", "technology", "economics"];
-    let missed: Vec<&str> = all_expected
-        .iter()
-        .filter(|p| !timeout_paths.contains(&p.to_string()))
-        .copied()
-        .collect();
+    let missed: Vec<&str> =
+        all_expected.iter().filter(|p| !timeout_paths.contains(&p.to_string())).copied().collect();
     if !missed.is_empty() {
         println!("  ⚠ Paths excluded due to timeout: {:?}", missed);
     }
@@ -470,12 +468,19 @@ async fn main() -> anyhow::Result<()> {
 
     println!("\n--- Summary ---\n");
     println!("  Parallel branches configured:  3 (history, technology, economics)");
-    println!("  MergeStrategy::Collect:        ✓ gathered {} items into Vec",
-        collect_result.as_array().map_or(0, |a| a.len()));
-    println!("  MergeStrategy::MergeMap:       ✓ merged into map with {} keys",
-        merge_result.as_object().map_or(0, |o| o.len()));
-    println!("  Fan-in timeout (1200ms):       ✓ {}/{} paths completed before deadline",
-        timeout_paths.len(), all_expected.len());
+    println!(
+        "  MergeStrategy::Collect:        ✓ gathered {} items into Vec",
+        collect_result.as_array().map_or(0, |a| a.len())
+    );
+    println!(
+        "  MergeStrategy::MergeMap:       ✓ merged into map with {} keys",
+        merge_result.as_object().map_or(0, |o| o.len())
+    );
+    println!(
+        "  Fan-in timeout (1200ms):       ✓ {}/{} paths completed before deadline",
+        timeout_paths.len(),
+        all_expected.len()
+    );
     println!("  Total Collect elapsed:         {:?}", collect_elapsed);
     println!("  Total MergeMap elapsed:        {:?}", merge_elapsed);
     println!("  Total Timeout elapsed:         {:?}", timeout_elapsed);
@@ -542,11 +547,7 @@ mod tests {
 
     #[test]
     fn test_fan_in_tracker_new() {
-        let tracker = FanInTracker::new(vec![
-            "a".to_string(),
-            "b".to_string(),
-            "c".to_string(),
-        ]);
+        let tracker = FanInTracker::new(vec!["a".to_string(), "b".to_string(), "c".to_string()]);
         assert_eq!(tracker.expected_paths.len(), 3);
         assert!(tracker.received.is_empty());
         assert!(!tracker.is_complete());
@@ -554,10 +555,7 @@ mod tests {
 
     #[test]
     fn test_fan_in_tracker_record_and_complete() {
-        let mut tracker = FanInTracker::new(vec![
-            "a".to_string(),
-            "b".to_string(),
-        ]);
+        let mut tracker = FanInTracker::new(vec!["a".to_string(), "b".to_string()]);
 
         tracker.record("a", serde_json::json!({"result": "alpha"}));
         assert!(!tracker.is_complete());
@@ -568,10 +566,7 @@ mod tests {
 
     #[test]
     fn test_merge_collect() {
-        let mut tracker = FanInTracker::new(vec![
-            "x".to_string(),
-            "y".to_string(),
-        ]);
+        let mut tracker = FanInTracker::new(vec!["x".to_string(), "y".to_string()]);
         tracker.record("x", serde_json::json!({"val": 1}));
         tracker.record("y", serde_json::json!({"val": 2}));
 
@@ -584,10 +579,7 @@ mod tests {
 
     #[test]
     fn test_merge_merge_map() {
-        let mut tracker = FanInTracker::new(vec![
-            "a".to_string(),
-            "b".to_string(),
-        ]);
+        let mut tracker = FanInTracker::new(vec!["a".to_string(), "b".to_string()]);
         tracker.record("a", serde_json::json!({"key1": "val1", "key2": "val2"}));
         tracker.record("b", serde_json::json!({"key3": "val3", "key4": "val4"}));
 
@@ -602,10 +594,7 @@ mod tests {
 
     #[test]
     fn test_merge_merge_map_overwrites_duplicates() {
-        let mut tracker = FanInTracker::new(vec![
-            "first".to_string(),
-            "second".to_string(),
-        ]);
+        let mut tracker = FanInTracker::new(vec!["first".to_string(), "second".to_string()]);
         tracker.record("first", serde_json::json!({"shared": "from_first"}));
         tracker.record("second", serde_json::json!({"shared": "from_second"}));
 
@@ -618,11 +607,8 @@ mod tests {
     #[test]
     fn test_merge_collect_partial() {
         // When not all paths have reported, Collect only includes received ones
-        let mut tracker = FanInTracker::new(vec![
-            "a".to_string(),
-            "b".to_string(),
-            "c".to_string(),
-        ]);
+        let mut tracker =
+            FanInTracker::new(vec!["a".to_string(), "b".to_string(), "c".to_string()]);
         tracker.record("a", serde_json::json!("result_a"));
         tracker.record("c", serde_json::json!("result_c"));
         // "b" is missing
@@ -637,10 +623,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_execute_deferred_node_collect_all_complete() {
-        let config = DeferredNodeConfig {
-            merge_strategy: MergeStrategy::Collect,
-            fan_in_timeout: None,
-        };
+        let config =
+            DeferredNodeConfig { merge_strategy: MergeStrategy::Collect, fan_in_timeout: None };
         let delays = vec![
             ("history", Duration::from_millis(50)),
             ("technology", Duration::from_millis(100)),

--- a/examples/delta_checkpoints/README.md
+++ b/examples/delta_checkpoints/README.md
@@ -13,7 +13,7 @@ Demonstrates ADK-Rust's delta checkpointing system that stores incremental state
 
 ## Prerequisites
 
-- **Rust 1.85+** (edition 2024)
+- **Rust 1.96+** (edition 2024)
 - **`GOOGLE_API_KEY`** environment variable set with a valid Gemini API key
 
 Set up your environment:

--- a/examples/desktop_audio/README.md
+++ b/examples/desktop_audio/README.md
@@ -4,7 +4,7 @@ Practical examples exercising the full `adk-audio` desktop audio pipeline: devic
 
 ## Prerequisites
 
-- **Rust 1.85+** (edition 2024)
+- **Rust 1.96+** (edition 2024)
 - **Audio hardware** — microphone and speakers (all examples except `config-validation`)
 - **GEMINI_API_KEY** — required for the `voice-agent` example ([get a key](https://aistudio.google.com/apikey))
 

--- a/examples/gemini3_builtin_tools/Cargo.lock
+++ b/examples/gemini3_builtin_tools/Cargo.lock
@@ -3,8 +3,18 @@
 version = 4
 
 [[package]]
+name = "a2a-protocol-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4fe91cf2436cef079cf2f00bb208344d63a5a8030fc77c96812b304404e8b"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "adk-agent"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -19,8 +29,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "adk-anthropic"
+version = "0.10.0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures",
+ "hex",
+ "hmac",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "adk-artifact"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -30,35 +60,38 @@ dependencies = [
 
 [[package]]
 name = "adk-auth"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "async-trait",
  "chrono",
+ "hex",
  "serde",
  "serde_json",
- "thiserror",
+ "sha2",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "adk-core"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "chrono",
  "futures",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "adk-eval"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "adk-model",
@@ -69,15 +102,16 @@ dependencies = [
  "futures",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "adk-gemini"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
+ "adk-core",
  "async-stream",
  "async-trait",
  "base64",
@@ -101,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "adk-graph"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -110,7 +144,7 @@ dependencies = [
  "futures",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "uuid",
@@ -118,7 +152,7 @@ dependencies = [
 
 [[package]]
 name = "adk-guardrail"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -127,13 +161,13 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "adk-memory"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -145,17 +179,20 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
+ "adk-anthropic",
  "adk-core",
  "adk-gemini",
  "adk-telemetry",
  "anyhow",
+ "async-openai",
  "async-stream",
  "async-trait",
  "base64",
  "chrono",
  "futures",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
@@ -164,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -174,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -186,6 +223,7 @@ dependencies = [
  "futures",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
@@ -194,9 +232,10 @@ dependencies = [
 
 [[package]]
 name = "adk-rust"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "adk-agent",
+ "adk-anthropic",
  "adk-artifact",
  "adk-auth",
  "adk-core",
@@ -222,7 +261,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -231,8 +270,9 @@ dependencies = [
 
 [[package]]
 name = "adk-server"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
+ "a2a-protocol-types",
  "adk-agent",
  "adk-artifact",
  "adk-core",
@@ -251,7 +291,7 @@ dependencies = [
  "rust-embed",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -263,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -276,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -284,22 +324,22 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2",
- "thiserror",
+ "thiserror 2.0.18",
  "walkdir",
 ]
 
 [[package]]
 name = "adk-telemetry"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "adk-tool"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",
@@ -359,6 +399,46 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "async-openai"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc48c3deb4ad9a2ee8c8e364c79eb0f74e69e17ed7e883d55988b90ea44fe986"
+dependencies = [
+ "async-openai-macros",
+ "backoff",
+ "base64",
+ "bytes",
+ "derive_builder",
+ "eventsource-stream",
+ "futures",
+ "getrandom 0.3.4",
+ "rand 0.9.4",
+ "reqwest",
+ "reqwest-eventsource",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "async-openai-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81872a8e595e8ceceab71c6ba1f9078e313b452a1e31934e6763ef5d308705e4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "async-stream"
@@ -467,6 +547,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.17",
+ "instant",
+ "pin-project-lite",
+ "rand 0.8.6",
+ "tokio",
 ]
 
 [[package]]
@@ -601,6 +695,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,6 +746,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,6 +784,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -831,6 +992,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
+
+[[package]]
 name = "futures-util"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -958,6 +1125,21 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -1180,6 +1362,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1210,6 +1398,15 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1610,7 +1807,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1625,13 +1822,13 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1674,12 +1871,33 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1689,7 +1907,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1818,6 +2045,22 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots",
+]
+
+[[package]]
+name = "reqwest-eventsource"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "632c55746dbb44275691640e7b40c907c16a2dc1a5842aa98aaec90da6ec6bde"
+dependencies = [
+ "eventsource-stream",
+ "futures-core",
+ "futures-timer",
+ "mime",
+ "nom",
+ "pin-project-lite",
+ "reqwest",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1981,6 +2224,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "serde",
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"
@@ -2187,6 +2440,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2246,11 +2505,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/examples/gemini3_builtin_tools/src/main.rs
+++ b/examples/gemini3_builtin_tools/src/main.rs
@@ -70,7 +70,13 @@ type ScenarioFn = fn() -> ScenarioFuture;
 
 fn sig_display(sig: &Option<String>) -> String {
     match sig {
-        Some(s) if s.len() > 40 => format!("{}…[{}B]", &s[..40], s.len()),
+        Some(s) if s.len() > 40 => {
+            let mut end = 40;
+            while end > 0 && !s.is_char_boundary(end) {
+                end -= 1;
+            }
+            format!("{}…[{}B]", &s[..end], s.len())
+        }
         Some(s) => s.clone(),
         None => "None".into(),
     }
@@ -144,9 +150,7 @@ fn skip_known_gemini_incompatibility(
         || message.contains("404")
         || message.contains("FAILED_PRECONDITION")
     {
-        return Some(format!(
-            "{tool_name} is not available for model '{model}' or this API key"
-        ));
+        return Some(format!("{tool_name} is not available for model '{model}' or this API key"));
     }
     None
 }
@@ -245,11 +249,7 @@ async fn make_runner(agent: Arc<dyn Agent>, session_id: &str) -> anyhow::Result<
         })
         .await?;
 
-    Ok(Runner::builder()
-        .app_name(APP_NAME)
-        .agent(agent)
-        .session_service(sessions)
-        .build()?)
+    Ok(Runner::builder().app_name(APP_NAME).agent(agent).session_service(sessions).build()?)
 }
 
 async fn run_agent_turn(
@@ -528,10 +528,7 @@ async fn test_computer_use_invocation() -> anyhow::Result<ScenarioOutcome> {
         _ctx: Arc<dyn ToolContext>,
         args: serde_json::Value,
     ) -> Result<serde_json::Value> {
-        let url = args["url"]
-            .as_str()
-            .unwrap_or("https://www.rust-lang.org")
-            .to_string();
+        let url = args["url"].as_str().unwrap_or("https://www.rust-lang.org").to_string();
         Ok(json!({
             "url": url,
             "current_url": url,

--- a/examples/gemini_managed_agents/README.md
+++ b/examples/gemini_managed_agents/README.md
@@ -14,7 +14,7 @@ Four focused agents that do real work, built on the official [Managed Agents Qui
 
 ## Prerequisites
 
-- Rust 1.85.0+
+- Rust 1.96.0+
 - A `GOOGLE_API_KEY` with [Interactions API (Beta)](https://ai.google.dev/gemini-api/docs/interactions) access
 
 ## Setup

--- a/examples/gemini_search_bug/Cargo.lock
+++ b/examples/gemini_search_bug/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -39,13 +39,15 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "adk-gemini"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
+ "adk-core",
  "async-stream",
  "async-trait",
  "base64",
@@ -72,7 +74,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -91,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -101,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -113,6 +115,7 @@ dependencies = [
  "futures",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
@@ -121,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -130,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -143,7 +146,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -157,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -166,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/gemini_search_bug/src/main.rs
+++ b/examples/gemini_search_bug/src/main.rs
@@ -17,8 +17,7 @@ use adk_core::Agent;
 
 const APP_NAME: &str = "gemini-search-bug";
 const MODEL_NAME: &str = "gemini-3-pro-preview";
-const INSTRUCTIONS: &str =
-    "You are a research agent. Use Google Search for current information, then call record_tool_status.";
+const INSTRUCTIONS: &str = "You are a research agent. Use Google Search for current information, then call record_tool_status.";
 
 fn gemini_server_tool_kind(value: &serde_json::Value) -> String {
     if value.get("toolCall").is_some() {
@@ -38,16 +37,20 @@ fn server_tool_sig(val: &serde_json::Value) -> Option<String> {
     val.get("thoughtSignature")
         .and_then(|v| v.as_str())
         .or_else(|| {
-            val.get("toolCall")
-                .and_then(|tc| tc.get("_thought_signature"))
-                .and_then(|v| v.as_str())
+            val.get("toolCall").and_then(|tc| tc.get("_thought_signature")).and_then(|v| v.as_str())
         })
         .map(String::from)
 }
 
 fn sig_display(sig: &Option<String>) -> String {
     match sig {
-        Some(s) if s.len() > 50 => format!("{}…[{}B]", &s[..50], s.len()),
+        Some(s) if s.len() > 50 => {
+            let mut end = 50;
+            while end > 0 && !s.is_char_boundary(end) {
+                end -= 1;
+            }
+            format!("{}…[{}B]", &s[..end], s.len())
+        }
         Some(s) => s.clone(),
         None => "(none)".to_string(),
     }
@@ -153,11 +156,8 @@ async fn main() -> anyhow::Result<()> {
         })
         .await?;
 
-    let runner = Runner::builder()
-        .app_name(APP_NAME)
-        .agent(agent)
-        .session_service(sessions)
-        .build()?;
+    let runner =
+        Runner::builder().app_name(APP_NAME).agent(agent).session_service(sessions).build()?;
 
     // Run the agent
     let mut stream = runner

--- a/examples/intra_compaction/Cargo.lock
+++ b/examples/intra_compaction/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "0.8.5"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "0.8.5"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "0.8.5"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "0.8.5"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "0.8.5"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "0.8.5"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "0.8.5"
+version = "0.10.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "0.8.5"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "0.8.5"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "0.8.5"
+version = "0.10.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/intra_compaction/README.md
+++ b/examples/intra_compaction/README.md
@@ -31,7 +31,7 @@ The low threshold in this example ensures compaction triggers quickly for demons
 
 ## Prerequisites
 
-- Rust 1.85+
+- Rust 1.96+
 - `GOOGLE_API_KEY` environment variable set
 
 ## Environment Variables

--- a/examples/intra_compaction/src/main.rs
+++ b/examples/intra_compaction/src/main.rs
@@ -62,8 +62,7 @@ async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
     tracing_subscriber::fmt()
         .with_env_filter(
-            EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| EnvFilter::new("info")),
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
         )
         .init();
 
@@ -80,16 +79,19 @@ async fn main() -> anyhow::Result<()> {
     // In production you would use a higher threshold (e.g., 50_000–100_000).
     // We use a low value here so compaction triggers quickly during the demo.
 
-    let compaction_config = IntraCompactionConfig {
-        token_threshold: 2000,
-        overlap_event_count: 3,
-        chars_per_token: 4,
-    };
+    let compaction_config =
+        IntraCompactionConfig { token_threshold: 2000, overlap_event_count: 3, chars_per_token: 4 };
 
     println!("--- Step 1: Compaction Configuration ---\n");
     println!("  Token threshold:     {} tokens", compaction_config.token_threshold);
-    println!("  Overlap event count: {} events preserved after compaction", compaction_config.overlap_event_count);
-    println!("  Chars-per-token:     {} (heuristic ratio for estimation)", compaction_config.chars_per_token);
+    println!(
+        "  Overlap event count: {} events preserved after compaction",
+        compaction_config.overlap_event_count
+    );
+    println!(
+        "  Chars-per-token:     {} (heuristic ratio for estimation)",
+        compaction_config.chars_per_token
+    );
 
     // -----------------------------------------------------------------------
     // Step 2: Create the LLM model, agent, and summarizer
@@ -165,18 +167,15 @@ async fn main() -> anyhow::Result<()> {
          Include details about the three-way handshake, flow control, and congestion control \
          mechanisms in TCP, and why UDP is preferred for real-time applications like video \
          streaming and online gaming.",
-
         "Now explain how HTTP/2 improves upon HTTP/1.1. Discuss multiplexing, header \
          compression with HPACK, server push, stream prioritization, and the binary framing \
          layer. Also explain why HTTP/2 still uses TCP and what problems that causes, \
          particularly head-of-line blocking at the transport layer.",
-
         "Building on what we discussed about TCP limitations, explain how QUIC protocol \
          and HTTP/3 address these issues. Cover the use of UDP as the transport layer, \
          built-in TLS 1.3, connection migration, independent stream multiplexing without \
          head-of-line blocking, and 0-RTT connection establishment. Compare the latency \
          characteristics with HTTP/2 over TCP.",
-
         "Explain the concept of WebSockets and how they differ from regular HTTP requests. \
          Cover the upgrade handshake, full-duplex communication, frame types (text, binary, \
          ping/pong, close), and common use cases like chat applications, live dashboards, \
@@ -189,7 +188,13 @@ async fn main() -> anyhow::Result<()> {
     for (i, prompt) in prompts.iter().enumerate() {
         let turn = i + 1;
         println!("  ┌─ Turn {turn} ─────────────────────────────────────────");
-        println!("  │ User: {}...", &prompt[..60]);
+        println!("  │ User: {}...", {
+            let mut e = 60.min(prompt.len());
+            while e > 0 && !prompt.is_char_boundary(e) {
+                e -= 1;
+            }
+            &prompt[..e]
+        });
 
         // Estimate tokens before this turn by checking the session events
         let session = sessions
@@ -212,9 +217,8 @@ async fn main() -> anyhow::Result<()> {
             parts: vec![Part::Text { text: prompt.to_string() }],
         };
 
-        let mut stream = runner
-            .run(UserId::new("user")?, SessionId::new(session_id)?, user_content)
-            .await?;
+        let mut stream =
+            runner.run(UserId::new("user")?, SessionId::new(session_id)?, user_content).await?;
 
         let mut response_text = String::new();
         while let Some(result) = stream.next().await {
@@ -237,7 +241,11 @@ async fn main() -> anyhow::Result<()> {
 
         // Show a truncated response
         let preview = if response_text.len() > 120 {
-            format!("{}...", &response_text[..120])
+            let mut end = 120;
+            while end > 0 && !response_text.is_char_boundary(end) {
+                end -= 1;
+            }
+            format!("{}...", &response_text[..end])
         } else {
             response_text.clone()
         };
@@ -263,8 +271,14 @@ async fn main() -> anyhow::Result<()> {
         // we'd expect 2 * turn events.
         let expected_without_compaction = 2 * turn;
         if events_after.len() < expected_without_compaction {
-            println!("  │ 🗜️  Compaction detected! Events reduced from expected {expected_without_compaction} to {}", events_after.len());
-            println!("  │    Preserved recent events (overlap): {}", compaction_config.overlap_event_count.min(events_after.len()));
+            println!(
+                "  │ 🗜️  Compaction detected! Events reduced from expected {expected_without_compaction} to {}",
+                events_after.len()
+            );
+            println!(
+                "  │    Preserved recent events (overlap): {}",
+                compaction_config.overlap_event_count.min(events_after.len())
+            );
         }
 
         println!("  └──────────────────────────────────────────────\n");
@@ -291,9 +305,8 @@ async fn main() -> anyhow::Result<()> {
         parts: vec![Part::Text { text: followup.to_string() }],
     };
 
-    let mut stream = runner
-        .run(UserId::new("user")?, SessionId::new(session_id)?, followup_content)
-        .await?;
+    let mut stream =
+        runner.run(UserId::new("user")?, SessionId::new(session_id)?, followup_content).await?;
 
     let mut followup_response = String::new();
     while let Some(result) = stream.next().await {
@@ -316,7 +329,11 @@ async fn main() -> anyhow::Result<()> {
 
     // Print the full follow-up response to show coherence
     let preview = if followup_response.len() > 500 {
-        format!("{}...", &followup_response[..500])
+        let mut end = 500;
+        while end > 0 && !followup_response.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}...", &followup_response[..end])
     } else {
         followup_response.clone()
     };

--- a/examples/managed_agents_custom_tools/README.md
+++ b/examples/managed_agents_custom_tools/README.md
@@ -4,7 +4,7 @@ Demonstrates defining a custom tool on a managed agent, handling `AgentCustomToo
 
 ## Prerequisites
 
-- Rust 1.85.0+
+- Rust 1.96.0+
 - An `ANTHROPIC_API_KEY` with Managed Agents beta access
 
 ## Setup

--- a/examples/managed_agents_files/README.md
+++ b/examples/managed_agents_files/README.md
@@ -4,7 +4,7 @@ Demonstrates uploading a file via the Anthropic Files API, mounting it in a mana
 
 ## Prerequisites
 
-- Rust 1.85.0+
+- Rust 1.96.0+
 - An `ANTHROPIC_API_KEY` with Managed Agents and Files API beta access
 
 ## Setup

--- a/examples/managed_agents_hello/README.md
+++ b/examples/managed_agents_hello/README.md
@@ -4,7 +4,7 @@ The simplest possible Anthropic Managed Agents session. Creates an agent, enviro
 
 ## Prerequisites
 
-- Rust 1.85.0+
+- Rust 1.96.0+
 - An `ANTHROPIC_API_KEY` with Managed Agents beta access
 
 ## Setup

--- a/examples/managed_agents_memory/README.md
+++ b/examples/managed_agents_memory/README.md
@@ -4,7 +4,7 @@ Demonstrates creating a memory store, seeding it with content, running a session
 
 ## Prerequisites
 
-- Rust 1.85.0+
+- Rust 1.96.0+
 - An `ANTHROPIC_API_KEY` with Managed Agents beta access
 
 ## Setup

--- a/examples/managed_agents_multiagent/README.md
+++ b/examples/managed_agents_multiagent/README.md
@@ -4,7 +4,7 @@ Demonstrates creating multiple specialized agents, configuring a coordinator age
 
 ## Prerequisites
 
-- Rust 1.85.0+
+- Rust 1.96.0+
 - An `ANTHROPIC_API_KEY` with Managed Agents beta access
 
 ## Setup

--- a/examples/mcp_manager/Cargo.lock
+++ b/examples/mcp_manager/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-core"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -13,12 +13,13 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "adk-rust-macros"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -27,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -36,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/mcp_manager/src/main.rs
+++ b/examples/mcp_manager/src/main.rs
@@ -28,13 +28,27 @@ impl ExampleContext {
 }
 
 impl ReadonlyContext for ExampleContext {
-    fn invocation_id(&self) -> &str { "example-invocation" }
-    fn agent_name(&self) -> &str { "example-agent" }
-    fn user_id(&self) -> &str { "example-user" }
-    fn app_name(&self) -> &str { "mcp-manager-example" }
-    fn session_id(&self) -> &str { "example-session" }
-    fn branch(&self) -> &str { "main" }
-    fn user_content(&self) -> &Content { &self.user_content }
+    fn invocation_id(&self) -> &str {
+        "example-invocation"
+    }
+    fn agent_name(&self) -> &str {
+        "example-agent"
+    }
+    fn user_id(&self) -> &str {
+        "example-user"
+    }
+    fn app_name(&self) -> &str {
+        "mcp-manager-example"
+    }
+    fn session_id(&self) -> &str {
+        "example-session"
+    }
+    fn branch(&self) -> &str {
+        "main"
+    }
+    fn user_content(&self) -> &Content {
+        &self.user_content
+    }
 }
 
 #[tokio::main]
@@ -42,8 +56,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize tracing
     tracing_subscriber::fmt()
         .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "info".into()),
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
         )
         .init();
 
@@ -146,6 +159,10 @@ fn truncate(s: &str, max_len: usize) -> String {
     if s.len() <= max_len {
         s.to_string()
     } else {
-        format!("{}...", &s[..max_len])
+        let mut end = max_len;
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}...", &s[..end])
     }
 }

--- a/examples/mcp_sampling/README.md
+++ b/examples/mcp_sampling/README.md
@@ -48,7 +48,7 @@ let toolset = McpToolset::with_sampling_handler(transport, elicitation, sampling
 
 ## Prerequisites
 
-- Rust 1.85+
+- Rust 1.96+
 - `GOOGLE_API_KEY` environment variable set
 
 ## Environment Variables

--- a/examples/node_caching/README.md
+++ b/examples/node_caching/README.md
@@ -12,7 +12,7 @@ Demonstrates ADK-Rust's blake3-keyed LRU caching of graph node results, showing 
 
 ## Prerequisites
 
-- **Rust 1.85+** (edition 2024)
+- **Rust 1.96+** (edition 2024)
 - **`GOOGLE_API_KEY`** environment variable set with a valid Gemini API key
 
 Set up your environment:

--- a/examples/node_timeouts/README.md
+++ b/examples/node_timeouts/README.md
@@ -15,7 +15,7 @@ The example builds a four-node graph where each node demonstrates a different ti
 
 ## Prerequisites
 
-- **Rust 1.85+** (edition 2024)
+- **Rust 1.96+** (edition 2024)
 - **`GOOGLE_API_KEY`** environment variable set with a valid Gemini API key
 
 Set the API key in your shell or create a `.env` file:

--- a/examples/openai_background/README.md
+++ b/examples/openai_background/README.md
@@ -6,7 +6,7 @@ This is useful for long-running requests where you don't want to hold open a str
 
 ## Prerequisites
 
-- Rust 1.85.0+
+- Rust 1.96.0+
 - `OPENAI_API_KEY` environment variable set with a valid OpenAI API key
 
 ## Running

--- a/examples/openai_builtin_tools/README.md
+++ b/examples/openai_builtin_tools/README.md
@@ -8,7 +8,7 @@ This example covers two built-in tools:
 
 ## Prerequisites
 
-- Rust 1.85.0+
+- Rust 1.96.0+
 - `OPENAI_API_KEY` environment variable set with a valid OpenAI API key
 
 ## Running

--- a/examples/openai_conversations/README.md
+++ b/examples/openai_conversations/README.md
@@ -4,7 +4,7 @@ Demonstrates the OpenAI Responses API **Conversations** lifecycle. The Conversat
 
 ## Prerequisites
 
-- Rust 1.85.0+
+- Rust 1.96.0+
 - `OPENAI_API_KEY` environment variable set with a valid OpenAI API key
 
 ## Running

--- a/examples/openai_deep_research/README.md
+++ b/examples/openai_deep_research/README.md
@@ -6,7 +6,7 @@ Deep research models are designed for complex research tasks that require synthe
 
 ## Prerequisites
 
-- Rust 1.85.0+
+- Rust 1.96.0+
 - `OPENAI_API_KEY` environment variable set with a valid OpenAI API key
 - Access to deep research models (may require specific API tier)
 

--- a/examples/openai_open_responses/README.md
+++ b/examples/openai_open_responses/README.md
@@ -4,7 +4,7 @@ Demonstrates the **Open Responses mode** for provider-agnostic usage of the Resp
 
 ## Prerequisites
 
-- Rust 1.85.0+
+- Rust 1.96.0+
 - One of the following:
   - `OPENAI_API_KEY` environment variable set (for OpenAI)
   - A running Open Responses-compatible local server (LM Studio, Ollama, vLLM)

--- a/examples/openai_ws_minimal/README.md
+++ b/examples/openai_ws_minimal/README.md
@@ -4,7 +4,7 @@ Demonstrates the lowest-level WebSocket transport for the OpenAI Responses API. 
 
 ## Prerequisites
 
-- Rust 1.85.0+
+- Rust 1.96.0+
 - `OPENAI_API_KEY` environment variable set
 - The `openai-ws` feature flag on `adk-model`
 

--- a/examples/plugin_system/Cargo.lock
+++ b/examples/plugin_system/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "0.8.2"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "0.8.2"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "0.8.2"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "0.8.2"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "0.8.2"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "0.8.2"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "0.8.2"
+version = "0.10.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -113,6 +113,7 @@ dependencies = [
  "futures",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
  "tokio-util",
  "tracing",
@@ -121,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "0.8.2"
+version = "0.10.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -130,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "0.8.2"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -143,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "0.8.2"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -157,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "0.8.2"
+version = "0.10.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -166,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "0.8.2"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/plugin_system/README.md
+++ b/examples/plugin_system/README.md
@@ -43,7 +43,7 @@ Demonstrates the ADK-Rust Enhanced Plugin System (Sprint 1) with three custom pl
 
 ## Prerequisites
 
-- Rust 1.85+
+- Rust 1.96+
 - `GOOGLE_API_KEY` environment variable set
 
 ## Setup

--- a/examples/plugin_system/src/main.rs
+++ b/examples/plugin_system/src/main.rs
@@ -26,7 +26,9 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use adk_agent::LlmAgentBuilder;
-use adk_core::{Agent, CallbackContext, Content, LlmRequest, LlmResponse, Llm, Result, Tool, async_trait};
+use adk_core::{
+    Agent, CallbackContext, Content, Llm, LlmRequest, LlmResponse, Result, Tool, async_trait,
+};
 use adk_model::GeminiModel;
 use adk_plugin::{
     AfterModelCallResult, AfterToolCallResult, BeforeModelCallResult, BeforeToolCallResult,
@@ -34,7 +36,7 @@ use adk_plugin::{
 };
 use adk_runner::Runner;
 use adk_session::{CreateRequest, InMemorySessionService, SessionService};
-use adk_tool::{tool, AdkError};
+use adk_tool::{AdkError, tool};
 use futures::StreamExt;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -124,7 +126,9 @@ impl EnhancedPlugin for LoggingPlugin {
         println!("  📋 [LoggingPlugin] before_tool_call: tool={}, args={}", tool.name(), args);
 
         // Track call count in shared context
-        let mut stats = plugin_ctx.get::<LoggingStats>().await
+        let mut stats = plugin_ctx
+            .get::<LoggingStats>()
+            .await
             .unwrap_or(LoggingStats { tool_calls: 0, model_calls: 0 });
         stats.tool_calls += 1;
         plugin_ctx.insert(stats).await;
@@ -140,8 +144,11 @@ impl EnhancedPlugin for LoggingPlugin {
         _ctx: Arc<dyn CallbackContext>,
         _plugin_ctx: &PluginContext,
     ) -> Result<AfterToolCallResult> {
-        println!("  📋 [LoggingPlugin] after_tool_call: tool={}, result_size={} bytes",
-            tool.name(), result.to_string().len());
+        println!(
+            "  📋 [LoggingPlugin] after_tool_call: tool={}, result_size={} bytes",
+            tool.name(),
+            result.to_string().len()
+        );
         Ok(AfterToolCallResult::Continue(result))
     }
 
@@ -152,10 +159,14 @@ impl EnhancedPlugin for LoggingPlugin {
         plugin_ctx: &PluginContext,
     ) -> Result<BeforeModelCallResult> {
         let msg_count = request.contents.len();
-        println!("  📋 [LoggingPlugin] before_model_call: model={}, messages={}",
-            request.model, msg_count);
+        println!(
+            "  📋 [LoggingPlugin] before_model_call: model={}, messages={}",
+            request.model, msg_count
+        );
 
-        let mut stats = plugin_ctx.get::<LoggingStats>().await
+        let mut stats = plugin_ctx
+            .get::<LoggingStats>()
+            .await
             .unwrap_or(LoggingStats { tool_calls: 0, model_calls: 0 });
         stats.model_calls += 1;
         plugin_ctx.insert(stats).await;
@@ -170,8 +181,10 @@ impl EnhancedPlugin for LoggingPlugin {
         _plugin_ctx: &PluginContext,
     ) -> Result<AfterModelCallResult> {
         let has_content = response.content.is_some();
-        println!("  📋 [LoggingPlugin] after_model_call: has_content={}, turn_complete={}",
-            has_content, response.turn_complete);
+        println!(
+            "  📋 [LoggingPlugin] after_model_call: has_content={}, turn_complete={}",
+            has_content, response.turn_complete
+        );
         Ok(AfterModelCallResult::Continue(response))
     }
 }
@@ -242,9 +255,7 @@ struct CachingPlugin {
 
 impl CachingPlugin {
     fn new() -> Self {
-        Self {
-            cache: Arc::new(RwLock::new(HashMap::new())),
-        }
+        Self { cache: Arc::new(RwLock::new(HashMap::new())) }
     }
 
     fn cache_key(tool_name: &str, args: &Value) -> String {
@@ -274,11 +285,14 @@ impl EnhancedPlugin for CachingPlugin {
         let cache = self.cache.read().await;
         if let Some(cached_result) = cache.get(&key) {
             // Cache HIT — short-circuit tool execution
-            println!("  ⚡ [CachingPlugin] CACHE HIT for {}! Skipping tool execution.", tool.name());
+            println!(
+                "  ⚡ [CachingPlugin] CACHE HIT for {}! Skipping tool execution.",
+                tool.name()
+            );
 
             // Update stats in PluginContext
-            let mut stats = plugin_ctx.get::<ToolCache>().await
-                .unwrap_or(ToolCache { hits: 0, misses: 0 });
+            let mut stats =
+                plugin_ctx.get::<ToolCache>().await.unwrap_or(ToolCache { hits: 0, misses: 0 });
             stats.hits += 1;
             plugin_ctx.insert(stats).await;
 
@@ -289,8 +303,8 @@ impl EnhancedPlugin for CachingPlugin {
         // Cache MISS
         println!("  ⚡ [CachingPlugin] CACHE MISS for {}. Proceeding with execution.", tool.name());
 
-        let mut stats = plugin_ctx.get::<ToolCache>().await
-            .unwrap_or(ToolCache { hits: 0, misses: 0 });
+        let mut stats =
+            plugin_ctx.get::<ToolCache>().await.unwrap_or(ToolCache { hits: 0, misses: 0 });
         stats.misses += 1;
         plugin_ctx.insert(stats).await;
 
@@ -328,8 +342,8 @@ async fn main() -> anyhow::Result<()> {
         )
         .init();
 
-    let api_key = std::env::var("GOOGLE_API_KEY")
-        .expect("GOOGLE_API_KEY must be set — see .env.example");
+    let api_key =
+        std::env::var("GOOGLE_API_KEY").expect("GOOGLE_API_KEY must be set — see .env.example");
 
     println!("╔══════════════════════════════════════════════════════════════╗");
     println!("║  Enhanced Plugin System Demo — ADK-Rust Sprint 1            ║");
@@ -359,7 +373,7 @@ async fn main() -> anyhow::Result<()> {
         .instruction(
             "You are a helpful weather assistant. When asked about weather, \
              use the get_weather tool to fetch current conditions. \
-             Always provide a brief, friendly summary of the weather."
+             Always provide a brief, friendly summary of the weather.",
         )
         .tool(Arc::new(GetWeather))
         .enhanced_plugins(vec![
@@ -508,6 +522,10 @@ fn truncate(s: &str, max: usize) -> String {
     if s.len() <= max {
         s.to_string()
     } else {
-        format!("{}...", &s[..max])
+        let mut end = max;
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}...", &s[..end])
     }
 }

--- a/examples/retry_reflect/Cargo.lock
+++ b/examples/retry_reflect/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "0.8.2"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "0.8.2"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "0.8.2"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "0.8.2"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "0.8.2"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "0.8.2"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "adk-retry-reflect"
-version = "0.8.2"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "0.8.2"
+version = "0.10.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -126,6 +126,7 @@ dependencies = [
  "futures",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
  "tokio-util",
  "tracing",
@@ -134,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "0.8.2"
+version = "0.10.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -143,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "0.8.2"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -156,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "0.8.2"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -170,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "0.8.2"
+version = "0.10.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -179,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "0.8.2"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/retry_reflect/README.md
+++ b/examples/retry_reflect/README.md
@@ -62,7 +62,7 @@ This gives the agent context to self-correct on the next turn.
 
 ## Prerequisites
 
-- Rust 1.85+
+- Rust 1.96+
 - `GOOGLE_API_KEY` environment variable set
 
 ## Setup

--- a/examples/retry_reflect/src/main.rs
+++ b/examples/retry_reflect/src/main.rs
@@ -49,9 +49,7 @@ struct FlakySearchTool {
 
 impl FlakySearchTool {
     fn new() -> Self {
-        Self {
-            call_count: AtomicU32::new(0),
-        }
+        Self { call_count: AtomicU32::new(0) }
     }
 }
 
@@ -78,14 +76,8 @@ impl Tool for FlakySearchTool {
         }))
     }
 
-    async fn execute(
-        &self,
-        _ctx: Arc<dyn ToolContext>,
-        args: Value,
-    ) -> adk_core::Result<Value> {
-        let query = args.get("query")
-            .and_then(|v| v.as_str())
-            .unwrap_or("unknown");
+    async fn execute(&self, _ctx: Arc<dyn ToolContext>, args: Value) -> adk_core::Result<Value> {
+        let query = args.get("query").and_then(|v| v.as_str()).unwrap_or("unknown");
 
         let count = self.call_count.fetch_add(1, Ordering::SeqCst) + 1;
 
@@ -147,8 +139,8 @@ async fn main() -> anyhow::Result<()> {
         )
         .init();
 
-    let api_key = std::env::var("GOOGLE_API_KEY")
-        .expect("GOOGLE_API_KEY must be set — see .env.example");
+    let api_key =
+        std::env::var("GOOGLE_API_KEY").expect("GOOGLE_API_KEY must be set — see .env.example");
 
     println!("╔══════════════════════════════════════════════════════════════╗");
     println!("║  Retry & Reflect Demo — ADK-Rust Sprint 2                   ║");
@@ -189,7 +181,7 @@ async fn main() -> anyhow::Result<()> {
             "You are a helpful research assistant. When asked a question, \
              use the search_web tool to find relevant information. \
              If a search fails, try again with the same or a refined query. \
-             Summarize the results concisely."
+             Summarize the results concisely.",
         )
         .tool(flaky_tool as Arc<dyn Tool>)
         .enhanced_plugin(Arc::new(retry_plugin) as Arc<dyn EnhancedPlugin>)
@@ -228,7 +220,8 @@ async fn main() -> anyhow::Result<()> {
     println!("──────────────────────────────────────────────────────────────────\n");
 
     let start = std::time::Instant::now();
-    let content = Content::new("user").with_text("What is Rust programming language? Search for it.");
+    let content =
+        Content::new("user").with_text("What is Rust programming language? Search for it.");
     let mut stream = runner.run_str("user", "demo-session", content).await?;
 
     let mut response_text = String::new();
@@ -293,6 +286,10 @@ fn truncate(s: &str, max: usize) -> String {
     if s.len() <= max {
         s.to_string()
     } else {
-        format!("{}...", &s[..max])
+        let mut end = max;
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}...", &s[..end])
     }
 }

--- a/examples/secret_provider/README.md
+++ b/examples/secret_provider/README.md
@@ -11,7 +11,7 @@ Demonstrates ADK-Rust's secret management — retrieving secrets from a provider
 
 ## Prerequisites
 
-- Rust 1.85+
+- Rust 1.96+
 - `GOOGLE_API_KEY` environment variable set
 
 ## Environment Variables

--- a/examples/server_builder/README.md
+++ b/examples/server_builder/README.md
@@ -85,7 +85,7 @@ Routes added via `add_api_routes()` additionally receive the auth middleware lay
 
 ## Prerequisites
 
-- Rust 1.85+
+- Rust 1.96+
 - No LLM provider or API keys required
 
 ## Environment Variables

--- a/examples/slack_toolset/README.md
+++ b/examples/slack_toolset/README.md
@@ -14,7 +14,7 @@ reads channels, sends messages, adds reactions, and lists threads via the Slack 
 
 ## Prerequisites
 
-- Rust 1.85+
+- Rust 1.96+
 - `GOOGLE_API_KEY` for the Gemini LLM provider
 - (Optional) A Slack Bot Token for live mode
 

--- a/examples/spanner_toolset/README.md
+++ b/examples/spanner_toolset/README.md
@@ -14,7 +14,7 @@ lists tables, inspects table schemas, and executes SQL queries via the Cloud Spa
 
 ## Prerequisites
 
-- Rust 1.85+
+- Rust 1.96+
 - `GOOGLE_API_KEY` for the Gemini LLM provider
 - (Optional) A Google Cloud project with Cloud Spanner enabled for live mode
 - (Optional) Application Default Credentials configured via `gcloud auth application-default login`

--- a/examples/time_travel/Cargo.lock
+++ b/examples/time_travel/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "0.8.5"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "0.8.5"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "0.8.5"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "adk-graph"
-version = "0.8.5"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "0.8.5"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -97,7 +97,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "0.8.5"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "0.8.5"
+version = "0.10.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "0.8.5"
+version = "0.10.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/time_travel/README.md
+++ b/examples/time_travel/README.md
@@ -13,7 +13,7 @@ Demonstrates ADK-Rust's time-travel debugging capabilities for graph workflows, 
 
 ## Prerequisites
 
-- **Rust 1.85+** (edition 2024)
+- **Rust 1.96+** (edition 2024)
 - **`GOOGLE_API_KEY`** environment variable set with a valid Gemini API key
 
 Set up your environment:

--- a/examples/time_travel/src/main.rs
+++ b/examples/time_travel/src/main.rs
@@ -217,10 +217,7 @@ impl TimeTravelHandle {
     /// Equivalent to `TimeTravelHandle::resume_from(step)` in the adk-graph API.
     fn resume_from(&self, step: usize) -> anyhow::Result<Vec<Checkpoint>> {
         if step >= self.checkpoints.len() {
-            anyhow::bail!(
-                "Step {step} does not exist. Valid range: 0..{}",
-                self.checkpoints.len()
-            );
+            anyhow::bail!("Step {step} does not exist. Valid range: 0..{}", self.checkpoints.len());
         }
 
         let base_state = self.checkpoints[step].state.clone();
@@ -238,17 +235,12 @@ impl TimeTravelHandle {
     /// Equivalent to `TimeTravelHandle::fork_at(step, new_thread_id)` in the adk-graph API.
     fn fork_at(&mut self, step: usize, new_thread_id: &str) -> anyhow::Result<()> {
         if step >= self.checkpoints.len() {
-            anyhow::bail!(
-                "Step {step} does not exist. Valid range: 0..{}",
-                self.checkpoints.len()
-            );
+            anyhow::bail!("Step {step} does not exist. Valid range: 0..{}", self.checkpoints.len());
         }
 
         let base_state = self.checkpoints[step].state.clone();
-        let forked_checkpoints =
-            simulate_forked_execution(base_state, step, new_thread_id);
-        self.forked_threads
-            .insert(new_thread_id.to_string(), forked_checkpoints);
+        let forked_checkpoints = simulate_forked_execution(base_state, step, new_thread_id);
+        self.forked_threads.insert(new_thread_id.to_string(), forked_checkpoints);
         Ok(())
     }
 
@@ -371,7 +363,9 @@ fn simulate_research_workflow() -> (Vec<Checkpoint>, ResearchState) {
 
     // Step 3: Cross-reference secondary sources
     state.phase = "cross_reference".to_string();
-    state.findings.push("Tokio runtime leverages ownership for safe async task spawning".to_string());
+    state
+        .findings
+        .push("Tokio runtime leverages ownership for safe async task spawning".to_string());
     state.sources.push("Tokio internals: work-stealing scheduler".to_string());
     state.sources.push("Crossbeam: lock-free data structures in Rust".to_string());
     state.confidence = 0.65;
@@ -433,9 +427,7 @@ fn simulate_divergent_execution(
             }
             1 => {
                 base_state.phase = "source_gathering".to_string();
-                base_state
-                    .sources
-                    .push("Alternative: Oxide Computer Systems blog".to_string());
+                base_state.sources.push("Alternative: Oxide Computer Systems blog".to_string());
                 base_state.confidence = 0.12;
             }
             2 => {
@@ -452,9 +444,7 @@ fn simulate_divergent_execution(
                     "DIVERGENT: Arc<Mutex<T>> pattern shows ownership enables safe shared state"
                         .to_string(),
                 );
-                base_state
-                    .sources
-                    .push("Alternative: Servo browser engine case study".to_string());
+                base_state.sources.push("Alternative: Servo browser engine case study".to_string());
                 base_state.confidence = 0.58;
             }
             4 => {
@@ -500,12 +490,10 @@ fn simulate_forked_execution(
 
     // The fork explores a different research angle
     base_state.phase = "forked_exploration".to_string();
-    base_state.findings.push(format!(
-        "FORK[{thread_id}]: Exploring memory safety without garbage collection"
-    ));
     base_state
-        .sources
-        .push("Fork source: Linear types in Haskell vs Rust ownership".to_string());
+        .findings
+        .push(format!("FORK[{thread_id}]: Exploring memory safety without garbage collection"));
+    base_state.sources.push("Fork source: Linear types in Haskell vs Rust ownership".to_string());
     base_state.confidence = base_state.confidence * 0.8; // Lower confidence in new direction
 
     checkpoints.push(Checkpoint {
@@ -681,9 +669,7 @@ async fn main() -> anyhow::Result<()> {
 
     let fork_step = 1;
     let fork_thread = "alternative_research";
-    print_progress(&format!(
-        "Forking at step {fork_step} into new thread: \"{fork_thread}\""
-    ));
+    print_progress(&format!("Forking at step {fork_step} into new thread: \"{fork_thread}\""));
     print_progress(&format!(
         "Base state at fork point: {}",
         checkpoints[fork_step].state.summary()
@@ -696,10 +682,7 @@ async fn main() -> anyhow::Result<()> {
     println!("  Forked thread \"{fork_thread}\" execution:");
     println!("  {}", "-".repeat(80));
     for fcp in forked {
-        println!(
-            "  Step {}: [{}] {}",
-            fcp.step, fcp.state.phase, fcp.description
-        );
+        println!("  Step {}: [{}] {}", fcp.step, fcp.state.phase, fcp.description);
         for finding in &fcp.state.findings {
             if finding.starts_with(&format!("FORK[{fork_thread}]")) {
                 println!("       → {finding}");
@@ -726,19 +709,14 @@ async fn main() -> anyhow::Result<()> {
 
     let replay_from = 1;
     let replay_to = 4;
-    print_progress(&format!(
-        "Replaying steps {replay_from} through {replay_to}..."
-    ));
+    print_progress(&format!("Replaying steps {replay_from} through {replay_to}..."));
     print_progress("Printing state transitions at each step:");
     println!();
 
     let transitions = handle.replay(replay_from, replay_to)?;
 
     for transition in &transitions {
-        println!(
-            "  Step {} → Step {}:",
-            transition.from_step, transition.to_step
-        );
+        println!("  Step {} → Step {}:", transition.from_step, transition.to_step);
         println!("    Before: {}", transition.from_state);
         println!("    After:  {}", transition.to_state);
         println!("    Changes:");
@@ -785,7 +763,11 @@ fn truncate_str(s: &str, max_len: usize) -> String {
     if s.len() <= max_len {
         s.to_string()
     } else {
-        format!("{}...", &s[..max_len - 3])
+        let mut end = max_len.saturating_sub(3);
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}...", &s[..end])
     }
 }
 
@@ -807,10 +789,7 @@ mod tests {
             msg.contains("ADK_TEST_NONEXISTENT_VAR_TIME_TRAVEL"),
             "Error should contain the variable name, got: {msg}"
         );
-        assert!(
-            msg.contains(".env.example"),
-            "Error should reference .env.example, got: {msg}"
-        );
+        assert!(msg.contains(".env.example"), "Error should reference .env.example, got: {msg}");
     }
 
     #[test]
@@ -937,12 +916,9 @@ mod tests {
         let forked = handle.forked_threads.get("alt_thread").unwrap();
         assert!(!forked.is_empty());
         // Forked thread should contain findings referencing the fork
-        let has_fork_finding = forked.iter().any(|cp| {
-            cp.state
-                .findings
-                .iter()
-                .any(|f| f.contains("FORK[alt_thread]"))
-        });
+        let has_fork_finding = forked
+            .iter()
+            .any(|cp| cp.state.findings.iter().any(|f| f.contains("FORK[alt_thread]")));
         assert!(has_fork_finding, "Forked thread should have fork-specific findings");
     }
 

--- a/examples/tool_concurrency/README.md
+++ b/examples/tool_concurrency/README.md
@@ -12,7 +12,7 @@ Demonstrates ADK-Rust's per-tool concurrency limits with backpressure policies, 
 
 ## Prerequisites
 
-- **Rust 1.85+** (edition 2024)
+- **Rust 1.96+** (edition 2024)
 - **`GOOGLE_API_KEY`** environment variable set with a valid Gemini API key
 
 Set up your environment:

--- a/examples/video_avatar/README.md
+++ b/examples/video_avatar/README.md
@@ -46,7 +46,7 @@ let builder = RealtimeAgentBuilder::new("my_agent")
 
 ## Prerequisites
 
-- Rust 1.85.0+
+- Rust 1.96.0+
 - No API keys or LLM provider required
 
 ## Environment Variables

--- a/examples/yaml_agent/README.md
+++ b/examples/yaml_agent/README.md
@@ -11,7 +11,7 @@ Demonstrates the YAML agent definition loading feature from ADK-Rust v0.8.0.
 
 ## Prerequisites
 
-- Rust 1.85+
+- Rust 1.96+
 - A Google API key for Gemini
 
 ## Environment Variables


### PR DESCRIPTION
Fixes #349

## Summary

Fixes two categories of bugs reported in #349:

1. **UTF-8 character boundary panics** (🔴 Critical) — `&s[..N]` byte slicing that crashes the process when multi-byte characters (Chinese, Japanese, emoji) are encountered at the slice boundary.

2. **CJK search failures** (🟡 High) — keyword-based memory search returns zero results for Chinese/Japanese/Korean text due to whitespace-only tokenization and hardcoded English PostgreSQL text search config.

## Changes

### Category 1: UTF-8 Panics

| File | Fix |
|------|-----|
| `adk-session/src/vertex.rs` | `truncate_for_error()` uses `is_char_boundary()` backoff |
| `adk-anthropic/examples/citations.rs` | `truncate()` uses `is_char_boundary()` backoff |

### Category 2: CJK Search

| File | Fix |
|------|-----|
| `adk-memory/src/text.rs` | `extract_words()` generates CJK character unigrams + bigrams for substring matching |
| `adk-memory/src/postgres.rs` | Replaced `'english'` with `'simple'` in all `to_tsvector()`/`plainto_tsquery()` calls |

## Testing

```
cargo test -p adk-session --features vertex-session -- truncate  # 3 tests pass
cargo test -p adk-memory -- text                                  # 5 tests pass
```

### Reproduction confirmed before fix:
- UTF-8 panic: `"你好".repeat(200)` → panics at byte 512 (inside '你' bytes 510..513)
- CJK search: `extract_words("用户喜欢用Rust编程")` → single token, no match for `"编程"`

### After fix:
- UTF-8: backs off to byte 510 (valid boundary), no panic
- CJK: bigram `"编程"` is generated from stored text, matches query