### PR TITLE
fix(model): accumulate streaming content in DeepSeek final event

### DIFF
--- a/adk-model/src/deepseek/client.rs
+++ b/adk-model/src/deepseek/client.rs
@@ -241,6 +241,7 @@ impl Llm for DeepSeekClient {
                 let mut tool_call_accumulators: std::collections::HashMap<u32, (String, String, String)> =
                     std::collections::HashMap::new();
                 let mut reasoning_buffer = String::new();
+                let mut text_buffer = String::new();
 
                 while let Some(chunk_result) = byte_stream.next().await {
                     let chunk = chunk_result
@@ -333,19 +334,31 @@ impl Llm for DeepSeekClient {
                                                         (id, name, args)
                                                     })
                                                     .collect();
+                                                let tool_reasoning = if thinking_enabled {
+                                                    Some(std::mem::take(&mut reasoning_buffer))
+                                                } else {
+                                                    None
+                                                };
                                                 yield convert::create_tool_call_response(
                                                     tool_calls,
                                                     finish_reason,
+                                                    tool_reasoning,
                                                 );
                                                 continue;
                                             }
 
                                             let mut parts = Vec::new();
-                                            if let Some(delta) = &choice.delta
-                                                && let Some(text) = &delta.content
-                                                    && !text.is_empty() {
-                                                        parts.push(Part::Text { text: text.clone() });
-                                                    }
+                                            if !reasoning_buffer.is_empty() {
+                                                parts.push(Part::Thinking {
+                                                    thinking: std::mem::take(&mut reasoning_buffer),
+                                                    signature: None,
+                                                });
+                                            }
+                                            if !text_buffer.is_empty() {
+                                                parts.push(Part::Text {
+                                                    text: std::mem::take(&mut text_buffer),
+                                                });
+                                            }
 
                                             yield LlmResponse {
                                                 content: if parts.is_empty() {
@@ -373,10 +386,11 @@ impl Llm for DeepSeekClient {
                                                 ..Default::default()
                                             };
                                         } else {
-                                            // Emit partial text content
+                                            // Emit partial text content and accumulate
                                             if let Some(delta) = &choice.delta
                                                 && let Some(text) = &delta.content
                                                     && !text.is_empty() {
+                                                        text_buffer.push_str(text);
                                                         yield LlmResponse {
                                                             content: Some(adk_core::Content {
                                                                 role: "model".to_string(),

--- a/adk-model/src/deepseek/convert.rs
+++ b/adk-model/src/deepseek/convert.rs
@@ -372,16 +372,25 @@ pub fn from_response(response: &ChatCompletionResponse) -> LlmResponse {
 pub fn create_tool_call_response(
     tool_calls: Vec<(String, String, Value)>, // (id, name, args)
     finish_reason: Option<FinishReason>,
+    reasoning: Option<String>,
 ) -> LlmResponse {
-    let parts: Vec<Part> = tool_calls
-        .into_iter()
-        .map(|(id, name, args)| Part::FunctionCall {
-            name,
-            args,
-            id: Some(id),
-            thought_signature: None,
-        })
-        .collect();
+    let mut parts: Vec<Part> = Vec::new();
+
+    if let Some(ref text) = reasoning
+        && !text.is_empty()
+    {
+        parts.push(Part::Thinking {
+            thinking: text.clone(),
+            signature: None,
+        });
+    }
+
+    parts.extend(tool_calls.into_iter().map(|(id, name, args)| Part::FunctionCall {
+        name,
+        args,
+        id: Some(id),
+        thought_signature: None,
+    }));
 
     LlmResponse {
         content: Some(Content { role: "model".to_string(), parts }),


### PR DESCRIPTION
The streaming finish handler was emitting partial=true chunks for Thinking and Text separately, but the final partial=false event only contained the last delta text — accumulated reasoning and text content were lost.

Since the runner persists only partial=false events, replayed sessions lost both thinking and text content.

- Add text_buffer alongside reasoning_buffer
- Accumulate text content during streaming chunks
- Reconstruct final event parts from accumulated buffers
- Include accumulated reasoning in tool call responses

## What

Brief description of the change.

## Why

Link to the issue this addresses: Fixes #___

## How

Summary of the approach taken.

## PR Checklist

### Quality Gates (all required)

- [ ] `devenv shell fmt` — code is formatted (Edition 2024)
- [ ] `devenv shell clippy` — zero warnings (-D warnings)
- [ ] `devenv shell test` — all non-ignored tests pass
- [ ] `devenv shell check` — fast workspace compilation check

### Code Quality

- [ ] New code has tests (unit, integration, or property tests as appropriate)
- [ ] Public APIs have rustdoc comments with `# Example` sections
- [ ] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [ ] No hardcoded secrets, API keys, or local paths

### Hygiene

- [ ] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [ ] No unrelated changes mixed in (formatting, refactoring, other features)
- [ ] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [ ] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [ ] PR targets `main` branch

### Documentation (if applicable)

- [ ] CHANGELOG.md updated for user-facing changes
- [ ] README updated if crate capabilities changed
- [ ] Examples added or updated for new features
