### PR TITLE
docs: fix broken intra-doc links surfaced by workspace doc gate

### DIFF
--- a/adk-agent/src/coding/mod.rs
+++ b/adk-agent/src/coding/mod.rs
@@ -1,4 +1,4 @@
-//! A coding-agent harness built on [`LlmAgent`](crate::LlmAgent).
+//! A coding-agent harness built on [`LlmAgent`].
 //!
 //! [`CodingAgent`] wires the [`adk_devtools`] developer toolset, a planning
 //! [`TodoTool`], and a minimal coding system prompt into a ready-to-run agent —

--- a/adk-audio/src/pipeline/builder.rs
+++ b/adk-audio/src/pipeline/builder.rs
@@ -211,7 +211,7 @@ impl AudioPipelineBuilder {
     /// When the `desktop-audio` feature is enabled and both `capture` and `playback`
     /// are configured, the caller should use the returned [`PipelineHandle`] to wire
     /// the capture stream into `input_tx` and route `output_rx` audio frames to
-    /// playback. Starting capture requires a device ID and [`CaptureConfig`](crate::desktop::CaptureConfig),
+    /// playback. Starting capture requires a device ID and a `CaptureConfig` (with the `desktop-audio` feature),
     /// and playback requires a device ID, so the builder stores the instances and
     /// the caller completes the wiring at runtime.
     pub fn build_voice_agent(self) -> AudioResult<PipelineHandle> {

--- a/adk-auth/src/secrets/provider.rs
+++ b/adk-auth/src/secrets/provider.rs
@@ -38,7 +38,7 @@ pub trait SecretProvider: Send + Sync {
 
 /// Adapter that wraps a [`SecretProvider`] as a
 /// [`SecretService`](adk_core::SecretService) for use with the runner's
-/// [`InvocationContext`].
+/// [`InvocationContext`](adk_core::InvocationContext).
 ///
 /// # Example
 ///

--- a/adk-bench/src/config.rs
+++ b/adk-bench/src/config.rs
@@ -1,7 +1,7 @@
 //! Benchmark configuration types mapped from CLI flags.
 //!
 //! This module defines [`BenchConfig`], the top-level configuration struct
-//! that maps CLI parameters to structured settings for the [`BenchRunner`].
+//! that maps CLI parameters to structured settings for the [`BenchRunner`](crate::BenchRunner).
 //! It also defines supporting types like [`OutputFormat`], [`TaskSuite`],
 //! and [`ExternalFrameworkConfig`].
 

--- a/adk-bench/src/external.rs
+++ b/adk-bench/src/external.rs
@@ -154,8 +154,8 @@ impl ExternalRunner {
     ///
     /// # Errors
     ///
-    /// - [`BenchError::ExternalTimeout`] if the subprocess exceeds the configured timeout
-    /// - [`BenchError::ExternalRunner`] if the subprocess exits with non-zero status or emits invalid JSON
+    /// - [`BenchError::ExternalTimeout`](crate::BenchError::ExternalTimeout) if the subprocess exceeds the configured timeout
+    /// - [`BenchError::ExternalRunner`](crate::BenchError::ExternalRunner) if the subprocess exits with non-zero status or emits invalid JSON
     pub async fn run(
         &self,
         config: &ExternalFrameworkConfig,
@@ -313,8 +313,8 @@ pub struct ExternalConfigFile {
 ///
 /// # Errors
 ///
-/// Returns [`BenchError::Io`] if the file cannot be read, or
-/// [`BenchError::Serialization`] if the JSON is invalid.
+/// Returns [`BenchError::Io`](crate::BenchError::Io) if the file cannot be read, or
+/// [`BenchError::Serialization`](crate::BenchError::Serialization) if the JSON is invalid.
 ///
 /// # Example
 ///

--- a/adk-cli/src/cli.rs
+++ b/adk-cli/src/cli.rs
@@ -100,7 +100,7 @@ pub enum Commands {
         #[arg(long, default_value_t = 8)]
         max_iters: u32,
 
-        /// Path to the durable goal-state file (default: <dir>/.adk/goal.json).
+        /// Path to the durable goal-state file (default: `<dir>/.adk/goal.json`).
         #[arg(long)]
         state: Option<String>,
 

--- a/adk-eval/src/conversation_scorer.rs
+++ b/adk-eval/src/conversation_scorer.rs
@@ -2,8 +2,8 @@
 //!
 //! The [`ConversationScorer`] evaluates multi-turn conversations using a
 //! [`StructuredJudge`] for semantic metrics (context retention, goal completion,
-//! coherence) and optionally an [`EmbeddingScorer`](crate::EmbeddingScorer) for
-//! topic drift measurement.
+//! coherence) and optionally an `EmbeddingScorer` (with the `embedding` feature)
+//! for topic drift measurement.
 //!
 //! # Example
 //!
@@ -87,7 +87,7 @@ impl Default for ConversationScorerConfig {
 /// Scores multi-turn conversations on quality metrics.
 ///
 /// Uses a [`StructuredJudge`] for context retention, goal completion, and
-/// coherence metrics. For topic drift, uses an [`EmbeddingScorer`] if available,
+/// coherence metrics. For topic drift, uses an `EmbeddingScorer` if available,
 /// otherwise falls back to the structured judge.
 pub struct ConversationScorer {
     judge: StructuredJudge,

--- a/adk-eval/src/test_generator.rs
+++ b/adk-eval/src/test_generator.rs
@@ -2,7 +2,7 @@
 //!
 //! Generates evaluation test cases from natural language descriptions (via LLM)
 //! or from production event logs (direct extraction). Produced cases follow
-//! the standard [`TestFile`] JSON format and include generation metadata.
+//! the standard [`TestFile`](crate::TestFile) JSON format and include generation metadata.
 //!
 //! # Example
 //!

--- a/adk-mistralrs/src/lib.rs
+++ b/adk-mistralrs/src/lib.rs
@@ -127,17 +127,17 @@
 //!
 //! ## Module Overview
 //!
-//! - [`client`] - Main [`MistralRsModel`] implementing the ADK [`Llm`] trait
-//! - [`config`] - Configuration types: [`MistralRsConfig`], [`ModelSource`], [`QuantizationLevel`]
-//! - [`adapter`] - LoRA/X-LoRA adapter support via [`MistralRsAdapterModel`]
-//! - [`vision`] - Vision model support via [`MistralRsVisionModel`]
-//! - [`embedding`] - Embedding model support via [`MistralRsEmbeddingModel`]
-//! - [`speech`] - Speech synthesis via [`MistralRsSpeechModel`]
-//! - [`diffusion`] - Image generation via [`MistralRsDiffusionModel`]
-//! - [`multimodel`] - Multi-model serving via [`MistralRsMultiModel`]
-//! - [`mcp`] - MCP client configuration via [`McpClientConfig`]
-//! - [`convert`] - Type conversion utilities between ADK and mistral.rs
-//! - [`error`] - Error types via [`MistralRsError`]
+//! - `client` - Main [`MistralRsModel`] implementing the ADK [`Llm`] trait
+//! - `config` - Configuration types: [`MistralRsConfig`], [`ModelSource`], [`QuantizationLevel`]
+//! - `adapter` - LoRA/X-LoRA adapter support via [`MistralRsAdapterModel`]
+//! - `vision` - Vision model support via [`MistralRsVisionModel`]
+//! - `embedding` - Embedding model support via [`MistralRsEmbeddingModel`]
+//! - `speech` - Speech synthesis via [`MistralRsSpeechModel`]
+//! - `diffusion` - Image generation via [`MistralRsDiffusionModel`]
+//! - `multimodel` - Multi-model serving via [`MistralRsMultiModel`]
+//! - `mcp` - MCP client configuration via [`McpClientConfig`]
+//! - `convert` - Type conversion utilities between ADK and mistral.rs
+//! - `error` - Error types via [`MistralRsError`]
 //!
 //! ## Feature Flags
 //!

--- a/adk-realtime/src/runner.rs
+++ b/adk-realtime/src/runner.rs
@@ -696,7 +696,7 @@ impl RealtimeRunner {
     /// This is the same dispatch the [`run`](Self::run) loop performs for a
     /// `response.function_call_arguments.done` event, exposed so that callers
     /// driving the session manually via [`next_event`](Self::next_event) — such
-    /// as [`IntegratedRealtimeRunner`](crate::integration::IntegratedRealtimeRunner) —
+    /// as `IntegratedRealtimeRunner` (available with the `integration` feature) —
     /// can execute tools without re-implementing the lookup/respond logic.
     pub async fn dispatch_tool_call(
         &self,

--- a/adk-telemetry/src/span_exporter.rs
+++ b/adk-telemetry/src/span_exporter.rs
@@ -7,7 +7,7 @@ use tracing_subscriber::{Layer, layer::Context, registry::LookupSpan};
 ///
 /// Implemented by [`AdkSpanExporter`] (in-memory, queried by the server debug
 /// routes) and, with the `sqlite` feature, by
-/// [`SqliteSpanExporter`](crate::sqlite::SqliteSpanExporter) (persistent,
+/// `SqliteSpanExporter` (persistent,
 /// zero-infrastructure tracing). Implementations decide which spans to keep —
 /// the layer forwards every closed span.
 pub trait SpanSink: Send + Sync {


### PR DESCRIPTION
## Summary

Follow-up to #417 (CI pipeline restructure). The collapsed `docs` job now runs `cargo doc --workspace --no-deps` with `-D warnings`, which validates intra-doc links across **all** workspace crates — the previous job only grepped for missing docs on a hand-picked subset. That stricter, broader gate surfaced pre-existing broken intra-doc links in nine crates. This PR fixes them so the new `docs` job is green.

## Fixes

- **Feature-gated items** referenced from always-compiled docs are now plain code spans (the doc build runs without those features): `EmbeddingScorer` (adk-eval), `CaptureConfig` (adk-audio), `SqliteSpanExporter` (adk-telemetry), `IntegratedRealtimeRunner` (adk-realtime).
- **adk-bench**: `BenchRunner` and `BenchError::{ExternalTimeout,ExternalRunner,Io,Serialization}` now link via their crate-root paths.
- **adk-eval**: `TestFile` links via `crate::TestFile`.
- **adk-auth**: `InvocationContext` links to `adk_core::InvocationContext`.
- **adk-mistralrs**: crate-doc module list no longer links to private modules (`client`, `config`, …) — those are code spans; the public type links remain.
- **adk-agent**: dropped a redundant explicit link target on `LlmAgent`.
- **adk-cli**: escaped `<dir>` in a clap help string so rustdoc stops parsing it as an HTML tag.

## Testing

- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` passes with exit 0 (previously failed across adk-realtime, adk-eval, adk-bench, adk-audio, adk-cli, adk-mistralrs, adk-auth, adk-telemetry, adk-agent).
- Pre-commit fmt + clippy passed; pre-push `cargo check --workspace` passed.

All changes are doc-comment only — no code or behavior changes.