### PR TITLE
fix(enterprise): UserEvent::Message uses content blocks per CANON

### DIFF
--- a/adk-enterprise/src/types/events.rs
+++ b/adk-enterprise/src/types/events.rs
@@ -11,7 +11,7 @@ use super::session::Usage;
 pub enum UserEvent {
     /// Send a text message to the agent.
     #[serde(rename = "user.message")]
-    Message { text: String },
+    Message { content: Vec<ContentBlock> },
 
     /// Interrupt the agent's current turn.
     #[serde(rename = "user.interrupt")]
@@ -46,7 +46,7 @@ pub enum ConfirmationResult {
 impl UserEvent {
     /// Create a `user.message` event with the given text.
     pub fn message(text: impl Into<String>) -> Self {
-        Self::Message { text: text.into() }
+        Self::Message { content: vec![ContentBlock::text(text)] }
     }
 
     /// Create a `user.interrupt` event.

--- a/adk-enterprise/tests/contract_tests.rs
+++ b/adk-enterprise/tests/contract_tests.rs
@@ -83,3 +83,32 @@ fn tool_confirmation_uses_result_field() {
     assert_eq!(json["result"], "allow");
     assert!(json.get("action").is_none());
 }
+
+#[test]
+fn user_message_serializes_with_content_blocks() {
+    // CANON §3.4: user.message carries content: ContentBlock[], not text: String
+    let event = UserEvent::message("Hello, agent!");
+    let json = serde_json::to_value(&event).unwrap();
+
+    assert_eq!(json["type"], "user.message");
+    assert!(json.get("text").is_none(), "user.message must NOT have a 'text' field");
+    assert!(json.get("content").is_some(), "user.message must have a 'content' field");
+    assert_eq!(json["content"][0]["type"], "text");
+    assert_eq!(json["content"][0]["text"], "Hello, agent!");
+}
+
+#[test]
+fn user_message_deserializes_from_canon() {
+    let json = r#"{"type":"user.message","content":[{"type":"text","text":"Hi there"}]}"#;
+    let event: UserEvent = serde_json::from_str(json).unwrap();
+    match event {
+        UserEvent::Message { content } => {
+            assert_eq!(content.len(), 1);
+            match &content[0] {
+                ContentBlock::Text { text } => assert_eq!(text, "Hi there"),
+                _ => panic!("expected Text block"),
+            }
+        }
+        _ => panic!("expected Message variant"),
+    }
+}

--- a/adk-enterprise/tests/user_event_serialization_tests.rs
+++ b/adk-enterprise/tests/user_event_serialization_tests.rs
@@ -8,16 +8,24 @@ fn test_user_event_message_serialization() {
     let json = serde_json::to_value(&event).unwrap();
 
     assert_eq!(json["type"], "user.message");
-    assert_eq!(json["text"], "Hello, agent!");
+    assert_eq!(json["content"][0]["type"], "text");
+    assert_eq!(json["content"][0]["text"], "Hello, agent!");
 }
 
 #[test]
 fn test_user_event_message_deserialization() {
-    let json = r#"{"type": "user.message", "text": "Hello, agent!"}"#;
+    let json =
+        r#"{"type": "user.message", "content": [{"type": "text", "text": "Hello, agent!"}]}"#;
     let event: UserEvent = serde_json::from_str(json).unwrap();
 
     match event {
-        UserEvent::Message { text } => assert_eq!(text, "Hello, agent!"),
+        UserEvent::Message { content } => {
+            assert_eq!(content.len(), 1);
+            match &content[0] {
+                ContentBlock::Text { text } => assert_eq!(text, "Hello, agent!"),
+                _ => panic!("expected Text block"),
+            }
+        }
         _ => panic!("expected Message variant"),
     }
 }


### PR DESCRIPTION
Fixes the last remaining wire-shape incompatibility that breaks `send_message` against the live server.

## Problem

The SDK serialized `user.message` as:
```json
{"type":"user.message","text":"Hello"}
```

The server expects CANON §3.4:
```json
{"type":"user.message","content":[{"type":"text","text":"Hello"}]}
```

Result: `send_message` — the most-used method — returned "missing field content".

## Fix

`UserEvent::Message` now holds `content: Vec<ContentBlock>` instead of `text: String`.
The `UserEvent::message(text)` convenience wraps in `ContentBlock::Text` automatically.

## Contract test added

Two new tests in `contract_tests.rs` validate the serialized and deserialized shapes,
so this can never regress silently.

## Verified

- `cargo fmt --all -- --check` ✅
- `cargo clippy --no-deps -D warnings` ✅  
- `cargo test -p adk-enterprise` — all 257 tests pass
- Contract test `user_message_serializes_with_content_blocks` passes
