### PR TITLE
Correct `functionDeclarations` field names for Gemini 3 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **adk-gemini: fix tool definition for Gemini 3 compatibility** — renamed
+  `function_declarations` field to `functionDeclarations` to match the
+  `camelCase` requirement of the Gemini 3 / 2.5 REST API.
 - **adk-sandbox: WASM timeout isolation.** Each execution gets its own
   wasmtime engine; previously the engine was shared and any execution's
   timeout timer (including stale timers from finished runs) tripped the epoch

--- a/adk-gemini/src/tools/model.rs
+++ b/adk-gemini/src/tools/model.rs
@@ -10,6 +10,7 @@ pub enum Tool {
     /// Function-based tool
     Function {
         /// The function declaration for the tool
+        #[serde(rename = "functionDeclarations")]
         function_declarations: Vec<FunctionDeclaration>,
     },
     /// Google Search tool
@@ -463,6 +464,17 @@ pub enum FunctionCallingMode {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn tool_function_declarations_uses_camel_case() {
+        let tool = Tool::Function {
+            function_declarations: vec![FunctionDeclaration::new("test_func", "desc", None)],
+        };
+
+        let json = serde_json::to_value(&tool).unwrap();
+        assert!(json.get("functionDeclarations").is_some());
+        assert!(json.get("function_declarations").is_none());
+    }
 
     #[test]
     fn tool_config_include_server_side_tool_invocations_serde_round_trip() {


### PR DESCRIPTION
Hi there!

I'm submitting this pull request to fix a compatibility issue with Gemini 3 (and 2.5) models. Currently, the REST API requires the tool field to be named `functionDeclarations` ( `camelCase` ).

I have applied the necessary Serde rename, added a regression test, and updated the `CHANGELOG.md`.

## What

Renamed the `function_declarations` field in the `Tool::Function` enum to `functionDeclarations` using `#[serde(rename)]` .

## Why

The Gemini 3 REST API (and Gemini 2.5) requires `camelCase` for tool definition fields.

## How

Declare `#[serde(rename)]` .

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed
- [x] Examples added or updated for new features
