### PR TITLE
feat: lefthook quality gates (closes #374)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,7 +157,9 @@ The repo ships a `lefthook.yml` that wires the [Quality Gates](#quality-gates) i
 
 The shellcheck gate only runs when shell scripts are staged, and runs at `--severity=warning` so informational notes (e.g. SC1091 about sourced files that can't be followed) don't block commits. `publish.sh` is skipped because it's a zsh script, which shellcheck doesn't support. Install shellcheck with `brew install shellcheck` (macOS) or `apt install shellcheck` (Debian/Ubuntu); `scripts/setup-dev.sh` installs it for you.
 
-Install [lefthook](https://github.com/evilmartians/lefthook):
+**devenv users: nothing to do.** The dev shell ships `lefthook` and `shellcheck` and registers the hooks automatically on shell entry — lefthook is the single hook manager for this repo (devenv's own `git-hooks` integration is not used, so the two never fight over `.git/hooks`).
+
+Everyone else, install [lefthook](https://github.com/evilmartians/lefthook):
 
 ```bash
 brew install lefthook        # macOS

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ Branch naming conventions:
 
 CI enforces three gates: format, lint, and test. The easiest way to catch failures before they reach CI is to let [lefthook](https://github.com/evilmartians/lefthook) run them automatically as git hooks (see [Git Hooks with Lefthook](#git-hooks-with-lefthook)):
 
-- **pre-commit** runs `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets -- -D warnings`
+- **pre-commit** runs `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets -- -D warnings`, plus `shellcheck --severity=warning` on any staged shell scripts
 - **pre-push** runs `cargo nextest run --workspace`
 
 Once installed, these run on every `git commit` and `git push` — no extra steps required.
@@ -152,8 +152,10 @@ cp .env.example .env
 
 The repo ships a `lefthook.yml` that wires the [Quality Gates](#quality-gates) into git hooks, so they run automatically:
 
-- **pre-commit** — format check (`cargo fmt --all -- --check`) and lint (`cargo clippy --workspace --all-targets -- -D warnings`)
+- **pre-commit** — format check (`cargo fmt --all -- --check`), lint (`cargo clippy --workspace --all-targets -- -D warnings`), and shell-script lint (`shellcheck --severity=warning` on staged `*.sh`, mirroring the shellcheck hook in `devenv.nix`)
 - **pre-push** — the full test suite (`cargo nextest run --workspace`)
+
+The shellcheck gate only runs when shell scripts are staged, and runs at `--severity=warning` so informational notes (e.g. SC1091 about sourced files that can't be followed) don't block commits. `publish.sh` is skipped because it's a zsh script, which shellcheck doesn't support. Install shellcheck with `brew install shellcheck` (macOS) or `apt install shellcheck` (Debian/Ubuntu); `scripts/setup-dev.sh` installs it for you.
 
 Install [lefthook](https://github.com/evilmartians/lefthook):
 
@@ -169,7 +171,7 @@ Then register the hooks in your local clone (run once, from the repo root):
 lefthook install
 ```
 
-From now on, commits run fmt + clippy and pushes run the test suite. If a gate fails, the commit or push is blocked with guidance on how to fix it.
+From now on, commits run fmt + clippy (and shellcheck on staged shell scripts) and pushes run the test suite. If a gate fails, the commit or push is blocked with guidance on how to fix it.
 
 Need to bypass a hook in an emergency? Use `LEFTHOOK=0 git commit ...` or `git commit --no-verify` — but CI will still enforce the gates, so prefer fixing the issue.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,14 @@ Branch naming conventions:
 
 ### 3. Develop with Quality Gates
 
-Run these before every commit. CI enforces them — save yourself the round-trip:
+CI enforces three gates: format, lint, and test. The easiest way to catch failures before they reach CI is to let [lefthook](https://github.com/evilmartians/lefthook) run them automatically as git hooks (see [Git Hooks with Lefthook](#git-hooks-with-lefthook)):
+
+- **pre-commit** runs `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets -- -D warnings`
+- **pre-push** runs `cargo nextest run --workspace`
+
+Once installed, these run on every `git commit` and `git push` — no extra steps required.
+
+Alternatively, run the gates manually before every commit:
 
 ```bash
 cargo fmt --all                                          # Format
@@ -141,6 +148,31 @@ cp .env.example .env
 
 **Important:** Never commit `.env` files, API keys, local paths, or IDE configuration.
 
+### Git Hooks with Lefthook
+
+The repo ships a `lefthook.yml` that wires the [Quality Gates](#quality-gates) into git hooks, so they run automatically:
+
+- **pre-commit** — format check (`cargo fmt --all -- --check`) and lint (`cargo clippy --workspace --all-targets -- -D warnings`)
+- **pre-push** — the full test suite (`cargo nextest run --workspace`)
+
+Install [lefthook](https://github.com/evilmartians/lefthook):
+
+```bash
+brew install lefthook        # macOS
+# or: cargo install lefthook  # any platform
+# or: npm install -g lefthook # via npm
+```
+
+Then register the hooks in your local clone (run once, from the repo root):
+
+```bash
+lefthook install
+```
+
+From now on, commits run fmt + clippy and pushes run the test suite. If a gate fails, the commit or push is blocked with guidance on how to fix it.
+
+Need to bypass a hook in an emergency? Use `LEFTHOOK=0 git commit ...` or `git commit --no-verify` — but CI will still enforce the gates, so prefer fixing the issue.
+
 ## Project Structure
 
 ADK-Rust is a Cargo workspace with 32 publishable crates organized by responsibility.
@@ -226,7 +258,7 @@ Every PR must pass these checks. CI enforces them automatically.
 
 ### Quick Validation
 
-Run all three in sequence:
+The simplest option is to install the git hooks (see [Git Hooks with Lefthook](#git-hooks-with-lefthook)) and let them run the gates on commit and push. To validate manually, run all three in sequence:
 
 ```bash
 cargo fmt --all && \

--- a/adk-agent/tests/agent_callback_tests.rs
+++ b/adk-agent/tests/agent_callback_tests.rs
@@ -94,14 +94,14 @@ async fn test_before_agent_callback_skip_execution() {
 
     let mut found_skip_message = false;
     while let Some(result) = stream.next().await {
-        if let Ok(event) = result {
-            if let Some(content) = &event.llm_response.content {
-                for part in &content.parts {
-                    if let Part::Text { text } = part {
-                        if text.contains("AGENT SKIPPED BY CALLBACK") {
-                            found_skip_message = true;
-                        }
-                    }
+        if let Ok(event) = result
+            && let Some(content) = &event.llm_response.content
+        {
+            for part in &content.parts {
+                if let Part::Text { text } = part
+                    && text.contains("AGENT SKIPPED BY CALLBACK")
+                {
+                    found_skip_message = true;
                 }
             }
         }
@@ -139,14 +139,14 @@ async fn test_after_agent_callback() {
 
     let mut found_after_message = false;
     while let Some(result) = stream.next().await {
-        if let Ok(event) = result {
-            if let Some(content) = &event.llm_response.content {
-                for part in &content.parts {
-                    if let Part::Text { text } = part {
-                        if text.contains("AFTER AGENT CALLBACK") {
-                            found_after_message = true;
-                        }
-                    }
+        if let Ok(event) = result
+            && let Some(content) = &event.llm_response.content
+        {
+            for part in &content.parts {
+                if let Part::Text { text } = part
+                    && text.contains("AFTER AGENT CALLBACK")
+                {
+                    found_after_message = true;
                 }
             }
         }

--- a/adk-agent/tests/callback_integration_test.rs
+++ b/adk-agent/tests/callback_integration_test.rs
@@ -243,12 +243,11 @@ async fn test_callback_short_circuit() {
     let mut found_short_circuit = false;
     while let Some(result) = stream.next().await {
         let event = result.unwrap();
-        if let Some(content) = event.llm_response.content {
-            if let Some(Part::Text { text }) = content.parts.first() {
-                if text.contains("Short-circuited") {
-                    found_short_circuit = true;
-                }
-            }
+        if let Some(content) = event.llm_response.content
+            && let Some(Part::Text { text }) = content.parts.first()
+            && text.contains("Short-circuited")
+        {
+            found_short_circuit = true;
         }
     }
 

--- a/adk-agent/tests/mcp_integration_test.rs
+++ b/adk-agent/tests/mcp_integration_test.rs
@@ -178,10 +178,10 @@ async fn test_mcp_tool_integration() {
 
     let mut received_response = false;
     while let Some(result) = stream.next().await {
-        if let Ok(event) = result {
-            if let Some(_content) = event.llm_response.content {
-                received_response = true;
-            }
+        if let Ok(event) = result
+            && let Some(_content) = event.llm_response.content
+        {
+            received_response = true;
         }
     }
 

--- a/adk-agent/tests/multi_agent_test.rs
+++ b/adk-agent/tests/multi_agent_test.rs
@@ -143,12 +143,12 @@ async fn test_multi_agent_workflow() {
 
     let mut response_text = String::new();
     while let Some(result) = stream.next().await {
-        if let Ok(event) = result {
-            if let Some(content) = event.llm_response.content {
-                for part in content.parts {
-                    if let Part::Text { text } = part {
-                        response_text.push_str(&text);
-                    }
+        if let Ok(event) = result
+            && let Some(content) = event.llm_response.content
+        {
+            for part in content.parts {
+                if let Part::Text { text } = part {
+                    response_text.push_str(&text);
                 }
             }
         }
@@ -191,14 +191,14 @@ async fn test_agent_delegation() {
 
     let mut has_answer = false;
     while let Some(result) = stream.next().await {
-        if let Ok(event) = result {
-            if let Some(content) = event.llm_response.content {
-                for part in content.parts {
-                    if let Part::Text { text } = part {
-                        if text.contains("345") {
-                            has_answer = true;
-                        }
-                    }
+        if let Ok(event) = result
+            && let Some(content) = event.llm_response.content
+        {
+            for part in content.parts {
+                if let Part::Text { text } = part
+                    && text.contains("345")
+                {
+                    has_answer = true;
                 }
             }
         }

--- a/adk-agent/tests/streaming_test.rs
+++ b/adk-agent/tests/streaming_test.rs
@@ -245,10 +245,10 @@ async fn test_streaming_chunks() {
 
     while let Some(result) = stream.next().await {
         let event = result.unwrap();
-        if let Some(content) = event.llm_response.content {
-            if let Some(Part::Text { text }) = content.parts.first() {
-                received_chunks.push(text.clone());
-            }
+        if let Some(content) = event.llm_response.content
+            && let Some(Part::Text { text }) = content.parts.first()
+        {
+            received_chunks.push(text.clone());
         }
     }
 

--- a/adk-agent/tests/tool_callback_tests.rs
+++ b/adk-agent/tests/tool_callback_tests.rs
@@ -316,10 +316,10 @@ async fn test_after_tool_callback_overrides_result_and_order() {
         let event = result.unwrap();
         if let Some(content) = event.llm_response.content {
             for part in content.parts {
-                if let Part::Text { text } = part {
-                    if text == "after-override" {
-                        saw_override = true;
-                    }
+                if let Part::Text { text } = part
+                    && text == "after-override"
+                {
+                    saw_override = true;
                 }
             }
         }
@@ -353,14 +353,14 @@ async fn test_before_tool_callback_error_aborts_tool_execution() {
     let mut saw_error_response = false;
 
     while let Some(result) = stream.next().await {
-        if let Ok(event) = result {
-            if let Some(ref content) = event.llm_response.content {
-                for part in &content.parts {
-                    if let Part::FunctionResponse { function_response, .. } = part {
-                        if function_response.response.get("error").is_some() {
-                            saw_error_response = true;
-                        }
-                    }
+        if let Ok(event) = result
+            && let Some(ref content) = event.llm_response.content
+        {
+            for part in &content.parts {
+                if let Part::FunctionResponse { function_response, .. } = part
+                    && function_response.response.get("error").is_some()
+                {
+                    saw_error_response = true;
                 }
             }
         }

--- a/adk-agent/tests/tool_confirmation_tests.rs
+++ b/adk-agent/tests/tool_confirmation_tests.rs
@@ -335,10 +335,10 @@ async fn test_tool_confirmation_approve_executes_tool() {
         let event = result.unwrap();
         if event.actions.tool_confirmation_decision == Some(ToolConfirmationDecision::Approve) {
             let content = event.llm_response.content.as_ref().unwrap();
-            if let Some(Part::FunctionResponse { function_response, .. }) = content.parts.first() {
-                if function_response.response.get("status") == Some(&json!("tool-ok")) {
-                    saw_tool_result = true;
-                }
+            if let Some(Part::FunctionResponse { function_response, .. }) = content.parts.first()
+                && function_response.response.get("status") == Some(&json!("tool-ok"))
+            {
+                saw_tool_result = true;
             }
         }
     }

--- a/adk-managed/src/types/events.rs
+++ b/adk-managed/src/types/events.rs
@@ -477,7 +477,7 @@ mod tests {
     #[test]
     fn test_session_event_seq_strictly_increasing() {
         // Simulate a sequence of events with strictly increasing seq values
-        let events = vec![
+        let events = [
             SessionEvent::StatusRunning { seq: 0 },
             SessionEvent::Message {
                 content: vec![ContentBlock::Text { text: "Hello".to_string() }],

--- a/adk-runner/tests/runner_config_property_tests.rs
+++ b/adk-runner/tests/runner_config_property_tests.rs
@@ -3,6 +3,12 @@
 //! Implements Property 2 (Runner Configuration Builder Round-Trip) from the
 //! one-point-zero-readiness design document.
 
+// prop_run_config_default_setter_equivalence deliberately builds a config via
+// Default + field setters to compare against the builder — the struct-literal
+// form clippy suggests would defeat the comparison. (File-level because the
+// allow can't attach inside the proptest! macro expansion.)
+#![allow(clippy::field_reassign_with_default)]
+
 use adk_core::{
     BackpressurePolicy, RunConfig, RunConfigBuilder, StreamingMode, ToolConcurrencyConfig,
     ToolConfirmationDecision,
@@ -141,7 +147,9 @@ proptest! {
             .trace_payload_max_bytes(trace_payload_max_bytes)
             .build();
 
-        // Build via Default + field setters
+        // Build via Default + field setters — the field-by-field path is the
+        // behavior under test here, so the struct-literal form clippy suggests
+        // would defeat the comparison.
         let mut via_default = RunConfig::default();
         via_default.streaming_mode = streaming_mode;
         via_default.auto_cache = auto_cache;

--- a/devenv.nix
+++ b/devenv.nix
@@ -80,6 +80,11 @@
     git
     jq
     curl
+
+    # Quality gates — lefthook is the single git-hook manager (see lefthook.yml);
+    # shellcheck backs its pre-commit shell-script gate
+    lefthook
+    shellcheck
   ]
   ++ lib.optionals pkgs.stdenv.isLinux [
     # Linux-only: faster linking, perf tools
@@ -195,16 +200,20 @@
   # --------------------------------------------------------------------------
   # Quality Gates (Git-Hooks)
   # --------------------------------------------------------------------------
-  git-hooks.hooks = {
-    rustfmt.enable = true;
-    clippy.enable = true;
-    shellcheck.enable = true;
-  };
+  # Managed by lefthook (see lefthook.yml) — registered automatically in
+  # enterShell below. devenv's own git-hooks integration is intentionally NOT
+  # used: two hook managers would fight over .git/hooks/pre-commit, and
+  # lefthook works identically for non-Nix contributors (scripts/setup-dev.sh
+  # installs it outside devenv).
 
   # --------------------------------------------------------------------------
   # Shell hooks — run on entering the dev shell
   # --------------------------------------------------------------------------
   enterShell = ''
+    # Register the lefthook-managed quality gates (idempotent; overwrites any
+    # stale hooks left behind by the previous devenv git-hooks integration).
+    lefthook install >/dev/null 2>&1 || true
+
     echo "🚀 Welcome to the ADK-Rust Development Environment!"
     echo "   Rust:    $(rustc --version)"
     echo "   Cargo:   $(cargo --version)"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,6 +9,12 @@
 # the gates entirely (lefthook skips a command when no matching files are
 # staged/pushed).
 #
+# Glob notes (lefthook's matcher): `*` crosses `/` (so `*.rs` matches nested
+# files), but `**` requires 1+ directories — so plain `Cargo.toml` only matches
+# the workspace root and `**/Cargo.toml` is needed for per-crate manifests.
+# We intentionally avoid `*.toml`/`*.lock`, which would also match non-Cargo
+# files like rustfmt.toml, deny.toml, and flake.lock.
+#
 # Install hooks once with: lefthook install
 
 pre-commit:
@@ -16,12 +22,20 @@ pre-commit:
   commands:
     fmt:
       tags: format
-      glob: "*.{rs,toml,lock}"
+      glob:
+        - "*.rs"
+        - "Cargo.toml"
+        - "**/Cargo.toml"
+        - "Cargo.lock"
       run: cargo fmt --all -- --check
       fail_text: "Formatting check failed. Run `cargo fmt --all` to fix."
     clippy:
       tags: lint
-      glob: "*.{rs,toml,lock}"
+      glob:
+        - "*.rs"
+        - "Cargo.toml"
+        - "**/Cargo.toml"
+        - "Cargo.lock"
       run: cargo clippy --workspace --all-targets -- -D warnings
       fail_text: "Clippy found warnings. Fix them before committing (zero-warnings policy)."
 
@@ -29,6 +43,10 @@ pre-push:
   commands:
     nextest:
       tags: test
-      glob: "*.{rs,toml,lock}"
+      glob:
+        - "*.rs"
+        - "Cargo.toml"
+        - "**/Cargo.toml"
+        - "Cargo.lock"
       run: cargo nextest run --workspace
       fail_text: "Tests failed. Fix regressions before pushing."

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -27,6 +27,7 @@ pre-commit:
         - "Cargo.toml"
         - "**/Cargo.toml"
         - "Cargo.lock"
+        - "**/Cargo.lock"
       run: cargo fmt --all -- --check
       fail_text: "Formatting check failed. Run `cargo fmt --all` to fix."
     clippy:
@@ -36,6 +37,7 @@ pre-commit:
         - "Cargo.toml"
         - "**/Cargo.toml"
         - "Cargo.lock"
+        - "**/Cargo.lock"
       run: cargo clippy --workspace --all-targets -- -D warnings
       fail_text: "Clippy found warnings. Fix them before committing (zero-warnings policy)."
 
@@ -48,5 +50,6 @@ pre-push:
         - "Cargo.toml"
         - "**/Cargo.toml"
         - "Cargo.lock"
+        - "**/Cargo.lock"
       run: cargo nextest run --workspace
       fail_text: "Tests failed. Fix regressions before pushing."

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -12,10 +12,16 @@
 # every gate.
 #
 # Each gate globs just the inputs that affect it:
-#   - fmt     Rust sources, rustfmt.toml, and the toolchain.
-#   - clippy  also Cargo manifests, the lockfile, .cargo/config.toml, and
-#             .clippy.toml (anything that changes compilation or lints).
-#   - nextest mirrors clippy's compile inputs plus .config/nextest.toml.
+#   - fmt        Rust sources, rustfmt.toml, and the toolchain.
+#   - clippy     also Cargo manifests, the lockfile, .cargo/config.toml, and
+#                .clippy.toml (anything that changes compilation or lints).
+#   - shellcheck shell scripts only. The non-Nix counterpart to the shellcheck
+#                hook in devenv.nix. Lints just the staged scripts. Runs at
+#                --severity=warning so info-level notes (e.g. SC1091 about
+#                sourced files that can't be followed) don't block commits;
+#                real warnings and errors still fail. `publish.sh` is excluded
+#                because it's zsh and shellcheck only supports sh/bash/dash/ksh.
+#   - nextest    mirrors clippy's compile inputs plus .config/nextest.toml.
 #
 # Glob notes (lefthook's matcher): `*` crosses `/`, so `adk-*/*.rs` matches
 # Rust files at any depth under an `adk-*` crate, and patterns are anchored at
@@ -53,6 +59,13 @@ pre-commit:
         - ".clippy.toml"
       run: cargo clippy --workspace --all-targets -- -D warnings
       fail_text: "Clippy found warnings. Fix them before committing (zero-warnings policy)."
+    shellcheck:
+      tags: lint
+      glob: "*.sh"
+      exclude:
+        - "publish.sh"
+      run: shellcheck --severity=warning {staged_files}
+      fail_text: "shellcheck found issues. Run `shellcheck --severity=warning <file>` to see them."
 
 pre-push:
   commands:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,26 @@
+# Lefthook configuration — enforces the ADK-Rust Quality Gates locally.
+# See CONTRIBUTING.md "3. Develop with Quality Gates".
+#
+# pre-commit: fast format + lint checks (zero warnings).
+# pre-push:   full test suite before code leaves your machine.
+#
+# Install hooks once with: lefthook install
+
+pre-commit:
+  parallel: false
+  commands:
+    fmt:
+      tags: format
+      run: cargo fmt --all -- --check
+      fail_text: "Formatting check failed. Run `cargo fmt --all` to fix."
+    clippy:
+      tags: lint
+      run: cargo clippy --workspace --all-targets -- -D warnings
+      fail_text: "Clippy found warnings. Fix them before committing (zero-warnings policy)."
+
+pre-push:
+  commands:
+    nextest:
+      tags: test
+      run: cargo nextest run --workspace
+      fail_text: "Tests failed. Fix regressions before pushing."

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -4,6 +4,11 @@
 # pre-commit: fast format + lint checks (zero warnings).
 # pre-push:   full test suite before code leaves your machine.
 #
+# Each gate is scoped with `glob` so it only runs when Rust sources or Cargo
+# manifests/lockfile are part of the change. Docs- or script-only commits skip
+# the gates entirely (lefthook skips a command when no matching files are
+# staged/pushed).
+#
 # Install hooks once with: lefthook install
 
 pre-commit:
@@ -11,10 +16,12 @@ pre-commit:
   commands:
     fmt:
       tags: format
+      glob: "*.{rs,toml,lock}"
       run: cargo fmt --all -- --check
       fail_text: "Formatting check failed. Run `cargo fmt --all` to fix."
     clippy:
       tags: lint
+      glob: "*.{rs,toml,lock}"
       run: cargo clippy --workspace --all-targets -- -D warnings
       fail_text: "Clippy found warnings. Fix them before committing (zero-warnings policy)."
 
@@ -22,5 +29,6 @@ pre-push:
   commands:
     nextest:
       tags: test
+      glob: "*.{rs,toml,lock}"
       run: cargo nextest run --workspace
       fail_text: "Tests failed. Fix regressions before pushing."

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -4,20 +4,23 @@
 # pre-commit: fast format + lint checks (zero warnings).
 # pre-push:   full test suite before code leaves your machine.
 #
-# Each gate is scoped with `glob` so it only runs when files that actually
-# affect that gate are part of the change. Docs- or script-only commits skip
-# the gates entirely (lefthook skips a command when no matching files are
-# staged/pushed). The globs are deliberately per-gate:
-#   - fmt     depends on Rust sources, rustfmt.toml, and the toolchain.
-#   - clippy  also depends on Cargo manifests/lockfiles, .cargo/config.toml,
-#             and .clippy.toml (anything that changes compilation or lints).
+# The gates run `cargo <tool> --workspace`, which only builds the workspace
+# members — the `adk-*`, `awp-*`, and `cargo-adk` crates plus the root manifest.
+# The standalone `examples/*` crates (and reference/learning dirs) are EXCLUDED
+# from the workspace, so changes there don't affect these gates. The globs are
+# therefore scoped to workspace-member paths only; an example-only change skips
+# every gate.
+#
+# Each gate globs just the inputs that affect it:
+#   - fmt     Rust sources, rustfmt.toml, and the toolchain.
+#   - clippy  also Cargo manifests, the lockfile, .cargo/config.toml, and
+#             .clippy.toml (anything that changes compilation or lints).
 #   - nextest mirrors clippy's compile inputs plus .config/nextest.toml.
 #
-# Glob notes (lefthook's matcher): `*` crosses `/` (so `*.rs` matches nested
-# files), but `**` requires 1+ directories — so plain `Cargo.toml` only matches
-# the workspace root and `**/Cargo.toml` is needed for per-crate manifests.
-# We intentionally avoid `*.toml`/`*.lock`, which would also match non-Cargo
-# files like deny.toml, .cargo/audit.toml, and flake.lock.
+# Glob notes (lefthook's matcher): `*` crosses `/`, so `adk-*/*.rs` matches
+# Rust files at any depth under an `adk-*` crate, and patterns are anchored at
+# the path start (so `examples/...` never matches). Workspace members share a
+# single root Cargo.lock — there are no per-member lockfiles to glob.
 #
 # Install hooks once with: lefthook install
 
@@ -27,7 +30,9 @@ pre-commit:
     fmt:
       tags: format
       glob:
-        - "*.rs"
+        - "adk-*/*.rs"
+        - "awp-*/*.rs"
+        - "cargo-adk/*.rs"
         - "rustfmt.toml"
         - "rust-toolchain.toml"
       run: cargo fmt --all -- --check
@@ -35,11 +40,14 @@ pre-commit:
     clippy:
       tags: lint
       glob:
-        - "*.rs"
+        - "adk-*/*.rs"
+        - "awp-*/*.rs"
+        - "cargo-adk/*.rs"
+        - "adk-*/Cargo.toml"
+        - "awp-*/Cargo.toml"
+        - "cargo-adk/Cargo.toml"
         - "Cargo.toml"
-        - "**/Cargo.toml"
         - "Cargo.lock"
-        - "**/Cargo.lock"
         - ".cargo/config.toml"
         - "rust-toolchain.toml"
         - ".clippy.toml"
@@ -51,11 +59,14 @@ pre-push:
     nextest:
       tags: test
       glob:
-        - "*.rs"
+        - "adk-*/*.rs"
+        - "awp-*/*.rs"
+        - "cargo-adk/*.rs"
+        - "adk-*/Cargo.toml"
+        - "awp-*/Cargo.toml"
+        - "cargo-adk/Cargo.toml"
         - "Cargo.toml"
-        - "**/Cargo.toml"
         - "Cargo.lock"
-        - "**/Cargo.lock"
         - ".cargo/config.toml"
         - "rust-toolchain.toml"
         - ".config/nextest.toml"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -4,16 +4,20 @@
 # pre-commit: fast format + lint checks (zero warnings).
 # pre-push:   full test suite before code leaves your machine.
 #
-# Each gate is scoped with `glob` so it only runs when Rust sources or Cargo
-# manifests/lockfile are part of the change. Docs- or script-only commits skip
+# Each gate is scoped with `glob` so it only runs when files that actually
+# affect that gate are part of the change. Docs- or script-only commits skip
 # the gates entirely (lefthook skips a command when no matching files are
-# staged/pushed).
+# staged/pushed). The globs are deliberately per-gate:
+#   - fmt     depends on Rust sources, rustfmt.toml, and the toolchain.
+#   - clippy  also depends on Cargo manifests/lockfiles, .cargo/config.toml,
+#             and .clippy.toml (anything that changes compilation or lints).
+#   - nextest mirrors clippy's compile inputs plus .config/nextest.toml.
 #
 # Glob notes (lefthook's matcher): `*` crosses `/` (so `*.rs` matches nested
 # files), but `**` requires 1+ directories — so plain `Cargo.toml` only matches
 # the workspace root and `**/Cargo.toml` is needed for per-crate manifests.
 # We intentionally avoid `*.toml`/`*.lock`, which would also match non-Cargo
-# files like rustfmt.toml, deny.toml, and flake.lock.
+# files like deny.toml, .cargo/audit.toml, and flake.lock.
 #
 # Install hooks once with: lefthook install
 
@@ -24,10 +28,8 @@ pre-commit:
       tags: format
       glob:
         - "*.rs"
-        - "Cargo.toml"
-        - "**/Cargo.toml"
-        - "Cargo.lock"
-        - "**/Cargo.lock"
+        - "rustfmt.toml"
+        - "rust-toolchain.toml"
       run: cargo fmt --all -- --check
       fail_text: "Formatting check failed. Run `cargo fmt --all` to fix."
     clippy:
@@ -38,6 +40,9 @@ pre-commit:
         - "**/Cargo.toml"
         - "Cargo.lock"
         - "**/Cargo.lock"
+        - ".cargo/config.toml"
+        - "rust-toolchain.toml"
+        - ".clippy.toml"
       run: cargo clippy --workspace --all-targets -- -D warnings
       fail_text: "Clippy found warnings. Fix them before committing (zero-warnings policy)."
 
@@ -51,5 +56,8 @@ pre-push:
         - "**/Cargo.toml"
         - "Cargo.lock"
         - "**/Cargo.lock"
+        - ".cargo/config.toml"
+        - "rust-toolchain.toml"
+        - ".config/nextest.toml"
       run: cargo nextest run --workspace
       fail_text: "Tests failed. Fix regressions before pushing."

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -134,7 +134,17 @@ fi
 echo ""
 echo "Git hooks (quality gates):"
 
-# lefthook — runs fmt + clippy on pre-commit, nextest on pre-push (see lefthook.yml)
+# Shell-script linter — backs the pre-commit shellcheck gate (see lefthook.yml).
+# devenv users get this for free via git-hooks.hooks; install it here so the
+# non-Nix lefthook path reaches the same parity.
+if command -v shellcheck &>/dev/null; then
+  ok "shellcheck $(shellcheck --version | awk '/^version:/ {print $2}')"
+else
+  miss "shellcheck — shell-script linter for the pre-commit gate"
+  install_pkg shellcheck
+fi
+
+# lefthook — runs fmt + clippy + shellcheck on pre-commit, nextest on pre-push (see lefthook.yml)
 if command -v lefthook &>/dev/null; then
   ok "lefthook $(lefthook version 2>/dev/null | head -1)"
 else

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -17,7 +17,7 @@ YELLOW='\033[1;33m'
 RED='\033[0;31m'
 NC='\033[0m'
 
-ok()   { echo -e "  ${GREEN}✓${NC} $1"; }
+ok() { echo -e "  ${GREEN}✓${NC} $1"; }
 warn() { echo -e "  ${YELLOW}⚠${NC} $1"; }
 miss() { echo -e "  ${RED}✗${NC} $1"; }
 
@@ -129,6 +129,40 @@ elif command -v npm &>/dev/null; then
   ok "npm $(npm --version) (pnpm recommended: npm i -g pnpm)"
 else
   miss "npm/pnpm — needed for ADK Studio UI"
+fi
+
+echo ""
+echo "Git hooks (quality gates):"
+
+# lefthook — runs fmt + clippy on pre-commit, nextest on pre-push (see lefthook.yml)
+if command -v lefthook &>/dev/null; then
+  ok "lefthook $(lefthook version 2>/dev/null | head -1)"
+else
+  miss "lefthook — git hook runner for the quality gates"
+  install_pkg lefthook
+  # install_pkg is best-effort: it silently no-ops when lefthook isn't in the
+  # platform's default repos (e.g. apt/dnf). Fall back to npm, then warn.
+  if ! $CHECK_ONLY && ! command -v lefthook &>/dev/null && command -v npm &>/dev/null; then
+    echo "  Installing lefthook via npm..."
+    npm install -g lefthook 2>/dev/null || true
+  fi
+  if ! $CHECK_ONLY && ! command -v lefthook &>/dev/null; then
+    warn "could not install lefthook automatically — install it manually: https://lefthook.dev"
+  fi
+fi
+
+# Register the hooks in this clone
+if ! $CHECK_ONLY && command -v lefthook &>/dev/null; then
+  if git rev-parse --git-dir &>/dev/null; then
+    echo "  Registering git hooks..."
+    if lefthook install &>/dev/null; then
+      ok "git hooks installed (pre-commit, pre-push)"
+    else
+      warn "run 'lefthook install' from the repo root to register hooks"
+    fi
+  else
+    warn "not a git repo — run 'lefthook install' from the repo root to register hooks"
+  fi
 fi
 
 echo ""


### PR DESCRIPTION
## What

Integrates lefthook as the repository's single git-hook manager: pre-commit runs fmt + clippy (workspace, -D warnings) + shellcheck on staged scripts; pre-push runs the full nextest suite.

Builds on #375 by @joseph-wortmann (his commits are included with full authorship) and resolves the two blockers found while validating it:

1. **Hook-manager collision** — devenv's own git-hooks integration is disabled; the dev shell now ships lefthook + shellcheck and registers the hooks on shell entry, so devenv users get the gates with zero setup and the two managers never fight over `.git/hooks`. Non-Nix contributors use `scripts/setup-dev.sh` as before. (The collision was real: installing lefthook here found and renamed a devenv-installed pre-push hook.)
2. **Gate-blocking clippy violations** — `--all-targets` surfaces test-target warnings that per-crate lib runs never caught; without fixing them, every contributor's first commit would have been blocked. 17 violations fixed across adk-agent/adk-managed/adk-runner.

## Why

Fixes #374. Supersedes #375 with credit — manual quality gating loses to CI round-trips, and the gates proved themselves immediately during this PR's own development by catching violations a piped exit code had masked.

## How

Validated live, not just statically: `lefthook run pre-commit --all-files` green, real commits through the installed hooks (including correct glob-skipping when no Rust/shell files are staged), and the pre-push gate passing 3338/3338 tests.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt`
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — 3338/3338 via the pre-push gate itself
- [x] `devenv shell check`

### Hygiene

- [x] No unrelated changes mixed in
- [x] Branch naming and conventional commits
- [x] Stacked on #376; targets main once it lands

### Documentation

- [x] CONTRIBUTING.md documents the hooks and the devenv zero-setup path