### PR TITLE
refactor: v1.0 readiness — resolve all critical audit findings

### DIFF
--- a/adk-agent/src/ambient/agent.rs
+++ b/adk-agent/src/ambient/agent.rs
@@ -1,11 +1,42 @@
 use std::sync::Arc;
 
-use adk_core::{AdkError, Agent, Result};
+use adk_core::{AdkError, Agent, EventStream, Result};
 use futures::StreamExt;
 use tokio::sync::{Notify, RwLock};
 use tokio::task::JoinHandle;
 
 use super::event_source::EventSource;
+
+/// Callback invoked when the ambient agent's event source fires.
+///
+/// Receives the trigger event and the agent reference. The callback is responsible
+/// for creating an appropriate `InvocationContext` (e.g. via a Runner) and invoking
+/// the agent. Return the resulting event stream for the ambient agent to consume.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use std::sync::Arc;
+/// use adk_agent::ambient::{AmbientAgent, TriggerHandler};
+///
+/// let handler: TriggerHandler = Arc::new(move |event, agent| {
+///     let runner = runner.clone();
+///     Box::pin(async move {
+///         // Use the event payload as user content and run through a Runner
+///         let content = Content::new("user").with_text(&event.payload.to_string());
+///         runner.run("user".into(), "session".into(), content).await
+///     })
+/// });
+/// ```
+pub type TriggerHandler = Arc<
+    dyn Fn(
+            super::event_source::TriggerEvent,
+            Arc<dyn Agent>,
+        )
+            -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<EventStream>> + Send>>
+        + Send
+        + Sync,
+>;
 
 /// Lifecycle status of an [`AmbientAgent`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -46,6 +77,7 @@ pub enum AmbientAgentStatus {
 pub struct AmbientAgent {
     agent: Arc<dyn Agent>,
     source: Arc<dyn EventSource>,
+    trigger_handler: Option<TriggerHandler>,
     status: Arc<RwLock<AmbientAgentStatus>>,
     resume_notify: Arc<Notify>,
     handle: Option<JoinHandle<()>>,
@@ -59,10 +91,21 @@ impl AmbientAgent {
         Self {
             agent,
             source,
+            trigger_handler: None,
             status: Arc::new(RwLock::new(AmbientAgentStatus::Stopped)),
             resume_notify: Arc::new(Notify::new()),
             handle: None,
         }
+    }
+
+    /// Set a trigger handler that will be called when the event source fires.
+    ///
+    /// The handler receives the trigger event and agent, and should invoke the
+    /// agent via a Runner or other mechanism. Without a handler, the ambient
+    /// agent only logs trigger events.
+    pub fn with_trigger_handler(mut self, handler: TriggerHandler) -> Self {
+        self.trigger_handler = Some(handler);
+        self
     }
 
     /// Start listening for events and invoking the agent.
@@ -82,6 +125,7 @@ impl AmbientAgent {
         let status = Arc::clone(&self.status);
         let resume_notify = Arc::clone(&self.resume_notify);
         let agent = Arc::clone(&self.agent);
+        let trigger_handler = self.trigger_handler.clone();
 
         *self.status.write().await = AmbientAgentStatus::Running;
 
@@ -102,15 +146,44 @@ impl AmbientAgent {
                     }
                 }
 
-                // Process the event — log the trigger and note that agent invocation
-                // would happen here. Without a Runner reference, we can't fully invoke
-                // the agent, so we log the event details.
+                // Process the event — invoke the agent via the trigger handler
                 tracing::info!(
                     agent = agent.name(),
                     source = %event.source,
-                    "ambient agent triggered (agent invocation placeholder)"
+                    "ambient agent triggered"
                 );
                 tracing::debug!(payload = %event.payload, "trigger event payload");
+
+                if let Some(ref handler) = trigger_handler {
+                    match handler(event, agent.clone()).await {
+                        Ok(mut event_stream) => {
+                            // Consume the event stream, logging results
+                            while let Some(result) = event_stream.next().await {
+                                match result {
+                                    Ok(ev) => {
+                                        tracing::debug!(
+                                            author = %ev.author,
+                                            "ambient agent produced event"
+                                        );
+                                    }
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            error = %e,
+                                            "ambient agent invocation error"
+                                        );
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                error = %e,
+                                "ambient agent trigger handler failed"
+                            );
+                        }
+                    }
+                }
             }
         });
 

--- a/adk-agent/src/ambient/mod.rs
+++ b/adk-agent/src/ambient/mod.rs
@@ -24,7 +24,7 @@ pub mod file_watch_trigger;
 /// WebhookTrigger event source.
 pub mod webhook_trigger;
 
-pub use agent::{AmbientAgent, AmbientAgentStatus};
+pub use agent::{AmbientAgent, AmbientAgentStatus, TriggerHandler};
 pub use cron_trigger::CronTrigger;
 pub use event_source::{EventSource, TriggerEvent};
 pub use file_watch_trigger::FileWatchTrigger;

--- a/adk-agent/src/compaction.rs
+++ b/adk-agent/src/compaction.rs
@@ -83,11 +83,11 @@ impl BaseEventsSummarizer for LlmEventSummarizer {
         use futures::StreamExt;
         let mut summary_content: Option<Content> = None;
         while let Some(chunk_result) = response_stream.next().await {
-            if let Ok(chunk) = chunk_result {
-                if chunk.content.is_some() {
-                    summary_content = chunk.content;
-                    break;
-                }
+            if let Ok(chunk) = chunk_result
+                && chunk.content.is_some()
+            {
+                summary_content = chunk.content;
+                break;
             }
         }
 

--- a/adk-agent/src/llm_agent.rs
+++ b/adk-agent/src/llm_agent.rs
@@ -81,7 +81,6 @@ pub struct LlmAgent {
     disallow_transfer_to_peers: bool,
     include_contents: adk_core::IncludeContents,
     tools: Vec<Arc<dyn Tool>>,
-    #[allow(dead_code)] // Used in runtime toolset resolution (task 2.2)
     toolsets: Vec<Arc<dyn Toolset>>,
     sub_agents: Vec<Arc<dyn Agent>>,
     output_key: Option<String>,
@@ -1417,12 +1416,11 @@ impl Agent for LlmAgent {
             let collect_long_running_ids = |content: &Content| -> Vec<String> {
                 content.parts.iter()
                     .filter_map(|p| {
-                        if let Part::FunctionCall { name, .. } = p {
-                            if let Some(tool) = tool_map.get(name) {
-                                if tool.is_long_running() {
-                                    return Some(name.clone());
-                                }
-                            }
+                        if let Part::FunctionCall { name, .. } = p
+                            && let Some(tool) = tool_map.get(name)
+                            && tool.is_long_running()
+                        {
+                            return Some(name.clone());
                         }
                         None
                     })
@@ -1896,24 +1894,24 @@ impl Agent for LlmAgent {
                     ));
 
                     // Handle output_key: save final agent output to state_delta
-                    if let Some(ref output_key) = output_key {
-                        if !has_function_calls {  // Only save if not calling tools
-                            let mut text_parts = String::new();
-                            for part in &content.parts {
-                                if let Part::Text { text } = part {
-                                    text_parts.push_str(text);
-                                }
+                    if let Some(ref output_key) = output_key
+                        && !has_function_calls
+                    {
+                        let mut text_parts = String::new();
+                        for part in &content.parts {
+                            if let Part::Text { text } = part {
+                                text_parts.push_str(text);
                             }
-                            if !text_parts.is_empty() {
-                                // Yield a final state update event
-                                let mut state_event = Event::new(&invocation_id);
-                                state_event.author = agent_name.clone();
-                                state_event.actions.state_delta.insert(
-                                    output_key.clone(),
-                                    serde_json::Value::String(text_parts),
-                                );
-                                yield Ok(state_event);
-                            }
+                        }
+                        if !text_parts.is_empty() {
+                            // Yield a final state update event
+                            let mut state_event = Event::new(&invocation_id);
+                            state_event.author = agent_name.clone();
+                            state_event.actions.state_delta.insert(
+                                output_key.clone(),
+                                serde_json::Value::String(text_parts),
+                            );
+                            yield Ok(state_event);
                         }
                     }
                 }
@@ -2057,11 +2055,11 @@ impl Agent for LlmAgent {
                         if fc_name == "transfer_to_agent" {
                             return false;
                         }
-                        if let Some(tool) = tool_map.get(fc_name) {
-                            if tool.is_builtin() {
-                                adk_telemetry::debug!(tool.name = %fc_name, "skipping built-in tool execution");
-                                return false;
-                            }
+                        if let Some(tool) = tool_map.get(fc_name)
+                            && tool.is_builtin()
+                        {
+                            adk_telemetry::debug!(tool.name = %fc_name, "skipping built-in tool execution");
+                            return false;
                         }
                         true
                     }).collect();
@@ -2282,25 +2280,25 @@ impl Agent for LlmAgent {
                             // Circuit breaker check
                             if response_content.is_none() {
                                 let guard = cb_mutex.lock().unwrap_or_else(|e| e.into_inner());
-                                if let Some(ref cb_state) = *guard {
-                                    if cb_state.is_open(&name) {
-                                        let msg = format!(
-                                            "Tool '{}' is temporarily disabled after {} consecutive failures",
-                                            name, cb_state.threshold
-                                        );
-                                        tracing::warn!(tool.name = %name, "circuit breaker open, skipping tool execution");
-                                        response_content = Some(Content {
-                                            role: "function".to_string(),
-                                            parts: vec![Part::FunctionResponse {
-                                                function_response: FunctionResponseData::new(
-                                                    name.clone(),
-                                                    serde_json::json!({ "error": msg }),
-                                                ),
-                                                id: id.clone(),
-                                            }],
-                                        });
-                                        run_after_tool_callbacks = false;
-                                    }
+                                if let Some(ref cb_state) = *guard
+                                    && cb_state.is_open(&name)
+                                {
+                                    let msg = format!(
+                                        "Tool '{}' is temporarily disabled after {} consecutive failures",
+                                        name, cb_state.threshold
+                                    );
+                                    tracing::warn!(tool.name = %name, "circuit breaker open, skipping tool execution");
+                                    response_content = Some(Content {
+                                        role: "function".to_string(),
+                                        parts: vec![Part::FunctionResponse {
+                                            function_response: FunctionResponseData::new(
+                                                name.clone(),
+                                                serde_json::json!({ "error": msg }),
+                                            ),
+                                            id: id.clone(),
+                                        }],
+                                    });
+                                    run_after_tool_callbacks = false;
                                 }
                                 drop(guard);
                             }
@@ -2346,7 +2344,15 @@ impl Agent for LlmAgent {
                                             );
                                             tracing::debug!(tool.name = %name, tool.args = %args_payload, attempt = attempt, "tool_call");
                                             let exec_future = tool_clone.execute(tool_ctx.clone(), final_args.clone());
-                                            tokio::time::timeout(tool_timeout, exec_future).await
+                                            let unwind_safe_future = std::panic::AssertUnwindSafe(
+                                                tokio::time::timeout(tool_timeout, exec_future)
+                                            );
+                                            match futures::FutureExt::catch_unwind(unwind_safe_future).await {
+                                                Ok(result) => result,
+                                                Err(_panic) => Ok(Err(adk_core::AdkError::tool(
+                                                    format!("tool '{}' panicked during execution", name),
+                                                ))),
+                                            }
                                         }.instrument(tool_span.clone()).await {
                                             Ok(Ok(value)) => {
                                                 let result_payload = trace_json_payload(

--- a/adk-agent/src/workflow/loop_agent.rs
+++ b/adk-agent/src/workflow/loop_agent.rs
@@ -171,24 +171,24 @@ impl HistoryTrackingSession {
 
             if event.llm_response.partial {
                 // Partial chunk — merge into last entry if same role
-                if let Some(last) = history.last_mut() {
-                    if last.role == content.role {
-                        for part in &content.parts {
-                            if let adk_core::Part::Text { text } = part {
-                                // Append text to the last Text part
-                                if let Some(adk_core::Part::Text { text: existing }) =
-                                    last.parts.last_mut()
-                                {
-                                    existing.push_str(text);
-                                } else {
-                                    last.parts.push(part.clone());
-                                }
+                if let Some(last) = history.last_mut()
+                    && last.role == content.role
+                {
+                    for part in &content.parts {
+                        if let adk_core::Part::Text { text } = part {
+                            // Append text to the last Text part
+                            if let Some(adk_core::Part::Text { text: existing }) =
+                                last.parts.last_mut()
+                            {
+                                existing.push_str(text);
                             } else {
                                 last.parts.push(part.clone());
                             }
+                        } else {
+                            last.parts.push(part.clone());
                         }
-                        return;
                     }
+                    return;
                 }
                 // No matching last entry — start a new one
                 history.push(content.clone());

--- a/adk-core/src/context.rs
+++ b/adk-core/src/context.rs
@@ -766,6 +766,11 @@ pub struct RunConfig {
     /// Maximum serialized bytes recorded for tracing payload fields when full
     /// payload recording is disabled.
     pub trace_payload_max_bytes: usize,
+    /// Maximum number of agent-to-agent transfers allowed in a single run.
+    ///
+    /// Prevents infinite transfer loops when agents transfer back and forth.
+    /// Defaults to 10 when `None`.
+    pub max_transfer_depth: Option<u32>,
 }
 
 impl Default for RunConfig {
@@ -781,6 +786,7 @@ impl Default for RunConfig {
             tool_concurrency: ToolConcurrencyConfig::default(),
             record_payloads: false,
             trace_payload_max_bytes: 2048,
+            max_transfer_depth: None,
         }
     }
 }
@@ -892,6 +898,14 @@ impl RunConfigBuilder {
         self
     }
 
+    /// Sets the maximum number of agent-to-agent transfers allowed in a single run.
+    ///
+    /// Prevents infinite transfer loops. Defaults to 10 when `None`.
+    pub fn max_transfer_depth(mut self, depth: u32) -> Self {
+        self.config.max_transfer_depth = Some(depth);
+        self
+    }
+
     /// Consumes the builder and returns the configured [`RunConfig`].
     pub fn build(self) -> RunConfig {
         self.config
@@ -913,6 +927,7 @@ mod tests {
         assert!(!config.record_payloads);
         assert_eq!(config.trace_payload_max_bytes, 2048);
         assert!(config.tool_confirmation_decisions.is_empty());
+        assert_eq!(config.max_transfer_depth, None);
     }
 
     #[test]

--- a/adk-gemini/src/client.rs
+++ b/adk-gemini/src/client.rs
@@ -63,10 +63,6 @@ pub enum Model {
     /// Gemini 3.1 Flash Lite — GA, most cost-efficient for high-volume agentic tasks.
     #[serde(rename = "models/gemini-3.1-flash-lite")]
     Gemini31FlashLite,
-    /// Gemini 3.1 Flash Lite preview (deprecated).
-    #[deprecated(note = "Shut down May 25, 2026. Use Model::Gemini31FlashLite instead.")]
-    #[serde(rename = "models/gemini-3.1-flash-lite-preview")]
-    Gemini31FlashLitePreview,
     /// Gemini 3.1 Flash Image (Nano Banana 2) — GA native image generation.
     #[serde(rename = "models/gemini-3.1-flash-image")]
     Gemini31FlashImage,
@@ -123,28 +119,6 @@ pub enum Model {
     #[serde(rename = "models/gemini-2.5-flash-lite-preview-09-2025")]
     Gemini25FlashLitePreview092025,
 
-    // ── Gemini 2.0 (deprecated, shutting down March 31, 2026) ────
-    /// Gemini 2.0 Flash (deprecated).
-    #[deprecated(note = "Gemini 2.0 models shut down March 31, 2026")]
-    #[serde(rename = "models/gemini-2.0-flash")]
-    Gemini20Flash,
-    /// Gemini 2.0 Flash 001 (deprecated).
-    #[deprecated(note = "Gemini 2.0 models shut down March 31, 2026")]
-    #[serde(rename = "models/gemini-2.0-flash-001")]
-    Gemini20Flash001,
-    /// Gemini 2.0 Flash experimental (deprecated).
-    #[deprecated(note = "Gemini 2.0 models shut down March 31, 2026")]
-    #[serde(rename = "models/gemini-2.0-flash-exp")]
-    Gemini20FlashExp,
-    /// Gemini 2.0 Flash Lite (deprecated).
-    #[deprecated(note = "Gemini 2.0 models shut down March 31, 2026")]
-    #[serde(rename = "models/gemini-2.0-flash-lite")]
-    Gemini20FlashLite,
-    /// Gemini 2.0 Flash Lite 001 (deprecated).
-    #[deprecated(note = "Gemini 2.0 models shut down March 31, 2026")]
-    #[serde(rename = "models/gemini-2.0-flash-lite-001")]
-    Gemini20FlashLite001,
-
     // ── Embedding models ─────────────────────────────────────────
     /// Gemini Embedding 2 — GA multimodal embeddings (text, image, video, audio, PDF).
     #[serde(rename = "models/gemini-embedding-2")]
@@ -152,10 +126,6 @@ pub enum Model {
     /// Gemini Embedding 001 (3072 dimensions). Replaces text-embedding-004.
     #[serde(rename = "models/gemini-embedding-001")]
     GeminiEmbedding001,
-    /// Deprecated: use `GeminiEmbedding001` instead.
-    #[deprecated(note = "Use Model::GeminiEmbedding001 (gemini-embedding-001) instead")]
-    #[serde(rename = "models/text-embedding-004")]
-    TextEmbedding004,
 
     // ── Custom ───────────────────────────────────────────────────
     /// A custom model identifier string (e.g. `"models/my-tuned-model"`).
@@ -171,7 +141,6 @@ impl Model {
             Model::Gemini35Flash => "models/gemini-3.5-flash",
             Model::Gemini31ProPreview => "models/gemini-3.1-pro-preview",
             Model::Gemini31FlashLite => "models/gemini-3.1-flash-lite",
-            Model::Gemini31FlashLitePreview => "models/gemini-3.1-flash-lite-preview",
             Model::Gemini31FlashImage => "models/gemini-3.1-flash-image",
             Model::Gemini3ProPreview => "models/gemini-3-pro-preview",
             Model::Gemini3ProImage => "models/gemini-3-pro-image",
@@ -192,14 +161,8 @@ impl Model {
             Model::Gemini25FlashPreviewTts => "models/gemini-2.5-flash-preview-tts",
             Model::Gemini25FlashLite => "models/gemini-2.5-flash-lite",
             Model::Gemini25FlashLitePreview092025 => "models/gemini-2.5-flash-lite-preview-09-2025",
-            Model::Gemini20Flash => "models/gemini-2.0-flash",
-            Model::Gemini20Flash001 => "models/gemini-2.0-flash-001",
-            Model::Gemini20FlashExp => "models/gemini-2.0-flash-exp",
-            Model::Gemini20FlashLite => "models/gemini-2.0-flash-lite",
-            Model::Gemini20FlashLite001 => "models/gemini-2.0-flash-lite-001",
             Model::GeminiEmbedding2 => "models/gemini-embedding-2",
             Model::GeminiEmbedding001 => "models/gemini-embedding-001",
-            Model::TextEmbedding004 => "models/text-embedding-004",
             Model::Custom(model) => model,
         }
     }
@@ -211,7 +174,6 @@ impl Model {
             Model::Gemini35Flash => "gemini-3.5-flash",
             Model::Gemini31ProPreview => "gemini-3.1-pro-preview",
             Model::Gemini31FlashLite => "gemini-3.1-flash-lite",
-            Model::Gemini31FlashLitePreview => "gemini-3.1-flash-lite-preview",
             Model::Gemini31FlashImage => "gemini-3.1-flash-image",
             Model::Gemini3ProPreview => "gemini-3-pro-preview",
             Model::Gemini3ProImage => "gemini-3-pro-image",
@@ -228,14 +190,8 @@ impl Model {
             Model::Gemini25FlashPreviewTts => "gemini-2.5-flash-preview-tts",
             Model::Gemini25FlashLite => "gemini-2.5-flash-lite",
             Model::Gemini25FlashLitePreview092025 => "gemini-2.5-flash-lite-preview-09-2025",
-            Model::Gemini20Flash => "gemini-2.0-flash",
-            Model::Gemini20Flash001 => "gemini-2.0-flash-001",
-            Model::Gemini20FlashExp => "gemini-2.0-flash-exp",
-            Model::Gemini20FlashLite => "gemini-2.0-flash-lite",
-            Model::Gemini20FlashLite001 => "gemini-2.0-flash-lite-001",
             Model::GeminiEmbedding2 => "gemini-embedding-2",
             Model::GeminiEmbedding001 => "gemini-embedding-001",
-            Model::TextEmbedding004 => "text-embedding-004",
             Model::Custom(model) => {
                 if model.starts_with("projects/") {
                     return model.clone();
@@ -261,7 +217,6 @@ impl From<String> for Model {
             // Gemini 3.1 models
             "gemini-3.1-pro-preview" => Self::Gemini31ProPreview,
             "gemini-3.1-flash-lite" => Self::Gemini31FlashLite,
-            "gemini-3.1-flash-lite-preview" => Self::Gemini31FlashLitePreview,
             "gemini-3.1-flash-image" => Self::Gemini31FlashImage,
             // Gemini 3 models
             "gemini-3-pro-preview" => Self::Gemini3ProPreview,
@@ -280,16 +235,9 @@ impl From<String> for Model {
             "gemini-2.5-flash-preview-tts" => Self::Gemini25FlashPreviewTts,
             "gemini-2.5-flash-lite" => Self::Gemini25FlashLite,
             "gemini-2.5-flash-lite-preview-09-2025" => Self::Gemini25FlashLitePreview092025,
-            // Gemini 2.0 models (deprecated, shutting down March 31, 2026)
-            "gemini-2.0-flash" => Self::Gemini20Flash,
-            "gemini-2.0-flash-001" => Self::Gemini20Flash001,
-            "gemini-2.0-flash-exp" => Self::Gemini20FlashExp,
-            "gemini-2.0-flash-lite" => Self::Gemini20FlashLite,
-            "gemini-2.0-flash-lite-001" => Self::Gemini20FlashLite001,
             // Embedding models
             "gemini-embedding-2" => Self::GeminiEmbedding2,
             "gemini-embedding-001" => Self::GeminiEmbedding001,
-            "text-embedding-004" => Self::TextEmbedding004,
             _ => Self::Custom(model),
         }
     }

--- a/adk-gemini/src/pricing.rs
+++ b/adk-gemini/src/pricing.rs
@@ -283,9 +283,7 @@ impl GeminiPricing {
         let pricing = match model {
             Model::Gemini35Flash => Self::GEMINI_35_FLASH,
             Model::Gemini31ProPreview => Self::GEMINI_31_PRO_PREVIEW,
-            Model::Gemini31FlashLite | Model::Gemini31FlashLitePreview => {
-                Self::GEMINI_31_FLASH_LITE
-            }
+            Model::Gemini31FlashLite => Self::GEMINI_31_FLASH_LITE,
             Model::Gemini31FlashImage => Self::GEMINI_31_FLASH_IMAGE,
             Model::Gemini3FlashPreview => Self::GEMINI_3_FLASH_PREVIEW,
             Model::Gemini3ProImage | Model::Gemini3ProImagePreview => Self::GEMINI_3_PRO_IMAGE,
@@ -302,13 +300,8 @@ impl GeminiPricing {
             Model::Gemini25FlashLive122025 | Model::Gemini25FlashLive092025 => {
                 Self::GEMINI_25_FLASH_NATIVE_AUDIO
             }
-            Model::Gemini20Flash
-            | Model::Gemini20Flash001
-            | Model::Gemini20FlashExp
-            | Model::Gemini20FlashLite
-            | Model::Gemini20FlashLite001 => Self::GEMINI_20_FLASH,
             Model::GeminiEmbedding2 => Self::GEMINI_EMBEDDING_2,
-            Model::GeminiEmbedding001 | Model::TextEmbedding004 => Self::GEMINI_EMBEDDING,
+            Model::GeminiEmbedding001 => Self::GEMINI_EMBEDDING,
             // No published per-token text pricing (Pro Image preview text uses 3.1 Pro
             // rates; the dedicated Gemini 3 Pro Preview text model is discontinued).
             Model::Gemini3ProPreview => Self::GEMINI_31_PRO_PREVIEW,

--- a/adk-graph/src/agent.rs
+++ b/adk-graph/src/agent.rs
@@ -146,12 +146,11 @@ impl Agent for GraphAgent {
                     let events = output_mapper(&state);
                     for event in events {
                         // Call after callback for each event
-                        if let Some(callback) = &after_callback {
-                            if let Err(e) = callback(ctx_clone.clone(), event.clone()).await {
+                        if let Some(callback) = &after_callback
+                            && let Err(e) = callback(ctx_clone.clone(), event.clone()).await {
                                 yield Err(e);
                                 return;
                             }
-                        }
                         yield Ok(event);
                     }
                 }
@@ -317,12 +316,11 @@ impl GraphAgentBuilder {
             let entry_idx = self.edges.iter().position(|e| matches!(e, Edge::Entry { .. }));
             match entry_idx {
                 Some(idx) => {
-                    if let Edge::Entry { targets } = &mut self.edges[idx] {
-                        if let EdgeTarget::Node(node) = &target {
-                            if !targets.contains(node) {
-                                targets.push(node.clone());
-                            }
-                        }
+                    if let Edge::Entry { targets } = &mut self.edges[idx]
+                        && let EdgeTarget::Node(node) = &target
+                        && !targets.contains(node)
+                    {
+                        targets.push(node.clone());
                     }
                 }
                 None => {

--- a/adk-graph/src/executor.rs
+++ b/adk-graph/src/executor.rs
@@ -221,11 +221,10 @@ impl<'a> PregelExecutor<'a> {
 
                             // Attach progress handle if idle timeout is configured
                             let policy = self.graph.timeout_policy_for(node_name).cloned();
-                            if let Some(ref p) = policy {
-                                if p.idle_timeout.is_some() {
+                            if let Some(ref p) = policy
+                                && p.idle_timeout.is_some() {
                                     ctx.set_progress_handle(ProgressHandle::new());
                                 }
-                            }
 
                             let start = std::time::Instant::now();
 
@@ -468,10 +467,10 @@ impl<'a> PregelExecutor<'a> {
 
         // If resuming from checkpoint, load it
         if let Some(checkpoint_id) = &self.config.resume_from {
-            if let Some(cp) = self.graph.checkpointer.as_ref() {
-                if let Some(checkpoint) = cp.load_by_id(checkpoint_id).await? {
-                    state = checkpoint.state;
-                }
+            if let Some(cp) = self.graph.checkpointer.as_ref()
+                && let Some(checkpoint) = cp.load_by_id(checkpoint_id).await?
+            {
+                state = checkpoint.state;
             }
         } else if let Some(cp) = self.graph.checkpointer.as_ref() {
             // Try to load latest checkpoint for thread
@@ -573,10 +572,10 @@ impl<'a> PregelExecutor<'a> {
                 let mut ctx = NodeContext::new(self.state.clone(), self.config.clone(), self.step);
 
                 // Attach a ProgressHandle when idle timeout is configured
-                if let Some(ref p) = policy {
-                    if p.idle_timeout.is_some() {
-                        ctx.set_progress_handle(ProgressHandle::new());
-                    }
+                if let Some(ref p) = policy
+                    && p.idle_timeout.is_some()
+                {
+                    ctx.set_progress_handle(ProgressHandle::new());
                 }
 
                 let step = self.step;
@@ -712,16 +711,16 @@ impl CompiledGraph {
         thread_id: &str,
         updates: impl IntoIterator<Item = (String, serde_json::Value)>,
     ) -> Result<()> {
-        if let Some(cp) = &self.checkpointer {
-            if let Some(checkpoint) = cp.load(thread_id).await? {
-                let mut state = checkpoint.state;
-                for (key, value) in updates {
-                    self.schema.apply_update(&mut state, &key, value);
-                }
-                let new_checkpoint =
-                    Checkpoint::new(thread_id, state, checkpoint.step, checkpoint.pending_nodes);
-                cp.save(&new_checkpoint).await?;
+        if let Some(cp) = &self.checkpointer
+            && let Some(checkpoint) = cp.load(thread_id).await?
+        {
+            let mut state = checkpoint.state;
+            for (key, value) in updates {
+                self.schema.apply_update(&mut state, &key, value);
             }
+            let new_checkpoint =
+                Checkpoint::new(thread_id, state, checkpoint.step, checkpoint.pending_nodes);
+            cp.save(&new_checkpoint).await?;
         }
         Ok(())
     }

--- a/adk-graph/src/graph.rs
+++ b/adk-graph/src/graph.rs
@@ -55,12 +55,11 @@ impl StateGraph {
 
             match entry_idx {
                 Some(idx) => {
-                    if let Edge::Entry { targets } = &mut self.edges[idx] {
-                        if let EdgeTarget::Node(node) = &target {
-                            if !targets.contains(node) {
-                                targets.push(node.clone());
-                            }
-                        }
+                    if let Edge::Entry { targets } = &mut self.edges[idx]
+                        && let EdgeTarget::Node(node) = &target
+                        && !targets.contains(node)
+                    {
+                        targets.push(node.clone());
                     }
                 }
                 None => {
@@ -151,10 +150,10 @@ impl StateGraph {
                     if source != START && !self.nodes.contains_key(source) {
                         return Err(GraphError::NodeNotFound(source.clone()));
                     }
-                    if let EdgeTarget::Node(name) = target {
-                        if !self.nodes.contains_key(name) {
-                            return Err(GraphError::EdgeTargetNotFound(name.clone()));
-                        }
+                    if let EdgeTarget::Node(name) = target
+                        && !self.nodes.contains_key(name)
+                    {
+                        return Err(GraphError::EdgeTargetNotFound(name.clone()));
                     }
                 }
                 Edge::Conditional { source, targets, .. } => {
@@ -162,10 +161,10 @@ impl StateGraph {
                         return Err(GraphError::NodeNotFound(source.clone()));
                     }
                     for target in targets.values() {
-                        if let EdgeTarget::Node(name) = target {
-                            if !self.nodes.contains_key(name) {
-                                return Err(GraphError::EdgeTargetNotFound(name.clone()));
-                            }
+                        if let EdgeTarget::Node(name) = target
+                            && !self.nodes.contains_key(name)
+                        {
+                            return Err(GraphError::EdgeTargetNotFound(name.clone()));
                         }
                     }
                 }
@@ -268,10 +267,10 @@ impl CompiledGraph {
                 }
                 Edge::Conditional { source, router, targets } if executed.contains(source) => {
                     let route = router(state);
-                    if let Some(EdgeTarget::Node(n)) = targets.get(&route) {
-                        if !next.contains(n) {
-                            next.push(n.clone());
-                        }
+                    if let Some(EdgeTarget::Node(n)) = targets.get(&route)
+                        && !next.contains(n)
+                    {
+                        next.push(n.clone());
                     }
                     // If route leads to END or not found in targets, next will be empty for this path
                 }
@@ -296,10 +295,10 @@ impl CompiledGraph {
                     if route == END {
                         return true;
                     }
-                    if let Some(target) = targets.get(&route) {
-                        if target.is_end() {
-                            return true;
-                        }
+                    if let Some(target) = targets.get(&route)
+                        && target.is_end()
+                    {
+                        return true;
                     }
                 }
                 _ => {}
@@ -322,18 +321,20 @@ impl CompiledGraph {
         for edge in &self.edges {
             match edge {
                 Edge::Direct { source, target } => {
-                    if let EdgeTarget::Node(name) = target {
-                        if name == target_node && !sources.contains(source) {
-                            sources.push(source.clone());
-                        }
+                    if let EdgeTarget::Node(name) = target
+                        && name == target_node
+                        && !sources.contains(source)
+                    {
+                        sources.push(source.clone());
                     }
                 }
                 Edge::Conditional { source, targets, .. } => {
                     for target in targets.values() {
-                        if let EdgeTarget::Node(name) = target {
-                            if name == target_node && !sources.contains(source) {
-                                sources.push(source.clone());
-                            }
+                        if let EdgeTarget::Node(name) = target
+                            && name == target_node
+                            && !sources.contains(source)
+                        {
+                            sources.push(source.clone());
                         }
                     }
                 }

--- a/adk-graph/src/node.rs
+++ b/adk-graph/src/node.rs
@@ -324,21 +324,19 @@ impl AgentNode {
 /// Default input mapper - looks for "messages" or "input" in state
 fn default_input_mapper(state: &State) -> adk_core::Content {
     // Try to get messages first
-    if let Some(messages) = state.get("messages") {
-        if let Some(arr) = messages.as_array() {
-            if let Some(last) = arr.last() {
-                if let Some(content) = last.get("content").and_then(|c| c.as_str()) {
-                    return adk_core::Content::new("user").with_text(content);
-                }
-            }
-        }
+    if let Some(messages) = state.get("messages")
+        && let Some(arr) = messages.as_array()
+        && let Some(last) = arr.last()
+        && let Some(content) = last.get("content").and_then(|c| c.as_str())
+    {
+        return adk_core::Content::new("user").with_text(content);
     }
 
     // Try input field
-    if let Some(input) = state.get("input") {
-        if let Some(text) = input.as_str() {
-            return adk_core::Content::new("user").with_text(text);
-        }
+    if let Some(input) = state.get("input")
+        && let Some(text) = input.as_str()
+    {
+        return adk_core::Content::new("user").with_text(text);
     }
 
     adk_core::Content::new("user")

--- a/adk-graph/src/time_travel.rs
+++ b/adk-graph/src/time_travel.rs
@@ -118,9 +118,7 @@ pub struct StepInfo {
 /// handle.fork_at(1, "alternative_thread").await?;
 /// ```
 pub struct TimeTravelHandle<'g> {
-    /// Reference to the compiled graph for re-execution.
-    /// Used by `resume_from` and `replay` (implemented in tasks 8.3, 8.5).
-    #[allow(dead_code)]
+    /// Reference to the compiled graph for re-execution in `resume_from`.
     pub(crate) graph: &'g CompiledGraph,
     /// The thread identifier whose history is being navigated.
     pub(crate) thread_id: String,

--- a/adk-runner/src/context.rs
+++ b/adk-runner/src/context.rs
@@ -135,10 +135,10 @@ impl MutableSession {
             }
 
             // Skip events that were already compacted
-            if let Some(boundary) = compaction_boundary {
-                if event.timestamp <= boundary {
-                    continue;
-                }
+            if let Some(boundary) = compaction_boundary
+                && event.timestamp <= boundary
+            {
+                continue;
             }
 
             // When filtering for a specific agent, skip events from other agents.
@@ -146,10 +146,11 @@ impl MutableSession {
             // Skip: other agents' events entirely (model-role, function calls,
             // and function/tool responses). This prevents the sub-agent from
             // seeing orphaned function responses without their preceding calls.
-            if let Some(name) = agent_name {
-                if event.author != "user" && event.author != name {
-                    continue;
-                }
+            if let Some(name) = agent_name
+                && event.author != "user"
+                && event.author != name
+            {
+                continue;
             }
 
             if let Some(content) = &event.llm_response.content {

--- a/adk-runner/src/runner.rs
+++ b/adk-runner/src/runner.rs
@@ -347,8 +347,8 @@ impl Runner {
             let selected_skill_id = String::new();
 
             #[cfg(feature = "skills")]
-            if let Some(injector) = skill_injector.as_ref() {
-                if let Some(matched) = adk_skill::apply_skill_injection(
+            if let Some(injector) = skill_injector.as_ref()
+                && let Some(matched) = adk_skill::apply_skill_injection(
                     &mut effective_user_content,
                     injector.index(),
                     injector.policy(),
@@ -357,7 +357,6 @@ impl Runner {
                     selected_skill_name = matched.skill.name;
                     selected_skill_id = matched.skill.id;
                 }
-            }
 
             let mut invocation_ctx = match InvocationContext::new_typed(
                 invocation_id.clone(),
@@ -531,15 +530,14 @@ impl Runner {
                                 old
                             };
 
-                            if let Some(old) = old_cache {
-                                if let Err(e) = cache_model.delete_cache(&old).await {
+                            if let Some(old) = old_cache
+                                && let Err(e) = cache_model.delete_cache(&old).await {
                                     tracing::warn!(
                                         old_cache = %old,
                                         error = %e,
                                         "failed to delete old cache, proceeding with new cache"
                                     );
                                 }
-                            }
                         }
                         Err(e) => {
                             tracing::warn!(
@@ -712,15 +710,14 @@ impl Runner {
             let mut transfer_target: Option<String> = None;
 
             while let Some(result) = {
-                if let Some(token) = cancellation_token.as_ref() {
-                    if token.is_cancelled() {
+                if let Some(token) = cancellation_token.as_ref()
+                    && token.is_cancelled() {
                         #[cfg(feature = "plugins")]
                         if let Some(manager) = plugin_manager.as_ref() {
                             manager.run_after_run(ctx.clone() as Arc<dyn adk_core::InvocationContext>).await;
                         }
                         return;
                     }
-                }
                 agent_stream.next().await
             } {
                 match result {
@@ -772,8 +769,8 @@ impl Runner {
                         // persisting each one would violate the primary key
                         // constraint. The final chunk (partial=false) carries the
                         // complete accumulated content.
-                        if !event.llm_response.partial {
-                            if let Err(e) = session_service.append_event(ctx.session_id(), event.clone()).await {
+                        if !event.llm_response.partial
+                            && let Err(e) = session_service.append_event(ctx.session_id(), event.clone()).await {
                                 #[cfg(feature = "plugins")]
                                 if let Some(manager) = plugin_manager.as_ref() {
                                     manager.run_after_run(ctx.clone() as Arc<dyn adk_core::InvocationContext>).await;
@@ -781,7 +778,6 @@ impl Runner {
                                 yield Err(e);
                                 return;
                             }
-                        }
                         yield Ok(event);
                     }
                     Err(e) => {
@@ -801,13 +797,14 @@ impl Runner {
             // target from the root agent tree, computes transfer_targets
             // (parent + peers) for the new agent, and runs it. This repeats
             // until no further transfer is requested or the depth limit is hit.
-            const MAX_TRANSFER_DEPTH: u32 = 10;
+            const DEFAULT_MAX_TRANSFER_DEPTH: u32 = 10;
+            let max_depth = run_config.max_transfer_depth.unwrap_or(DEFAULT_MAX_TRANSFER_DEPTH);
             let mut transfer_depth: u32 = 0;
             let mut current_transfer_target = transfer_target;
 
             while let Some(target_name) = current_transfer_target.take() {
                 transfer_depth += 1;
-                if transfer_depth > MAX_TRANSFER_DEPTH {
+                if transfer_depth > max_depth {
                     tracing::warn!(
                         depth = transfer_depth,
                         target = %target_name,
@@ -892,15 +889,14 @@ impl Runner {
 
                 // Stream events from the transferred agent, capturing any further transfer
                 while let Some(result) = {
-                    if let Some(token) = cancellation_token.as_ref() {
-                        if token.is_cancelled() {
+                    if let Some(token) = cancellation_token.as_ref()
+                        && token.is_cancelled() {
                             #[cfg(feature = "plugins")]
                             if let Some(manager) = plugin_manager.as_ref() {
                                 manager.run_after_run(ctx.clone() as Arc<dyn adk_core::InvocationContext>).await;
                             }
                             return;
                         }
-                    }
                     transfer_stream.next().await
                 } {
                     match result {
@@ -941,8 +937,8 @@ impl Runner {
                             // Add to mutable session
                             transfer_ctx.mutable_session().append_event(event.clone());
 
-                            if !event.llm_response.partial {
-                                if let Err(e) = session_service.append_event(ctx.session_id(), event.clone()).await {
+                            if !event.llm_response.partial
+                                && let Err(e) = session_service.append_event(ctx.session_id(), event.clone()).await {
                                     #[cfg(feature = "plugins")]
                                     if let Some(manager) = plugin_manager.as_ref() {
                                         manager.run_after_run(ctx.clone() as Arc<dyn adk_core::InvocationContext>).await;
@@ -950,7 +946,6 @@ impl Runner {
                                     yield Err(e);
                                     return;
                                 }
-                            }
                             yield Ok(event);
                         }
                         Err(e) => {
@@ -977,7 +972,7 @@ impl Runner {
                         as u32;
 
                     if invocation_count > 0
-                        && invocation_count % compaction_cfg.compaction_interval == 0
+                        && invocation_count.is_multiple_of(compaction_cfg.compaction_interval)
                     {
                         // Determine the window of events to compact
                         // We compact all events except the most recent overlap_size invocations
@@ -1123,10 +1118,10 @@ impl Runner {
         for i in (0..events.len()).rev() {
             if let Some(event) = events.at(i) {
                 // Check for explicit transfer
-                if let Some(target_name) = &event.actions.transfer_to_agent {
-                    if let Some(agent) = Self::find_agent(root_agent, target_name) {
-                        return agent;
-                    }
+                if let Some(target_name) = &event.actions.transfer_to_agent
+                    && let Some(agent) = Self::find_agent(root_agent, target_name)
+                {
+                    return agent;
                 }
 
                 if event.author == "user" {


### PR DESCRIPTION
1. Ambient agent: Add TriggerHandler callback for real agent invocation. No longer a stub — accepts a handler that creates InvocationContext and runs the agent through Runner. Backward compatible (without handler it still logs triggers).

2. Toolsets field: Removed stale #[allow(dead_code)] — the field IS used (toolset resolution is fully implemented at line ~1370). The comment "task 2.2" was outdated.

3. Deprecated Gemini 2.0 models removed: Gemini20Flash, Gemini20FlashLite, Gemini20FlashExp, Gemini31FlashLitePreview, TextEmbedding004 — all past their shutdown dates.

4. Panic recovery: Tool execution in LlmAgent wrapped in catch_unwind. Panicking tools now return AdkError instead of crashing the stream.

5. Time-travel dead_code: Removed #[allow(dead_code)] — the graph field IS used by resume_from(). Updated doc comment.

6. Configurable transfer depth: RunConfig.max_transfer_depth (Option<u32>, defaults to None = 10). Runner reads it instead of hardcoded const.

7. Fixed 36 collapsible_if clippy warnings across adk-agent, adk-runner, adk-graph.

Verified: cargo check --workspace, clippy -D warnings on all affected crates, fmt clean, 449 tests pass (core+agent+runner+gemini+graph).

## What

Brief description of the change.

## Why

Link to the issue this addresses: Fixes #___

## How

Summary of the approach taken.

## PR Checklist

### Quality Gates (all required)

- [ ] `devenv shell fmt` — code is formatted (Edition 2024)
- [ ] `devenv shell clippy` — zero warnings (-D warnings)
- [ ] `devenv shell test` — all non-ignored tests pass
- [ ] `devenv shell check` — fast workspace compilation check

### Code Quality

- [ ] New code has tests (unit, integration, or property tests as appropriate)
- [ ] Public APIs have rustdoc comments with `# Example` sections
- [ ] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [ ] No hardcoded secrets, API keys, or local paths

### Hygiene

- [ ] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [ ] No unrelated changes mixed in (formatting, refactoring, other features)
- [ ] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [ ] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [ ] PR targets `main` branch

### Documentation (if applicable)

- [ ] CHANGELOG.md updated for user-facing changes
- [ ] README updated if crate capabilities changed
- [ ] Examples added or updated for new features
