### PR TITLE
feat: add fallback to 'reasoning' field for OpenAI-compatible providers enhancement

### DIFF
--- a/adk-model/src/openai/convert.rs
+++ b/adk-model/src/openai/convert.rs
@@ -346,7 +346,12 @@ pub fn from_raw_openai_response(json: &serde_json::Value) -> LlmResponse {
         let mut parts = Vec::new();
 
         // Extract reasoning_content (returned by reasoning models like o3, gpt-5-mini)
-        if let Some(reasoning) = message.get("reasoning_content").and_then(|v| v.as_str())
+        // Fallback to "reasoning" field for OpenRouter, Kilo Gateway, SambaNova, Cerebras, Groq
+        let reasoning = message
+            .get("reasoning_content")
+            .or_else(|| message.get("reasoning"))
+            .and_then(|v| v.as_str());
+        if let Some(reasoning) = reasoning
             && !reasoning.is_empty()
         {
             parts.push(Part::Thinking { thinking: reasoning.to_string(), signature: None });

--- a/adk-model/src/openai_compatible.rs
+++ b/adk-model/src/openai_compatible.rs
@@ -666,8 +666,11 @@ impl Llm for OpenAICompatible {
                             }
 
                             // Emit partial reasoning_content as Part::Thinking.
-                            if let Some(reasoning) =
-                                delta.get("reasoning_content").and_then(|v| v.as_str())
+                            // Fallback to "reasoning" field for OpenRouter, Kilo Gateway, SambaNova, Cerebras, Groq
+                            let reasoning = delta.get("reasoning_content")
+                                .or_else(|| delta.get("reasoning"))
+                                .and_then(|v| v.as_str());
+                            if let Some(reasoning) = reasoning
                                 && !reasoning.is_empty() {
                                     yield LlmResponse {
                                         content: Some(Content {

--- a/adk-model/tests/openai_client_preservation_tests.rs
+++ b/adk-model/tests/openai_client_preservation_tests.rs
@@ -196,4 +196,66 @@ mod openai_client_preservation {
         let usage = resp.usage_metadata.as_ref().expect("should have usage");
         assert_eq!(usage.thinking_token_count, Some(40));
     }
+
+    /// Regression test for providers using "reasoning" field instead of "reasoning_content"
+    /// (OpenRouter, Kilo Gateway, SambaNova, Cerebras, Groq).
+    /// Without the fallback fix, this test would fail — reasoning silently dropped.
+    #[tokio::test]
+    async fn non_streaming_reasoning_field_fallback() {
+        let server = MockServer::start().await;
+
+        let body = serde_json::json!({
+            "id": "chatcmpl-3",
+            "object": "chat.completion",
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "reasoning": "Let me think step by step...",  // NOT reasoning_content
+                    "content": "The answer is 42."
+                },
+                "finish_reason": "stop"
+            }],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 50,
+                "total_tokens": 60
+            }
+        });
+
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = make_reasoning_client(&server.uri());
+        let request = make_request("o3");
+
+        let mut stream =
+            client.generate_content(request, false).await.expect("generate_content should succeed");
+
+        let mut responses = Vec::new();
+        while let Some(item) = stream.next().await {
+            responses.push(item.expect("stream item should be Ok"));
+        }
+
+        assert_eq!(responses.len(), 1, "non-streaming should yield exactly 1 response");
+
+        let resp = &responses[0];
+        let content = resp.content.as_ref().expect("response should have content");
+
+        // Should have Thinking + Text parts (not just Text)
+        assert_eq!(content.parts.len(), 2, "should have Thinking + Text parts via fallback");
+
+        // First part: Thinking from "reasoning" field
+        assert!(
+            matches!(
+                &content.parts[0],
+                Part::Thinking { thinking, .. } if thinking == "Let me think step by step..."
+            ),
+            "first part should be Part::Thinking from 'reasoning' field fallback"
+        );
+    }
 }

--- a/adk-model/tests/openai_streaming_exploration_tests.rs
+++ b/adk-model/tests/openai_streaming_exploration_tests.rs
@@ -316,4 +316,73 @@ mod streaming_exploration {
             "final response with tool calls should have turn_complete=true"
         );
     }
+
+    /// Regression test for providers using "delta.reasoning" field instead of "delta.reasoning_content"
+    /// (OpenRouter, Kilo Gateway, SambaNova, Cerebras, Groq).
+    /// Without the fallback fix, this test would fail — reasoning silently dropped in streaming.
+    #[tokio::test]
+    async fn reasoning_field_fallback_streaming() {
+        let server = MockServer::start().await;
+
+        let sse_body = [
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"reasoning\":\"Let me think...\"},\"finish_reason\":null}]}\n\n",
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"reasoning\":\" about this.\"},\"finish_reason\":null}]}\n\n",
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"The answer is 42.\"},\"finish_reason\":null}]}\n\n",
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":10,\"total_tokens\":15}}\n\n",
+            "data: [DONE]\n\n",
+        ]
+        .join("");
+
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string(&sse_body)
+                    .insert_header("content-type", "text/event-stream"),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = make_client(&server.uri());
+        let request = make_request();
+
+        let stream_result = client.generate_content(request, true).await;
+        assert!(stream_result.is_ok(), "generate_content should not error");
+
+        let mut stream = stream_result.unwrap();
+        let mut responses = Vec::new();
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(resp) => responses.push(resp),
+                Err(e) => panic!("stream yielded error: {e}"),
+            }
+        }
+
+        // Collect all Part::Thinking parts from all responses
+        let thinking_parts: Vec<&str> = responses
+            .iter()
+            .filter_map(|r| r.content.as_ref())
+            .flat_map(|c| &c.parts)
+            .filter_map(|p| match p {
+                Part::Thinking { thinking, .. } => Some(thinking.as_str()),
+                _ => None,
+            })
+            .collect();
+
+        // BUG CONDITION: on unfixed code, delta.reasoning is not parsed,
+        // so no Part::Thinking is yielded from streaming delta chunks.
+        assert!(
+            !thinking_parts.is_empty(),
+            "expected Part::Thinking responses from delta.reasoning chunks (fallback). \
+             Counterexample: no Part::Thinking yielded — reasoning field not parsed — bug confirmed."
+        );
+
+        // Verify the thinking content matches what was sent
+        let combined_thinking: String = thinking_parts.join("");
+        assert!(
+            combined_thinking.contains("Let me think"),
+            "thinking content should contain the reasoning text"
+        );
+    }
 }


### PR DESCRIPTION
## What

Add fallback parsing for the `reasoning` field (in addition to `reasoning_content`) in OpenAI-compatible provider responses. This unblocks reasoning support for OpenRouter, Kilo Gateway, SambaNova, Cerebras, Groq, and other providers that use the `reasoning` field format.

## Why

Link to the issue this addresses: Fixes #386

Several major OpenAI-compatible providers return reasoning tokens in a `reasoning` field instead of the OpenAI-standard `reasoning_content` field:

| Provider | Response field for reasoning |
|----------|------------------------------|
| OpenRouter | `reasoning` + `reasoning_details[]` |
| Kilo Gateway | `reasoning` + `reasoning_details[]` |
| SambaNova | `reasoning` |
| Cerebras | `reasoning` |
| Groq | `reasoning` (in streaming delta) |

Currently, ADK's OpenAI-compatible client only parses `reasoning_content`, causing reasoning to be **silently dropped** for all these providers.

## How

Added a simple fallback: check `reasoning_content` first, then fall back to `reasoning` field in two locations:

1. **`adk-model/src/openai/convert.rs`** (non-streaming): Added `.or_else(|| message.get("reasoning"))` fallback
2. **`adk-model/src/openai_compatible.rs`** (streaming): Added `.or_else(|| delta.get("reasoning"))` fallback

This is backward-compatible (OpenAI models still work), minimal (~10 lines changed), and unblocks 5+ providers immediately.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass (3504 tests passed)
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
  - Added `non_streaming_reasoning_field_fallback` test in `openai_client_preservation_tests.rs`
  - Added `reasoning_field_fallback_streaming` test in `openai_streaming_exploration_tests.rs`
  - Both are regression tests that fail without the fix
- [x] Public APIs have rustdoc comments with `# Example` sections (no new public APIs added)
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`fix/openai-compat-reasoning-fallback`)
- [x] Commit messages follow conventional format (`fix(openai-compat): ...`)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [ ] CHANGELOG.md updated for user-facing changes (optional for internal fix)
- [ ] README updated if crate capabilities changed (no API surface change)
- [ ] Examples added or updated for new features (N/A)