### PR TITLE
Gemini realtime + memory fixes: batched tool calls, text() concat, add_entry, list_recent

### DIFF
--- a/adk-gemini/src/generation/model.rs
+++ b/adk-gemini/src/generation/model.rs
@@ -378,17 +378,30 @@ pub struct PromptFeedback {
 }
 
 impl GenerationResponse {
-    /// Get the text of the first candidate
+    /// Get the visible answer text of the first candidate.
+    ///
+    /// Concatenates every non-thought text part, in order. This is deliberately
+    /// not "the first part": responses that use thinking or built-in tools
+    /// (Google Search, URL context, code execution) commonly lead with thought
+    /// or tool parts and place the answer text in a later part — so reading only
+    /// the first part would return an empty string. Thought parts are excluded;
+    /// use [`text_with_thoughts`](Self::text_with_thoughts) to inspect them.
     pub fn text(&self) -> String {
         self.candidates
             .first()
-            .and_then(|c| {
-                c.content.parts.as_ref().and_then(|parts| {
-                    parts.first().and_then(|p| match p {
-                        Part::Text { text, thought: _, thought_signature: _ } => Some(text.clone()),
+            .and_then(|c| c.content.parts.as_ref())
+            .map(|parts| {
+                parts
+                    .iter()
+                    .filter_map(|p| match p {
+                        Part::Text { text, thought, thought_signature: _ }
+                            if !thought.unwrap_or(false) =>
+                        {
+                            Some(text.as_str())
+                        }
                         _ => None,
                     })
-                })
+                    .collect::<String>()
             })
             .unwrap_or_default()
     }

--- a/adk-memory/src/inmemory.rs
+++ b/adk-memory/src/inmemory.rs
@@ -164,6 +164,25 @@ impl MemoryService for InMemoryMemoryService {
         Ok(removed)
     }
 
+    async fn list_recent(
+        &self,
+        app_name: &str,
+        user_id: &str,
+        limit: usize,
+    ) -> Result<Vec<MemoryEntry>> {
+        let key = MemoryKey { app_name: app_name.to_string(), user_id: user_id.to_string() };
+        let store = self.store.read().unwrap();
+        let mut entries: Vec<MemoryEntry> = store
+            .get(&key)
+            .map(|sessions| {
+                sessions.values().flatten().map(|stored| stored.entry.clone()).collect()
+            })
+            .unwrap_or_default();
+        entries.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        entries.truncate(limit);
+        Ok(entries)
+    }
+
     async fn delete_entries_in_project(
         &self,
         app_name: &str,

--- a/adk-memory/src/postgres.rs
+++ b/adk-memory/src/postgres.rs
@@ -782,6 +782,71 @@ impl MemoryService for PostgresMemoryService {
         Ok(())
     }
 
+    /// Add a single global entry (`project_id = NULL`).
+    ///
+    /// Without this override the trait default returns "not implemented",
+    /// making direct global writes impossible on the Postgres backend even
+    /// though project-scoped writes work.
+    #[instrument(skip_all, fields(app_name = %app_name, user_id = %user_id))]
+    async fn add_entry(&self, app_name: &str, user_id: &str, entry: MemoryEntry) -> Result<()> {
+        let text = crate::text::extract_text(&entry.content);
+        let content_json = serde_json::to_value(&entry.content)
+            .map_err(|e| adk_core::AdkError::memory(format!("serialization failed: {e}")))?;
+
+        if let Some(provider) = &self.embedding_provider {
+            let embed_text = if text.is_empty() { " ".to_string() } else { text.clone() };
+            let embeddings = provider.embed(&[embed_text]).await.map_err(|e| {
+                adk_core::AdkError::memory(format!("embedding generation failed: {e}"))
+            })?;
+            let embedding =
+                pgvector::Vector::from(embeddings.into_iter().next().ok_or_else(|| {
+                    adk_core::AdkError::memory(
+                        "embedding provider returned empty result".to_string(),
+                    )
+                })?);
+            sqlx::query(
+                r#"
+                INSERT INTO memory_entries
+                    (app_name, user_id, session_id, content, author, timestamp, embedding, search_text, project_id)
+                VALUES
+                    ($1, $2, $3, $4, $5, $6, $7, to_tsvector('simple', $8), NULL)
+                "#,
+            )
+            .bind(app_name)
+            .bind(user_id)
+            .bind("")
+            .bind(&content_json)
+            .bind(&entry.author)
+            .bind(entry.timestamp)
+            .bind(embedding)
+            .bind(&text)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| adk_core::AdkError::memory(format!("insert failed: {e}")))?;
+        } else {
+            sqlx::query(
+                r#"
+                INSERT INTO memory_entries
+                    (app_name, user_id, session_id, content, author, timestamp, search_text, project_id)
+                VALUES
+                    ($1, $2, $3, $4, $5, $6, to_tsvector('simple', $7), NULL)
+                "#,
+            )
+            .bind(app_name)
+            .bind(user_id)
+            .bind("")
+            .bind(&content_json)
+            .bind(&entry.author)
+            .bind(entry.timestamp)
+            .bind(&text)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| adk_core::AdkError::memory(format!("insert failed: {e}")))?;
+        }
+
+        Ok(())
+    }
+
     #[instrument(skip_all, fields(app_name = %app_name, user_id = %user_id, project_id = %project_id))]
     async fn add_entry_to_project(
         &self,

--- a/adk-memory/src/postgres.rs
+++ b/adk-memory/src/postgres.rs
@@ -654,6 +654,45 @@ impl MemoryService for PostgresMemoryService {
         Ok(SearchResponse { memories })
     }
 
+    #[instrument(skip_all, fields(app_name = %app_name, user_id = %user_id, limit = %limit))]
+    async fn list_recent(
+        &self,
+        app_name: &str,
+        user_id: &str,
+        limit: usize,
+    ) -> Result<Vec<MemoryEntry>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT content, author, timestamp
+            FROM memory_entries
+            WHERE app_name = $1 AND user_id = $2
+            ORDER BY timestamp DESC
+            LIMIT $3
+            "#,
+        )
+        .bind(app_name)
+        .bind(user_id)
+        .bind(limit as i64)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| adk_core::AdkError::memory(format!("list_recent failed: {e}")))?;
+
+        Ok(rows
+            .into_iter()
+            .map(|row| {
+                let content_json: serde_json::Value = row.get("content");
+                let content: adk_core::Content = serde_json::from_value(content_json)
+                    .unwrap_or_else(|_| adk_core::Content {
+                        role: "user".to_string(),
+                        parts: vec![],
+                    });
+                let author: String = row.get("author");
+                let timestamp: chrono::DateTime<chrono::Utc> = row.get("timestamp");
+                MemoryEntry { content, author, timestamp }
+            })
+            .collect())
+    }
+
     #[instrument(skip_all, fields(app_name = %app_name, user_id = %user_id))]
     async fn delete_user(&self, app_name: &str, user_id: &str) -> Result<()> {
         sqlx::query("DELETE FROM memory_entries WHERE app_name = $1 AND user_id = $2")

--- a/adk-memory/src/service.rs
+++ b/adk-memory/src/service.rs
@@ -85,6 +85,20 @@ pub trait MemoryService: Send + Sync {
         Err(adk_core::AdkError::memory("delete_entries not implemented"))
     }
 
+    /// List the most recent entries for a user (global + project-scoped),
+    /// newest first. Unlike `search`, this is a pure recency listing — no
+    /// query, no similarity ranking — suitable for "what does the agent
+    /// remember?" UIs and latest-item lookups.
+    async fn list_recent(
+        &self,
+        app_name: &str,
+        user_id: &str,
+        limit: usize,
+    ) -> Result<Vec<MemoryEntry>> {
+        let _ = (app_name, user_id, limit);
+        Err(adk_core::AdkError::memory("list_recent not implemented"))
+    }
+
     /// Verify backend connectivity.
     ///
     /// Returns `Ok(())` if the backend is reachable and responsive.

--- a/adk-realtime/src/gemini/session.rs
+++ b/adk-realtime/src/gemini/session.rs
@@ -619,21 +619,29 @@ impl GeminiRealtimeSession {
         // Check for tool calls
         if let Some(tool_call) = value.get("toolCall")
             && let Some(calls) = tool_call.get("functionCalls").and_then(|c| c.as_array())
-            && let Some(call) = calls.first()
+            && !calls.is_empty()
         {
-            let name = call.get("name").and_then(|n| n.as_str()).unwrap_or("");
-            let id = call.get("id").and_then(|i| i.as_str()).unwrap_or("");
-            let args = call.get("args").cloned().unwrap_or(json!({}));
-
-            return Ok(vec![ServerEvent::FunctionCallDone {
-                event_id: uuid::Uuid::new_v4().to_string(),
-                response_id: String::new(),
-                item_id: String::new(),
-                output_index: 0,
-                call_id: id.to_string(),
-                name: name.to_string(),
-                arguments: serde_json::to_string(&args).unwrap_or_default(),
-            }]);
+            // Gemini batches parallel function calls in one frame; emit one
+            // event per call — dropping any leaves the model waiting forever
+            // for the missing function response.
+            return Ok(calls
+                .iter()
+                .enumerate()
+                .map(|(idx, call)| {
+                    let name = call.get("name").and_then(|n| n.as_str()).unwrap_or("");
+                    let id = call.get("id").and_then(|i| i.as_str()).unwrap_or("");
+                    let args = call.get("args").cloned().unwrap_or(json!({}));
+                    ServerEvent::FunctionCallDone {
+                        event_id: uuid::Uuid::new_v4().to_string(),
+                        response_id: String::new(),
+                        item_id: String::new(),
+                        output_index: idx as u32,
+                        call_id: id.to_string(),
+                        name: name.to_string(),
+                        arguments: serde_json::to_string(&args).unwrap_or_default(),
+                    }
+                })
+                .collect());
         }
 
         Ok(vec![ServerEvent::Unknown])


### PR DESCRIPTION
## Summary

Four fixes/additions driven by a production realtime-agent deployment (Gemini Live + adk-memory):

- **fix(realtime)**: a batched Gemini `toolCall` frame emits **every** function call, not just the first — parallel tool calls were being silently dropped.
- **fix(adk-gemini)**: `GenerationResponse::text()` concatenates all non-thought `Text` parts; it previously read only `parts.first()`, returning empty non-deterministically when the model emitted a thought part first.
- **fix(memory)**: implement `add_entry` on `PostgresMemoryService` (was default-unimplemented).
- **feat(memory)**: new `MemoryService::list_recent(app, user, limit)` — a pure recency listing (`ORDER BY timestamp DESC` in Postgres, timestamp sort in-memory). `search()` requires a query and ranks by similarity, which is the wrong primitive for "what does the agent remember?" UIs and latest-entry lookups.

## Verification
- Workspace builds; downstream consumer (amos) builds and its memory-hygiene test suite passes against these changes (dedup skip/keep, forget, recency ordering).