### PR TITLE
fix(model): turn_complete=false on tool-call responses (#401)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that renders live `bash` output and one-shot tool results (`read_file`, `grep`,
   `glob`) from a single event feed. Also runs as a console demo (`-- cli`).
 
+### Fixed
+
+- **adk-model: `turn_complete` on tool-call responses** (#401) — `deepseek` and
+  `openai_compatible` providers no longer set `turn_complete: true` when a
+  response carries tool calls; the turn continues until tool results are
+  processed. Adds `Content::has_function_calls()` to `adk-core`. Direct
+  `LlmResponseStream` consumers can now rely on `turn_complete` instead of
+  scanning for `Part::FunctionCall`.
+
 ### Added
 
 - **adk-realtime: GA realtime providers + integration tool dispatch** — OpenAI

--- a/adk-core/src/types.rs
+++ b/adk-core/src/types.rs
@@ -273,6 +273,32 @@ pub enum Part {
 }
 
 impl Content {
+    /// Returns `true` if any part of this content is a function (tool) call.
+    ///
+    /// Useful for deciding response semantics — e.g. a model turn that emits
+    /// tool calls is **not** complete, since tool results must still be
+    /// processed and sent back.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use adk_core::{Content, Part};
+    ///
+    /// let mut content = Content::new("model").with_text("calling a tool");
+    /// assert!(!content.has_function_calls());
+    ///
+    /// content.parts.push(Part::FunctionCall {
+    ///     name: "get_weather".to_string(),
+    ///     args: serde_json::json!({}),
+    ///     id: None,
+    ///     thought_signature: None,
+    /// });
+    /// assert!(content.has_function_calls());
+    /// ```
+    pub fn has_function_calls(&self) -> bool {
+        self.parts.iter().any(|p| matches!(p, Part::FunctionCall { .. }))
+    }
+
     /// Creates a new empty content with the given role.
     pub fn new(role: impl Into<String>) -> Self {
         Self { role: role.into(), parts: Vec::new() }

--- a/adk-model/src/deepseek/client.rs
+++ b/adk-model/src/deepseek/client.rs
@@ -360,15 +360,21 @@ impl Llm for DeepSeekClient {
                                                 });
                                             }
 
+                                            let content = if parts.is_empty() {
+                                                None
+                                            } else {
+                                                Some(adk_core::Content {
+                                                    role: "model".to_string(),
+                                                    parts,
+                                                })
+                                            };
+                                            // Tool-call turns are not complete (issue #401).
+                                            let turn_complete = content
+                                                .as_ref()
+                                                .is_none_or(|c| !c.has_function_calls());
+
                                             yield LlmResponse {
-                                                content: if parts.is_empty() {
-                                                    None
-                                                } else {
-                                                    Some(adk_core::Content {
-                                                        role: "model".to_string(),
-                                                        parts,
-                                                    })
-                                                },
+                                                content,
                                                 usage_metadata: chunk_response.usage.map(|u| {
                                                     adk_core::UsageMetadata {
                                                         prompt_token_count: u.prompt_tokens as i32,
@@ -382,7 +388,7 @@ impl Llm for DeepSeekClient {
                                                 }),
                                                 finish_reason,
                                                 partial: false,
-                                                turn_complete: true,
+                                                turn_complete,
                                                 ..Default::default()
                                             };
                                         } else {

--- a/adk-model/src/deepseek/convert.rs
+++ b/adk-model/src/deepseek/convert.rs
@@ -353,13 +353,17 @@ pub fn from_response(response: &ChatCompletionResponse) -> LlmResponse {
         ..Default::default()
     });
 
+    // A turn that emits tool calls is not complete — tool results must still be
+    // processed and sent back to the model (issue #401).
+    let turn_complete = content.as_ref().is_none_or(|c| !c.has_function_calls());
+
     LlmResponse {
         content,
         usage_metadata: usage,
         finish_reason,
         citation_metadata: None,
         partial: false,
-        turn_complete: true,
+        turn_complete,
         interrupted: false,
         error_code: None,
         error_message: None,
@@ -379,10 +383,7 @@ pub fn create_tool_call_response(
     if let Some(ref text) = reasoning
         && !text.is_empty()
     {
-        parts.push(Part::Thinking {
-            thinking: text.clone(),
-            signature: None,
-        });
+        parts.push(Part::Thinking { thinking: text.clone(), signature: None });
     }
 
     parts.extend(tool_calls.into_iter().map(|(id, name, args)| Part::FunctionCall {
@@ -398,7 +399,8 @@ pub fn create_tool_call_response(
         finish_reason,
         citation_metadata: None,
         partial: false,
-        turn_complete: true,
+        // This response carries tool calls, so the turn continues (issue #401).
+        turn_complete: false,
         interrupted: false,
         error_code: None,
         error_message: None,
@@ -410,6 +412,18 @@ pub fn create_tool_call_response(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn tool_call_response_is_not_turn_complete() {
+        // Issue #401: a response carrying tool calls must not mark the turn complete.
+        let resp = create_tool_call_response(
+            vec![("call_1".to_string(), "get_weather".to_string(), serde_json::json!({}))],
+            Some(FinishReason::Stop),
+            None,
+        );
+        assert!(!resp.turn_complete);
+        assert!(resp.content.as_ref().unwrap().has_function_calls());
+    }
 
     #[test]
     fn content_to_message_keeps_inline_attachment_payload() {

--- a/adk-model/src/openai_compatible.rs
+++ b/adk-model/src/openai_compatible.rs
@@ -643,7 +643,9 @@ impl Llm for OpenAICompatible {
                                         finish_reason,
                                         citation_metadata: None,
                                         partial: false,
-                                        turn_complete: true,
+                                        // Tool-call turns are not complete — tool
+                                        // results must still be processed (issue #401).
+                                        turn_complete: false,
                                         interrupted: false,
                                         error_code: None,
                                         error_message: None,

--- a/adk-model/tests/openai_streaming_exploration_tests.rs
+++ b/adk-model/tests/openai_streaming_exploration_tests.rs
@@ -312,8 +312,9 @@ mod streaming_exploration {
         let final_resp = responses.last().unwrap();
         assert!(!final_resp.partial, "final response with tool calls should have partial=false");
         assert!(
-            final_resp.turn_complete,
-            "final response with tool calls should have turn_complete=true"
+            !final_resp.turn_complete,
+            "final response carrying tool calls must have turn_complete=false — the turn \
+             continues until tool results are processed (issue #401)"
         );
     }
 


### PR DESCRIPTION
## What

`deepseek` and `openai_compatible` providers set `turn_complete: true` on the final `LlmResponse` even when it carries tool calls. They now set `turn_complete: false` in that case — the turn continues until tool results are processed and sent back.

Adds `Content::has_function_calls()` to `adk-core` to derive the flag.

## Why

Fixes #401. Consumers that read `LlmResponseStream` directly (not via `adk-runner`) rely on `turn_complete` to distinguish "model finished" from "model is calling tools". Hardcoding `true` forced them to scan for `Part::FunctionCall` as a workaround. `adk-runner` does not read the field, so the runner is unaffected.

## How

- `adk-core`: new `Content::has_function_calls()` helper (additive).
- `deepseek/convert.rs`: final response derives `turn_complete` from content; `create_tool_call_response` is always `false`.
- `deepseek/client.rs`: streaming final derives `turn_complete` from content.
- `openai_compatible.rs`: the tool-call yield is `false`.
- Updated the streaming exploration test that asserted the old behavior; added a unit test.

Scoped to the two providers named in the issue.

## Verification

- `cargo nextest run -p adk-model --features "openai deepseek"` — affected tests pass (incl. the previously-failing `tool_call_chunks_accumulated_and_yielded_on_finish`).
- clippy `-D warnings` + fmt clean (pre-commit hook).
