### PR TITLE
feat: real cargo-adk templates, publish hardening, and v1.0.1 version tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,16 @@ jobs:
       run: |
         CI=true devenv shell bash scripts/check-example-name-collisions.sh
         CI=true devenv shell bash scripts/check-doc-examples.sh
+        # Doc rot guard: dependency-snippet versions in docs/READMEs/lib.rs must
+        # match the workspace version, and every adk-rust feature named in docs
+        # must exist in adk-rust/Cargo.toml (catches stale "0.8.2" snippets and
+        # phantom features like the removed `labs`).
+        CI=true devenv shell bash scripts/check-doc-versions.sh
+        # Publish-order guard: publish.sh tiers must satisfy the workspace
+        # dependency graph, including versioned dev-deps (what broke v1.0.0).
+        CI=true devenv shell bash scripts/check-publish-order.sh
+        # Scaffold every advertised template — including addon combos and
+        # default-provider resolution — and cargo-check the generated projects.
         CI=true devenv shell bash scripts/check-cargo-adk-templates.sh
 
   # ── Cross-platform: macOS build + test ─────────────────────────

--- a/.skills/skills/adk-rust-app-bootstrap/references/bootstrap-checklist.md
+++ b/.skills/skills/adk-rust-app-bootstrap/references/bootstrap-checklist.md
@@ -1,7 +1,7 @@
 # Bootstrap Checklist
 
 ## Cargo setup
-- Add `adk-rust = "0.3.0"` for broad usage.
+- Add `adk-rust = "1.0.1"` for broad usage.
 - Or add targeted crates (`adk-agent`, `adk-model`, `adk-runner`, etc.).
 
 ## Provider selection

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "adk-acp"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "adk-core",
  "adk-runner",
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "adk-action"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "adk-core",
  "proptest",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "adk-agent"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "adk-core",
  "adk-guardrail",
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "adk-anthropic"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "adk-audio"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "adk-core",
  "adk-realtime",
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "adk-auth"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "adk-core",
  "adk-server",
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "adk-awp"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "adk-core",
  "arc-swap",
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "adk-bench"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "adk-agent",
  "adk-core",
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "adk-browser"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "adk-cli"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "adk-agent",
  "adk-artifact",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "adk-code"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "adk-core",
  "adk-sandbox",
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "adk-deploy"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -387,7 +387,7 @@ dependencies = [
 
 [[package]]
 name = "adk-enterprise"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "adk-eval"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "adk-core",
  "adk-memory",
@@ -432,7 +432,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "adk-graph"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "adk-action",
  "adk-core",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "adk-guardrail"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "adk-managed"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "adk-agent",
  "adk-core",
@@ -536,7 +536,7 @@ dependencies = [
 
 [[package]]
 name = "adk-memory"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -555,7 +555,7 @@ dependencies = [
 
 [[package]]
 name = "adk-mistralrs"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "adk-core",
  "adk-telemetry",
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "adk-anthropic",
  "adk-core",
@@ -613,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "adk-payments"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "adk-artifact",
  "adk-auth",
@@ -642,7 +642,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -652,7 +652,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rag"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -676,7 +676,7 @@ dependencies = [
 
 [[package]]
 name = "adk-realtime"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "adk-retry-reflect"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "adk-acp",
  "adk-action",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -810,7 +810,7 @@ dependencies = [
 
 [[package]]
 name = "adk-sandbox"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "adk-server"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "a2a-protocol-types",
  "adk-agent",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "adk-core",
  "aes-gcm",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "opentelemetry 0.31.0",
  "opentelemetry-otlp",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "adk-code",
  "adk-core",
@@ -2165,7 +2165,7 @@ dependencies = [
 
 [[package]]
 name = "awp-types"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chrono",
  "proptest",
@@ -3883,7 +3883,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-adk"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "adk-bench",
  "adk-deploy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ strip = false
 opt-level = 2
 
 [workspace.package]
-version = "1.0.0"
+version = "1.0.1"
 edition = "2024"
 rust-version = "1.94.0"
 license = "Apache-2.0"
@@ -147,39 +147,39 @@ livekit = { version = "0.7.36", default-features = false, features = ["tokio", "
 livekit-api = { version = "0.4.18", default-features = false, features = ["signal-client-tokio", "services-tokio", "access-token"] }
 
 # ADK internal crates (use { workspace = true } in member crates)
-adk-core = { path = "adk-core", version = "1.0.0" }
-adk-rust-macros = { path = "adk-rust-macros", version = "1.0.0" }
-adk-agent = { path = "adk-agent", version = "1.0.0", default-features = false }
-adk-model = { path = "adk-model", version = "1.0.0", default-features = false }
-adk-tool = { path = "adk-tool", version = "1.0.0" }
-adk-runner = { path = "adk-runner", version = "1.0.0", default-features = false }
-adk-server = { path = "adk-server", version = "1.0.0" }
-adk-session = { path = "adk-session", version = "1.0.0" }
-adk-artifact = { path = "adk-artifact", version = "1.0.0" }
-adk-memory = { path = "adk-memory", version = "1.0.0" }
-adk-cli = { path = "adk-cli", version = "1.0.0", default-features = false }
-adk-realtime = { path = "adk-realtime", version = "1.0.0" }
-adk-graph = { path = "adk-graph", version = "1.0.0" }
-adk-browser = { path = "adk-browser", version = "1.0.0" }
-adk-eval = { path = "adk-eval", version = "1.0.0" }
-adk-telemetry = { path = "adk-telemetry", version = "1.0.0" }
-adk-guardrail = { path = "adk-guardrail", version = "1.0.0" }
-adk-auth = { path = "adk-auth", version = "1.0.0" }
-adk-plugin = { path = "adk-plugin", version = "1.0.0" }
-adk-skill = { path = "adk-skill", version = "1.0.0" }
-adk-gemini = { path = "adk-gemini", version = "1.0.0" }
-adk-code = { path = "adk-code", version = "1.0.0" }
-adk-sandbox = { path = "adk-sandbox", version = "1.0.0" }
-adk-rag = { path = "adk-rag", version = "1.0.0" }
-adk-audio = { path = "adk-audio", version = "1.0.0" }
-adk-mistralrs = { path = "adk-mistralrs", version = "1.0.0", default-features = false }
-adk-deploy = { path = "adk-deploy", version = "1.0.0" }
-adk-payments = { path = "adk-payments", version = "1.0.0" }
-adk-action = { path = "adk-action", version = "1.0.0" }
-adk-anthropic = { path = "adk-anthropic", version = "1.0.0" }
-adk-managed = { path = "adk-managed", version = "1.0.0", default-features = false }
-adk-enterprise = { path = "adk-enterprise", version = "1.0.0" }
-adk-bench = { path = "adk-bench", version = "1.0.0" }
-awp-types = { path = "awp-types", version = "1.0.0" }
-adk-awp = { path = "adk-awp", version = "1.0.0" }
-adk-acp = { path = "adk-acp", version = "1.0.0" }
+adk-core = { path = "adk-core", version = "1.0.1" }
+adk-rust-macros = { path = "adk-rust-macros", version = "1.0.1" }
+adk-agent = { path = "adk-agent", version = "1.0.1", default-features = false }
+adk-model = { path = "adk-model", version = "1.0.1", default-features = false }
+adk-tool = { path = "adk-tool", version = "1.0.1" }
+adk-runner = { path = "adk-runner", version = "1.0.1", default-features = false }
+adk-server = { path = "adk-server", version = "1.0.1" }
+adk-session = { path = "adk-session", version = "1.0.1" }
+adk-artifact = { path = "adk-artifact", version = "1.0.1" }
+adk-memory = { path = "adk-memory", version = "1.0.1" }
+adk-cli = { path = "adk-cli", version = "1.0.1", default-features = false }
+adk-realtime = { path = "adk-realtime", version = "1.0.1" }
+adk-graph = { path = "adk-graph", version = "1.0.1" }
+adk-browser = { path = "adk-browser", version = "1.0.1" }
+adk-eval = { path = "adk-eval", version = "1.0.1" }
+adk-telemetry = { path = "adk-telemetry", version = "1.0.1" }
+adk-guardrail = { path = "adk-guardrail", version = "1.0.1" }
+adk-auth = { path = "adk-auth", version = "1.0.1" }
+adk-plugin = { path = "adk-plugin", version = "1.0.1" }
+adk-skill = { path = "adk-skill", version = "1.0.1" }
+adk-gemini = { path = "adk-gemini", version = "1.0.1" }
+adk-code = { path = "adk-code", version = "1.0.1" }
+adk-sandbox = { path = "adk-sandbox", version = "1.0.1" }
+adk-rag = { path = "adk-rag", version = "1.0.1" }
+adk-audio = { path = "adk-audio", version = "1.0.1" }
+adk-mistralrs = { path = "adk-mistralrs", version = "1.0.1", default-features = false }
+adk-deploy = { path = "adk-deploy", version = "1.0.1" }
+adk-payments = { path = "adk-payments", version = "1.0.1" }
+adk-action = { path = "adk-action", version = "1.0.1" }
+adk-anthropic = { path = "adk-anthropic", version = "1.0.1" }
+adk-managed = { path = "adk-managed", version = "1.0.1", default-features = false }
+adk-enterprise = { path = "adk-enterprise", version = "1.0.1" }
+adk-bench = { path = "adk-bench", version = "1.0.1" }
+awp-types = { path = "awp-types", version = "1.0.1" }
+adk-awp = { path = "adk-awp", version = "1.0.1" }
+adk-acp = { path = "adk-acp", version = "1.0.1" }

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ cargo adk new my-agent
 cd my-agent && cargo run
 ```
 
-Or pick a template: `--template tools` | `rag` | `api` | `openai` | `a2a` | `graph` | `realtime`. Combine with addons: `--addon telemetry` | `docker` | `ci`. See [Quick Start](#quick-start) for details.
+Or pick a template: `--template tools` | `rag` | `api` | `openai` | `a2a` | `graph` | `realtime` | `sequential` | `parallel` | `loop`. Combine with addons: `--addon telemetry` | `auth` | `sessions` | `memory` | `mcp` | `guardrails` | `eval` | `browser` | `server`. Run `cargo adk templates` and `cargo adk addons` for the full list, and see [Quick Start](#quick-start) for details.
 
 ## Overview
 
@@ -98,7 +98,7 @@ ADK-Rust provides a comprehensive framework for building AI agents in Rust, feat
 - **Agentic commerce**: ACP and AP2 payment orchestration with durable transaction journals and evidence-backed recall
 - **Agentic Web Protocol (AWP)**: Make websites agent-native with discovery, capability manifests, trust levels, rate limiting, consent, and health monitoring
 - **Production features**: Session management, artifact storage, memory systems with project-scoped isolation, REST/A2A APIs
-- **Developer experience**: Interactive CLI, 120+ working examples, comprehensive documentation
+- **Developer experience**: Interactive CLI, 75+ in-repo examples (120+ in the [playground](https://github.com/zavora-ai/adk-playground)), comprehensive documentation
 
 **Status**: Production-ready, actively maintained
 
@@ -192,7 +192,7 @@ Built-in tools:
 - **Session Management**: In-memory and SQLite-backed sessions with state persistence, encrypted sessions with AES-256-GCM and key rotation
 - **Memory System**: Long-term memory with semantic search, vector embeddings, and project-scoped isolation
 - **Servers**: REST API with SSE streaming, A2A v1.0.0 protocol for agent-to-agent communication
-- **A2A Quick Start**: `A2aServer::quick_start(agent)` — expose any agent via A2A in one line. Or use `cargo adk new --template a2a` to scaffold a complete project.
+- **A2A Quick Start**: `A2aServer::quick_start(agent)` — expose any agent via A2A in one line. Or use `cargo adk new --template a2a-server` to scaffold a complete project.
 - **Guardrails**: PII redaction, content filtering, JSON schema validation
 - **Tool Authorization**: Human-in-the-loop confirmation, before-tool callbacks, RBAC, graph interrupts
 - **Payments**: ACP and AP2 commerce support through `adk-payments`
@@ -241,18 +241,19 @@ Built-in tools:
 ```bash
 cargo install cargo-adk
 
-cargo adk new my-agent                    # basic Gemini agent
-cargo adk new my-agent --template tools   # agent with #[tool] custom tools
-cargo adk new my-agent --template rag     # RAG with vector search
-cargo adk new my-agent --template api     # REST server
-cargo adk new my-agent --template openai  # OpenAI-powered agent
-cargo adk new my-agent --template a2a     # A2A protocol agent
-cargo adk new my-agent --template graph   # graph workflow agent
-cargo adk new my-agent --template realtime # realtime voice agent
+cargo adk new my-agent                       # basic Gemini agent
+cargo adk new my-agent --template tools      # agent with #[tool] custom tools
+cargo adk new my-agent --template rag        # RAG with vector search
+cargo adk new my-agent --template api        # REST server
+cargo adk new my-agent --template openai     # OpenAI-powered agent
+cargo adk new my-agent --template a2a        # A2A protocol agent
+cargo adk new my-agent --template graph      # graph workflow agent
+cargo adk new my-agent --template realtime   # realtime voice agent
+cargo adk new my-agent --template sequential # sequential multi-agent pipeline
 
 # Compose with addons
-cargo adk new my-agent --template tools --addon telemetry --addon docker
-cargo adk new my-agent --template api --addon ci --addon monitoring
+cargo adk new my-agent --template tools --addon telemetry --addon sessions
+cargo adk new my-agent --addon mcp --addon guardrails
 
 cd my-agent
 cp .env.example .env    # add your API key
@@ -267,13 +268,13 @@ Requires Rust 1.94 or later (Rust 2024 edition). Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-rust = "1.0.0"  # Minimal (default): Gemini + agent runtime + sessions
+adk-rust = "1.0.1"  # Minimal (default): Gemini + agent runtime + sessions
 
 # Need server, auth, graph workflows, eval?
-# adk-rust = { version = "1.0.0", features = ["standard"] }
+# adk-rust = { version = "1.0.1", features = ["standard"] }
 
 # Need everything (realtime, browser, RAG, payments, AWP)?
-# adk-rust = { version = "1.0.0", features = ["enterprise"] }
+# adk-rust = { version = "1.0.1", features = ["enterprise"] }
 ```
 
 **Feature tiers:**
@@ -376,7 +377,7 @@ async fn main() -> AnyhowResult<()> {
 
 ### OpenAI Example
 
-Enable OpenAI with `adk-rust = { version = "1.0.0", features = ["openai"] }`.
+Enable OpenAI with `adk-rust = { version = "1.0.1", features = ["openai"] }`.
 
 ```rust
 use adk_rust::prelude::*;
@@ -426,7 +427,7 @@ async fn main() -> AnyhowResult<()> {
 
 ### Anthropic Example
 
-Enable Anthropic with `adk-rust = { version = "1.0.0", features = ["anthropic"] }`.
+Enable Anthropic with `adk-rust = { version = "1.0.1", features = ["anthropic"] }`.
 
 ```rust
 use adk_rust::prelude::*;
@@ -450,7 +451,7 @@ async fn main() -> AnyhowResult<()> {
 
 ### DeepSeek Example
 
-Enable DeepSeek with `adk-rust = { version = "1.0.0", features = ["deepseek"] }`.
+Enable DeepSeek with `adk-rust = { version = "1.0.1", features = ["deepseek"] }`.
 
 ```rust
 use adk_rust::prelude::*;
@@ -479,7 +480,7 @@ async fn main() -> AnyhowResult<()> {
 
 ### Groq Example (Ultra-Fast)
 
-Enable Groq with `adk-rust = { version = "1.0.0", features = ["groq"] }`.
+Enable Groq with `adk-rust = { version = "1.0.1", features = ["groq"] }`.
 
 ```rust
 use adk_rust::prelude::*;
@@ -503,7 +504,7 @@ async fn main() -> AnyhowResult<()> {
 
 ### Ollama Example (Local)
 
-Enable Ollama with `adk-rust = { version = "1.0.0", features = ["ollama"] }`.
+Enable Ollama with `adk-rust = { version = "1.0.1", features = ["ollama"] }`.
 
 ```rust
 use adk_rust::prelude::*;
@@ -819,7 +820,7 @@ async fn main() -> anyhow::Result<()> {
 
 `adk-mistralrs` is published to crates.io as a workspace member. GPU features are opt-in:
 ```toml
-adk-mistralrs = { version = "1.0.0", features = ["metal"] }  # macOS Apple Silicon
+adk-mistralrs = { version = "1.0.1", features = ["metal"] }  # macOS Apple Silicon
 # Or: features = ["cuda"] for NVIDIA GPU
 ```
 
@@ -897,26 +898,26 @@ Add to your `Cargo.toml`:
 ```toml
 [dependencies]
 # Minimal (default) — Gemini, agents, runner, sessions
-adk-rust = "1.0.0"
+adk-rust = "1.0.1"
 
 # Add a provider explicitly when you need it
-adk-rust = { version = "1.0.0", features = ["openai"] }
+adk-rust = { version = "1.0.1", features = ["openai"] }
 
 # Production tier without CLI provider fan-out
-adk-rust = { version = "1.0.0", features = ["standard"] }
+adk-rust = { version = "1.0.1", features = ["standard"] }
 
 # Full — enterprise plus audio, code execution, sandbox
-adk-rust = { version = "1.0.0", features = ["full"] }
+adk-rust = { version = "1.0.1", features = ["full"] }
 
 # Minimal — just agents + Gemini + runner (fastest build)
-adk-rust = { version = "1.0.0", default-features = false, features = ["minimal"] }
+adk-rust = { version = "1.0.1", default-features = false, features = ["minimal"] }
 
 # Or individual crates for finer control
-adk-core = "1.0.0"
-adk-agent = "1.0.0"
-adk-model = { version = "1.0.0", features = ["openai", "anthropic"] }
-adk-tool = "1.0.0"
-adk-runner = "1.0.0"
+adk-core = "1.0.1"
+adk-agent = "1.0.1"
+adk-model = { version = "1.0.1", features = ["openai", "anthropic"] }
+adk-tool = "1.0.1"
+adk-runner = "1.0.1"
 ```
 
 ## Examples
@@ -975,7 +976,7 @@ cargo build --release
 - **Wiki**: [GitHub Wiki](https://github.com/zavora-ai/adk-rust/wiki) - Comprehensive guides and tutorials
 - **API Reference**: [docs.rs/adk-rust](https://docs.rs/adk-rust) - Full API documentation
 - **Official payments docs**: [Payments and Commerce](docs/official_docs/security/payments.md) - ACP/AP2 support, agentic commerce journeys, and validation paths
-- **Examples**: [examples/README.md](examples/README.md) - 120+ working examples with detailed explanations
+- **Examples**: [examples/README.md](examples/README.md) - 75+ working examples with detailed explanations
 
 ## Performance
 
@@ -1042,7 +1043,7 @@ Contributions welcome! Please open an issue or pull request on GitHub.
 **v1.0.0** (current) — first stable release:
 - **Composable Template System** — 8 base templates, 9 addons, 5 enterprise patterns via `cargo adk new --addon`.
 - **Cargo Adk Build** — compile-without-deploy subcommand for pre-deployment verification.
-- **A2A Simple Scaffolding** — `A2aServer::quick_start`, `A2aServer::builder`, and `cargo adk new --template a2a`.
+- **A2A Simple Scaffolding** — `A2aServer::quick_start`, `A2aServer::builder`, and `cargo adk new --template a2a-server`.
 - **Security** — hickory-proto 0.26.1, openssl 0.10.80, rubato 3.0, similar 3.
 
 <details>

--- a/adk-acp/Cargo.toml
+++ b/adk-acp/Cargo.toml
@@ -36,6 +36,8 @@ uuid = { workspace = true, optional = true }
 async-stream = { workspace = true, optional = true }
 
 [dev-dependencies]
+# Internal dev-deps are path-only (no version) so cargo strips them from the
+# published manifest — they can never block or reorder a crates.io publish.
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }
-adk-session = { workspace = true }
-adk-runner = { workspace = true }
+adk-session = { path = "../adk-session" }
+adk-runner = { path = "../adk-runner" }

--- a/adk-acp/README.md
+++ b/adk-acp/README.md
@@ -13,10 +13,10 @@ The [Agent Client Protocol](https://agentclientprotocol.com/) standardizes commu
 
 ```toml
 [dependencies]
-adk-acp = "1.0.0"
+adk-acp = "1.0.1"
 
 # Or via the umbrella crate:
-adk-rust = { version = "1.0.0", features = ["acp"] }
+adk-rust = { version = "1.0.1", features = ["acp"] }
 ```
 
 ## Quick Start

--- a/adk-action/README.md
+++ b/adk-action/README.md
@@ -41,7 +41,7 @@ Action nodes are programmatic graph nodes that perform specific operations — H
 
 ```toml
 [dependencies]
-adk-action = "1.0.0"
+adk-action = "1.0.1"
 ```
 
 ## Usage

--- a/adk-agent/Cargo.toml
+++ b/adk-agent/Cargo.toml
@@ -43,10 +43,12 @@ record-payloads = []
 ambient = ["dep:cron", "dep:notify", "dep:axum"]
 
 [dev-dependencies]
-adk-model = { workspace = true, features = ["gemini", "gemini-interactions"] }
-adk-runner = { workspace = true }
-adk-session = { workspace = true }
-adk-tool = { workspace = true }
+# Internal dev-deps are path-only (no version) so cargo strips them from the
+# published manifest — they can never block or reorder a crates.io publish.
+adk-model = { path = "../adk-model", features = ["gemini", "gemini-interactions"] }
+adk-runner = { path = "../adk-runner" }
+adk-session = { path = "../adk-session" }
+adk-tool = { path = "../adk-tool" }
 dotenvy = "0.15"
 proptest = "1.5"
 tempfile = "3"

--- a/adk-agent/README.md
+++ b/adk-agent/README.md
@@ -23,14 +23,14 @@ Agent implementations for ADK-Rust (LLM, Custom, Workflow agents).
 
 ```toml
 [dependencies]
-adk-agent = "1.0.0"
+adk-agent = "1.0.1"
 ```
 
 Or use the umbrella crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "1.0.0", features = ["agents"] }
+adk-rust = { version = "1.0.1", features = ["agents"] }
 ```
 
 ## Quick Start

--- a/adk-agent/src/llm_agent.rs
+++ b/adk-agent/src/llm_agent.rs
@@ -1840,8 +1840,8 @@ impl Agent for LlmAgent {
                 // Enhanced plugins can modify the accumulated model response.
                 // They run after the full response is accumulated (not per-chunk).
                 #[cfg(feature = "enhanced-plugins")]
-                if let Some(epm) = &enhanced_plugin_manager {
-                    if let Some(ref content) = accumulated_content {
+                if let Some(epm) = &enhanced_plugin_manager
+                    && let Some(ref content) = accumulated_content {
                         let response_for_hook = LlmResponse {
                             content: Some(content.clone()),
                             provider_metadata: final_provider_metadata.clone(),
@@ -1860,7 +1860,6 @@ impl Agent for LlmAgent {
                             }
                         }
                     }
-                }
 
                 // After streaming/caching completes, check for function calls in accumulated content
                 let function_call_names: Vec<String> = accumulated_content.as_ref()
@@ -2206,9 +2205,9 @@ impl Agent for LlmAgent {
 
                             // ===== ENHANCED PLUGIN: BEFORE TOOL CALL =====
                             #[cfg(feature = "enhanced-plugins")]
-                            if response_content.is_none() {
-                                if let Some(epm) = &enhanced_plugin_manager {
-                                    if let Some(tool_ref) = tool_map.get(&name) {
+                            if response_content.is_none()
+                                && let Some(epm) = &enhanced_plugin_manager
+                                    && let Some(tool_ref) = tool_map.get(&name) {
                                         match epm.run_before_tool_call(
                                             tool_ref.clone(),
                                             final_args.clone(),
@@ -2246,8 +2245,6 @@ impl Agent for LlmAgent {
                                             }
                                         }
                                     }
-                                }
-                            }
 
                             if response_content.is_none() {
                                 let tool_ctx = Arc::new(ToolCallbackContext::new(
@@ -2537,8 +2534,8 @@ impl Agent for LlmAgent {
                                 // ===== ENHANCED PLUGIN: AFTER TOOL CALL =====
                                 // Enhanced plugins can modify the tool result after legacy callbacks.
                                 #[cfg(feature = "enhanced-plugins")]
-                                if let Some(epm) = &enhanced_plugin_manager {
-                                    if let Some(tool_ref) = &executed_tool {
+                                if let Some(epm) = &enhanced_plugin_manager
+                                    && let Some(tool_ref) = &executed_tool {
                                         // Extract the result value from the response content
                                         let result_value = response_content.parts.iter()
                                             .find_map(|p| {
@@ -2582,7 +2579,6 @@ impl Agent for LlmAgent {
                                             }
                                         }
                                     }
-                                }
                             }
 
                             let escalate_or_skip = tool_actions.escalate || tool_actions.skip_summarization;

--- a/adk-artifact/README.md
+++ b/adk-artifact/README.md
@@ -23,14 +23,14 @@ Both implement the `ArtifactService` trait, so you can swap backends without cha
 
 ```toml
 [dependencies]
-adk-artifact = "1.0.0"
+adk-artifact = "1.0.1"
 ```
 
 Or via the umbrella crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "1.0.0", features = ["artifacts"] }
+adk-rust = { version = "1.0.1", features = ["artifacts"] }
 ```
 
 ## Quick Start

--- a/adk-audio/README.md
+++ b/adk-audio/README.md
@@ -8,14 +8,14 @@ Provides unified traits for Text-to-Speech (TTS), Speech-to-Text (STT), music ge
 
 ```toml
 [dependencies]
-adk-audio = "1.0.0"
+adk-audio = "1.0.1"
 ```
 
 Or via the umbrella crate (experimental):
 
 ```toml
 [dependencies]
-adk-rust = { version = "1.0.0", features = ["audio"] }
+adk-rust = { version = "1.0.1", features = ["audio"] }
 ```
 
 ## Feature Flags

--- a/adk-auth/README.md
+++ b/adk-auth/README.md
@@ -20,13 +20,13 @@ Access control and authentication for Rust Agent Development Kit (ADK-Rust).
 
 ```toml
 [dependencies]
-adk-auth = "1.0.0"
+adk-auth = "1.0.1"
 
 # With SSO/JWT validation
-adk-auth = { version = "1.0.0", features = ["sso"] }
+adk-auth = { version = "1.0.1", features = ["sso"] }
 
 # With auth bridge for adk-server identity flow (implies sso)
-adk-auth = { version = "1.0.0", features = ["auth-bridge"] }
+adk-auth = { version = "1.0.1", features = ["auth-bridge"] }
 ```
 
 ## Features

--- a/adk-auth/src/sso/mod.rs
+++ b/adk-auth/src/sso/mod.rs
@@ -8,7 +8,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-auth = { version = "0.8.0", features = ["sso"] }
+//! adk-auth = { version = "1.0.1", features = ["sso"] }
 //! ```
 //!
 //! # Quick Start

--- a/adk-browser/README.md
+++ b/adk-browser/README.md
@@ -6,14 +6,14 @@ Browser automation tools for ADK-Rust agents using WebDriver (via [thirtyfour](h
 
 ```toml
 [dependencies]
-adk-browser = "1.0.0"
+adk-browser = "1.0.1"
 ```
 
 Or via the umbrella crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "1.0.0", features = ["browser"] }
+adk-rust = { version = "1.0.1", features = ["browser"] }
 ```
 
 ## Overview

--- a/adk-core/README.md
+++ b/adk-core/README.md
@@ -26,14 +26,14 @@ This crate is model-agnostic and contains no LLM-specific code.
 
 ```toml
 [dependencies]
-adk-core = "1.0.0"
+adk-core = "1.0.1"
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = "1.0.0"
+adk-rust = "1.0.1"
 ```
 
 ## Core Traits

--- a/adk-deploy/README.md
+++ b/adk-deploy/README.md
@@ -19,7 +19,7 @@ Deployment manifest, bundling, and control-plane client for ADK-Rust agents.
 
 ```toml
 [dependencies]
-adk-deploy = "1.0.0"
+adk-deploy = "1.0.1"
 ```
 
 ## Manifest Format

--- a/adk-gemini/README.md
+++ b/adk-gemini/README.md
@@ -34,14 +34,14 @@ Rust client library for Google's Gemini API — content generation, streaming, f
 
 ```toml
 [dependencies]
-adk-gemini = "1.0.0"
+adk-gemini = "1.0.1"
 ```
 
 Or through `adk-model`:
 
 ```toml
 [dependencies]
-adk-model = { version = "1.0.0", features = ["gemini"] }
+adk-model = { version = "1.0.1", features = ["gemini"] }
 ```
 
 ## Quick Start

--- a/adk-graph/Cargo.toml
+++ b/adk-graph/Cargo.toml
@@ -69,6 +69,8 @@ action-full = ["action", "action-trigger", "action-http", "action-db", "action-c
 full = ["sqlite", "action-full"]
 
 [dev-dependencies]
+# Internal dev-deps are path-only (no version) so cargo strips them from the
+# published manifest — they can never block or reorder a crates.io publish.
 tokio = { workspace = true, features = ["rt", "macros", "test-util"] }
 proptest = "1.5"
-adk-action = { workspace = true }
+adk-action = { path = "../adk-action" }

--- a/adk-graph/README.md
+++ b/adk-graph/README.md
@@ -49,10 +49,10 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-graph = { version = "1.0.0", features = ["sqlite"] }
-adk-agent = "1.0.0"
-adk-model = "1.0.0"
-adk-core = "1.0.0"
+adk-graph = { version = "1.0.1", features = ["sqlite"] }
+adk-agent = "1.0.1"
+adk-model = "1.0.1"
+adk-core = "1.0.1"
 ```
 
 ### Basic Graph with AgentNode
@@ -508,7 +508,7 @@ The Functional API (feature: `functional`) provides a higher-level programming m
 
 ```toml
 [dependencies]
-adk-graph = { version = "1.0.0", features = ["functional"] }
+adk-graph = { version = "1.0.1", features = ["functional"] }
 ```
 
 ```rust

--- a/adk-guardrail/README.md
+++ b/adk-guardrail/README.md
@@ -19,10 +19,10 @@ Guardrails framework for ADK agents - input/output validation, content filtering
 
 ```toml
 [dependencies]
-adk-guardrail = "1.0.0"
+adk-guardrail = "1.0.1"
 
 # With JSON schema validation (default)
-adk-guardrail = { version = "1.0.0", features = ["schema"] }
+adk-guardrail = { version = "1.0.1", features = ["schema"] }
 ```
 
 ## Quick Start
@@ -63,7 +63,7 @@ let filter = ContentFilter::blocked_keywords(vec!["forbidden".into()]);
 Requires `guardrails` feature on `adk-agent`:
 
 ```toml
-adk-agent = { version = "1.0.0", features = ["guardrails"] }
+adk-agent = { version = "1.0.1", features = ["guardrails"] }
 ```
 
 ```rust

--- a/adk-memory/README.md
+++ b/adk-memory/README.md
@@ -25,14 +25,14 @@ Semantic memory and search for Rust Agent Development Kit (ADK-Rust) agents.
 
 ```toml
 [dependencies]
-adk-memory = "1.0.0"
+adk-memory = "1.0.1"
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "1.0.0", features = ["memory"] }
+adk-rust = { version = "1.0.1", features = ["memory"] }
 ```
 
 ## Quick Start
@@ -181,10 +181,10 @@ validate_project_id(&"x".repeat(257))?; // Err: exceeds 256 chars
 
 ```toml
 # SQLite
-adk-memory = { version = "1.0.0", features = ["sqlite-memory"] }
+adk-memory = { version = "1.0.1", features = ["sqlite-memory"] }
 
 # PostgreSQL + pgvector
-adk-memory = { version = "1.0.0", features = ["database-memory"] }
+adk-memory = { version = "1.0.1", features = ["database-memory"] }
 ```
 
 ## Schema Migrations

--- a/adk-mistralrs/src/lib.rs
+++ b/adk-mistralrs/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-mistralrs = "1.0.0"
+//! adk-mistralrs = "1.0.1"
 //! ```
 //!
 //! ## Features
@@ -145,7 +145,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-mistralrs = { version = "1.0.0", features = ["cuda"] }
+//! adk-mistralrs = { version = "1.0.1", features = ["cuda"] }
 //! ```
 //!
 //! Available features:

--- a/adk-model/Cargo.toml
+++ b/adk-model/Cargo.toml
@@ -44,7 +44,10 @@ gemini-interactions = ["gemini", "adk-gemini/interactions"]
 openai = ["dep:async-openai", "dep:reqwest"]
 openai-ws = ["openai", "dep:tokio-tungstenite"]
 openai-conversations = ["openai"]
-# openai-webhooks feature removed — moved to adk-model-webhooks crate (breaks circular dep)
+# openai-webhooks feature removed: it only forwarded a dep on adk-server, creating the
+# cycle adk-model -> adk-server -> adk-agent -> (dev) adk-model. The webhooks
+# implementation lives in adk-server (`openai-webhooks` feature, src/webhooks/) — use
+# adk-server directly for webhook verification/handling.
 openai-responses-full = ["openai-ws", "openai-conversations"]
 xai = ["openai"]
 anthropic = ["dep:adk-anthropic"]

--- a/adk-model/README.md
+++ b/adk-model/README.md
@@ -35,21 +35,21 @@ The crate implements the `Llm` trait from `adk-core`, allowing models to be used
 
 ```toml
 [dependencies]
-adk-model = "1.0.0"
+adk-model = "1.0.1"
 ```
 
 Enable provider-specific features as needed:
 
 ```toml
 [dependencies]
-adk-model = { version = "1.0.0", features = ["openrouter"] }
+adk-model = { version = "1.0.1", features = ["openrouter"] }
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "1.0.0", features = ["models"] }
+adk-rust = { version = "1.0.1", features = ["models"] }
 ```
 
 ## Quick Start
@@ -712,24 +712,24 @@ Enable specific providers with feature flags:
 ```toml
 [dependencies]
 # All providers (default)
-adk-model = { version = "1.0.0", features = ["all-providers"] }
+adk-model = { version = "1.0.1", features = ["all-providers"] }
 
 # Individual providers
-adk-model = { version = "1.0.0", features = ["gemini"] }
-adk-model = { version = "1.0.0", features = ["openai"] }
-adk-model = { version = "1.0.0", features = ["xai"] }
-adk-model = { version = "1.0.0", features = ["anthropic"] }
-adk-model = { version = "1.0.0", features = ["deepseek"] }
-adk-model = { version = "1.0.0", features = ["groq"] }
-adk-model = { version = "1.0.0", features = ["ollama"] }
-adk-model = { version = "1.0.0", features = ["fireworks"] }
-adk-model = { version = "1.0.0", features = ["together"] }
-adk-model = { version = "1.0.0", features = ["mistral"] }
-adk-model = { version = "1.0.0", features = ["perplexity"] }
-adk-model = { version = "1.0.0", features = ["cerebras"] }
-adk-model = { version = "1.0.0", features = ["sambanova"] }
-adk-model = { version = "1.0.0", features = ["bedrock"] }
-adk-model = { version = "1.0.0", features = ["azure-ai"] }
+adk-model = { version = "1.0.1", features = ["gemini"] }
+adk-model = { version = "1.0.1", features = ["openai"] }
+adk-model = { version = "1.0.1", features = ["xai"] }
+adk-model = { version = "1.0.1", features = ["anthropic"] }
+adk-model = { version = "1.0.1", features = ["deepseek"] }
+adk-model = { version = "1.0.1", features = ["groq"] }
+adk-model = { version = "1.0.1", features = ["ollama"] }
+adk-model = { version = "1.0.1", features = ["fireworks"] }
+adk-model = { version = "1.0.1", features = ["together"] }
+adk-model = { version = "1.0.1", features = ["mistral"] }
+adk-model = { version = "1.0.1", features = ["perplexity"] }
+adk-model = { version = "1.0.1", features = ["cerebras"] }
+adk-model = { version = "1.0.1", features = ["sambanova"] }
+adk-model = { version = "1.0.1", features = ["bedrock"] }
+adk-model = { version = "1.0.1", features = ["azure-ai"] }
 ```
 
 ## Related Crates

--- a/adk-payments/README.md
+++ b/adk-payments/README.md
@@ -54,17 +54,17 @@ Choose only the features you need:
 
 ```toml
 [dependencies]
-adk-payments = { version = "1.0.0", features = ["acp"] }
+adk-payments = { version = "1.0.1", features = ["acp"] }
 ```
 
 ```toml
 [dependencies]
-adk-payments = { version = "1.0.0", features = ["ap2", "ap2-a2a", "ap2-mcp"] }
+adk-payments = { version = "1.0.1", features = ["ap2", "ap2-a2a", "ap2-mcp"] }
 ```
 
 ```toml
 [dependencies]
-adk-payments = { version = "1.0.0", features = ["acp", "acp-experimental", "ap2"] }
+adk-payments = { version = "1.0.1", features = ["acp", "acp-experimental", "ap2"] }
 ```
 
 ## Core Concepts

--- a/adk-plugin/README.md
+++ b/adk-plugin/README.md
@@ -31,7 +31,7 @@ Plugin system for ADK-Rust agents.
 
 ```toml
 [dependencies]
-adk-plugin = "1.0.0"
+adk-plugin = "1.0.1"
 ```
 
 ## Quick Start

--- a/adk-rag/README.md
+++ b/adk-rag/README.md
@@ -24,7 +24,7 @@ The fastest way to get a working RAG pipeline. Uses Gemini for embeddings (free 
 
 ```toml
 [dependencies]
-adk-rag = { version = "1.0.0", features = ["gemini"] }
+adk-rag = { version = "1.0.1", features = ["gemini"] }
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -70,10 +70,10 @@ The practical use case — an agent that searches your knowledge base to answer 
 
 ```toml
 [dependencies]
-adk-rag = { version = "1.0.0", features = ["gemini"] }
-adk-agent = "1.0.0"
-adk-model = "1.0.0"
-adk-cli = "1.0.0"
+adk-rag = { version = "1.0.1", features = ["gemini"] }
+adk-agent = "1.0.1"
+adk-model = "1.0.1"
+adk-cli = "1.0.1"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -149,7 +149,7 @@ The `RagPipeline` wires these together. The `RagTool` wraps the pipeline as an `
 Uses Google's `gemini-embedding-001` model (3072 dimensions). Free tier available.
 
 ```toml
-adk-rag = { version = "1.0.0", features = ["gemini"] }
+adk-rag = { version = "1.0.1", features = ["gemini"] }
 ```
 
 ```rust
@@ -161,7 +161,7 @@ let provider = GeminiEmbeddingProvider::new(&api_key)?;
 Uses `text-embedding-3-small` (1536 dimensions) by default. Supports dimension truncation via Matryoshka.
 
 ```toml
-adk-rag = { version = "1.0.0", features = ["openai"] }
+adk-rag = { version = "1.0.1", features = ["openai"] }
 ```
 
 ```rust
@@ -217,7 +217,7 @@ let store = InMemoryVectorStore::new();
 Production-ready vector database with filtering, snapshots, and clustering.
 
 ```toml
-adk-rag = { version = "1.0.0", features = ["qdrant"] }
+adk-rag = { version = "1.0.1", features = ["qdrant"] }
 ```
 
 ```rust
@@ -229,7 +229,7 @@ let store = QdrantVectorStore::new("http://localhost:6334").await?;
 Embedded vector database with no server required. Data persists to disk.
 
 ```toml
-adk-rag = { version = "1.0.0", features = ["lancedb"] }
+adk-rag = { version = "1.0.1", features = ["lancedb"] }
 ```
 
 > Requires `protoc` installed: `brew install protobuf` (macOS), `apt install protobuf-compiler` (Ubuntu).
@@ -243,7 +243,7 @@ let store = LanceDBVectorStore::new("/tmp/my-vectors").await?;
 Use your existing PostgreSQL database for vector search.
 
 ```toml
-adk-rag = { version = "1.0.0", features = ["pgvector"] }
+adk-rag = { version = "1.0.1", features = ["pgvector"] }
 ```
 
 ```rust
@@ -255,7 +255,7 @@ let store = PgVectorStore::new("postgres://user:pass@localhost/mydb").await?;
 Embedded or remote multi-model database with built-in vector search.
 
 ```toml
-adk-rag = { version = "1.0.0", features = ["surrealdb"] }
+adk-rag = { version = "1.0.1", features = ["surrealdb"] }
 ```
 
 ```rust
@@ -305,7 +305,7 @@ The default `NoOpReranker` passes results through unchanged. Write your own to i
 
 ```toml
 [dependencies]
-adk-rag = { version = "1.0.0", features = ["gemini"] }
+adk-rag = { version = "1.0.1", features = ["gemini"] }
 async-trait = "0.1"
 tokio = { version = "1", features = ["full"] }
 ```
@@ -358,19 +358,19 @@ let pipeline = RagPipeline::builder()
 
 ```toml
 # Core only (in-memory store, all chunkers, no external deps)
-adk-rag = "1.0.0"
+adk-rag = "1.0.1"
 
 # With Gemini embeddings (recommended)
-adk-rag = { version = "1.0.0", features = ["gemini"] }
+adk-rag = { version = "1.0.1", features = ["gemini"] }
 
 # With OpenAI embeddings
-adk-rag = { version = "1.0.0", features = ["openai"] }
+adk-rag = { version = "1.0.1", features = ["openai"] }
 
 # With a persistent vector store
-adk-rag = { version = "1.0.0", features = ["gemini", "qdrant"] }
+adk-rag = { version = "1.0.1", features = ["gemini", "qdrant"] }
 
 # Everything
-adk-rag = { version = "1.0.0", features = ["full"] }
+adk-rag = { version = "1.0.1", features = ["full"] }
 ```
 
 | Feature | Enables | Extra dependency |

--- a/adk-realtime/README.md
+++ b/adk-realtime/README.md
@@ -74,7 +74,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-realtime = { version = "1.0.0", features = ["openai"] }
+adk-realtime = { version = "1.0.1", features = ["openai"] }
 ```
 
 ### Using RealtimeAgent (Recommended)
@@ -139,7 +139,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 Connect to Gemini Live API via Vertex AI with Application Default Credentials:
 
 ```toml
-adk-realtime = { version = "1.0.0", features = ["vertex-live"] }
+adk-realtime = { version = "1.0.1", features = ["vertex-live"] }
 ```
 
 ```rust
@@ -169,7 +169,7 @@ Prerequisites:
 Lower-latency audio transport using Sans-IO WebRTC with Opus codec:
 
 ```toml
-adk-realtime = { version = "1.0.0", features = ["openai-webrtc"] }
+adk-realtime = { version = "1.0.1", features = ["openai-webrtc"] }
 ```
 
 ```rust
@@ -191,7 +191,7 @@ export CMAKE_POLICY_VERSION_MINIMUM=3.5
 Bridge any `EventHandler` to a LiveKit room for production voice apps:
 
 ```toml
-adk-realtime = { version = "1.0.0", features = ["livekit", "openai"] }
+adk-realtime = { version = "1.0.1", features = ["livekit", "openai"] }
 ```
 
 #### LiveKitConfig and LiveKitRoomBuilder

--- a/adk-runner/README.md
+++ b/adk-runner/README.md
@@ -24,14 +24,14 @@ Agent execution runtime for ADK-Rust.
 
 ```toml
 [dependencies]
-adk-runner = "1.0.0"
+adk-runner = "1.0.1"
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "1.0.0", features = ["runner"] }
+adk-rust = { version = "1.0.1", features = ["runner"] }
 ```
 
 ## Quick Start

--- a/adk-rust-macros/Cargo.toml
+++ b/adk-rust-macros/Cargo.toml
@@ -21,7 +21,9 @@ quote = "1"
 syn = { version = "2", features = ["full", "extra-traits"] }
 
 [dev-dependencies]
-adk-core.workspace = true
+# Internal dev-deps are path-only (no version) so cargo strips them from the
+# published manifest — they can never block or reorder a crates.io publish.
+adk-core = { path = "../adk-core" }
 async-trait.workspace = true
 schemars = "1.0"
 serde = { workspace = true }

--- a/adk-rust-macros/README.md
+++ b/adk-rust-macros/README.md
@@ -10,8 +10,8 @@ This crate provides the `#[tool]` attribute macro that turns an async function i
 
 ```toml
 [dependencies]
-adk-rust-macros = "1.0.0"
-adk-tool = "1.0.0"
+adk-rust-macros = "1.0.1"
+adk-tool = "1.0.1"
 schemars = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/adk-rust/README.md
+++ b/adk-rust/README.md
@@ -39,7 +39,7 @@ cargo new my_agent && cd my_agent
 
 ```toml
 [dependencies]
-adk-rust = "1.0.0"
+adk-rust = "1.0.1"
 tokio = { version = "1.40", features = ["full"] }
 dotenvy = "0.15"
 ```
@@ -289,34 +289,31 @@ cargo run -- serve --port 8080
 ## Installation Options
 
 ```toml
-# Standard (default) — agents, models, tools, sessions, runner, guardrails, auth
-adk-rust = "1.0.0"
+# Minimal (default) — agents, Gemini, runner, sessions (fastest build)
+adk-rust = "1.0.1"
 
-# Full — standard + all stable specialist crates (graph, realtime, browser, eval, rag)
-# Does NOT include experimental crates (code, sandbox, audio) — use `labs` for those
-adk-rust = { version = "1.0.0", features = ["full"] }
+# Standard — minimal + tools, memory, OpenAI, Anthropic, server, auth,
+# graph, eval, guardrails, skills, plugins, artifacts, telemetry
+adk-rust = { version = "1.0.1", features = ["standard"] }
 
-# Labs — standard + experimental crates (code, sandbox, audio)
-adk-rust = { version = "1.0.0", features = ["labs"] }
+# Enterprise — standard + realtime, browser, rag, payments, awp
+adk-rust = { version = "1.0.1", features = ["enterprise"] }
 
-# Full + Labs — everything including experimental crates
-adk-rust = { version = "1.0.0", features = ["full", "labs"] }
-
-# Minimal
-adk-rust = { version = "1.0.0", default-features = false, features = ["minimal"] }
+# Full — enterprise + experimental crates (audio, code, sandbox)
+adk-rust = { version = "1.0.1", features = ["full"] }
 
 # Custom
-adk-rust = { version = "1.0.0", default-features = false, features = ["agents", "gemini", "tools"] }
+adk-rust = { version = "1.0.1", default-features = false, features = ["agents", "gemini", "tools"] }
 
 # With new providers (forwarded to adk-model)
-adk-model = { version = "1.0.0", features = ["fireworks", "together", "mistral", "perplexity", "cerebras", "sambanova", "bedrock", "azure-ai"] }
+adk-model = { version = "1.0.1", features = ["fireworks", "together", "mistral", "perplexity", "cerebras", "sambanova", "bedrock", "azure-ai"] }
 ```
 
 ## Documentation
 
 - [API Reference](https://docs.rs/adk-rust)
 - [Official Guides](https://github.com/zavora-ai/adk-rust/tree/main/docs/official_docs)
-- [Examples](https://github.com/zavora-ai/adk-rust/tree/main/examples) — 120+ working examples
+- [Examples](https://github.com/zavora-ai/adk-rust/tree/main/examples) — 75+ working examples in-repo, 120+ in the [playground](https://github.com/zavora-ai/adk-playground)
 - [Wiki](https://github.com/zavora-ai/adk-rust/wiki) — Comprehensive guides and tutorials
 
 ## License

--- a/adk-rust/src/lib.rs
+++ b/adk-rust/src/lib.rs
@@ -40,7 +40,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-rust = "0.8.2"
+//! adk-rust = "1.0.1"
 //! tokio = { version = "1.40", features = ["full"] }
 //! dotenvy = "0.15"  # For loading .env files
 //! ```
@@ -48,24 +48,21 @@
 //! ### Feature Presets
 //!
 //! ```toml
-//! # Standard (default) — agents, models, tools, sessions, runner, guardrails, auth
-//! adk-rust = "0.8.2"
+//! # Minimal (default) — agents, Gemini, runner, sessions (fastest build)
+//! adk-rust = "1.0.1"
 //!
-//! # Full — standard + all stable specialist crates (graph, realtime, browser, eval, rag)
-//! # Does NOT include experimental crates (code, sandbox, audio) — use `labs` for those
-//! adk-rust = { version = "0.8.2", features = ["full"] }
+//! # Standard — minimal + tools, memory, OpenAI, Anthropic, server, auth,
+//! # graph, eval, guardrails, skills, plugins, artifacts, telemetry
+//! adk-rust = { version = "1.0.1", features = ["standard"] }
 //!
-//! # Labs — standard + experimental crates (code, sandbox, audio)
-//! adk-rust = { version = "0.8.2", features = ["labs"] }
+//! # Enterprise — standard + realtime, browser, rag, payments, awp
+//! adk-rust = { version = "1.0.1", features = ["enterprise"] }
 //!
-//! # Full + Labs — everything including experimental crates
-//! adk-rust = { version = "0.8.2", features = ["full", "labs"] }
-//!
-//! # Minimal — just agents + Gemini + runner (fastest build)
-//! adk-rust = { version = "0.8.2", default-features = false, features = ["minimal"] }
+//! # Full — enterprise + experimental crates (audio, code, sandbox)
+//! adk-rust = { version = "1.0.1", features = ["full"] }
 //!
 //! # Custom — pick exactly what you need
-//! adk-rust = { version = "0.8.2", default-features = false, features = [
+//! adk-rust = { version = "1.0.1", default-features = false, features = [
 //!     "agents", "gemini", "tools", "sessions", "openai", "openrouter"
 //! ] }
 //! ```
@@ -408,29 +405,33 @@
 //!
 //! | Feature | Description | Preset |
 //! |---------|-------------|--------|
-//! | `agents` | Agent implementations | standard |
-//! | `models` | Model integrations | standard |
-//! | `gemini` | Gemini model support | standard |
+//! | `agents` | Agent implementations | minimal (default) |
+//! | `models` | Model integrations | minimal (default) |
+//! | `gemini` | Gemini model support | minimal (default) |
+//! | `runner` | Execution runtime | minimal (default) |
+//! | `sessions` | Session management | minimal (default) |
 //! | `tools` | Tool system | standard |
 //! | `skills` | Skill discovery | standard |
-//! | `sessions` | Session management | standard |
 //! | `artifacts` | Artifact storage | standard |
 //! | `memory` | Semantic memory | standard |
-//! | `runner` | Execution runtime | standard |
 //! | `telemetry` | OpenTelemetry | standard |
 //! | `guardrail` | Input/output validation | standard |
 //! | `auth` | Access control | standard |
 //! | `plugin` | Plugin system | standard |
 //! | `server` | HTTP server + A2A | standard |
-//! | `cli` | CLI launcher | standard |
-//! | `graph` | Graph workflows | full |
-//! | `browser` | Browser automation | full |
-//! | `eval` | Agent evaluation | full |
-//! | `realtime` | Voice/audio streaming | full |
-//! | `rag` | RAG pipeline | full |
-//! | `code` | Code execution | labs (experimental) |
-//! | `sandbox` | Sandboxed execution | labs (experimental) |
-//! | `audio` | Audio processing | labs (experimental) |
+//! | `graph` | Graph workflows | standard |
+//! | `eval` | Agent evaluation | standard |
+//! | `openai` | OpenAI model support | standard |
+//! | `anthropic` | Anthropic model support | standard |
+//! | `realtime` | Voice/audio streaming | enterprise |
+//! | `browser` | Browser automation | enterprise |
+//! | `rag` | RAG pipeline | enterprise |
+//! | `payments` | Agentic commerce (ACP/AP2) | enterprise |
+//! | `awp` | Agentic Web Protocol | enterprise |
+//! | `code` | Code execution | full (experimental) |
+//! | `sandbox` | Sandboxed execution | full (experimental) |
+//! | `audio` | Audio processing | full (experimental) |
+//! | `cli` | CLI launcher | (opt-in, any preset) |
 //!
 //! ## Examples
 //!
@@ -647,7 +648,7 @@ pub mod graph {
     pub use adk_graph::*;
 }
 
-/// Code execution substrate (experimental — `labs` preset).
+/// Code execution substrate (experimental — `full` preset).
 ///
 /// First-class code execution for agents, Studio, and generated projects:
 /// - [`CodeExecutor`](code::CodeExecutor) - Backend trait for execution
@@ -663,7 +664,7 @@ pub mod code {
     pub use adk_code::*;
 }
 
-/// Isolated code execution runtime (experimental — `labs` preset).
+/// Isolated code execution runtime (experimental — `full` preset).
 ///
 /// Provides the [`SandboxBackend`](sandbox::SandboxBackend) trait and built-in backends:
 /// - [`ProcessBackend`](sandbox::ProcessBackend) - Subprocess execution with timeout and env isolation
@@ -787,7 +788,7 @@ pub mod plugin {
     pub use adk_plugin::*;
 }
 
-/// Audio processing pipeline (experimental — `labs` preset).
+/// Audio processing pipeline (experimental — `full` preset).
 ///
 /// Provides audio capabilities for agents:
 /// - [`TtsProvider`](audio::TtsProvider) - Text-to-speech synthesis

--- a/adk-sandbox/src/wasm.rs
+++ b/adk-sandbox/src/wasm.rs
@@ -56,9 +56,7 @@ const MAX_OUTPUT_BYTES: usize = 1_024 * 1_024;
 /// let backend = WasmBackend::new();
 /// assert_eq!(backend.name(), "wasm");
 /// ```
-pub struct WasmBackend {
-    engine: Engine,
-}
+pub struct WasmBackend;
 
 /// Store data combining WASI context with resource limits.
 struct WasmStoreData {
@@ -67,13 +65,25 @@ struct WasmStoreData {
 }
 
 impl WasmBackend {
-    /// Creates a new `WasmBackend` with epoch interruption enabled.
+    /// Creates a new `WasmBackend`.
     pub fn new() -> Self {
+        Self
+    }
+
+    /// Creates a fresh engine with epoch interruption enabled.
+    ///
+    /// Each execution gets its own engine: wasmtime epochs are engine-global,
+    /// so sharing one engine would let any execution's timeout timer (or a
+    /// stale timer from an already-finished execution) trip the epoch
+    /// deadline of every other in-flight execution.
+    fn make_engine() -> Result<Engine, SandboxError> {
         let mut config = wasmtime::Config::new();
         config.epoch_interruption(true);
-        let engine =
-            Engine::new(&config).expect("failed to create wasmtime engine with epoch support");
-        Self { engine }
+        Engine::new(&config).map_err(|e| {
+            SandboxError::ExecutionFailed(format!(
+                "failed to create wasmtime engine with epoch support: {e}"
+            ))
+        })
     }
 
     /// Synchronous WASM execution — runs on a blocking thread.
@@ -229,7 +239,9 @@ impl SandboxBackend for WasmBackend {
             )));
         }
 
-        let engine = self.engine.clone();
+        // A fresh engine per execution keeps epoch deadlines isolated; see
+        // `make_engine` for why the engine must not be shared.
+        let engine = Self::make_engine()?;
 
         // Run WASM execution on a blocking thread so we don't block the
         // async runtime. The epoch timer OS thread fires independently.

--- a/adk-server/README.md
+++ b/adk-server/README.md
@@ -29,14 +29,14 @@ HTTP server and A2A v1.0.0 protocol for Rust Agent Development Kit (ADK-Rust) ag
 
 ```toml
 [dependencies]
-adk-server = "1.0.0"
+adk-server = "1.0.1"
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "1.0.0", features = ["server"] }
+adk-rust = { version = "1.0.1", features = ["server"] }
 ```
 
 ## Quick Start

--- a/adk-session/README.md
+++ b/adk-session/README.md
@@ -24,14 +24,14 @@ Session management and state persistence for Rust Agent Development Kit (ADK-Rus
 
 ```toml
 [dependencies]
-adk-session = "1.0.0"
+adk-session = "1.0.1"
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "1.0.0", features = ["sessions"] }
+adk-rust = { version = "1.0.1", features = ["sessions"] }
 ```
 
 ## Quick Start
@@ -80,16 +80,16 @@ let name = session.state().get("user:name");
 
 ```toml
 # SQLite
-adk-session = { version = "1.0.0", features = ["sqlite"] }
+adk-session = { version = "1.0.1", features = ["sqlite"] }
 
 # PostgreSQL
-adk-session = { version = "1.0.0", features = ["postgres"] }
+adk-session = { version = "1.0.1", features = ["postgres"] }
 
 # Redis
-adk-session = { version = "1.0.0", features = ["redis"] }
+adk-session = { version = "1.0.1", features = ["redis"] }
 
 # Encrypted sessions
-adk-session = { version = "1.0.0", features = ["encrypted-session"] }
+adk-session = { version = "1.0.1", features = ["encrypted-session"] }
 ```
 
 ## Encrypted Sessions

--- a/adk-telemetry/README.md
+++ b/adk-telemetry/README.md
@@ -26,14 +26,14 @@ OpenTelemetry integration for Rust Agent Development Kit (ADK-Rust) agent observ
 
 ```toml
 [dependencies]
-adk-telemetry = "1.0.0"
+adk-telemetry = "1.0.1"
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "1.0.0", features = ["telemetry"] }
+adk-rust = { version = "1.0.1", features = ["telemetry"] }
 ```
 
 ## Quick Start

--- a/adk-tool/Cargo.toml
+++ b/adk-tool/Cargo.toml
@@ -64,11 +64,13 @@ gcp-bigquery-client = { version = "0.28", optional = true }
 google-cloud-spanner = { version = "0.33", optional = true }
 
 [dev-dependencies]
+# Internal dev-deps are path-only (no version) so cargo strips them from the
+# published manifest — they can never block or reorder a crates.io publish.
 async-stream.workspace = true
 proptest = "1.5"
 tokio = { workspace = true, features = ["test-util", "macros", "rt-multi-thread"] }
-adk-code = { workspace = true }
-adk-sandbox = { workspace = true }
+adk-code = { path = "../adk-code" }
+adk-sandbox = { path = "../adk-sandbox" }
 
 [[test]]
 name = "mcp_server_lifecycle_integration_tests"

--- a/adk-tool/README.md
+++ b/adk-tool/README.md
@@ -31,17 +31,17 @@ Tool system for Rust Agent Development Kit (ADK-Rust) agents (FunctionTool, MCP,
 
 ```toml
 [dependencies]
-adk-tool = "1.0.0"
+adk-tool = "1.0.1"
 
 # For remote MCP servers via HTTP:
-adk-tool = { version = "1.0.0", features = ["http-transport"] }
+adk-tool = { version = "1.0.1", features = ["http-transport"] }
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "1.0.0", features = ["tools"] }
+adk-rust = { version = "1.0.1", features = ["tools"] }
 ```
 
 ## Quick Start

--- a/cargo-adk/README.md
+++ b/cargo-adk/README.md
@@ -239,7 +239,7 @@ Current version: **1.0.0**
 
 ```toml
 [dependencies]
-cargo-adk = "1.0.0"
+cargo-adk = "1.0.1"
 ```
 
 ## Part of ADK-Rust

--- a/cargo-adk/proptest-regressions/main.txt
+++ b/cargo-adk/proptest-regressions/main.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc fa284293509a7a11425da5ed6cceafceb53571318599fa7f2b40e73d8908bab6 # shrinks to name = "a", provider = "gemini"

--- a/cargo-adk/src/codegen.rs
+++ b/cargo-adk/src/codegen.rs
@@ -11,7 +11,7 @@ use crate::provider::get_provider_config;
 use crate::registry::TemplateRegistry;
 
 /// Current ADK-Rust version, read from this crate's own version at compile time.
-const ADK_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const ADK_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Generate all project files from a composition manifest.
 ///
@@ -31,14 +31,24 @@ const ADK_VERSION: &str = env!("CARGO_PKG_VERSION");
 /// }
 /// ```
 pub fn generate_project(manifest: &CompositionManifest, project_name: &str) -> Vec<GeneratedFile> {
-    vec![
+    generate_project_with_registry(&TemplateRegistry::builtin(), manifest, project_name)
+}
+
+/// Like [`generate_project`], but uses the given registry so custom templates
+/// (loaded via `--template-dir`) contribute their code fragments.
+pub fn generate_project_with_registry(
+    registry: &TemplateRegistry,
+    manifest: &CompositionManifest,
+    project_name: &str,
+) -> Vec<GeneratedFile> {
+    let mut files = vec![
         GeneratedFile {
             path: "Cargo.toml".to_string(),
             content: generate_cargo_toml(manifest, project_name),
         },
         GeneratedFile {
             path: "src/main.rs".to_string(),
-            content: generate_main_rs(manifest, project_name),
+            content: generate_main_rs_with_registry(registry, manifest, project_name),
         },
         GeneratedFile { path: ".env.example".to_string(), content: generate_env_example(manifest) },
         GeneratedFile {
@@ -46,7 +56,29 @@ pub fn generate_project(manifest: &CompositionManifest, project_name: &str) -> V
             content: generate_readme(manifest, project_name),
         },
         GeneratedFile { path: ".gitignore".to_string(), content: generate_gitignore() },
-    ]
+    ];
+
+    // Append additional files contributed by the template and addons.
+    if let Some(template) = registry.resolve_template(&manifest.template_name) {
+        for fragment in &template.code_fragments.additional_files {
+            files.push(GeneratedFile {
+                path: fragment.path.to_string(),
+                content: fragment.content.to_string(),
+            });
+        }
+    }
+    for addon_name in &manifest.addons {
+        if let Some(addon) = registry.capability_addons.iter().find(|a| a.name == *addon_name) {
+            for fragment in &addon.code_fragments.additional_files {
+                files.push(GeneratedFile {
+                    path: fragment.path.to_string(),
+                    content: fragment.content.to_string(),
+                });
+            }
+        }
+    }
+
+    files
 }
 
 /// Generate `Cargo.toml` with minimal dependencies from the composition manifest.
@@ -90,6 +122,21 @@ anyhow = "1"
     output
 }
 
+/// Fallback agent construction used when a template has no (or placeholder)
+/// `agent_construction` fragment. Uses fully qualified `Arc` because the
+/// fallback path cannot rely on template-provided imports.
+fn placeholder_agent_construction(project_name: &str) -> String {
+    format!(
+        r#"    let agent: std::sync::Arc<dyn Agent> = std::sync::Arc::new(
+        LlmAgentBuilder::new("{project_name}")
+            .description("An AI assistant")
+            .instruction("You are a helpful assistant.")
+            .model(std::sync::Arc::new(model))
+            .build()?,
+    );"#,
+    )
+}
+
 /// Generate `src/main.rs` with proper composition of template and addons.
 ///
 /// The generated code merges:
@@ -101,8 +148,16 @@ anyhow = "1"
 ///
 /// The server addon uses `std::env::var("PORT")` for port binding.
 pub fn generate_main_rs(manifest: &CompositionManifest, project_name: &str) -> String {
-    let registry = TemplateRegistry::builtin();
+    generate_main_rs_with_registry(&TemplateRegistry::builtin(), manifest, project_name)
+}
 
+/// Like [`generate_main_rs`], but uses the given registry so custom templates
+/// (loaded via `--template-dir`) contribute their code fragments.
+pub fn generate_main_rs_with_registry(
+    registry: &TemplateRegistry,
+    manifest: &CompositionManifest,
+    project_name: &str,
+) -> String {
     // Resolve provider config for model init code
     let provider_config = get_provider_config(&manifest.provider).ok();
 
@@ -139,6 +194,17 @@ pub fn generate_main_rs(manifest: &CompositionManifest, project_name: &str) -> S
         }
     }
 
+    // When nothing serves (no server addon, template doesn't start its own
+    // server), run the agent in the interactive console so `cargo run` does
+    // something useful out of the box.
+    const SELF_SERVING_TEMPLATES: &[&str] = &["api"];
+    let has_server_addon = manifest.addons.iter().any(|a| a == "server");
+    let interactive =
+        !has_server_addon && !SELF_SERVING_TEMPLATES.contains(&manifest.template_name.as_str());
+    if interactive {
+        imports.push("use adk_rust::Launcher;".to_string());
+    }
+
     let imports_section = imports.join("\n");
 
     // Build model initialization (includes api_key loading from env)
@@ -151,7 +217,7 @@ pub fn generate_main_rs(manifest: &CompositionManifest, project_name: &str) -> S
         };
         if pc.requires_api_key {
             format!(
-                "    let api_key = std::env::var(\"{}\").expect(\"{} must be set\");\n    let model = {};",
+                "    let api_key = std::env::var(\"{}\")\n        .map_err(|_| anyhow::anyhow!(\"{} is not set — copy .env.example to .env and add your key\"))?;\n    let model = {};",
                 pc.env_var, pc.env_var, init_code
             )
         } else {
@@ -160,7 +226,7 @@ pub fn generate_main_rs(manifest: &CompositionManifest, project_name: &str) -> S
     } else {
         let model_id = manifest.model_override.as_deref().unwrap_or("gemini-3.5-flash");
         format!(
-            "    let api_key = std::env::var(\"GOOGLE_API_KEY\").expect(\"GOOGLE_API_KEY must be set\");\n    let model = adk_rust::model::GeminiModel::new(&api_key, \"{model_id}\")?;"
+            "    let api_key = std::env::var(\"GOOGLE_API_KEY\")\n        .map_err(|_| anyhow::anyhow!(\"GOOGLE_API_KEY is not set — copy .env.example to .env and add your key\"))?;\n    let model = adk_rust::model::GeminiModel::new(&api_key, \"{model_id}\")?;"
         )
     };
 
@@ -169,26 +235,14 @@ pub fn generate_main_rs(manifest: &CompositionManifest, project_name: &str) -> S
         let code = tmpl.code_fragments.agent_construction;
         if code.is_empty() || code.starts_with("// TODO") {
             // Placeholder agent construction
-            format!(
-                r#"    let agent = LlmAgent::builder()
-        .name("{project_name}")
-        .model(model)
-        .instruction("You are a helpful assistant.")
-        .build();"#,
-            )
+            placeholder_agent_construction(project_name)
         } else {
             // Replace {name} placeholder with actual project name
             let resolved = code.replace("{name}", project_name);
             format!("    {resolved}")
         }
     } else {
-        format!(
-            r#"    let agent = LlmAgent::builder()
-        .name("{project_name}")
-        .model(model)
-        .instruction("You are a helpful assistant.")
-        .build();"#,
-        )
+        placeholder_agent_construction(project_name)
     };
 
     // Build addon initialization (sorted by priority)
@@ -218,7 +272,6 @@ pub fn generate_main_rs(manifest: &CompositionManifest, project_name: &str) -> S
 
     // Check if telemetry addon is present for tracing init
     let has_telemetry = manifest.addons.iter().any(|a| a == "telemetry");
-    let has_server = manifest.addons.iter().any(|a| a == "server");
 
     // Build tracing subscriber init
     let tracing_init = if has_telemetry {
@@ -235,14 +288,15 @@ pub fn generate_main_rs(manifest: &CompositionManifest, project_name: &str) -> S
             .to_string()
     };
 
-    // Build server binding (if server addon present)
-    let server_section = if has_server {
+    // Run the interactive console when nothing else drives the agent.
+    // (When the server addon is present, its initialization binds and serves;
+    // self-serving templates like `api` serve inside their construction code.)
+    let launcher_section = if interactive {
         r#"
-    // Server binding
-    let port = std::env::var("PORT").unwrap_or_else(|_| "8080".to_string());
-    let addr = format!("0.0.0.0:{port}");
-    tracing::info!("starting server on {}", addr);"#
-            .to_string()
+    // Interactive console
+    Launcher::new(agent).run().await?;
+"#
+        .to_string()
     } else {
         String::new()
     };
@@ -277,7 +331,7 @@ async fn main() -> anyhow::Result<()> {{
 
     // Agent construction
 {agent_construction}
-{addon_init_section}{builder_calls_section}{server_section}
+{addon_init_section}{builder_calls_section}{launcher_section}
     Ok(())
 }}
 "#

--- a/cargo-adk/src/composition.rs
+++ b/cargo-adk/src/composition.rs
@@ -218,8 +218,16 @@ pub fn resolve_composition(
     }
     feature_set.insert(provider_config.feature_flag.to_string());
 
-    // 6. Collect dependencies from all addons
+    // 6. Collect dependencies from the template and all addons
     let mut dependencies = Vec::new();
+    for dep in &resolved_template.additional_deps {
+        dependencies.push(ResolvedDependency {
+            crate_name: dep.crate_name.to_string(),
+            version: dep.version.to_string(),
+            features: dep.features.iter().map(|f| f.to_string()).collect(),
+            default_features: true,
+        });
+    }
     for addon in &resolved_addons {
         for dep in &addon.additional_deps {
             dependencies.push(ResolvedDependency {

--- a/cargo-adk/src/main.rs
+++ b/cargo-adk/src/main.rs
@@ -24,7 +24,7 @@ use serde::Serialize;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use cargo_adk::codegen::generate_project;
+use cargo_adk::codegen::generate_project_with_registry;
 use cargo_adk::composition::{DryRunFile, DryRunOutput, resolve_composition};
 use cargo_adk::registry::TemplateRegistry;
 
@@ -60,9 +60,10 @@ enum AdkCommand {
         #[arg(short, long, default_value = "basic")]
         template: String,
 
-        /// LLM provider to use
-        #[arg(short, long, default_value = "gemini")]
-        provider: String,
+        /// LLM provider to use (defaults to the template's default provider,
+        /// which is gemini for most templates)
+        #[arg(short, long)]
+        provider: Option<String>,
 
         /// Model ID to use (overrides provider default)
         #[arg(short, long)]
@@ -87,6 +88,10 @@ enum AdkCommand {
         /// Capability addons to include (repeatable)
         #[arg(long, action = clap::ArgAction::Append)]
         addon: Vec<String>,
+
+        /// Directory of custom template manifests (*.toml) to include
+        #[arg(long)]
+        template_dir: Option<PathBuf>,
 
         /// Preview what would be generated without writing files
         #[arg(long)]
@@ -365,8 +370,11 @@ fn main() {
             json_output,
             with_yaml,
             addon,
+            template_dir,
             dry_run,
         } => {
+            let provider = provider
+                .unwrap_or_else(|| default_provider_for(&template, template_dir.as_deref()));
             if let Err(e) = create_project(
                 &name,
                 &template,
@@ -376,6 +384,7 @@ fn main() {
                 json_output,
                 with_yaml,
                 &addon,
+                template_dir.as_deref(),
                 dry_run,
             ) {
                 if json_output {
@@ -1629,7 +1638,7 @@ fn get_builtin_templates() -> Vec<TemplateInfo> {
         },
         TemplateInfo {
             name: "api",
-            description: "REST API server with health check and A2A protocol",
+            description: "REST API server with /chat and /health endpoints",
             default_provider: "gemini",
             features: vec!["minimal", "server"],
         },
@@ -1654,30 +1663,32 @@ fn get_builtin_templates() -> Vec<TemplateInfo> {
     ]
 }
 
-fn print_templates(_template_dir: Option<&Path>) {
+fn print_templates(template_dir: Option<&Path>) {
+    let mut registry = TemplateRegistry::builtin();
+    if let Some(dir) = template_dir
+        && let Err(e) = registry.load_custom_dir(dir)
+    {
+        eprintln!("warning: {e}");
+    }
+
     println!("Available templates:\n");
 
     println!("  Agent Types:");
-    println!("    {:<14} Single LLM agent with tool calling support", "llm");
-    println!("    {:<14} Sequential multi-agent pipeline", "sequential");
-    println!("    {:<14} Parallel multi-agent execution", "parallel");
-    println!("    {:<14} Loop agent with termination condition", "loop");
-    println!("    {:<14} Conditional routing agent", "conditional");
-    println!("    {:<14} Graph-based workflow with checkpoints", "graph");
-    println!("    {:<14} Real-time voice/audio streaming agent", "realtime");
-    println!("    {:<14} Custom agent with manual trait implementation", "custom");
-
-    println!("\n  Enterprise Patterns:");
-    println!("    {:<14} LLM + server, auth, sessions, telemetry", "production");
-    println!("    {:<14} Supervisor orchestrating sub-agents", "multi-agent");
-    println!("    {:<14} Sequential pipeline with state passing", "pipeline");
-    println!("    {:<14} Conversational agent with memory + server", "chatbot");
-    println!("    {:<14} A2A protocol server with sessions", "a2a-server");
-
-    println!("\n  Legacy (backward-compatible):");
-    for t in get_builtin_templates() {
+    for t in &registry.agent_templates {
         println!("    {:<14} {}", t.name, t.description);
     }
+
+    println!("\n  Enterprise Patterns:");
+    for p in &registry.enterprise_patterns {
+        println!("    {:<14} {}", p.name, p.description);
+    }
+
+    println!("\n  Aliases:");
+    println!("    {:<14} Alias for llm", "basic");
+    println!("    {:<14} Alias for a2a-server", "a2a");
+
+    println!("\n  Other:");
+    println!("    {:<14} Anthropic Managed Agents session with SSE streaming", "managed-agents");
 
     println!("\n  Addons (composable with any template):");
     println!("    --addon {:<12} OpenTelemetry tracing", "telemetry");
@@ -1699,6 +1710,33 @@ fn print_templates(_template_dir: Option<&Path>) {
 
 fn print_templates_json(template_dir: Option<&Path>) {
     let mut templates = get_builtin_templates();
+
+    // Include composable registry templates and patterns not already listed.
+    let registry = TemplateRegistry::builtin();
+    for t in &registry.agent_templates {
+        if !templates.iter().any(|info| info.name == t.name) {
+            templates.push(TemplateInfo {
+                name: t.name,
+                description: t.description,
+                default_provider: t.default_provider,
+                features: t.required_features.clone(),
+            });
+        }
+    }
+    for p in &registry.enterprise_patterns {
+        if !templates.iter().any(|info| info.name == p.name) {
+            let default_provider = registry
+                .resolve_template(p.base_template)
+                .map(|t| t.default_provider)
+                .unwrap_or("gemini");
+            templates.push(TemplateInfo {
+                name: p.name,
+                description: p.description,
+                default_provider,
+                features: vec![],
+            });
+        }
+    }
 
     // Load custom templates from directory if provided
     if let Some(dir) = template_dir
@@ -1733,30 +1771,43 @@ fn print_templates_json(template_dir: Option<&Path>) {
 
 // ── Scaffolding commands ────────────────────────────────────────
 
-/// New composable template names.
-const COMPOSABLE_TEMPLATES: &[&str] =
-    &["llm", "sequential", "parallel", "loop", "conditional", "graph", "realtime", "custom"];
+/// Templates that still use the legacy generators in this binary instead of
+/// the composable registry (template + addon composition).
+const LEGACY_ONLY_TEMPLATES: &[&str] = &["managed-agents"];
 
-/// Enterprise pattern names.
-const ENTERPRISE_PATTERNS: &[&str] =
-    &["multi-agent", "production", "pipeline", "chatbot", "a2a-server"];
+/// Determine whether to use the composable system for a given template.
+///
+/// Everything routes through the composable registry except the few
+/// `LEGACY_ONLY_TEMPLATES` that have no composable equivalent yet. Unknown
+/// template names also go composable so the registry produces the
+/// canonical "unknown template" error.
+fn should_use_composable(template: &str, _addons: &[String]) -> bool {
+    !LEGACY_ONLY_TEMPLATES.contains(&template)
+}
 
-/// Determine whether to use the composable system for a given template + addons.
-fn should_use_composable(template: &str, addons: &[String]) -> bool {
-    // If addons are specified, always use the composable system
-    if !addons.is_empty() {
-        return true;
+/// The default provider for a template when `--provider` is not given.
+///
+/// Looks up the template (or pattern base template) in the registry;
+/// falls back to "gemini" for legacy-only and unknown names.
+fn default_provider_for(template: &str, template_dir: Option<&Path>) -> String {
+    let mut registry = TemplateRegistry::builtin();
+    if let Some(dir) = template_dir {
+        // Errors surface later during project creation; default resolution
+        // just falls back to the built-ins.
+        let _ = registry.load_custom_dir(dir);
     }
-    // If template is a new composable template name, use composable
-    if COMPOSABLE_TEMPLATES.contains(&template) {
-        return true;
+    if let Some(tmpl) = registry.resolve_template(template) {
+        return tmpl.default_provider.to_string();
     }
-    // If template is an enterprise pattern, use composable
-    if ENTERPRISE_PATTERNS.contains(&template) {
-        return true;
+    if let Some(pattern) = registry.resolve_pattern(template)
+        && let Some(base) = registry.resolve_template(pattern.base_template)
+    {
+        return base.default_provider.to_string();
     }
-    // Otherwise (legacy template with no addons), use legacy
-    false
+    if template == "managed-agents" {
+        return "anthropic".to_string();
+    }
+    "gemini".to_string()
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1769,6 +1820,7 @@ fn create_project(
     json_output: bool,
     with_yaml: bool,
     addons: &[String],
+    template_dir: Option<&Path>,
     dry_run: bool,
 ) -> Result<(), String> {
     if should_use_composable(template, addons) {
@@ -1779,7 +1831,9 @@ fn create_project(
             model_override,
             output_dir,
             json_output,
+            with_yaml,
             addons,
+            template_dir,
             dry_run,
         );
     }
@@ -1866,10 +1920,15 @@ fn create_project_composable(
     model_override: Option<&str>,
     output_dir: Option<&Path>,
     json_output: bool,
+    with_yaml: bool,
     addons: &[String],
+    template_dir: Option<&Path>,
     dry_run: bool,
 ) -> Result<(), String> {
-    let registry = TemplateRegistry::builtin();
+    let mut registry = TemplateRegistry::builtin();
+    if let Some(dir) = template_dir {
+        registry.load_custom_dir(dir)?;
+    }
 
     // Determine the base template and effective addons
     let (base_template, effective_addons) =
@@ -1901,7 +1960,15 @@ fn create_project_composable(
     }
 
     // Generate project files
-    let files = generate_project(&manifest, name);
+    let mut files = generate_project_with_registry(&registry, &manifest, name);
+
+    // Optionally include a YAML agent definition
+    if with_yaml {
+        files.push(cargo_adk::composition::GeneratedFile {
+            path: format!("agents/{name}.yaml"),
+            content: generate_yaml_definition(name, provider, &manifest.template_name),
+        });
+    }
 
     // Handle dry-run mode
     if dry_run {
@@ -2604,6 +2671,7 @@ mod tests {
             false,
             false,
             &[],
+            None,
             false,
         );
         assert!(result.is_ok());
@@ -2628,6 +2696,7 @@ mod tests {
             false,
             true,
             &[],
+            None,
             false,
         );
         assert!(result.is_ok());
@@ -2659,6 +2728,7 @@ mod tests {
             true,
             false,
             &[],
+            None,
             false,
         );
         assert!(result.is_ok());
@@ -2775,7 +2845,8 @@ mod tests {
         // *For any* valid project name (alphanumeric with hyphens, 1-64 chars) and
         // supported provider (gemini, openai, anthropic), the `a2a` template SHALL
         // generate a project containing Cargo.toml, src/main.rs, .env.example, and
-        // .gitignore files, and the Cargo.toml SHALL contain the `standard` feature.
+        // .gitignore files, and the Cargo.toml SHALL enable the `server` and
+        // `sessions` features (the a2a-server composition).
         // **Validates: Requirements 1.1, 1.2, 1.4**
         proptest! {
             #![proptest_config(ProptestConfig::with_cases(100))]
@@ -2789,7 +2860,7 @@ mod tests {
                 let _ = fs::remove_dir_all(&tmp);
                 fs::create_dir_all(&tmp).unwrap();
 
-                let result = create_project(&name, "a2a", provider, None, Some(&tmp), false, false, &[], false);
+                let result = create_project(&name, "a2a", provider, None, Some(&tmp), false, false, &[], None, false);
                 prop_assert!(result.is_ok(), "create_project failed for name={name}, provider={provider}: {:?}", result.err());
 
                 let project_path = tmp.join(&name);
@@ -2812,11 +2883,11 @@ mod tests {
                     ".gitignore missing for name={name}"
                 );
 
-                // Cargo.toml must contain the standard feature
+                // Cargo.toml must enable the server + sessions features
                 let cargo_content = fs::read_to_string(project_path.join("Cargo.toml")).unwrap();
                 prop_assert!(
-                    cargo_content.contains(r#"features = ["standard"]"#),
-                    "Cargo.toml missing standard feature for name={name}"
+                    cargo_content.contains(r#""server""#) && cargo_content.contains(r#""sessions""#),
+                    "Cargo.toml missing server/sessions features for name={name}"
                 );
 
                 // Cargo.toml must contain the current version

--- a/cargo-adk/src/registry.rs
+++ b/cargo-adk/src/registry.rs
@@ -6,9 +6,10 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use crate::addon::{AddonCodeFragments, CapabilityAddon};
+use crate::addon::{AddonCodeFragments, CapabilityAddon, DependencySpec};
+use crate::codegen::ADK_VERSION;
 use crate::pattern::EnterprisePattern;
-use crate::template::{AgentCodeFragments, AgentTemplate, TemplateCategory};
+use crate::template::{AgentCodeFragments, AgentTemplate, FileFragment, TemplateCategory};
 
 /// Central registry of all available templates, addons, and patterns.
 #[derive(Debug, Clone)]
@@ -26,8 +27,8 @@ pub struct TemplateRegistry {
 impl TemplateRegistry {
     /// Build the default registry with all built-in templates.
     ///
-    /// Populates 8 agent templates, 9 capability addons, 5 enterprise patterns,
-    /// and 6 legacy aliases.
+    /// Populates 12 agent templates, 9 capability addons, 5 enterprise patterns,
+    /// and 2 legacy aliases.
     pub fn builtin() -> Self {
         Self {
             agent_templates: builtin_agent_templates(),
@@ -37,9 +38,49 @@ impl TemplateRegistry {
         }
     }
 
-    /// Load additional templates from a directory.
-    pub fn load_custom_dir(&mut self, _dir: &Path) -> Result<(), String> {
-        // Will be implemented in a later task
+    /// Load additional templates from a directory of TOML manifests.
+    ///
+    /// Each `*.toml` file describes one template:
+    ///
+    /// ```toml
+    /// name = "my-template"                   # required
+    /// description = "My custom agent"        # optional
+    /// provider = "gemini"                    # optional, default provider
+    /// features = ["minimal", "tools"]        # optional, adk-rust features
+    /// imports = ["use std::sync::Arc;"]      # optional, main.rs imports
+    /// # optional; falls back to a basic LLM agent when omitted
+    /// agent_construction = '''
+    /// let agent: Arc<dyn Agent> = Arc::new(
+    ///     LlmAgentBuilder::new("{name}").model(Arc::new(model)).build()?,
+    /// );
+    /// '''
+    /// ```
+    ///
+    /// A custom template with the same name as a built-in replaces it.
+    pub fn load_custom_dir(&mut self, dir: &Path) -> Result<(), String> {
+        let entries = std::fs::read_dir(dir)
+            .map_err(|e| format!("failed to read template directory '{}': {e}", dir.display()))?;
+
+        let mut loaded = 0;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().is_none_or(|ext| ext != "toml") {
+                continue;
+            }
+            let content = std::fs::read_to_string(&path)
+                .map_err(|e| format!("failed to read '{}': {e}", path.display()))?;
+            let template = parse_custom_template(&content)
+                .map_err(|e| format!("invalid template manifest '{}': {e}", path.display()))?;
+
+            // Same-name custom templates replace built-ins.
+            self.agent_templates.retain(|t| t.name != template.name);
+            self.agent_templates.push(template);
+            loaded += 1;
+        }
+
+        if loaded == 0 {
+            return Err(format!("no .toml template manifests found in '{}'", dir.display()));
+        }
         Ok(())
     }
 
@@ -68,17 +109,67 @@ impl TemplateRegistry {
             .collect()
     }
 
-    /// Resolve an enterprise pattern into its definition.
+    /// Resolve an enterprise pattern into its definition (handling aliases).
     pub fn resolve_pattern(&self, name: &str) -> Option<&EnterprisePattern> {
-        self.enterprise_patterns.iter().find(|p| p.name == name)
+        let resolved_name = self.aliases.get(name).copied().unwrap_or(name);
+        self.enterprise_patterns.iter().find(|p| p.name == resolved_name)
     }
+}
+
+/// Parse a custom template TOML manifest into an [`AgentTemplate`].
+///
+/// Strings are leaked to satisfy the `&'static str` fields; the CLI is a
+/// short-lived process, so this is bounded and acceptable (the JSON template
+/// listing uses the same approach).
+fn parse_custom_template(content: &str) -> Result<AgentTemplate, String> {
+    fn leak(s: &str) -> &'static str {
+        Box::leak(s.to_string().into_boxed_str())
+    }
+
+    let value: toml::Value = content.parse().map_err(|e| format!("TOML parse error: {e}"))?;
+
+    let name = value.get("name").and_then(|v| v.as_str()).ok_or("missing required 'name' field")?;
+    let description =
+        value.get("description").and_then(|v| v.as_str()).unwrap_or("Custom agent template");
+    let default_provider = value.get("provider").and_then(|v| v.as_str()).unwrap_or("gemini");
+
+    let required_features: Vec<&'static str> = value
+        .get("features")
+        .and_then(|v| v.as_array())
+        .map(|arr| arr.iter().filter_map(|f| f.as_str()).map(leak).collect())
+        .unwrap_or_else(|| vec!["minimal"]);
+
+    let imports: Vec<&'static str> = value
+        .get("imports")
+        .and_then(|v| v.as_array())
+        .map(|arr| arr.iter().filter_map(|f| f.as_str()).map(leak).collect())
+        .unwrap_or_else(|| vec!["use std::sync::Arc;"]);
+
+    // Empty construction falls back to the basic LLM agent in codegen.
+    let agent_construction =
+        value.get("agent_construction").and_then(|v| v.as_str()).map(leak).unwrap_or("");
+
+    Ok(AgentTemplate {
+        name: leak(name),
+        description: leak(description),
+        category: TemplateCategory::AgentType,
+        default_provider: leak(default_provider),
+        required_features,
+        incompatible_addons: vec![],
+        additional_deps: vec![],
+        code_fragments: AgentCodeFragments {
+            imports,
+            agent_construction,
+            additional_files: vec![],
+        },
+    })
 }
 
 // ---------------------------------------------------------------------------
 // Built-in data population
 // ---------------------------------------------------------------------------
 
-/// All 8 built-in agent templates.
+/// All 12 built-in agent templates.
 fn builtin_agent_templates() -> Vec<AgentTemplate> {
     vec![
         AgentTemplate {
@@ -88,6 +179,7 @@ fn builtin_agent_templates() -> Vec<AgentTemplate> {
             default_provider: "gemini",
             required_features: vec!["minimal"],
             incompatible_addons: vec![],
+            additional_deps: vec![],
             code_fragments: AgentCodeFragments {
                 imports: vec!["use std::sync::Arc;"],
                 agent_construction: r#"let agent: Arc<dyn Agent> = Arc::new(
@@ -107,6 +199,7 @@ fn builtin_agent_templates() -> Vec<AgentTemplate> {
             default_provider: "gemini",
             required_features: vec!["minimal"],
             incompatible_addons: vec![],
+            additional_deps: vec![],
             code_fragments: AgentCodeFragments {
                 imports: vec!["use std::sync::Arc;", "use adk_rust::agents::SequentialAgent;"],
                 agent_construction: r#"let researcher = Arc::new(
@@ -138,6 +231,7 @@ fn builtin_agent_templates() -> Vec<AgentTemplate> {
             default_provider: "gemini",
             required_features: vec!["minimal"],
             incompatible_addons: vec![],
+            additional_deps: vec![],
             code_fragments: AgentCodeFragments {
                 imports: vec!["use std::sync::Arc;", "use adk_rust::agents::ParallelAgent;"],
                 agent_construction: r#"let analyst = Arc::new(
@@ -169,6 +263,7 @@ fn builtin_agent_templates() -> Vec<AgentTemplate> {
             default_provider: "gemini",
             required_features: vec!["minimal"],
             incompatible_addons: vec![],
+            additional_deps: vec![],
             code_fragments: AgentCodeFragments {
                 imports: vec!["use std::sync::Arc;", "use adk_rust::agents::LoopAgent;"],
                 agent_construction: r#"let worker = Arc::new(
@@ -196,6 +291,7 @@ fn builtin_agent_templates() -> Vec<AgentTemplate> {
             default_provider: "gemini",
             required_features: vec!["minimal"],
             incompatible_addons: vec![],
+            additional_deps: vec![],
             code_fragments: AgentCodeFragments {
                 imports: vec!["use std::sync::Arc;", "use adk_rust::agents::ConditionalAgent;"],
                 agent_construction: r#"let technical = Arc::new(
@@ -227,6 +323,7 @@ fn builtin_agent_templates() -> Vec<AgentTemplate> {
             default_provider: "gemini",
             required_features: vec!["minimal", "graph"],
             incompatible_addons: vec![],
+            additional_deps: vec![],
             code_fragments: AgentCodeFragments {
                 imports: vec!["use std::sync::Arc;", "use adk_rust::graph::*;"],
                 agent_construction: r#"// Graph-based workflow with checkpoints
@@ -247,6 +344,7 @@ fn builtin_agent_templates() -> Vec<AgentTemplate> {
             default_provider: "gemini",
             required_features: vec!["minimal", "realtime"],
             incompatible_addons: vec![],
+            additional_deps: vec![],
             code_fragments: AgentCodeFragments {
                 imports: vec!["use std::sync::Arc;", "use adk_rust::realtime::*;"],
                 agent_construction: r#"// Real-time voice agent with bidirectional audio
@@ -267,6 +365,7 @@ fn builtin_agent_templates() -> Vec<AgentTemplate> {
             default_provider: "gemini",
             required_features: vec!["minimal"],
             incompatible_addons: vec![],
+            additional_deps: vec![],
             code_fragments: AgentCodeFragments {
                 imports: vec!["use std::sync::Arc;", "use async_trait::async_trait;"],
                 agent_construction: r#"// Custom agent implementing the Agent trait directly
@@ -284,6 +383,177 @@ fn builtin_agent_templates() -> Vec<AgentTemplate> {
     }
 
     let agent: Arc<dyn Agent> = Arc::new(MyAgent);"#,
+                additional_files: vec![],
+            },
+        },
+        AgentTemplate {
+            name: "tools",
+            description: "LLM agent with #[tool] custom tools",
+            category: TemplateCategory::AgentType,
+            default_provider: "gemini",
+            required_features: vec!["minimal", "tools"],
+            incompatible_addons: vec![],
+            additional_deps: vec![
+                DependencySpec { crate_name: "adk-tool", version: ADK_VERSION, features: vec![] },
+                DependencySpec { crate_name: "serde", version: "1", features: vec!["derive"] },
+                DependencySpec { crate_name: "serde_json", version: "1", features: vec![] },
+                DependencySpec { crate_name: "schemars", version: "1", features: vec![] },
+            ],
+            code_fragments: AgentCodeFragments {
+                imports: vec!["use std::sync::Arc;", "mod tools;", "use tools::Greet;"],
+                agent_construction: r#"let agent: Arc<dyn Agent> = Arc::new(
+        LlmAgentBuilder::new("{name}")
+            .description("Assistant with custom tools")
+            .instruction("You are a helpful assistant. Use the greet tool when asked to greet someone.")
+            .model(Arc::new(model))
+            .tool(Arc::new(Greet))
+            .build()?,
+    );"#,
+                additional_files: vec![FileFragment {
+                    path: "src/tools.rs",
+                    content: r#"//! Custom tools exposed to the agent via the `#[tool]` macro.
+
+use adk_tool::{AdkError, tool};
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+#[derive(Deserialize, JsonSchema)]
+pub struct GreetArgs {
+    /// Name of the person to greet
+    pub name: String,
+    /// Greeting style: formal or casual
+    pub style: Option<String>,
+}
+
+/// Greet a person by name.
+#[tool]
+pub async fn greet(args: GreetArgs) -> std::result::Result<Value, AdkError> {
+    let greeting = match args.style.as_deref() {
+        Some("formal") => format!("Good day, {}. How may I assist you?", args.name),
+        _ => format!("Hey {}! What's up?", args.name),
+    };
+    Ok(json!({ "greeting": greeting }))
+}
+"#,
+                }],
+            },
+        },
+        AgentTemplate {
+            name: "rag",
+            description: "RAG agent with vector search over a knowledge base",
+            category: TemplateCategory::AgentType,
+            default_provider: "gemini",
+            required_features: vec!["minimal"],
+            incompatible_addons: vec![],
+            additional_deps: vec![DependencySpec {
+                crate_name: "adk-rag",
+                version: ADK_VERSION,
+                features: vec!["gemini"],
+            }],
+            code_fragments: AgentCodeFragments {
+                imports: vec![
+                    "use std::sync::Arc;",
+                    "use adk_rag::{Document, FixedSizeChunker, GeminiEmbeddingProvider, InMemoryVectorStore, RagConfig, RagPipeline, RagTool};",
+                ],
+                agent_construction: r#"// Embeddings use Gemini; set GOOGLE_API_KEY for the embedding provider.
+    let gemini_key = std::env::var("GOOGLE_API_KEY")
+        .map_err(|_| anyhow::anyhow!("GOOGLE_API_KEY is required for Gemini embeddings — copy .env.example to .env and add your key"))?;
+
+    let pipeline = Arc::new(
+        RagPipeline::builder()
+            .config(RagConfig::default())
+            .embedding_provider(Arc::new(GeminiEmbeddingProvider::new(&gemini_key)?))
+            .vector_store(Arc::new(InMemoryVectorStore::new()))
+            .chunker(Arc::new(FixedSizeChunker::new(256, 50)))
+            .build()?,
+    );
+
+    pipeline.create_collection("docs").await?;
+    pipeline.ingest("docs", &Document {
+        id: "example".into(),
+        text: "ADK-Rust is a framework for building AI agents in Rust. \
+               It supports multiple LLM providers, tool calling, RAG, and more.".into(),
+        metadata: Default::default(),
+        source_uri: None,
+    }).await?;
+
+    tracing::info!("ingested example document into the 'docs' collection");
+
+    let agent: Arc<dyn Agent> = Arc::new(
+        LlmAgentBuilder::new("{name}")
+            .description("RAG-powered knowledge assistant")
+            .instruction("Use the rag_search tool to find relevant documents before answering.")
+            .model(Arc::new(model))
+            .tool(Arc::new(RagTool::new(pipeline, "docs")))
+            .build()?,
+    );"#,
+                additional_files: vec![],
+            },
+        },
+        AgentTemplate {
+            name: "api",
+            description: "REST API server exposing the agent over HTTP",
+            category: TemplateCategory::AgentType,
+            default_provider: "gemini",
+            required_features: vec!["minimal", "server"],
+            incompatible_addons: vec!["server"],
+            additional_deps: vec![DependencySpec {
+                crate_name: "axum",
+                version: "0.8",
+                features: vec![],
+            }],
+            code_fragments: AgentCodeFragments {
+                imports: vec![
+                    "use std::sync::Arc;",
+                    "use adk_rust::server::{ServerConfig, create_app};",
+                    "use adk_rust::session::InMemorySessionService;",
+                ],
+                agent_construction: r#"let agent: Arc<dyn Agent> = Arc::new(
+        LlmAgentBuilder::new("{name}")
+            .description("REST API agent")
+            .instruction("You are a helpful assistant accessible via REST API.")
+            .model(Arc::new(model))
+            .build()?,
+    );
+
+    let session_service = Arc::new(InMemorySessionService::new());
+
+    let config = ServerConfig::new(
+        Arc::new(adk_rust::SingleAgentLoader::new(agent)),
+        session_service,
+    );
+    let app = create_app(config);
+
+    let port = std::env::var("PORT").unwrap_or_else(|_| "8080".to_string());
+    let addr = format!("0.0.0.0:{port}");
+    tracing::info!("ADK agent server running on http://{addr}");
+    tracing::info!("  GET  /api/health                                — health check");
+    tracing::info!("  POST /api/sessions                              — create a session (appName, userId)");
+    tracing::info!("  POST /api/run/{name}/<user_id>/<session_id>     — send a message, SSE response");
+
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    axum::serve(listener, app).await?;"#,
+                additional_files: vec![],
+            },
+        },
+        AgentTemplate {
+            name: "openai",
+            description: "OpenAI-powered LLM agent",
+            category: TemplateCategory::AgentType,
+            default_provider: "openai",
+            required_features: vec!["minimal", "openai"],
+            incompatible_addons: vec![],
+            additional_deps: vec![],
+            code_fragments: AgentCodeFragments {
+                imports: vec!["use std::sync::Arc;"],
+                agent_construction: r#"let agent: Arc<dyn Agent> = Arc::new(
+        LlmAgentBuilder::new("{name}")
+            .description("An AI assistant")
+            .instruction("You are a helpful assistant.")
+            .model(Arc::new(model))
+            .build()?,
+    );"#,
                 additional_files: vec![],
             },
         },
@@ -508,14 +778,79 @@ fn builtin_enterprise_patterns() -> Vec<EnterprisePattern> {
     ]
 }
 
-/// Legacy alias mappings (6 total).
+/// Legacy alias mappings.
+///
+/// `tools`, `rag`, and `openai` are real templates and `api` is a real
+/// pattern (they previously aliased to plain `llm`, silently dropping the
+/// capability the name promised). `a2a` resolves to the `a2a-server` pattern.
 fn builtin_aliases() -> HashMap<&'static str, &'static str> {
     let mut aliases = HashMap::new();
     aliases.insert("basic", "llm");
-    aliases.insert("tools", "llm");
-    aliases.insert("rag", "llm");
-    aliases.insert("api", "llm");
-    aliases.insert("openai", "llm");
-    aliases.insert("a2a", "llm");
+    aliases.insert("a2a", "a2a-server");
     aliases
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builtin_registry_has_advertised_templates() {
+        let registry = TemplateRegistry::builtin();
+        for name in ["llm", "tools", "rag", "api", "openai", "graph", "realtime"] {
+            assert!(
+                registry.resolve_template(name).is_some(),
+                "advertised template '{name}' missing from registry"
+            );
+        }
+        // Aliases resolve to real targets.
+        assert_eq!(registry.resolve_template("basic").unwrap().name, "llm");
+        assert_eq!(registry.resolve_pattern("a2a").unwrap().name, "a2a-server");
+    }
+
+    #[test]
+    fn openai_template_defaults_to_openai_provider() {
+        let registry = TemplateRegistry::builtin();
+        assert_eq!(registry.resolve_template("openai").unwrap().default_provider, "openai");
+    }
+
+    #[test]
+    fn load_custom_dir_parses_toml_manifest() {
+        let dir = std::env::temp_dir().join("cargo-adk-custom-templates-test");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("greeter.toml"),
+            r#"
+name = "greeter"
+description = "A custom greeter agent"
+provider = "gemini"
+features = ["minimal"]
+"#,
+        )
+        .unwrap();
+
+        let mut registry = TemplateRegistry::builtin();
+        registry.load_custom_dir(&dir).unwrap();
+
+        let tmpl = registry.resolve_template("greeter").expect("custom template loaded");
+        assert_eq!(tmpl.description, "A custom greeter agent");
+        assert_eq!(tmpl.default_provider, "gemini");
+        // Empty construction means codegen falls back to the basic LLM agent.
+        assert!(tmpl.code_fragments.agent_construction.is_empty());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn load_custom_dir_rejects_empty_dir() {
+        let dir = std::env::temp_dir().join("cargo-adk-custom-templates-empty");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let mut registry = TemplateRegistry::builtin();
+        assert!(registry.load_custom_dir(&dir).is_err());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/cargo-adk/src/template.rs
+++ b/cargo-adk/src/template.rs
@@ -2,6 +2,8 @@
 //!
 //! Templates define the *agent structure* — the core agent type and its construction code.
 
+use crate::addon::DependencySpec;
+
 /// Category of a template in the registry.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TemplateCategory {
@@ -48,6 +50,9 @@ pub struct AgentTemplate {
     pub required_features: Vec<&'static str>,
     /// Addons that are incompatible with this template.
     pub incompatible_addons: Vec<&'static str>,
+    /// Additional crate dependencies beyond `adk-rust` (e.g., `adk-tool`,
+    /// `schemars` for the `tools` template).
+    pub additional_deps: Vec<DependencySpec>,
     /// Code fragments for generating the agent.
     pub code_fragments: AgentCodeFragments,
 }

--- a/docs/official_docs/agents/desktop-audio.md
+++ b/docs/official_docs/agents/desktop-audio.md
@@ -17,7 +17,7 @@ All components use the `cpal` crate for cross-platform audio (CoreAudio on macOS
 ```toml
 [dependencies]
 # Cross-platform (macOS, Linux, Windows) via cpal
-adk-audio = { version = "1.0.0", features = ["desktop-audio"] }
+adk-audio = { version = "1.0.1", features = ["desktop-audio"] }
 ```
 
 The `desktop-audio` feature implies `vad` (for `VadProcessor`) and adds `cpal` as a dependency. It is intentionally excluded from the `all` feature to avoid pulling platform-specific audio dependencies into CI builds.

--- a/docs/official_docs/agents/functional-api.md
+++ b/docs/official_docs/agents/functional-api.md
@@ -17,8 +17,8 @@ The Functional API (`functional` feature in `adk-graph`) provides a higher-level
 
 ```toml
 [dependencies]
-adk-graph = { version = "1.0.0", features = ["functional"] }
-adk-rust-macros = "1.0.0"
+adk-graph = { version = "1.0.1", features = ["functional"] }
+adk-rust-macros = "1.0.1"
 ```
 
 ## Core Types

--- a/docs/official_docs/agents/graph-agents.md
+++ b/docs/official_docs/agents/graph-agents.md
@@ -115,10 +115,10 @@ Add dependencies to `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-graph = { version = "1.0.0", features = ["sqlite"] }
-adk-agent = "1.0.0"
-adk-model = "1.0.0"
-adk-core = "1.0.0"
+adk-graph = { version = "1.0.1", features = ["sqlite"] }
+adk-agent = "1.0.1"
+adk-model = "1.0.1"
+adk-core = "1.0.1"
 tokio = { version = "1", features = ["full"] }
 dotenvy = "0.15"
 serde_json = "1.0"

--- a/docs/official_docs/agents/llm-agent.md
+++ b/docs/official_docs/agents/llm-agent.md
@@ -15,7 +15,7 @@ Add dependencies to `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-rust = "1.0.0"
+adk-rust = "1.0.1"
 tokio = { version = "1.40", features = ["full"] }
 dotenvy = "0.15"
 serde_json = "1.0"
@@ -297,7 +297,7 @@ Add dependencies to `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-rust = { version = "1.0.0", features = ["tools"] }
+adk-rust = { version = "1.0.1", features = ["tools"] }
 tokio = { version = "1.40", features = ["full"] }
 dotenvy = "0.15"
 serde_json = "1.0"

--- a/docs/official_docs/agents/multi-agent.md
+++ b/docs/official_docs/agents/multi-agent.md
@@ -66,7 +66,7 @@ Add dependencies to `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-rust = "1.0.0"
+adk-rust = "1.0.1"
 tokio = { version = "1", features = ["full"] }
 dotenvy = "0.15"
 ```

--- a/docs/official_docs/agents/realtime-agents.md
+++ b/docs/official_docs/agents/realtime-agents.md
@@ -44,16 +44,16 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-realtime = { version = "1.0.0", features = ["openai"] }
+adk-realtime = { version = "1.0.1", features = ["openai"] }
 
 # For Vertex AI Live (Google Cloud with ADC auth)
-# adk-realtime = { version = "1.0.0", features = ["vertex-live"] }
+# adk-realtime = { version = "1.0.1", features = ["vertex-live"] }
 
 # For LiveKit WebRTC bridge
-# adk-realtime = { version = "1.0.0", features = ["livekit"] }
+# adk-realtime = { version = "1.0.1", features = ["livekit"] }
 
 # For all transports (except WebRTC which needs cmake)
-# adk-realtime = { version = "1.0.0", features = ["full"] }
+# adk-realtime = { version = "1.0.1", features = ["full"] }
 ```
 
 ### Basic Usage

--- a/docs/official_docs/agents/workflow-agents.md
+++ b/docs/official_docs/agents/workflow-agents.md
@@ -15,7 +15,7 @@ Add dependencies to `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-rust = "1.0.0"
+adk-rust = "1.0.1"
 tokio = { version = "1.40", features = ["full"] }
 dotenvy = "0.15"
 ```

--- a/docs/official_docs/core/plugins.md
+++ b/docs/official_docs/core/plugins.md
@@ -17,10 +17,10 @@ Plugins run in a priority-ordered pipeline, enabling composable middleware stack
 
 ```toml
 [dependencies]
-adk-plugin = "1.0.0"
+adk-plugin = "1.0.1"
 
 # Or via umbrella crate (included in standard tier)
-adk-rust = { version = "1.0.0", features = ["standard"] }
+adk-rust = { version = "1.0.1", features = ["standard"] }
 ```
 
 ## Quick Start

--- a/docs/official_docs/core/runner.md
+++ b/docs/official_docs/core/runner.md
@@ -47,7 +47,7 @@ sequenceDiagram
 
 ```toml
 [dependencies]
-adk-runner = "1.0.0"
+adk-runner = "1.0.1"
 ```
 
 ## RunnerConfig

--- a/docs/official_docs/development/cargo-adk-build.md
+++ b/docs/official_docs/development/cargo-adk-build.md
@@ -114,7 +114,7 @@ error[E0432]: unresolved import `adk_tool`
 
 ```toml
 [dependencies]
-adk-tool = { version = "1.0.0", features = ["mcp"] }
+adk-tool = { version = "1.0.1", features = ["mcp"] }
 ```
 
 ### Invalid project structure

--- a/docs/official_docs/introduction.md
+++ b/docs/official_docs/introduction.md
@@ -16,7 +16,7 @@ Or add it to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-rust = "1.0.0"
+adk-rust = "1.0.1"
 tokio = { version = "1.40", features = ["full"] }
 ```
 
@@ -187,22 +187,22 @@ ADK-Rust uses Cargo features for modularity. Four presets control which crates a
 
 ```toml
 # Minimal (default) — Gemini, agents, runner, sessions
-adk-rust = "1.0.0"
+adk-rust = "1.0.1"
 
 # Standard — adds tools, memory, telemetry, server, auth, graph, eval, guardrail, plugins, artifacts, skills
-adk-rust = { version = "1.0.0", features = ["standard"] }
+adk-rust = { version = "1.0.1", features = ["standard"] }
 
 # Enterprise — standard + realtime, browser, RAG, payments, AWP
-adk-rust = { version = "1.0.0", features = ["enterprise"] }
+adk-rust = { version = "1.0.1", features = ["enterprise"] }
 
 # Full — enterprise + audio, code execution, sandbox
-adk-rust = { version = "1.0.0", features = ["full"] }
+adk-rust = { version = "1.0.1", features = ["full"] }
 
 # Equivalent explicit minimal selection
-adk-rust = { version = "1.0.0", default-features = false, features = ["minimal"] }
+adk-rust = { version = "1.0.1", default-features = false, features = ["minimal"] }
 
 # Custom: Pick what you need
-adk-rust = { version = "1.0.0", default-features = false, features = ["agents", "gemini", "tools"] }
+adk-rust = { version = "1.0.1", default-features = false, features = ["agents", "gemini", "tools"] }
 ```
 
 Available features:

--- a/docs/official_docs/managed-agents/runtime.md
+++ b/docs/official_docs/managed-agents/runtime.md
@@ -23,15 +23,15 @@ Add the feature to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-rust = { version = "1.0.0", features = ["managed-runtime"] }
+adk-rust = { version = "1.0.1", features = ["managed-runtime"] }
 ```
 
 Or use the `adk-managed` crate directly:
 
 ```toml
 [dependencies]
-adk-managed = "1.0.0"
-adk-session = "1.0.0"
+adk-managed = "1.0.1"
+adk-session = "1.0.1"
 ```
 
 ### Minimal Example (ScriptedLlm — no API key)

--- a/docs/official_docs/models/gemini-interactions.md
+++ b/docs/official_docs/models/gemini-interactions.md
@@ -55,7 +55,7 @@ adk-gemini = { version = "1.0.1", features = ["interactions"] }
 
 # Through the model facade / umbrella
 adk-model = { version = "1.0.1", features = ["gemini-interactions"] }
-adk-rust  = { version = "1.0.0", features = ["gemini-interactions"] }
+adk-rust  = { version = "1.0.1", features = ["gemini-interactions"] }
 ```
 
 The feature adds **no new dependencies** and is fully additive to the existing `generateContent` API.
@@ -223,7 +223,7 @@ The transport is gated behind the `gemini-interactions` feature (forwarded from
 
 ```toml
 adk-model = { version = "1.0.1", features = ["gemini-interactions"] }
-adk-rust  = { version = "1.0.0", features = ["gemini-interactions"] }
+adk-rust  = { version = "1.0.1", features = ["gemini-interactions"] }
 ```
 
 Flip the switch on the model and wrap it in a normal `LlmAgent` and `Runner` —

--- a/docs/official_docs/models/gemini-interactions.md
+++ b/docs/official_docs/models/gemini-interactions.md
@@ -51,10 +51,10 @@ The ADK agent runtime (the `Llm` trait, tool loop, and `Runner`) uses `generateC
 
 ```toml
 # Direct client (adk-gemini)
-adk-gemini = { version = "1.0.0", features = ["interactions"] }
+adk-gemini = { version = "1.0.1", features = ["interactions"] }
 
 # Through the model facade / umbrella
-adk-model = { version = "1.0.0", features = ["gemini-interactions"] }
+adk-model = { version = "1.0.1", features = ["gemini-interactions"] }
 adk-rust  = { version = "1.0.0", features = ["gemini-interactions"] }
 ```
 
@@ -222,7 +222,7 @@ The transport is gated behind the `gemini-interactions` feature (forwarded from
 `adk-rust` → `adk-model` → `adk-gemini/interactions`):
 
 ```toml
-adk-model = { version = "1.0.0", features = ["gemini-interactions"] }
+adk-model = { version = "1.0.1", features = ["gemini-interactions"] }
 adk-rust  = { version = "1.0.0", features = ["gemini-interactions"] }
 ```
 

--- a/docs/official_docs/models/mistralrs.md
+++ b/docs/official_docs/models/mistralrs.md
@@ -31,9 +31,9 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-adk-mistralrs = "1.0.0"
-adk-agent = "1.0.0"
-adk-rust = "1.0.0"
+adk-mistralrs = "1.0.1"
+adk-agent = "1.0.1"
+adk-rust = "1.0.1"
 tokio = { version = "1", features = ["full"] }
 anyhow = "1.0"
 ```
@@ -42,10 +42,10 @@ For hardware acceleration, add feature flags:
 
 ```toml
 # macOS with Apple Silicon
-adk-mistralrs = { version = "1.0.0", features = ["metal"] }
+adk-mistralrs = { version = "1.0.1", features = ["metal"] }
 
 # NVIDIA GPU (requires CUDA toolkit)
-adk-mistralrs = { version = "1.0.0", features = ["cuda"] }
+adk-mistralrs = { version = "1.0.1", features = ["cuda"] }
 ```
 
 ---
@@ -282,7 +282,7 @@ ModelSource::gguf("/path/to/model.Q4_K_M.gguf")
 ### macOS (Apple Silicon)
 
 ```toml
-adk-mistralrs = { version = "1.0.0", features = ["metal"] }
+adk-mistralrs = { version = "1.0.1", features = ["metal"] }
 ```
 
 Metal acceleration is automatic on M1/M2/M3 Macs.
@@ -290,7 +290,7 @@ Metal acceleration is automatic on M1/M2/M3 Macs.
 ### NVIDIA GPU
 
 ```toml
-adk-mistralrs = { version = "1.0.0", features = ["cuda"] }
+adk-mistralrs = { version = "1.0.1", features = ["cuda"] }
 ```
 
 Requires CUDA toolkit 11.8+.

--- a/docs/official_docs/models/ollama.md
+++ b/docs/official_docs/models/ollama.md
@@ -98,7 +98,7 @@ ollama pull codellama:13b     # Code generation
 
 ```toml
 [dependencies]
-adk-model = { version = "1.0.0", features = ["ollama"] }
+adk-model = { version = "1.0.1", features = ["ollama"] }
 ```
 
 ---
@@ -158,7 +158,7 @@ async fn main() -> anyhow::Result<()> {
 
 ```toml
 [dependencies]
-adk-rust = { version = "1.0.0", features = ["ollama"] }
+adk-rust = { version = "1.0.1", features = ["ollama"] }
 tokio = { version = "1", features = ["full"] }
 dotenvy = "0.15"
 anyhow = "1.0"

--- a/docs/official_docs/models/openai-responses.md
+++ b/docs/official_docs/models/openai-responses.md
@@ -53,15 +53,15 @@ Use `OpenAIResponsesClient` when you need reasoning models with summaries, built
 
 ```toml
 [dependencies]
-adk-rust = { version = "1.0.0", features = ["openai"] }
-adk-tool = "1.0.0"
+adk-rust = { version = "1.0.1", features = ["openai"] }
+adk-tool = "1.0.1"
 ```
 
 Or with `adk-model` directly:
 
 ```toml
 [dependencies]
-adk-model = { version = "1.0.0", features = ["openai"] }
+adk-model = { version = "1.0.1", features = ["openai"] }
 ```
 
 Set your API key:

--- a/docs/official_docs/models/providers.md
+++ b/docs/official_docs/models/providers.md
@@ -41,14 +41,14 @@ Add the providers you need to your `Cargo.toml`:
 ```toml
 [dependencies]
 # Pick one or more providers:
-adk-model = { version = "1.0.0", features = ["gemini"] }        # Google Gemini (default)
-adk-model = { version = "1.0.0", features = ["openai"] }        # OpenAI GPT-5
-adk-model = { version = "1.0.0", features = ["anthropic"] }     # Anthropic Claude
-adk-model = { version = "1.0.0", features = ["deepseek"] }      # DeepSeek
-adk-model = { version = "1.0.0", features = ["groq"] }          # Groq (ultra-fast)
+adk-model = { version = "1.0.1", features = ["gemini"] }        # Google Gemini (default)
+adk-model = { version = "1.0.1", features = ["openai"] }        # OpenAI GPT-5
+adk-model = { version = "1.0.1", features = ["anthropic"] }     # Anthropic Claude
+adk-model = { version = "1.0.1", features = ["deepseek"] }      # DeepSeek
+adk-model = { version = "1.0.1", features = ["groq"] }          # Groq (ultra-fast)
 
 # Or all cloud providers at once:
-adk-model = { version = "1.0.0", features = ["all-providers"] }
+adk-model = { version = "1.0.1", features = ["all-providers"] }
 ```
 
 ## Step 2: Set Your API Key

--- a/docs/official_docs/quickstart-a2ui.md
+++ b/docs/official_docs/quickstart-a2ui.md
@@ -7,8 +7,8 @@ This guide shows how to emit A2UI JSONL from an ADK agent and render it with the
 ```toml
 [dependencies]
 adk-ui = { git = "https://github.com/zavora-ai/adk-ui" }
-adk-agent = "1.0.0"
-adk-model = "1.0.0"
+adk-agent = "1.0.1"
+adk-model = "1.0.1"
 ```
 
 React renderer:

--- a/docs/official_docs/quickstart.md
+++ b/docs/official_docs/quickstart.md
@@ -146,7 +146,7 @@ The fastest way to add tools is the `#[tool]` macro. Add `adk-tool` to your depe
 
 ```toml
 [dependencies]
-adk-tool = "1.0.0"
+adk-tool = "1.0.1"
 schemars = "1"
 serde = { version = "1", features = ["derive"] }
 ```
@@ -218,7 +218,7 @@ Enable providers via feature flags. The default build stays Gemini-only for fast
 
 ```toml
 [dependencies]
-adk-rust = { version = "1.0.0", features = ["openai"] }
+adk-rust = { version = "1.0.1", features = ["openai"] }
 ```
 
 Or scaffold with a provider: `cargo adk new my-agent --provider openai`

--- a/docs/official_docs/sandbox/index.md
+++ b/docs/official_docs/sandbox/index.md
@@ -61,11 +61,11 @@ let result = backend.execute(request).await?;
 ```toml
 [dependencies]
 # Auto-detect platform enforcer
-adk-sandbox = { version = "1.0.0", features = ["process", "sandbox-native"] }
+adk-sandbox = { version = "1.0.1", features = ["process", "sandbox-native"] }
 
 # Or pick a specific platform
-adk-sandbox = { version = "1.0.0", features = ["process", "sandbox-macos"] }
-adk-sandbox = { version = "1.0.0", features = ["process", "sandbox-linux"] }
+adk-sandbox = { version = "1.0.1", features = ["process", "sandbox-macos"] }
+adk-sandbox = { version = "1.0.1", features = ["process", "sandbox-linux"] }
 ```
 
 ### SandboxPolicy

--- a/docs/official_docs/security/access-control.md
+++ b/docs/official_docs/security/access-control.md
@@ -126,10 +126,10 @@ sso.check_token(token, &permission).await?;
 
 ```toml
 [dependencies]
-adk-auth = "1.0.0"
+adk-auth = "1.0.1"
 
 # For SSO/OAuth support
-adk-auth = { version = "1.0.0", features = ["sso"] }
+adk-auth = { version = "1.0.1", features = ["sso"] }
 ```
 
 ## Core Components

--- a/docs/official_docs/security/guardrails.md
+++ b/docs/official_docs/security/guardrails.md
@@ -15,10 +15,10 @@ Guardrails validate and transform agent inputs and outputs to ensure safety, com
 
 ```toml
 [dependencies]
-adk-guardrail = "1.0.0"
+adk-guardrail = "1.0.1"
 
 # For JSON schema validation
-adk-guardrail = { version = "1.0.0", features = ["schema"] }
+adk-guardrail = { version = "1.0.1", features = ["schema"] }
 ```
 
 ## Core Concepts

--- a/docs/official_docs/security/memory.md
+++ b/docs/official_docs/security/memory.md
@@ -10,7 +10,7 @@ The memory system provides persistent, searchable storage for agent conversation
 
 ```toml
 [dependencies]
-adk-memory = "1.0.0"
+adk-memory = "1.0.1"
 ```
 
 ## Core Concepts

--- a/docs/official_docs/sessions/sessions.md
+++ b/docs/official_docs/sessions/sessions.md
@@ -218,7 +218,7 @@ async fn main() -> anyhow::Result<()> {
 
 > **Note**: The `SqliteSessionService` requires the `sqlite` feature flag:
 > ```toml
-> adk-session = { version = "1.0.0", features = ["sqlite"] }
+> adk-session = { version = "1.0.1", features = ["sqlite"] }
 > ```
 
 ### PostgresSessionService
@@ -251,7 +251,7 @@ async fn main() -> anyhow::Result<()> {
 
 > **Note**: Requires the `postgres` feature flag:
 > ```toml
-> adk-session = { version = "1.0.0", features = ["postgres"] }
+> adk-session = { version = "1.0.1", features = ["postgres"] }
 > ```
 
 ### MongoSessionService
@@ -296,7 +296,7 @@ async fn main() -> anyhow::Result<()> {
 
 > **Note**: Requires the `mongodb` feature flag:
 > ```toml
-> adk-session = { version = "1.0.0", features = ["mongodb"] }
+> adk-session = { version = "1.0.1", features = ["mongodb"] }
 > ```
 
 #### MongoDB deployment modes
@@ -350,7 +350,7 @@ async fn main() -> anyhow::Result<()> {
 
 > **Note**: Requires the `neo4j` feature flag:
 > ```toml
-> adk-session = { version = "1.0.0", features = ["neo4j"] }
+> adk-session = { version = "1.0.1", features = ["neo4j"] }
 > ```
 
 ### RedisSessionService
@@ -366,7 +366,7 @@ let session_service = RedisSessionService::new(config).await?;
 
 > **Note**: Requires the `redis` feature flag:
 > ```toml
-> adk-session = { version = "1.0.0", features = ["redis"] }
+> adk-session = { version = "1.0.1", features = ["redis"] }
 > ```
 
 ## Schema Migrations
@@ -378,7 +378,7 @@ All database-backed session services (SQLite, PostgreSQL, MongoDB, Neo4j) includ
 Wrap any `SessionService` with `EncryptedSession` to encrypt session state at rest using AES-256-GCM. Requires the `encrypted-session` feature flag.
 
 ```toml
-adk-session = { version = "1.0.0", features = ["encrypted-session"] }
+adk-session = { version = "1.0.1", features = ["encrypted-session"] }
 ```
 
 #### Basic Usage

--- a/docs/official_docs/studio/studio.md
+++ b/docs/official_docs/studio/studio.md
@@ -356,13 +356,13 @@ The generated `Cargo.toml` automatically includes the correct `adk-model` featur
 
 ```toml
 # Only Gemini
-adk-model = { version = "1.0.0", default-features = false, features = ["gemini"] }
+adk-model = { version = "1.0.1", default-features = false, features = ["gemini"] }
 
 # Mixed providers (e.g., Gemini + Anthropic)
-adk-model = { version = "1.0.0", default-features = false, features = ["gemini", "anthropic"] }
+adk-model = { version = "1.0.1", default-features = false, features = ["gemini", "anthropic"] }
 
 # Ollama only (no API key needed)
-adk-model = { version = "1.0.0", default-features = false, features = ["ollama"] }
+adk-model = { version = "1.0.1", default-features = false, features = ["ollama"] }
 ```
 
 ### Generated Code with Action Nodes

--- a/docs/official_docs/tools/acp-tools.md
+++ b/docs/official_docs/tools/acp-tools.md
@@ -14,10 +14,10 @@ ACP is a protocol for agent-to-agent communication over stdio or network transpo
 
 ```toml
 [dependencies]
-adk-acp = "1.0.0"
+adk-acp = "1.0.1"
 
 # Or via the umbrella crate
-adk-rust = { version = "1.0.0", features = ["acp"] }
+adk-rust = { version = "1.0.1", features = ["acp"] }
 ```
 
 ## AcpAgentTool — Remote Agent as a Tool

--- a/docs/official_docs/tools/action-nodes.md
+++ b/docs/official_docs/tools/action-nodes.md
@@ -15,10 +15,10 @@ Action nodes are the building blocks of visual and programmatic workflow graphs.
 
 ```toml
 [dependencies]
-adk-action = "1.0.0"
+adk-action = "1.0.1"
 
 # Or specific action features via umbrella crate
-adk-rust = { version = "1.0.0", features = ["action"] }
+adk-rust = { version = "1.0.1", features = ["action"] }
 ```
 
 ## Node Types (14)

--- a/docs/official_docs/tools/browser-tools.md
+++ b/docs/official_docs/tools/browser-tools.md
@@ -19,9 +19,9 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-browser = "1.0.0"
-adk-agent = "1.0.0"
-adk-model = "1.0.0"
+adk-browser = "1.0.1"
+adk-agent = "1.0.1"
+adk-model = "1.0.1"
 ```
 
 ### Prerequisites

--- a/docs/official_docs/tools/memory-tools.md
+++ b/docs/official_docs/tools/memory-tools.md
@@ -45,8 +45,8 @@ let agent = LlmAgentBuilder::new("assistant")
 
 ```toml
 [dependencies]
-adk-tool = { version = "1.0.0", features = ["memory-tools"] }
-adk-memory = "1.0.0"
+adk-tool = { version = "1.0.1", features = ["memory-tools"] }
+adk-memory = "1.0.1"
 ```
 
 ## LoadMemoryTool

--- a/docs/official_docs/tools/rag.md
+++ b/docs/official_docs/tools/rag.md
@@ -29,10 +29,10 @@ This means your agent can answer questions about product docs, company policies,
 ```toml
 [dependencies]
 # Core only (in-memory store, all chunkers, no external deps)
-adk-rag = "1.0.0"
+adk-rag = "1.0.1"
 
 # With Gemini embeddings (recommended for getting started)
-adk-rag = { version = "1.0.0", features = ["gemini"] }
+adk-rag = { version = "1.0.1", features = ["gemini"] }
 ```
 
 ---
@@ -353,13 +353,13 @@ Only pull the dependencies you need:
 
 ```toml
 # Just core
-adk-rag = "1.0.0"
+adk-rag = "1.0.1"
 
 # With Gemini embeddings
-adk-rag = { version = "1.0.0", features = ["gemini"] }
+adk-rag = { version = "1.0.1", features = ["gemini"] }
 
 # Everything
-adk-rag = { version = "1.0.0", features = ["full"] }
+adk-rag = { version = "1.0.1", features = ["full"] }
 ```
 
 > **Note:** The `lancedb` feature requires `protoc` installed. Install with `brew install protobuf` (macOS) or `apt install protobuf-compiler` (Ubuntu).

--- a/docs/official_docs/tools/retry-reflect.md
+++ b/docs/official_docs/tools/retry-reflect.md
@@ -16,10 +16,10 @@ When a tool call fails, the default behavior is to return the error to the LLM a
 
 ```toml
 [dependencies]
-adk-retry-reflect = "1.0.0"
+adk-retry-reflect = "1.0.1"
 
 # Or via umbrella crate (included in standard tier)
-adk-rust = { version = "1.0.0", features = ["standard"] }
+adk-rust = { version = "1.0.1", features = ["standard"] }
 ```
 
 ## Quick Start

--- a/docs/official_docs/tools/ui-tools.md
+++ b/docs/official_docs/tools/ui-tools.md
@@ -115,8 +115,8 @@ Add to your `Cargo.toml`:
 ```toml
 [dependencies]
 adk-ui = { git = "https://github.com/zavora-ai/adk-ui" }
-adk-agent = "1.0.0"
-adk-model = "1.0.0"
+adk-agent = "1.0.1"
+adk-model = "1.0.1"
 ```
 
 ### Basic Usage

--- a/examples/tier_examples/README.md
+++ b/examples/tier_examples/README.md
@@ -6,7 +6,7 @@ Validates that all README and quickstart code examples work across every feature
 
 ### Minimal (default — no features needed)
 
-These examples use `adk-rust = "1.0.0"` with **no explicit features**. The `minimal` default includes Gemini, agents, runner, sessions, and the lightweight launcher.
+These examples use `adk-rust = "1.0.1"` with **no explicit features**. The `minimal` default includes Gemini, agents, runner, sessions, and the lightweight launcher.
 
 | # | Example | What it validates | Source |
 |---|---------|-------------------|--------|
@@ -90,7 +90,7 @@ cargo run --bin 16-full-sandbox            # needs python3 and rustc
 
 ## Key Point
 
-All minimal/quickstart examples use `adk-rust = "1.0.0"` with **no explicit features** unless the example name is a provider opt-in. The `minimal` default includes the smallest useful agent stack: Gemini, agents, runner, sessions, and the lightweight launcher.
+All minimal/quickstart examples use `adk-rust = "1.0.1"` with **no explicit features** unless the example name is a provider opt-in. The `minimal` default includes the smallest useful agent stack: Gemini, agents, runner, sessions, and the lightweight launcher.
 
 Higher tiers add production and specialist capabilities:
 - **standard** → tools, memory, telemetry, server, auth, graph workflows, eval

--- a/examples/tier_examples/src/01_minimal_hello.rs
+++ b/examples/tier_examples/src/01_minimal_hello.rs
@@ -5,7 +5,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-rust = "0.8.2"
+//! adk-rust = "1.0.1"
 //! ```
 
 use adk_rust::run;

--- a/examples/tier_examples/src/02_minimal_launcher.rs
+++ b/examples/tier_examples/src/02_minimal_launcher.rs
@@ -5,7 +5,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-rust = "0.8.2"
+//! adk-rust = "1.0.1"
 //! ```
 
 use adk_rust::Launcher;

--- a/examples/tier_examples/src/03_minimal_openai.rs
+++ b/examples/tier_examples/src/03_minimal_openai.rs
@@ -5,7 +5,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-rust = { version = "0.8.2", features = ["openai"] }
+//! adk-rust = { version = "1.0.1", features = ["openai"] }
 //! ```
 
 use adk_rust::Launcher;

--- a/examples/tier_examples/src/04_minimal_anthropic.rs
+++ b/examples/tier_examples/src/04_minimal_anthropic.rs
@@ -5,7 +5,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-rust = { version = "0.8.2", features = ["anthropic"] }
+//! adk-rust = { version = "1.0.1", features = ["anthropic"] }
 //! ```
 
 use adk_rust::Launcher;

--- a/examples/tier_examples/src/05_minimal_tools.rs
+++ b/examples/tier_examples/src/05_minimal_tools.rs
@@ -5,8 +5,8 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-rust = "0.8.2"
-//! adk-tool = "0.8.2"
+//! adk-rust = "1.0.1"
+//! adk-tool = "1.0.1"
 //! ```
 
 use adk_rust::Launcher;

--- a/examples/tier_examples/src/06_minimal_multi_provider.rs
+++ b/examples/tier_examples/src/06_minimal_multi_provider.rs
@@ -5,7 +5,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-rust = "0.8.2"
+//! adk-rust = "1.0.1"
 //! ```
 
 use adk_rust::Launcher;

--- a/examples/tier_examples/src/07_minimal_memory.rs
+++ b/examples/tier_examples/src/07_minimal_memory.rs
@@ -5,7 +5,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-rust = "0.8.2"
+//! adk-rust = "1.0.1"
 //! ```
 
 use adk_rust::prelude::*;

--- a/examples/tier_examples/src/08_quickstart_scaffold.rs
+++ b/examples/tier_examples/src/08_quickstart_scaffold.rs
@@ -5,7 +5,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-rust = "0.8.2"
+//! adk-rust = "1.0.1"
 //! ```
 
 use adk_rust::Launcher;

--- a/examples/tier_examples/src/09_quickstart_tools.rs
+++ b/examples/tier_examples/src/09_quickstart_tools.rs
@@ -5,8 +5,8 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-rust = "0.8.2"
-//! adk-tool = "0.8.2"
+//! adk-rust = "1.0.1"
+//! adk-tool = "1.0.1"
 //! schemars = "1"
 //! serde = { version = "1", features = ["derive"] }
 //! ```

--- a/examples/tier_examples/src/10_quickstart_zero_config.rs
+++ b/examples/tier_examples/src/10_quickstart_zero_config.rs
@@ -5,7 +5,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-rust = "0.8.2"
+//! adk-rust = "1.0.1"
 //! ```
 
 use adk_rust::run;

--- a/examples/tier_examples/src/11_standard_graph.rs
+++ b/examples/tier_examples/src/11_standard_graph.rs
@@ -5,7 +5,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-rust = { version = "0.8.2", features = ["standard"] }
+//! adk-rust = { version = "1.0.1", features = ["standard"] }
 //! ```
 
 use adk_rust::graph::node::AgentNode;

--- a/examples/tier_examples/src/12_standard_sequential.rs
+++ b/examples/tier_examples/src/12_standard_sequential.rs
@@ -5,7 +5,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-rust = { version = "0.8.2", features = ["standard"] }
+//! adk-rust = { version = "1.0.1", features = ["standard"] }
 //! ```
 
 use adk_rust::prelude::*;

--- a/examples/tier_examples/src/13_standard_cli_launcher.rs
+++ b/examples/tier_examples/src/13_standard_cli_launcher.rs
@@ -7,7 +7,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-rust = { version = "0.8.2", features = ["standard"] }
+//! adk-rust = { version = "1.0.1", features = ["standard"] }
 //! ```
 
 use adk_rust::Launcher;

--- a/examples/tier_examples/src/14_enterprise_multi_agent.rs
+++ b/examples/tier_examples/src/14_enterprise_multi_agent.rs
@@ -6,7 +6,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-rust = { version = "0.8.2", features = ["enterprise"] }
+//! adk-rust = { version = "1.0.1", features = ["enterprise"] }
 //! ```
 
 use adk_rust::artifact::{ArtifactService, InMemoryArtifactService, SaveRequest};

--- a/examples/tier_examples/src/15_enterprise_parallel.rs
+++ b/examples/tier_examples/src/15_enterprise_parallel.rs
@@ -6,7 +6,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-rust = { version = "0.8.2", features = ["enterprise"] }
+//! adk-rust = { version = "1.0.1", features = ["enterprise"] }
 //! ```
 
 use adk_rust::prelude::*;

--- a/examples/tier_examples/src/16_full_sandbox.rs
+++ b/examples/tier_examples/src/16_full_sandbox.rs
@@ -5,7 +5,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-rust = { version = "0.8.2", features = ["full"] }
+//! adk-rust = { version = "1.0.1", features = ["full"] }
 //! ```
 
 use adk_rust::sandbox::{ExecRequest, Language, ProcessBackend, ProcessConfig, SandboxBackend};

--- a/publish.sh
+++ b/publish.sh
@@ -1,11 +1,19 @@
 #!/bin/zsh
-# Publish all workspace crates to crates.io in correct dependency order.
-# Tiers generated from `cargo metadata` dependency graph (no dev-deps).
-# Waits for crates.io indexing between publishes.
+# Publish all workspace crates to crates.io.
+#
+# Default mode uses cargo's native workspace publish (cargo >= 1.90), which
+# computes the dependency-correct order itself and verifies each crate against
+# the in-flight set. If a run fails partway (network, rate limit), use
+# --resume: it walks the tiered list below sequentially and skips crates whose
+# version is already on crates.io.
+#
+# Internal dev-deps are path-only (no version), so cargo strips them from
+# published manifests — only normal/build deps constrain publish order.
 #
 # Usage:
-#   ./publish.sh          # publish all
-#   ./publish.sh --resume # skip already-published crates
+#   ./publish.sh           # native workspace publish (recommended)
+#   ./publish.sh --dry-run # native publish, no upload
+#   ./publish.sh --resume  # sequential tiered publish, skip already-published
 
 set -euo pipefail
 
@@ -42,10 +50,10 @@ CRATES=(
   adk-skill
 
   # Tier 4: depends on Tier 1-3
-  adk-agent
-  adk-audio
   adk-runner
   adk-tool
+  adk-agent
+  adk-audio
 
   # Tier 5: depends on Tier 1-4
   adk-acp
@@ -66,7 +74,29 @@ CRATES=(
   adk-rust
 )
 
-echo "=== Publishing ADK-Rust ==="
+MODE="native"
+DRY_RUN=""
+for arg in "$@"; do
+  case "$arg" in
+    --resume)  MODE="resume" ;;
+    --dry-run) DRY_RUN="--dry-run" ;;
+    *) echo "unknown flag: $arg"; exit 2 ;;
+  esac
+done
+
+if [[ "$MODE" == "native" ]]; then
+  echo "=== Publishing ADK-Rust (cargo publish --workspace) ==="
+  echo "Crates: ${#CRATES[@]}  $DRY_RUN"
+  echo "If this fails partway, finish with: ./publish.sh --resume"
+  echo ""
+  cargo publish --workspace ${DRY_RUN:+$DRY_RUN}
+  echo "✅ Done"
+  exit 0
+fi
+
+# ── Resume mode: sequential tiered publish, skipping published crates ──────
+
+echo "=== Publishing ADK-Rust (sequential resume) ==="
 echo "Total crates: ${#CRATES[@]}"
 echo ""
 
@@ -80,8 +110,8 @@ for crate in "${CRATES[@]}"; do
   echo "📦 [$((PUBLISHED + SKIPPED + FAILED + 1))/${#CRATES[@]}] Publishing: $crate"
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
-  OUTPUT=$(cargo publish -p "$crate" 2>&1)
-  STATUS=$?
+  STATUS=0
+  OUTPUT=$(cargo publish -p "$crate" 2>&1) || STATUS=$?
 
   echo "$OUTPUT"
   echo ""
@@ -116,5 +146,6 @@ if [ ${#FAILED_CRATES[@]} -gt 0 ]; then
   for c in "${FAILED_CRATES[@]}"; do
     echo "- $c"
   done
+  exit 1
 fi
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -100,7 +100,7 @@ def main() -> None:
     # --- 2. Dependency snippets in docs / READMEs / Rust doc comments ------
     snippet_patterns = [
         # adk-rust = "1.0.0"
-        re.compile(rf'\b((?:adk|awp|cargo)-[a-z0-9-]+ = "){cur_re}(")'),
+        re.compile(rf'\b((?:adk|awp|cargo)-[a-z0-9-]+\s*=\s*"){cur_re}(")'),
         # adk-graph = { version = "1.0.0", features = [...] }
         re.compile(rf'\b((?:adk|awp|cargo)-[a-z0-9-]+ = \{{ version = "){cur_re}(")'),
     ]

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Bump the workspace version across the repository.
+
+Updates, precisely and only:
+  1. Root Cargo.toml — [workspace.package] version and the internal
+     path-dependency pins (adk-*, awp-*, cargo-adk).
+  2. Dependency snippets in docs, READMEs, and Rust doc comments —
+     lines like `adk-rust = "1.0.0"` or `adk-graph = { version = "1.0.0", ... }`.
+
+Deliberately never touched:
+  - CHANGELOG.md (history must not be rewritten)
+  - Lock files (Cargo.lock is synced separately via `cargo update --workspace`,
+    which only re-pins workspace members, never third-party deps)
+  - reference/, learning/, tmp/, output/, target/, docs/podcast/ (historical
+    or third-party content)
+  - Prose mentions like "v1.0.0 Released!" — only dependency-snippet
+    patterns are rewritten, so announcements and history stay intact.
+
+Usage:
+  python3 scripts/bump-version.py <new-version> [--dry-run]
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+SKIP_PARTS = {"reference", "learning", "tmp", "output", "target", ".git", "proptest-regressions"}
+SKIP_SUFFIXES = (".lock",)
+
+
+def fail(msg: str) -> None:
+    print(f"error: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def current_version(cargo_toml: str) -> str:
+    in_pkg = False
+    for line in cargo_toml.splitlines():
+        if line.strip().startswith("["):
+            in_pkg = line.strip() == "[workspace.package]"
+        elif in_pkg:
+            m = re.match(r'version = "([^"]+)"', line.strip())
+            if m:
+                return m.group(1)
+    fail("could not find [workspace.package] version in Cargo.toml")
+    raise AssertionError  # unreachable
+
+
+def skip(path: Path) -> bool:
+    rel = path.relative_to(ROOT)
+    if any(part in SKIP_PARTS for part in rel.parts):
+        return True
+    if rel.parts[:2] == ("docs", "podcast"):
+        return True
+    if path.name == "CHANGELOG.md":
+        return True
+    if path.suffix in SKIP_SUFFIXES:
+        return True
+    return False
+
+
+def main() -> None:
+    args = [a for a in sys.argv[1:] if a != "--dry-run"]
+    dry_run = "--dry-run" in sys.argv[1:]
+    if len(args) != 1:
+        fail(f"usage: {sys.argv[0]} <new-version> [--dry-run]")
+    new = args[0]
+    if not re.fullmatch(r"\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?", new):
+        fail(f"'{new}' is not a valid semver version")
+
+    root_cargo = ROOT / "Cargo.toml"
+    cargo_text = root_cargo.read_text()
+    cur = current_version(cargo_text)
+    if cur == new:
+        fail(f"workspace is already at {cur}")
+    print(f"Bumping {cur} -> {new}\n")
+    cur_re = re.escape(cur)
+
+    # --- 1. Root Cargo.toml ------------------------------------------------
+    # [workspace.package] version — exactly one bare `version = "<cur>"` line
+    # exists (member crates use `version.workspace = true`).
+    pkg_pattern = re.compile(rf'^version = "{cur_re}"$', re.M)
+    if len(pkg_pattern.findall(cargo_text)) != 1:
+        fail("expected exactly one bare workspace `version` line in Cargo.toml")
+    cargo_text = pkg_pattern.sub(f'version = "{new}"', cargo_text)
+
+    # Internal path-dependency pins: `name = { path = "...", version = "<cur>" ... }`
+    pin_pattern = re.compile(
+        rf'^((?:adk|awp|cargo)-[a-z0-9-]+ = \{{ path = "[^"]+", version = "){cur_re}(")',
+        re.M,
+    )
+    cargo_text, pin_count = pin_pattern.subn(rf"\g<1>{new}\g<2>", cargo_text)
+    print(f"Cargo.toml: workspace version + {pin_count} internal dependency pins")
+    if not dry_run:
+        root_cargo.write_text(cargo_text)
+
+    # --- 2. Dependency snippets in docs / READMEs / Rust doc comments ------
+    snippet_patterns = [
+        # adk-rust = "1.0.0"
+        re.compile(rf'\b((?:adk|awp|cargo)-[a-z0-9-]+ = "){cur_re}(")'),
+        # adk-graph = { version = "1.0.0", features = [...] }
+        re.compile(rf'\b((?:adk|awp|cargo)-[a-z0-9-]+ = \{{ version = "){cur_re}(")'),
+    ]
+
+    tracked = subprocess.run(
+        ["git", "ls-files", "*.md", "*.rs"],
+        cwd=ROOT, capture_output=True, text=True, check=True,
+    ).stdout.splitlines()
+
+    total = 0
+    changed_files = 0
+    for rel in tracked:
+        path = ROOT / rel
+        if skip(path) or not path.exists():
+            continue
+        text = path.read_text()
+        count = 0
+        for pattern in snippet_patterns:
+            text, n = pattern.subn(rf"\g<1>{new}\g<2>", text)
+            count += n
+        if count:
+            changed_files += 1
+            total += count
+            print(f"{rel}: {count} snippet(s)")
+            if not dry_run:
+                path.write_text(text)
+
+    print(f"\n{'[dry-run] would update' if dry_run else 'Updated'} "
+          f"{changed_files} doc/source files ({total} snippets) + Cargo.toml")
+    if not dry_run:
+        print("\nNext steps:")
+        print("  cargo update --workspace   # re-pin workspace members in Cargo.lock (third-party deps untouched)")
+        print("  bash scripts/check-doc-versions.sh")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Bump the workspace version everywhere it matters (Cargo.toml, docs, READMEs,
+# Rust doc comments), skipping CHANGELOG.md, lock files, and historical content.
+# Then re-pin workspace members in Cargo.lock (third-party deps untouched).
+#
+# Usage: bash scripts/bump-version.sh <new-version> [--dry-run]
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+python3 "$ROOT/scripts/bump-version.py" "$@"
+
+if [[ "$*" != *--dry-run* ]]; then
+  echo
+  echo "Syncing Cargo.lock workspace members..."
+  cargo update --workspace --manifest-path "$ROOT/Cargo.toml"
+  bash "$ROOT/scripts/check-doc-versions.sh"
+fi

--- a/scripts/check-cargo-adk-templates.sh
+++ b/scripts/check-cargo-adk-templates.sh
@@ -6,6 +6,9 @@ TMPDIR="$(mktemp -d)"
 CHECK_TARGET_DIR="$TMPDIR/target"
 trap 'rm -rf "$TMPDIR"' EXIT
 
+# Entries are "template:provider[:addon1,addon2]".
+# An empty provider means "omit --provider" (exercises the template's
+# default provider, e.g. openai for the openai template).
 templates=(
   "basic:gemini"
   "basic:openai"
@@ -14,18 +17,33 @@ templates=(
   "tools:anthropic"
   "rag:gemini"
   "api:gemini"
-  "openai:gemini"
+  "openai:"
+  "a2a:gemini"
+  "tools:gemini:telemetry,sessions"
+  "llm:gemini:server,sessions"
 )
 
 for entry in "${templates[@]}"; do
-  template="${entry%%:*}"
-  provider="${entry##*:}"
-  name="adk_${template}_${provider}_check"
+  IFS=':' read -r template provider addons <<<"$entry"
+  name="adk_${template}_${provider:-default}_check"
+  if [[ -n "$addons" ]]; then
+    name="${name}_addons"
+  fi
+
+  args=(adk new "$name" --template "$template")
+  if [[ -n "$provider" ]]; then
+    args+=(--provider "$provider")
+  fi
+  if [[ -n "$addons" ]]; then
+    IFS=',' read -ra addon_list <<<"$addons"
+    for addon in "${addon_list[@]}"; do
+      args+=(--addon "$addon")
+    done
+  fi
 
   (
     cd "$TMPDIR"
-    cargo run --manifest-path "$ROOT/Cargo.toml" -p cargo-adk -- \
-      adk new "$name" --template "$template" --provider "$provider"
+    cargo run --manifest-path "$ROOT/Cargo.toml" -p cargo-adk -- "${args[@]}"
 
     cat >> "$name/Cargo.toml" <<PATCH
 

--- a/scripts/check-doc-versions.py
+++ b/scripts/check-doc-versions.py
@@ -61,7 +61,7 @@ def main() -> None:
     errors: list[str] = []
 
     version_pattern = re.compile(
-        r'\b(?:adk|awp|cargo)-[a-z0-9-]+ = (?:"(\d+\.\d+\.\d+)"|\{ version = "(\d+\.\d+\.\d+)")'
+        r'\b(?:adk|awp|cargo)-[a-z0-9-]+\s*=\s*(?:"(\d+\.\d+\.\d+)"|\{\s*version\s*=\s*"(\d+\.\d+\.\d+)")'
     )
     # `adk-rust = { version = "...", features = [...] }` or
     # `adk-rust = { ... features = ["a", "b"] }` on one line

--- a/scripts/check-doc-versions.py
+++ b/scripts/check-doc-versions.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""CI check: documentation version snippets and feature names must be real.
+
+Two classes of doc rot this catches (both shipped in the past):
+  1. Stale versions — install snippets like `adk-rust = "0.8.2"` surviving a
+     release (the docs.rs landing page advertised 0.8.2 while 1.0.0 was out).
+  2. Phantom features — docs telling users to enable a feature that does not
+     exist in adk-rust/Cargo.toml (the `labs` feature was documented for
+     months after it was removed).
+
+Checks every tracked *.md and *.rs file, excluding CHANGELOG.md and
+historical/third-party content (reference/, docs/podcast/, learning/, etc.).
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+SKIP_PARTS = {"reference", "learning", "tmp", "output", "target", ".git", "proptest-regressions"}
+
+
+def workspace_version() -> str:
+    in_pkg = False
+    for line in (ROOT / "Cargo.toml").read_text().splitlines():
+        if line.strip().startswith("["):
+            in_pkg = line.strip() == "[workspace.package]"
+        elif in_pkg:
+            m = re.match(r'version = "([^"]+)"', line.strip())
+            if m:
+                return m.group(1)
+    sys.exit("error: could not find workspace version")
+
+
+def adk_rust_features() -> set[str]:
+    text = (ROOT / "adk-rust" / "Cargo.toml").read_text()
+    m = re.search(r"^\[features\]$(.*?)^\[", text, re.M | re.S)
+    if not m:
+        sys.exit("error: could not find [features] in adk-rust/Cargo.toml")
+    features = set()
+    for line in m.group(1).splitlines():
+        fm = re.match(r"^([A-Za-z0-9_-]+)\s*=", line.strip())
+        if fm:
+            features.add(fm.group(1))
+    return features
+
+
+def skip(rel: Path) -> bool:
+    if any(part in SKIP_PARTS for part in rel.parts):
+        return True
+    if rel.parts[:2] == ("docs", "podcast"):
+        return True
+    return rel.name == "CHANGELOG.md"
+
+
+def main() -> None:
+    version = workspace_version()
+    features = adk_rust_features()
+    errors: list[str] = []
+
+    version_pattern = re.compile(
+        r'\b(?:adk|awp|cargo)-[a-z0-9-]+ = (?:"(\d+\.\d+\.\d+)"|\{ version = "(\d+\.\d+\.\d+)")'
+    )
+    # `adk-rust = { version = "...", features = [...] }` or
+    # `adk-rust = { ... features = ["a", "b"] }` on one line
+    adk_rust_features_pattern = re.compile(
+        r'\badk-rust = \{[^}]*features = \[([^\]]*)\]'
+    )
+
+    tracked = subprocess.run(
+        ["git", "ls-files", "*.md", "*.rs"],
+        cwd=ROOT, capture_output=True, text=True, check=True,
+    ).stdout.splitlines()
+
+    for rel_str in tracked:
+        rel = Path(rel_str)
+        path = ROOT / rel
+        if skip(rel) or not path.exists():
+            continue
+        for lineno, line in enumerate(path.read_text().splitlines(), 1):
+            for m in version_pattern.finditer(line):
+                found = m.group(1) or m.group(2)
+                if found != version:
+                    errors.append(
+                        f"{rel}:{lineno}: version '{found}' != workspace '{version}': {line.strip()}"
+                    )
+            for m in adk_rust_features_pattern.finditer(line):
+                for feat in re.findall(r'"([^"]+)"', m.group(1)):
+                    if feat not in features:
+                        errors.append(
+                            f"{rel}:{lineno}: feature '{feat}' does not exist in adk-rust/Cargo.toml"
+                        )
+
+    if errors:
+        print(f"check-doc-versions: {len(errors)} problem(s) found "
+              f"(workspace version: {version}):\n", file=sys.stderr)
+        for e in errors:
+            print(f"  {e}", file=sys.stderr)
+        print("\nRun `bash scripts/bump-version.sh <version>` to update version "
+              "snippets, or fix the feature names by hand.", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"check-doc-versions: OK (version {version}, {len(features)} features)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check-doc-versions.sh
+++ b/scripts/check-doc-versions.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+python3 "$ROOT/scripts/check-doc-versions.py"

--- a/scripts/check-publish-order.py
+++ b/scripts/check-publish-order.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""CI check: publish.sh order must satisfy the workspace dependency graph.
+
+Validates, for every crate in publish.sh's CRATES list:
+  1. All workspace crates are listed (and nothing extra).
+  2. Every normal/build dependency on another workspace crate is published
+     earlier in the sequence.
+  3. Every dev-dependency that carries a version requirement is published
+     earlier too — `cargo publish` resolves versioned dev-deps when generating
+     the package lockfile, so an unpublished one aborts the publish (this is
+     what broke the v1.0.0 release). Path-only dev-deps are stripped at
+     publish and are exempt.
+"""
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def main() -> None:
+    meta = json.loads(subprocess.run(
+        ["cargo", "metadata", "--format-version", "1", "--no-deps"],
+        cwd=ROOT, capture_output=True, text=True, check=True,
+    ).stdout)
+    members = {p["name"]: p for p in meta["packages"]}
+
+    order = []
+    for line in (ROOT / "publish.sh").read_text().splitlines():
+        s = line.strip()
+        if re.fullmatch(r"(adk-[a-z0-9-]+|awp-types|cargo-adk)", s):
+            order.append(s)
+    pos = {c: i for i, c in enumerate(order)}
+
+    errors = []
+    missing = set(members) - set(order)
+    extra = set(order) - set(members)
+    for c in sorted(missing):
+        errors.append(f"workspace crate '{c}' is missing from publish.sh")
+    for c in sorted(extra):
+        errors.append(f"publish.sh lists '{c}' which is not a workspace crate")
+
+    for name, p in members.items():
+        if name not in pos:
+            continue
+        for d in p["dependencies"]:
+            if d["name"] not in pos or pos[d["name"]] <= pos[name]:
+                continue
+            kind = d["kind"]
+            if kind in (None, "build"):
+                errors.append(
+                    f"{name} ({kind or 'normal'} dep) must come after {d['name']} in publish.sh"
+                )
+            elif kind == "dev" and d["req"] != "*":
+                errors.append(
+                    f"{name} dev-depends on {d['name']} {d['req']} which publishes later — "
+                    f"make the dev-dep path-only or reorder"
+                )
+
+    if errors:
+        print(f"check-publish-order: {len(errors)} problem(s):\n", file=sys.stderr)
+        for e in errors:
+            print(f"  {e}", file=sys.stderr)
+        sys.exit(1)
+    print(f"check-publish-order: OK ({len(order)} crates, order fully resolvable)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check-publish-order.sh
+++ b/scripts/check-publish-order.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+python3 "$ROOT/scripts/check-publish-order.py"


### PR DESCRIPTION
## What

Three related hardening efforts, validated end-to-end:

**cargo-adk templates implemented for real.** `--template tools/rag/api/openai/a2a` were aliases that silently collapsed to a plain llm agent whenever any `--addon` was used. They are now real composable templates (tools scaffolds a working `#[tool]` in `src/tools.rs`; rag wires a full embedding + vector-store pipeline; api generates a REST server with the previously-missing axum dep; openai carries its own default provider; a2a resolves to the a2a-server pattern). Custom template directories (`--template-dir` with TOML manifests) are implemented, generated mains run an interactive `Launcher` console so `cargo run` works out of the box, and a missing API key produces a friendly error instead of a panic. Validated live: scaffolded projects built against published crates.io deps, drove the console agent through a real Gemini tool call, and exercised the REST server over SSE.

**Publish flow hardened.** Internal dev-deps are now path-only (stripped from published manifests), `publish.sh` defaults to `cargo publish --workspace` with a tiered `--resume` fallback, Tier 4 ordering is fixed, and the WASM sandbox got per-execution engines so one execution's timeout can no longer spuriously kill another.

**v1.0.1 + version tooling.** `scripts/bump-version.sh` bumps Cargo.toml, docs, READMEs, and doc-comment snippets while never touching CHANGELOG/locks/historical text. New CI guards: `check-doc-versions.sh` (caught 20 stale snippets on first run, including the 0.8.2 docs.rs landing page and the removed `labs` feature) and `check-publish-order.sh` (validates publish.sh against the dependency graph including versioned dev-deps — the v1.0.0 publish breaker).

## Why

The advertised quickstart produced wrong projects, the docs.rs landing page was a major version behind with nonexistent features, and the v1.0.0 publish required emergency dev-dep amputations that this makes structurally impossible to need again.

## How

See individual commits — each is self-contained with its own validation notes.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts
- [x] No unrelated changes mixed in
- [x] Branch naming follows convention
- [x] Commit messages follow conventional format
- [x] PR targets `main` branch

### Documentation

- [x] README updated (template list, feature tiers, example counts)
- [x] Examples: scaffold check script covers all template/addon combos