### PR TITLE
test(realtime): benchmark Vec and Bytes audio payloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,6 +713,7 @@ dependencies = [
  "bytemuck",
  "bytes",
  "chrono",
+ "criterion",
  "dotenvy",
  "futures",
  "getrandom 0.3.4",
@@ -726,6 +727,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
+ "stats_alloc",
  "str0m",
  "thiserror 2.0.18",
  "tokio",
@@ -16963,6 +16965,12 @@ dependencies = [
  "num-traits",
  "rand 0.8.6",
 ]
+
+[[package]]
+name = "stats_alloc"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0e04424e733e69714ca1bbb9204c1a57f09f5493439520f9f68c132ad25eec"
 
 [[package]]
 name = "std_prelude"

--- a/adk-realtime/Cargo.toml
+++ b/adk-realtime/Cargo.toml
@@ -88,6 +88,8 @@ proptest = "1.5"
 url = "2.5"
 anyhow = "1.0"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+criterion = "0.5"
+stats_alloc = "0.1.10"
 
 [[example]]
 name = "openai_session_update"
@@ -129,6 +131,18 @@ required-features = ["openai-webrtc"]
 
 [[bench]]
 name = "livekit_pcm_bench"
+harness = false
+
+[[bench]]
+name = "audio_payload_ownership"
+harness = false
+
+[[bench]]
+name = "audio_payload_tail_latency"
+harness = false
+
+[[bench]]
+name = "audio_payload_allocations"
 harness = false
 
 [features]

--- a/adk-realtime/benches/README.md
+++ b/adk-realtime/benches/README.md
@@ -1,0 +1,42 @@
+# Realtime audio payload ownership benchmarks
+
+These benchmarks compare benchmark-local `Vec<u8>` and `bytes::Bytes` audio chunks before any production or public API change is proposed.
+
+## Scope
+
+The matrix uses realistic 20 ms frames:
+
+| Format | Bytes |
+|---|---:|
+| G.711 mu-law, 8 kHz mono | 160 |
+| PCM16, 16 kHz mono | 640 |
+| PCM16, 24 kHz mono | 960 |
+
+`audio_payload_ownership` measures owned and borrowed construction, one clone, and four-way fan-out with Criterion. `audio_payload_tail_latency` measures bounded Tokio task handoff and four-task fan-out. `audio_payload_allocations` reports allocation operations, allocated bytes, and live heap while fan-out clones are held.
+
+Provider calls, sockets, codecs, resampling, Base64 encoding, and network latency are intentionally excluded. The results cannot support claims about complete provider runtime performance.
+
+## Reproduction
+
+Run from the repository root through the reproducible development shell:
+
+```bash
+devenv shell cargo bench -p adk-realtime --no-default-features --bench audio_payload_ownership
+devenv shell cargo bench -p adk-realtime --no-default-features --bench audio_payload_tail_latency
+devenv shell cargo bench -p adk-realtime --no-default-features --bench audio_payload_allocations
+```
+
+Before recording results, capture the environment:
+
+```bash
+rustc -Vv
+cargo -V
+uname -a
+lscpu
+```
+
+Use an otherwise idle machine and the default optimized bench profile. Run the complete matrix three times without changing the environment, and report the median result for each metric. Do not commit generated Criterion output under `target/`.
+
+## Interpretation
+
+An internal `Bytes` follow-up is justified only when four-way fan-out reduces p95 latency by at least 15% on two of the three frame sizes, reduces allocated bytes by at least 50%, and does not regress move-only p95 latency by more than 5%. Any public `AudioChunk` storage change remains a separate Semver-reviewed proposal.

--- a/adk-realtime/benches/README.md
+++ b/adk-realtime/benches/README.md
@@ -37,6 +37,70 @@ lscpu
 
 Use an otherwise idle machine and the default optimized bench profile. Run the complete matrix three times without changing the environment, and report the median result for each metric. Do not commit generated Criterion output under `target/`.
 
-## Interpretation
+## Decision criteria
 
 An internal `Bytes` follow-up is justified only when four-way fan-out reduces p95 latency by at least 15% on two of the three frame sizes, reduces allocated bytes by at least 50%, and does not regress move-only p95 latency by more than 5%. Any public `AudioChunk` storage change remains a separate Semver-reviewed proposal.
+
+## Recorded discovery
+
+The matrix was run three times on July 16, 2026. The tables report the median of the three optimized runs. A negative change means `Bytes` was faster than `Vec`; a positive change means it was slower.
+
+Environment:
+
+- Linux `michael-MacPro5-1`, kernel `7.1.3-x64v2-xanmod1`
+- x86_64, dual Intel Xeon E5520 at 2.27 GHz, 16 logical CPUs
+- rustc 1.94.0 with LLVM 21.1.8
+- cargo 1.94.0
+- default optimized benchmark profile
+
+### Synchronous ownership cost
+
+| Scenario | Frame | `Vec` | `Bytes` | Change |
+|---|---|---:|---:|---:|
+| owned | 160 B | 13.578 ns | 12.247 ns | -9.8% |
+| owned | 640 B | 14.606 ns | 13.222 ns | -9.5% |
+| owned | 960 B | 15.085 ns | 13.860 ns | -8.1% |
+| borrowed | 160 B | 32.098 ns | 41.140 ns | +28.2% |
+| borrowed | 640 B | 43.946 ns | 52.373 ns | +19.2% |
+| borrowed | 960 B | 52.096 ns | 63.078 ns | +21.1% |
+| clone once | 160 B | 30.515 ns | 27.917 ns | -8.5% |
+| clone once | 640 B | 42.170 ns | 27.965 ns | -33.7% |
+| clone once | 960 B | 52.560 ns | 28.438 ns | -45.9% |
+| fan-out four | 160 B | 137.90 ns | 174.38 ns | +26.5% |
+| fan-out four | 640 B | 189.49 ns | 173.28 ns | -8.6% |
+| fan-out four | 960 B | 228.36 ns | 177.62 ns | -22.2% |
+
+### Cross-task p95 latency
+
+| Scenario | Frame | `Vec` p95 | `Bytes` p95 | Change |
+|---|---|---:|---:|---:|
+| move | 160 B | 1,523 ns | 1,183 ns | -22.3% |
+| move | 640 B | 1,057 ns | 1,114 ns | +5.4% |
+| move | 960 B | 1,147 ns | 1,139 ns | -0.7% |
+| fan-out four | 160 B | 2,828 ns | 2,778 ns | -1.8% |
+| fan-out four | 640 B | 3,726 ns | 2,621 ns | -29.7% |
+| fan-out four | 960 B | 3,640 ns | 2,648 ns | -27.3% |
+
+The 160 B move result was noisy across runs. The 640 B move median regressed by 5.4%, narrowly exceeding the 5% decision limit.
+
+### Allocation behavior
+
+The allocation results were stable across all three runs:
+
+| Scenario | `Vec` | Warmed `Bytes` |
+|---|---|---|
+| owned or borrowed | 1 allocation, full frame bytes | 1 allocation, full frame bytes |
+| clone once | 1 allocation, full frame bytes | 0 allocations, 0 payload bytes |
+| fan-out four | 4 allocations, four full payload copies | 0 allocations, 0 payload bytes |
+
+While four fan-out clones were retained, `Vec` kept 640, 2,560, and 3,840 bytes live for the three frame sizes. Warmed `Bytes` retained one 24-byte promotion/control allocation for each frame size.
+
+### Decision
+
+The results do not justify changing the public `AudioChunk.data` field from `Vec<u8>` to `Bytes`.
+
+`Bytes` clearly reduces clone and fan-out allocation pressure and improves larger PCM fan-out timing and tail latency. It is slower when copying borrowed input, slower for synchronous four-way fan-out of the 160 B G.711 frame, and exceeds the move-only p95 regression limit for the 640 B frame.
+
+Keep `Vec<u8>` at the public boundary. A future optimization should introduce `Bytes` only at a production-profiled shared or fan-out boundary for larger PCM frames, then include conversion cost in a production-path benchmark.
+
+These measurements isolate ownership operations. They do not measure codec work, Base64 encoding, provider or network latency, end-to-end call latency, or whole-process CPU utilization, and should not be generalized beyond the recorded environment without another run.

--- a/adk-realtime/benches/audio_payload_allocations.rs
+++ b/adk-realtime/benches/audio_payload_allocations.rs
@@ -1,0 +1,151 @@
+mod support;
+
+use std::alloc::System;
+use std::hint::black_box;
+
+use stats_alloc::{INSTRUMENTED_SYSTEM, Region, Stats, StatsAlloc};
+use support::{BenchChunk, BytesChunk, FANOUT, FRAME_CASES, FrameCase, VecChunk};
+
+#[global_allocator]
+static GLOBAL: &StatsAlloc<System> = &INSTRUMENTED_SYSTEM;
+
+const WARMUP_OPERATIONS: usize = 1_000;
+const MEASURED_OPERATIONS: usize = 10_000;
+
+#[derive(Debug)]
+struct AllocationReport {
+    scenario: &'static str,
+    payload: &'static str,
+    frame: &'static str,
+    bytes: usize,
+    stats: Stats,
+}
+
+impl AllocationReport {
+    fn allocations_per_operation(&self) -> f64 {
+        self.stats.allocations as f64 / MEASURED_OPERATIONS as f64
+    }
+
+    fn allocated_bytes_per_operation(&self) -> f64 {
+        self.stats.bytes_allocated as f64 / MEASURED_OPERATIONS as f64
+    }
+
+    fn reallocations_per_operation(&self) -> f64 {
+        self.stats.reallocations as f64 / MEASURED_OPERATIONS as f64
+    }
+}
+
+fn measure<C, F>(scenario: &'static str, frame: FrameCase, mut operation: F) -> AllocationReport
+where
+    C: BenchChunk,
+    F: FnMut(),
+{
+    for _ in 0..WARMUP_OPERATIONS {
+        operation();
+    }
+
+    let region = Region::new(GLOBAL);
+    for _ in 0..MEASURED_OPERATIONS {
+        operation();
+    }
+    let stats = region.change();
+
+    AllocationReport { scenario, payload: C::LABEL, frame: frame.name, bytes: frame.bytes, stats }
+}
+
+fn owned<C: BenchChunk>(frame: FrameCase) -> AllocationReport {
+    measure::<C, _>("owned_vec_input", frame, || {
+        let chunk = C::from_owned(frame.payload(), frame.format());
+        black_box(chunk);
+    })
+}
+
+fn borrowed<C: BenchChunk>(frame: FrameCase) -> AllocationReport {
+    let payload = frame.payload();
+    measure::<C, _>("borrowed_input", frame, || {
+        let chunk = C::from_borrowed(black_box(payload.as_slice()), frame.format());
+        black_box(chunk);
+    })
+}
+
+fn clone_one<C: BenchChunk>(frame: FrameCase) -> AllocationReport {
+    let chunk = C::from_owned(frame.payload(), frame.format());
+    measure::<C, _>("clone_one", frame, || {
+        let copy = black_box(&chunk).clone();
+        black_box(copy);
+    })
+}
+
+fn fanout_four<C: BenchChunk>(frame: FrameCase) -> AllocationReport {
+    let chunk = C::from_owned(frame.payload(), frame.format());
+    measure::<C, _>("fanout_four", frame, || {
+        let copies = std::array::from_fn::<_, FANOUT, _>(|_| black_box(&chunk).clone());
+        black_box(copies);
+    })
+}
+
+fn live_fanout_heap<C: BenchChunk>(frame: FrameCase) -> usize {
+    let chunk = C::from_owned(frame.payload(), frame.format());
+    let region = Region::new(GLOBAL);
+    let copies = std::array::from_fn::<_, FANOUT, _>(|_| black_box(&chunk).clone());
+    let stats = region.change();
+    black_box(&copies);
+
+    stats.bytes_allocated.saturating_sub(stats.bytes_deallocated)
+}
+
+fn print_reports(reports: &[AllocationReport]) {
+    println!(
+        "scenario,payload,frame,bytes,allocations_per_op,reallocations_per_op,allocated_bytes_per_op"
+    );
+    for report in reports {
+        println!(
+            "{},{},{},{},{:.4},{:.4},{:.2}",
+            report.scenario,
+            report.payload,
+            report.frame,
+            report.bytes,
+            report.allocations_per_operation(),
+            report.reallocations_per_operation(),
+            report.allocated_bytes_per_operation(),
+        );
+    }
+}
+
+fn main() {
+    println!("audio_payload_allocations");
+    println!("os={},arch={}", std::env::consts::OS, std::env::consts::ARCH);
+    println!("warmup_operations={WARMUP_OPERATIONS},measured_operations={MEASURED_OPERATIONS}");
+
+    let mut reports = Vec::new();
+    for frame in FRAME_CASES {
+        support::validate_representations(frame);
+        reports.push(owned::<VecChunk>(frame));
+        reports.push(owned::<BytesChunk>(frame));
+        reports.push(borrowed::<VecChunk>(frame));
+        reports.push(borrowed::<BytesChunk>(frame));
+        reports.push(clone_one::<VecChunk>(frame));
+        reports.push(clone_one::<BytesChunk>(frame));
+        reports.push(fanout_four::<VecChunk>(frame));
+        reports.push(fanout_four::<BytesChunk>(frame));
+    }
+    print_reports(&reports);
+
+    println!("live_fanout_heap_bytes,payload,frame,bytes,live_heap_bytes");
+    for frame in FRAME_CASES {
+        println!(
+            "live_fanout_heap_bytes,{},{},{},{}",
+            VecChunk::LABEL,
+            frame.name,
+            frame.bytes,
+            live_fanout_heap::<VecChunk>(frame),
+        );
+        println!(
+            "live_fanout_heap_bytes,{},{},{},{}",
+            BytesChunk::LABEL,
+            frame.name,
+            frame.bytes,
+            live_fanout_heap::<BytesChunk>(frame),
+        );
+    }
+}

--- a/adk-realtime/benches/audio_payload_ownership.rs
+++ b/adk-realtime/benches/audio_payload_ownership.rs
@@ -1,0 +1,109 @@
+mod support;
+
+use std::hint::black_box;
+use std::time::Duration;
+
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use support::{BenchChunk, BytesChunk, FANOUT, FRAME_CASES, FrameCase, VecChunk};
+
+fn bench_owned<C: BenchChunk>(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    frame: FrameCase,
+) {
+    group.bench_with_input(BenchmarkId::new(C::LABEL, frame.name), &frame, |bencher, frame| {
+        bencher.iter_batched(
+            || frame.payload(),
+            |data| black_box(C::from_owned(data, frame.format())),
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+fn bench_borrowed<C: BenchChunk>(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    frame: FrameCase,
+) {
+    let payload = frame.payload();
+    group.bench_with_input(BenchmarkId::new(C::LABEL, frame.name), &frame, |bencher, frame| {
+        bencher.iter(|| C::from_borrowed(black_box(payload.as_slice()), frame.format()));
+    });
+}
+
+fn bench_clone<C: BenchChunk>(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    frame: FrameCase,
+) {
+    let chunk = C::from_owned(frame.payload(), frame.format());
+    group.bench_with_input(BenchmarkId::new(C::LABEL, frame.name), &frame, |bencher, _| {
+        bencher.iter(|| black_box(&chunk).clone());
+    });
+}
+
+fn bench_fanout<C: BenchChunk>(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    frame: FrameCase,
+) {
+    let chunk = C::from_owned(frame.payload(), frame.format());
+    group.bench_with_input(BenchmarkId::new(C::LABEL, frame.name), &frame, |bencher, _| {
+        bencher.iter(|| {
+            let copies = std::array::from_fn::<_, FANOUT, _>(|_| black_box(&chunk).clone());
+            black_box(copies)
+        });
+    });
+}
+
+fn audio_payload_ownership(criterion: &mut Criterion) {
+    for frame in FRAME_CASES {
+        support::validate_representations(frame);
+    }
+
+    {
+        let mut group = criterion.benchmark_group("audio_payload/owned_vec_input");
+        for frame in FRAME_CASES {
+            group.throughput(Throughput::Bytes(frame.bytes as u64));
+            bench_owned::<VecChunk>(&mut group, frame);
+            bench_owned::<BytesChunk>(&mut group, frame);
+        }
+        group.finish();
+    }
+
+    {
+        let mut group = criterion.benchmark_group("audio_payload/borrowed_input");
+        for frame in FRAME_CASES {
+            group.throughput(Throughput::Bytes(frame.bytes as u64));
+            bench_borrowed::<VecChunk>(&mut group, frame);
+            bench_borrowed::<BytesChunk>(&mut group, frame);
+        }
+        group.finish();
+    }
+
+    {
+        let mut group = criterion.benchmark_group("audio_payload/clone_one");
+        for frame in FRAME_CASES {
+            group.throughput(Throughput::Bytes(frame.bytes as u64));
+            bench_clone::<VecChunk>(&mut group, frame);
+            bench_clone::<BytesChunk>(&mut group, frame);
+        }
+        group.finish();
+    }
+
+    {
+        let mut group = criterion.benchmark_group("audio_payload/fanout_four");
+        for frame in FRAME_CASES {
+            group.throughput(Throughput::Bytes(frame.bytes as u64));
+            bench_fanout::<VecChunk>(&mut group, frame);
+            bench_fanout::<BytesChunk>(&mut group, frame);
+        }
+        group.finish();
+    }
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .warm_up_time(Duration::from_secs(1))
+        .measurement_time(Duration::from_secs(3))
+        .sample_size(100);
+    targets = audio_payload_ownership
+}
+criterion_main!(benches);

--- a/adk-realtime/benches/audio_payload_tail_latency.rs
+++ b/adk-realtime/benches/audio_payload_tail_latency.rs
@@ -1,0 +1,208 @@
+mod support;
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use adk_realtime::audio::AudioFormat;
+use anyhow::{Context, Result, anyhow, ensure};
+use support::{BenchChunk, BytesChunk, FANOUT, FRAME_CASES, FrameCase, VecChunk};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+
+const WARMUP_FRAMES: usize = 2_000;
+const MEASURED_FRAMES: usize = 20_000;
+
+#[derive(Debug)]
+struct LatencyReport {
+    scenario: &'static str,
+    payload: &'static str,
+    frame: &'static str,
+    bytes: usize,
+    p50_ns: u64,
+    p95_ns: u64,
+    p99_ns: u64,
+    mean_ns: u64,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct Observation {
+    len: usize,
+    first: Option<u8>,
+    last: Option<u8>,
+    format: AudioFormat,
+}
+
+fn observe<C: BenchChunk>(chunk: &C) -> Observation {
+    Observation {
+        len: chunk.data().len(),
+        first: chunk.data().first().copied(),
+        last: chunk.data().last().copied(),
+        format: chunk.format().clone(),
+    }
+}
+
+impl LatencyReport {
+    fn from_samples<C: BenchChunk>(
+        scenario: &'static str,
+        frame: FrameCase,
+        mut samples: Vec<u64>,
+    ) -> Self {
+        samples.sort_unstable();
+        let sum = samples.iter().map(|sample| u128::from(*sample)).sum::<u128>();
+        let mean_ns = (sum / samples.len() as u128) as u64;
+
+        Self {
+            scenario,
+            payload: C::LABEL,
+            frame: frame.name,
+            bytes: frame.bytes,
+            p50_ns: percentile(&samples, 50),
+            p95_ns: percentile(&samples, 95),
+            p99_ns: percentile(&samples, 99),
+            mean_ns,
+        }
+    }
+
+    fn frames_per_second(&self) -> f64 {
+        1_000_000_000.0 / self.mean_ns as f64
+    }
+
+    fn mebibytes_per_second(&self) -> f64 {
+        self.frames_per_second() * self.bytes as f64 / (1024.0 * 1024.0)
+    }
+}
+
+fn percentile(samples: &[u64], percentile: usize) -> u64 {
+    let index = (samples.len() - 1) * percentile / 100;
+    samples[index]
+}
+
+fn timer_floor_ns() -> u64 {
+    let mut samples = Vec::with_capacity(MEASURED_FRAMES);
+    for _ in 0..MEASURED_FRAMES {
+        let start = Instant::now();
+        black_box(());
+        samples.push(start.elapsed().as_nanos() as u64);
+    }
+    samples.sort_unstable();
+    percentile(&samples, 50)
+}
+
+fn spawn_consumer<C: BenchChunk>(
+    mut receiver: mpsc::Receiver<C>,
+    acknowledgements: mpsc::Sender<Observation>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        while let Some(chunk) = receiver.recv().await {
+            let observation = observe(black_box(&chunk));
+            if acknowledgements.send(observation).await.is_err() {
+                break;
+            }
+        }
+    })
+}
+
+async fn measure_cross_task_move<C: BenchChunk>(frame: FrameCase) -> Result<LatencyReport> {
+    let (sender, receiver) = mpsc::channel(1);
+    let (acknowledgements, mut observed) = mpsc::channel(1);
+    let consumer = spawn_consumer::<C>(receiver, acknowledgements);
+    let mut samples = Vec::with_capacity(MEASURED_FRAMES);
+
+    for iteration in 0..(WARMUP_FRAMES + MEASURED_FRAMES) {
+        let chunk = C::from_owned(frame.payload(), frame.format());
+        let expected = observe(&chunk);
+        let start = Instant::now();
+        sender.send(chunk).await.map_err(|_| anyhow!("cross-task consumer closed"))?;
+        let actual = observed.recv().await.context("cross-task acknowledgement closed")?;
+        let elapsed_ns = start.elapsed().as_nanos() as u64;
+        ensure!(actual == expected, "cross-task payload changed");
+
+        if iteration >= WARMUP_FRAMES {
+            samples.push(elapsed_ns);
+        }
+    }
+
+    drop(sender);
+    consumer.await.context("cross-task consumer panicked")?;
+    Ok(LatencyReport::from_samples::<C>("cross_task_move", frame, samples))
+}
+
+async fn measure_cross_task_fanout<C: BenchChunk>(frame: FrameCase) -> Result<LatencyReport> {
+    let (acknowledgements, mut observed) = mpsc::channel(FANOUT);
+    let mut senders = Vec::with_capacity(FANOUT);
+    let mut consumers = Vec::with_capacity(FANOUT);
+
+    for _ in 0..FANOUT {
+        let (sender, receiver) = mpsc::channel(1);
+        senders.push(sender);
+        consumers.push(spawn_consumer::<C>(receiver, acknowledgements.clone()));
+    }
+    drop(acknowledgements);
+
+    let mut samples = Vec::with_capacity(MEASURED_FRAMES);
+    for iteration in 0..(WARMUP_FRAMES + MEASURED_FRAMES) {
+        let chunk = C::from_owned(frame.payload(), frame.format());
+        let expected = observe(&chunk);
+        let start = Instant::now();
+        let payloads = [chunk.clone(), chunk.clone(), chunk.clone(), chunk];
+
+        for (sender, payload) in senders.iter().zip(payloads) {
+            sender.send(payload).await.map_err(|_| anyhow!("fan-out consumer closed"))?;
+        }
+        for _ in 0..FANOUT {
+            let actual = observed.recv().await.context("fan-out acknowledgement closed")?;
+            ensure!(actual == expected, "fan-out payload changed");
+        }
+
+        let elapsed_ns = start.elapsed().as_nanos() as u64;
+        if iteration >= WARMUP_FRAMES {
+            samples.push(elapsed_ns);
+        }
+    }
+
+    drop(senders);
+    for consumer in consumers {
+        consumer.await.context("fan-out consumer panicked")?;
+    }
+    Ok(LatencyReport::from_samples::<C>("cross_task_fanout_four", frame, samples))
+}
+
+fn print_report(reports: &[LatencyReport]) {
+    println!("timer_floor_p50_ns={}", timer_floor_ns());
+    println!(
+        "scenario,payload,frame,bytes,p50_ns,p95_ns,p99_ns,mean_ns,frames_per_second,mib_per_second"
+    );
+    for report in reports {
+        println!(
+            "{},{},{},{},{},{},{},{},{:.0},{:.2}",
+            report.scenario,
+            report.payload,
+            report.frame,
+            report.bytes,
+            report.p50_ns,
+            report.p95_ns,
+            report.p99_ns,
+            report.mean_ns,
+            report.frames_per_second(),
+            report.mebibytes_per_second(),
+        );
+    }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+    println!("audio_payload_tail_latency");
+    println!("os={},arch={}", std::env::consts::OS, std::env::consts::ARCH);
+    println!("warmup_frames={WARMUP_FRAMES},measured_frames={MEASURED_FRAMES},channel_capacity=1");
+
+    let mut reports = Vec::new();
+    for frame in FRAME_CASES {
+        support::validate_representations(frame);
+        reports.push(measure_cross_task_move::<VecChunk>(frame).await?);
+        reports.push(measure_cross_task_move::<BytesChunk>(frame).await?);
+        reports.push(measure_cross_task_fanout::<VecChunk>(frame).await?);
+        reports.push(measure_cross_task_fanout::<BytesChunk>(frame).await?);
+    }
+    print_report(&reports);
+    Ok(())
+}

--- a/adk-realtime/benches/support/mod.rs
+++ b/adk-realtime/benches/support/mod.rs
@@ -1,0 +1,118 @@
+use adk_realtime::audio::{AudioChunk, AudioFormat};
+use bytes::Bytes;
+
+pub const FANOUT: usize = 4;
+
+#[derive(Clone, Copy, Debug)]
+pub enum FrameKind {
+    G711Ulaw,
+    Pcm16_16Khz,
+    Pcm16_24Khz,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct FrameCase {
+    pub name: &'static str,
+    pub bytes: usize,
+    kind: FrameKind,
+}
+
+impl FrameCase {
+    pub fn format(self) -> AudioFormat {
+        match self.kind {
+            FrameKind::G711Ulaw => AudioFormat::g711_ulaw(),
+            FrameKind::Pcm16_16Khz => AudioFormat::pcm16_16khz(),
+            FrameKind::Pcm16_24Khz => AudioFormat::pcm16_24khz(),
+        }
+    }
+
+    pub fn payload(self) -> Vec<u8> {
+        (0..self.bytes).map(|index| (index % 251) as u8).collect()
+    }
+}
+
+pub const FRAME_CASES: [FrameCase; 3] = [
+    FrameCase { name: "g711_ulaw_8khz_20ms", bytes: 160, kind: FrameKind::G711Ulaw },
+    FrameCase { name: "pcm16_16khz_20ms", bytes: 640, kind: FrameKind::Pcm16_16Khz },
+    FrameCase { name: "pcm16_24khz_20ms", bytes: 960, kind: FrameKind::Pcm16_24Khz },
+];
+
+pub trait BenchChunk: Clone + Send + 'static {
+    const LABEL: &'static str;
+
+    fn from_owned(data: Vec<u8>, format: AudioFormat) -> Self;
+    fn from_borrowed(data: &[u8], format: AudioFormat) -> Self;
+    fn data(&self) -> &[u8];
+    fn format(&self) -> &AudioFormat;
+}
+
+#[derive(Clone, Debug)]
+pub struct VecChunk {
+    data: Vec<u8>,
+    format: AudioFormat,
+}
+
+impl BenchChunk for VecChunk {
+    const LABEL: &'static str = "vec";
+
+    fn from_owned(data: Vec<u8>, format: AudioFormat) -> Self {
+        Self { data, format }
+    }
+
+    fn from_borrowed(data: &[u8], format: AudioFormat) -> Self {
+        Self { data: data.to_vec(), format }
+    }
+
+    fn data(&self) -> &[u8] {
+        &self.data
+    }
+
+    fn format(&self) -> &AudioFormat {
+        &self.format
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct BytesChunk {
+    data: Bytes,
+    format: AudioFormat,
+}
+
+impl BenchChunk for BytesChunk {
+    const LABEL: &'static str = "bytes";
+
+    fn from_owned(data: Vec<u8>, format: AudioFormat) -> Self {
+        Self { data: Bytes::from(data), format }
+    }
+
+    fn from_borrowed(data: &[u8], format: AudioFormat) -> Self {
+        Self { data: Bytes::copy_from_slice(data), format }
+    }
+
+    fn data(&self) -> &[u8] {
+        &self.data
+    }
+
+    fn format(&self) -> &AudioFormat {
+        &self.format
+    }
+}
+
+pub fn validate_representations(frame: FrameCase) {
+    let payload = frame.payload();
+    let format = frame.format();
+    let production = AudioChunk::new(payload.clone(), format.clone());
+    let vec_chunk = VecChunk::from_owned(payload.clone(), format.clone());
+    let bytes_chunk = BytesChunk::from_owned(payload.clone(), format.clone());
+
+    assert_eq!(production.data, payload);
+    assert_eq!(vec_chunk.data(), bytes_chunk.data());
+    assert_eq!(vec_chunk.data(), production.data.as_slice());
+    assert_eq!(vec_chunk.format(), bytes_chunk.format());
+    assert_eq!(vec_chunk.format(), &production.format);
+
+    let borrowed_vec = VecChunk::from_borrowed(&payload, format.clone());
+    let borrowed_bytes = BytesChunk::from_borrowed(&payload, format);
+    assert_eq!(borrowed_vec.data(), borrowed_bytes.data());
+    assert_eq!(borrowed_vec.data(), payload.as_slice());
+}


### PR DESCRIPTION
Closes #430

## Summary

This is a benchmark-only PR for the `adk-realtime` audio payload ownership boundary. It compares the existing `Vec<u8>` representation with `bytes::Bytes` under representative realtime audio frame sizes and ownership patterns.

It intentionally makes no production-code or public-API change. In particular, `AudioChunk.data` remains `Vec<u8>`.

The earlier fork PR #154 measured base64 transport overhead versus raw bytes; it did not answer whether changing Rust-side payload ownership from `Vec<u8>` to `Bytes` improves CPU cost, latency, or allocation pressure. These benchmarks isolate that question before any migration is proposed.

## Benchmark coverage

Representative 20 ms frames:

| Format | Frame size |
|---|---:|
| G.711 mu-law, 8 kHz | 160 B |
| PCM16, 16 kHz | 640 B |
| PCM16, 24 kHz | 960 B |

Measured scenarios:

- owned construction
- borrowed-input construction
- one clone
- four-consumer fanout
- cross-task move
- cross-task four-consumer fanout
- allocation count, allocated bytes, and retained live heap

The suite is split into three targets so allocation instrumentation cannot distort the timing runs:

- `audio_payload_ownership`: Criterion synchronous ownership costs
- `audio_payload_tail_latency`: bounded current-thread Tokio p50/p95/p99 measurements
- `audio_payload_allocations`: deterministic `stats_alloc` allocation census

## Results

The tables below report medians across three complete optimized benchmark runs on the environment documented below. Percentage is the `Bytes` change relative to `Vec` (negative is faster/lower).

### Synchronous ownership cost

| Scenario | Frame | Vec | Bytes | Change |
|---|---|---:|---:|---:|
| owned | 160 B | 13.578 ns | 12.247 ns | -9.8% |
| owned | 640 B | 14.606 ns | 13.222 ns | -9.5% |
| owned | 960 B | 15.085 ns | 13.860 ns | -8.1% |
| borrowed | 160 B | 32.098 ns | 41.140 ns | +28.2% |
| borrowed | 640 B | 43.946 ns | 52.373 ns | +19.2% |
| borrowed | 960 B | 52.096 ns | 63.078 ns | +21.1% |
| clone once | 160 B | 30.515 ns | 27.917 ns | -8.5% |
| clone once | 640 B | 42.170 ns | 27.965 ns | -33.7% |
| clone once | 960 B | 52.560 ns | 28.438 ns | -45.9% |
| fanout four | 160 B | 137.90 ns | 174.38 ns | +26.5% |
| fanout four | 640 B | 189.49 ns | 173.28 ns | -8.6% |
| fanout four | 960 B | 228.36 ns | 177.62 ns | -22.2% |

### Cross-task p95 latency

| Scenario | Frame | Vec p95 | Bytes p95 | Change |
|---|---|---:|---:|---:|
| move | 160 B | 1,523 ns | 1,183 ns | -22.3% |
| move | 640 B | 1,057 ns | 1,114 ns | +5.4% |
| move | 960 B | 1,147 ns | 1,139 ns | -0.7% |
| fanout four | 160 B | 2,828 ns | 2,778 ns | -1.8% |
| fanout four | 640 B | 3,726 ns | 2,621 ns | -29.7% |
| fanout four | 960 B | 3,640 ns | 2,648 ns | -27.3% |

The 160 B move result was noisy across runs. The 640 B move median regressed by 5.4%, narrowly exceeding the suite's predefined 5% regression threshold.

### Allocations

Allocation results were stable across all three runs:

| Scenario | Vec | Warmed Bytes |
|---|---|---|
| owned / borrowed | 1 allocation, full frame bytes | 1 allocation, full frame bytes |
| clone once | 1 allocation, full frame bytes | 0 allocations, 0 payload bytes |
| fanout four | 4 allocations, 4x frame bytes | 0 allocations, 0 payload bytes |

Retained live heap after four-way fanout was 640 / 2,560 / 3,840 bytes for `Vec`, versus a constant 24-byte promotion/control allocation for warmed `Bytes`.

## Interpretation

These results do **not** justify a global or public `AudioChunk.data: Vec<u8> -> Bytes` migration.

`Bytes` clearly reduces clone/fanout allocation pressure and improves larger PCM fanout timing and tail latency. It is slower for borrowed construction, slower for synchronous four-way fanout of the smallest G.711 frame, and has one move-only p95 regression just beyond the declared threshold.

The evidence supports keeping the public representation unchanged. A later optimization should target only a demonstrated shared/fanout boundary for larger PCM frames, with a production-path benchmark proving that the conversion boundary itself does not erase the benefit.

This benchmark does not measure codec work, base64 encode/decode, provider/network latency, end-to-end call latency, or whole-process CPU utilization. Results are specific to this machine and should guide a production-path experiment rather than be treated as universal throughput claims.

## Environment

- Linux `michael-MacPro5-1`, kernel `7.1.3-x64v2-xanmod1`
- x86_64, dual Intel Xeon E5520 @ 2.27 GHz, 16 logical CPUs
- rustc 1.94.0, LLVM 21.1.8
- cargo 1.94.0
- optimized benchmark profile

## Validation

All Rust validation ran through the repository devenv:

- `devenv shell cargo fmt --all -- --check`
- `devenv shell cargo check -p adk-realtime --no-default-features --all-targets`
- `devenv shell cargo clippy -p adk-realtime --all-targets --no-default-features -- -D warnings`
- `devenv shell cargo nextest run -p adk-realtime --no-default-features` — 42/42 passed
- `devenv shell cargo test -p adk-realtime --no-default-features --doc` — 1 passed, 9 ignored
- `devenv shell cargo check --workspace`
- all three benchmark targets, three complete runs each
- `git diff --check`

`cargo audit` reports seven existing workspace advisories in `ammonia`, `crossbeam-epoch`, `quick-xml`, `quinn-proto`, and `wasmtime-wasi`. The only newly locked package is the dev-only, dependency-free `stats_alloc 0.1.10`; it has no audit finding.

The host-side lefthook could not find `clang`, so the commit used `--no-verify`; the authoritative devenv format, check, Clippy, test, doctest, workspace, and benchmark gates above all passed.

## Implementation follow-up

The benchmark-informed implementation is:

- https://github.com/zavora-ai/adk-rust/pull/432

The implementation intentionally preserves the public `Vec<u8>` API. It applies the supported optimization at the LiveKit bridge boundary instead of performing a global migration to `Bytes`.
