### PR TITLE
fix(model): update deepseek max tokens config

### DIFF
--- a/adk-model/src/deepseek/config.rs
+++ b/adk-model/src/deepseek/config.rs
@@ -133,7 +133,7 @@ impl DeepSeekConfig {
             model: "deepseek-v4-pro".to_string(),
             thinking: Some(ThinkingMode::Enabled),
             reasoning_effort: Some(ReasoningEffort::High),
-            max_tokens: Some(8192),
+            max_tokens: Some(393_216),
             ..Default::default()
         }
     }
@@ -143,6 +143,7 @@ impl DeepSeekConfig {
         Self {
             api_key: api_key.into(),
             model: "deepseek-v4-flash".to_string(),
+            max_tokens: Some(393_216),
             ..Default::default()
         }
     }
@@ -263,6 +264,7 @@ mod tests {
         assert_eq!(config.model, "deepseek-v4-pro");
         assert_eq!(config.thinking, Some(ThinkingMode::Enabled));
         assert_eq!(config.reasoning_effort, Some(ReasoningEffort::High));
+        assert_eq!(config.max_tokens, Some(393_216));
         assert!(config.is_thinking_enabled());
     }
 
@@ -270,6 +272,7 @@ mod tests {
     fn test_v4_flash_constructor() {
         let config = DeepSeekConfig::v4_flash("key");
         assert_eq!(config.model, "deepseek-v4-flash");
+        assert_eq!(config.max_tokens, Some(393_216));
         assert!(config.thinking.is_none());
     }
 

--- a/adk-model/src/deepseek/convert.rs
+++ b/adk-model/src/deepseek/convert.rs
@@ -379,10 +379,7 @@ pub fn create_tool_call_response(
     if let Some(ref text) = reasoning
         && !text.is_empty()
     {
-        parts.push(Part::Thinking {
-            thinking: text.clone(),
-            signature: None,
-        });
+        parts.push(Part::Thinking { thinking: text.clone(), signature: None });
     }
 
     parts.extend(tool_calls.into_iter().map(|(id, name, args)| Part::FunctionCall {


### PR DESCRIPTION
## What

Updates DeepSeek V4 Pro and Flash config presets to use a 393,216 max token limit.

## Why

DeepSeek V4 supports a 384K token limit, so the config presets should reflect that capacity.

Reference: https://api-docs.deepseek.com/zh-cn/quick_start/pricing

Fixes #406

## How

Sets `max_tokens: Some(393_216)` for `DeepSeekConfig::v4_pro` and `DeepSeekConfig::v4_flash`, and updates the existing constructor tests.

## PR Checklist

### Quality Gates (all required)

- [x] `cargo fmt --all` — code is formatted
- [x] `cargo test -p adk-model deepseek::config --features deepseek` — affected tests pass
- [x] `cargo clippy -p adk-model --all-targets --features deepseek -- -D warnings` — zero warnings

### Code Quality

- [x] Existing tests updated for the config default change
- [x] No public API added
- [x] No `println!` / `eprintln!` in library code
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts
- [x] No unrelated changes mixed in
- [x] Branch naming follows convention
- [x] Commit message follows conventional format
- [x] PR targets `main` branch

### Documentation

- [x] Not applicable: no README or examples needed for this config default update