### PR TITLE
perf(realtime): preserve typed audio through LiveKit bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **adk-realtime: typed raw-audio submission through `RealtimeRunner`.**
+  `RealtimeRunner::send_audio_chunk` preserves `AudioFormat` through the provider-neutral
+  boundary, and the LiveKit input bridges now use it instead of forcing callers through
+  the base64 compatibility API.
+
 ### Fixed
 
 - **adk-core: Event serialization no longer produces duplicate `"provider_metadata"` keys.**

--- a/adk-realtime/src/livekit/bridge.rs
+++ b/adk-realtime/src/livekit/bridge.rs
@@ -18,7 +18,7 @@ const DEFAULT_NUM_CHANNELS: i32 = 1;
 const BUFFER_DURATION_MS: u32 = 40;
 
 /// Reads audio frames from a LiveKit [`RemoteAudioTrack`] and sends them as
-/// base64-encoded PCM16 audio (24kHz) to the given [`RealtimeRunner`].
+/// typed PCM16 audio (24kHz) to the given [`RealtimeRunner`].
 ///
 /// This function runs continuously until the remote track stream ends, at which
 /// point it returns `Ok(())`. If sending audio to the runner fails, the error
@@ -38,13 +38,13 @@ pub async fn bridge_input(track: RemoteAudioTrack, runner: &RealtimeRunner) -> R
         if let Some(samples) = buffer.flush() {
             // Convert i16 samples to little-endian PCM16 bytes
             let chunk = AudioChunk::from_i16_samples(&samples, AudioFormat::pcm16_24khz());
-            runner.send_audio(&chunk.to_base64()).await?;
+            runner.send_audio_chunk(&chunk).await?;
         }
     }
 
     if let Some(samples) = buffer.flush_remaining() {
         let chunk = AudioChunk::from_i16_samples(&samples, AudioFormat::pcm16_24khz());
-        runner.send_audio(&chunk.to_base64()).await?;
+        runner.send_audio_chunk(&chunk).await?;
     }
 
     Ok(())
@@ -71,13 +71,13 @@ pub async fn bridge_gemini_input(track: RemoteAudioTrack, runner: &RealtimeRunne
         buffer.push(&frame.data);
         if let Some(samples) = buffer.flush() {
             let chunk = AudioChunk::from_i16_samples(&samples, AudioFormat::pcm16_16khz());
-            runner.send_audio(&chunk.to_base64()).await?;
+            runner.send_audio_chunk(&chunk).await?;
         }
     }
 
     if let Some(samples) = buffer.flush_remaining() {
         let chunk = AudioChunk::from_i16_samples(&samples, AudioFormat::pcm16_16khz());
-        runner.send_audio(&chunk.to_base64()).await?;
+        runner.send_audio_chunk(&chunk).await?;
     }
 
     Ok(())

--- a/adk-realtime/src/runner.rs
+++ b/adk-realtime/src/runner.rs
@@ -599,7 +599,22 @@ impl RealtimeRunner {
         session.send_event(event).await
     }
 
-    /// Send audio to the session.
+    /// Send a typed raw-audio chunk to the session.
+    ///
+    /// This preserves the audio format at the provider boundary and lets the
+    /// provider choose its native encoding path. Prefer this method when the
+    /// caller already owns raw audio bytes.
+    pub async fn send_audio_chunk(&self, audio: &crate::audio::AudioChunk) -> Result<()> {
+        let session = self.session_handle().await?;
+        session.send_audio(audio).await
+    }
+
+    /// Send base64-encoded audio to the session.
+    ///
+    /// This compatibility entry point is useful when the caller already has a
+    /// base64 payload. Raw-audio callers should use
+    /// [`send_audio_chunk`](Self::send_audio_chunk) to avoid forcing an encoding
+    /// decision at the provider-neutral runner boundary.
     pub async fn send_audio(&self, audio_base64: &str) -> Result<()> {
         let session = self.session_handle().await?;
         session.send_audio_base64(audio_base64).await
@@ -936,7 +951,7 @@ impl RealtimeRunner {
 }
 
 #[cfg(test)]
-mod tool_response_tests {
+mod runner_tests {
     use super::*;
     use crate::audio::{AudioChunk, AudioFormat};
     use crate::events::{ClientEvent, ToolResponse};
@@ -970,11 +985,12 @@ mod tool_response_tests {
         }
     }
 
-    /// Records how the runner talks to the wire: tool outputs, create_response
-    /// calls, and the combined send_tool_response (which the runner must NOT use
-    /// on the auto-dispatch path).
+    /// Records which provider-session entry points the runner calls.
     #[derive(Default)]
     struct Counts {
+        raw_audio: AtomicUsize,
+        base64_audio: AtomicUsize,
+        last_audio: parking_lot::Mutex<Option<AudioChunk>>,
         tool_output: AtomicUsize,
         tool_response: AtomicUsize,
         create_response: AtomicUsize,
@@ -992,10 +1008,13 @@ mod tool_response_tests {
         fn is_connected(&self) -> bool {
             true
         }
-        async fn send_audio(&self, _audio: &AudioChunk) -> Result<()> {
+        async fn send_audio(&self, audio: &AudioChunk) -> Result<()> {
+            self.counts.raw_audio.fetch_add(1, Ordering::SeqCst);
+            *self.counts.last_audio.lock() = Some(audio.clone());
             Ok(())
         }
         async fn send_audio_base64(&self, _audio: &str) -> Result<()> {
+            self.counts.base64_audio.fetch_add(1, Ordering::SeqCst);
             Ok(())
         }
         async fn send_text(&self, _text: &str) -> Result<()> {
@@ -1061,6 +1080,44 @@ mod tool_response_tests {
 
     fn response_done() -> ServerEvent {
         ServerEvent::ResponseDone { event_id: "evt".into(), response: serde_json::json!({}) }
+    }
+
+    async fn runner_with_session(counts: Arc<Counts>) -> RealtimeRunner {
+        let runner =
+            RealtimeRunner::builder().model(Arc::new(MockModel) as BoxedModel).build().unwrap();
+        let session = Arc::new(RecordingSession { counts }) as Arc<dyn RealtimeSession>;
+
+        // The unit test owns the runner and installs the same session handle
+        // that `connect` would publish after provider setup.
+        *runner.session.write().await = Some(session);
+        runner
+    }
+
+    #[tokio::test]
+    async fn send_audio_chunk_preserves_bytes_and_format_on_raw_path() {
+        let counts = Arc::new(Counts::default());
+        let runner = runner_with_session(Arc::clone(&counts)).await;
+        let chunk = AudioChunk::pcm16_24khz(vec![1, 2, 3, 4]);
+
+        runner.send_audio_chunk(&chunk).await.unwrap();
+
+        assert_eq!(counts.raw_audio.load(Ordering::SeqCst), 1);
+        assert_eq!(counts.base64_audio.load(Ordering::SeqCst), 0);
+        let recorded = counts.last_audio.lock();
+        let recorded = recorded.as_ref().unwrap();
+        assert_eq!(recorded.data, chunk.data);
+        assert_eq!(recorded.format, chunk.format);
+    }
+
+    #[tokio::test]
+    async fn send_audio_keeps_base64_compatibility_path() {
+        let counts = Arc::new(Counts::default());
+        let runner = runner_with_session(Arc::clone(&counts)).await;
+
+        runner.send_audio("AQIDBA==").await.unwrap();
+
+        assert_eq!(counts.raw_audio.load(Ordering::SeqCst), 0);
+        assert_eq!(counts.base64_audio.load(Ordering::SeqCst), 1);
     }
 
     /// Two parallel tool calls in one response must produce exactly one


### PR DESCRIPTION
Blocked by: https://github.com/zavora-ai/adk-rust/pull/433

Companion implementation to #431.

## Summary

Adds a typed raw-audio entry point to `RealtimeRunner` and migrates the two LiveKit input bridges to use it.

The benchmark discovery in #431 does not justify changing public `AudioChunk.data` from `Vec<u8>` to `Bytes`, so this PR deliberately keeps that API unchanged. Instead, it removes the provider-neutral bridge's forced Base64 boundary:

```text
LiveKit RemoteAudioTrack
→ AudioChunk { Vec<u8>, AudioFormat }
→ RealtimeRunner::send_audio_chunk
→ RealtimeSession::send_audio
→ provider-specific native or wire encoding
```

For transports such as OpenAI WebRTC, this avoids encoding raw PCM as Base64 in the LiveKit bridge only to decode it again before native media processing. WebSocket providers remain responsible for the Base64 encoding their wire protocol requires. The `AudioFormat` now reaches that provider decision intact.

## Changes

- Add `RealtimeRunner::send_audio_chunk(&AudioChunk)`.
- Keep `RealtimeRunner::send_audio(&str)` as the existing Base64 compatibility path.
- Route both 24 kHz and Gemini 16 kHz LiveKit bridge output through the typed path.
- Test that raw bytes and `AudioFormat` reach `RealtimeSession::send_audio` exactly once and do not call the Base64 path.
- Test that the existing Base64 API still dispatches exactly once to `send_audio_base64`.
- Document the additive API in the changelog.

## Scope

This PR intentionally does not:

- change `AudioChunk` storage to `Bytes`;
- add Twilio framing or G.711 conversion;
- change provider format support;
- add cross-frame odd-byte state;
- modify linker or devenv configuration;
- claim an end-to-end CPU or latency improvement.

The odd-byte PCM16 carry concern in `LiveKitEventHandler` is a separate resilience change because it needs item/lifecycle-aware state and boundary-reset tests.

## Validation

Run through the repository devenv:

- `devenv shell ws-fmt -- --check` — passed
- `devenv shell cargo test -p adk-realtime --no-default-features runner_tests::send_audio -- --nocapture` — 2 passed
- `devenv shell cargo clippy -p adk-realtime --all-targets --no-default-features -- -D warnings` — passed
- `devenv shell cargo nextest run -p adk-realtime --no-default-features` — 44/44 passed
- `devenv shell cargo test -p adk-realtime --no-default-features --doc` — 1 passed, 9 ignored
- `git diff --check` — passed

The LiveKit-feature check is currently blocked before this crate is compiled by the `upstream/main` lockfile selecting incompatible LiveKit packages: `livekit-api 0.4.24` fails against newer protocol structs because `page_token`, `revoke_token_ts`, and `auth_realm` fields are missing. That dependency repair is intentionally excluded from this focused PR.

## Benchmark evidence

This implementation follows the measurements in:

- https://github.com/zavora-ai/adk-rust/pull/431

The benchmark showed that globally changing `AudioChunk.data` from `Vec<u8>` to `Bytes` would not be a uniform performance improvement. `Bytes` helped larger clone/fan-out workloads, but small borrowed and G.711 workloads did not consistently benefit, and one measured path regressed at p95.

Accordingly, this PR keeps the existing public `Vec<u8>` API and applies the lower-risk optimization supported by the benchmark: preserve typed audio through the LiveKit bridge and avoid unnecessary intermediate conversions or allocations.