### PR TITLE
fix(core): fix duplicate provider_metadata key in Event JSON serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **adk-core: Event serialization no longer produces duplicate `"provider_metadata"` keys.**
+  `Event.provider_metadata` is now serialized as `"event_metadata"` to avoid collision
+  with `LlmResponse.provider_metadata` (which is flattened into the same JSON object).
+  Regression test added. (`#414`)
+
 ## [2.0.0] - 2026-06-28
 
 ### Changed

--- a/adk-core/src/event.rs
+++ b/adk-core/src/event.rs
@@ -51,7 +51,9 @@ pub struct Event {
     pub llm_request: Option<String>,
     /// Provider-specific metadata (e.g., GCP Vertex, Azure OpenAI).
     /// Keeps the core Event struct provider-agnostic.
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    /// Serialized as `"event_metadata"` to avoid collision with
+    /// [`LlmResponse::provider_metadata`](crate::LlmResponse) when flattened.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty", rename = "event_metadata")]
     pub provider_metadata: HashMap<String, String>,
 }
 
@@ -635,6 +637,33 @@ mod tests {
         });
         // Trailing function response -> NOT final
         assert!(!event.is_final_response());
+    }
+
+    #[test]
+    fn test_event_roundtrip_with_both_provider_metadata() {
+        let mut event = Event::new("inv-1");
+        event.provider_metadata.insert("adk.tool_progress.stream".into(), "stdout".into());
+        event.provider_metadata.insert("adk.tool_progress.call_id".into(), "call-7".into());
+        event.llm_response.provider_metadata = Some(serde_json::json!({"response_id": "resp-xyz"}));
+
+        let json = serde_json::to_string(&event).expect("serialize");
+        // Round-trip must succeed — regression test for the duplicate
+        // `provider_metadata` flatten collision with LlmResponse.
+        let back: Event = serde_json::from_str(&json)
+            .expect("round-trip must succeed without duplicate field error");
+
+        assert_eq!(
+            back.provider_metadata.get("adk.tool_progress.stream").map(String::as_str),
+            Some("stdout"),
+        );
+        assert_eq!(
+            back.provider_metadata.get("adk.tool_progress.call_id").map(String::as_str),
+            Some("call-7"),
+        );
+        assert_eq!(
+            back.llm_response.provider_metadata,
+            Some(serde_json::json!({"response_id": "resp-xyz"})),
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Fix duplicate `provider_metadata` key in Event JSON serialization caused by `#[serde(flatten)]` collision between `Event.provider_metadata` and `LlmResponse.provider_metadata`.

## Why

Fixes #414

When both `Event.provider_metadata` and `LlmResponse.provider_metadata` are populated, `serde_json::to_string` produces a JSON object with two `"provider_metadata"` keys, and `serde_json::from_str` rejects it with `duplicate field 'provider_metadata'`. This breaks round-trip serialization for Event — currently triggered by the Vertex agent path in `adk-agent` and growing as more providers set `llm_response.provider_metadata`.

## How

Renamed the serde serialization name of `Event.provider_metadata` to `"event_metadata"` via `#[serde(rename = "event_metadata")]`. The Rust field name stays `provider_metadata` — zero Rust API breakage. `LlmResponse.provider_metadata` continues to serialize as `"provider_metadata"`. Added a regression test (`test_event_roundtrip_with_both_provider_metadata`) that round-trips an Event with both fields populated.

## PR Checklist

### Quality Gates (all required)

- [X] `devenv shell fmt` — code is formatted (Edition 2024)
- [X] `devenv shell clippy` — zero warnings (-D warnings)
- [X] `devenv shell test` — all non-ignored tests pass
- [X] `devenv shell check` — fast workspace compilation check

### Code Quality

- [X] New code has tests (unit, integration, or property tests as appropriate)
- [X] Public APIs have rustdoc comments with `# Example` sections
- [X] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [X] No hardcoded secrets, API keys, or local paths

### Hygiene

- [X] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [X] No unrelated changes mixed in (formatting, refactoring, other features)
- [X] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [X] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [X] PR targets `main` branch

### Documentation (if applicable)

- [X] CHANGELOG.md updated for user-facing changes
- [ ] README updated if crate capabilities changed
- [ ] Examples added or updated for new features
