### PR TITLE
fix: break circular deps + missing environment_id field

### DIFF
--- a/adk-model/src/gemini/client.rs
+++ b/adk-model/src/gemini/client.rs
@@ -2247,6 +2247,7 @@ mod interactions_transport_tests {
             usage: None,
             created: None,
             updated: None,
+            environment_id: None,
         };
 
         let err = interaction_status_to_result(interaction.status)

--- a/adk-model/src/gemini/interactions_convert.rs
+++ b/adk-model/src/gemini/interactions_convert.rs
@@ -1430,6 +1430,7 @@ mod tests {
             usage: None,
             created: None,
             updated: None,
+            environment_id: None,
         }
     }
 


### PR DESCRIPTION
## Changes

1. **Break circular deps for crates.io publishing** (from PR #371 which was merged)
2. **Add missing `environment_id` field** to `Interaction` struct initializers in test code

The `environment_id: Option<String>` field was added to `adk_gemini::interactions::Interaction` but two test initializers in `adk-model` weren't updated, causing CI to fail on Windows.

### Files Changed
- `adk-model/src/gemini/client.rs:2241` — added `environment_id: None`
- `adk-model/src/gemini/interactions_convert.rs:1424` — added `environment_id: None`
- Plus: circular dep fixes, publish.sh regeneration, test relocation (from merged #371)