### PR TITLE
chore(release): fold unreleased changes into the 2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,119 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Added
-
-- **adk-core: embedded-resource content part (issue #400).** New
-  `Part::EmbeddedResource` variant carries a complete resource — a source URI
-  plus inline text or binary contents — mirroring the MCP / ACP embedded-resource
-  block. Adds `EmbeddedResource` (untagged `Text` | `Blob`),
-  `TextResourceContents`, `BlobResourceContents`, and the
-  `Content::with_embedded_resource(..)` helper. `BlobResourceContents::new(..)`
-  is a checked constructor that rejects payloads larger than
-  `MAX_INLINE_DATA_SIZE` instead of truncating. The variant is additive: older
-  serialized `Content` values continue to deserialize unchanged, and existing
-  `Part::InlineData` construction sites are untouched.
-- **adk-acp: embedded-resource prompt content.** A new shared `content` module
-  (`block_to_part` / `part_to_block`) maps ACP `ContentBlock`s to `adk_core::Part`
-  in both directions. The server prompt parser and streamer route through it, so
-  `@`-mentioned file context arrives as a `Part::EmbeddedResource` and ADK
-  embedded-resource content streams back as an ACP embedded-resource block. Text
-  resources are preserved verbatim; binary resources are base64-encoded on the
-  wire and decoded to raw bytes internally. The server now advertises the
-  `embedded_context` prompt capability.
-- **adk-acp: usage updates.** The server emits a `SessionUpdate::UsageUpdate`
-  derived from ADK usage metadata (token counts, and cost in USD when reported).
-  Events without usage metadata produce no update, and counts are never
-  fabricated.
-- **adk-acp: richer tool-call updates.** `ToolCallUpdate` now carries the tool
-  result `content`, affected file `locations` (from a reported `path` string or
-  `paths`/`locations` arrays), and a tool `kind` inferred from the tool name,
-  while preserving the existing tool-call identifier correlation between a
-  `ToolCall` and its later `ToolCallUpdate`.
-- **adk-acp: `session/load` with history replay.** The server implements
-  `session/load`: it reactivates a persisted session (validating the supplied
-  `cwd` like `session/resume`), then reads the stored events and replays each
-  user, agent, thought, and tool event as an ordered `session/update`
-  notification in original chronological order before completing the request.
-  The server advertises the `load_session` capability. A load for an unknown
-  session returns a session-not-found error, and a mismatched working directory
-  is rejected rather than reattached.
-- **adk-acp: multimodal prompt content.** The server accepts image and audio
-  prompt content blocks, mapping each to a `Part::InlineData` that preserves the
-  MIME type and decoded bytes, and advertises the corresponding `image` and
-  `audio` prompt capabilities alongside `embedded_context`. Prompt content of a
-  type the server has not advertised is rejected with a descriptive error. The
-  client prompt path now transmits non-text ADK content (embedded-resource,
-  image, audio) as the matching ACP content block rather than dropping it.
-- **adk-acp: server-side permission bridge.** When the ADK Runner pauses on a
-  `ToolConfirmationRequest` during a prompt turn, the server now maps it to an
-  ACP `session/request_permission` request describing the tool and its
-  arguments, awaits the client's outcome, and resumes execution with the mapped
-  decision fed back through `RunConfig::tool_confirmation_decisions`, correlated
-  by function-call id (allow → approve, deny/cancel → deny). The nested request
-  is issued from the spawned prompt task, so the outer prompt response still
-  completes — the earlier concern that the official Rust SDK loses the outer
-  response after a nested request does not reproduce with this pause/resume
-  flow, and the stale limitation note has been removed.
-- **adk-acp: client-direction tool-update and usage fidelity.** The client
-  streaming surface (`OutputChunk`) now surfaces an External_Agent's
-  `ToolCallUpdate` as `OutputChunk::ToolUpdate` (id-correlated, with status,
-  kind, title, extracted content text, and affected file locations) and its
-  `UsageUpdate` as `OutputChunk::Usage` (tokens used/size, plus cost and
-  currency when reported), in addition to the existing text, thought, and
-  tool-call surfaces. Agent message text is surfaced unchanged.
-- **adk-acp: `examples/acp_full_protocol` reference crate.** A new no-API-key,
-  `Runner`-backed `AcpServer` reference example that exercises the full Phase 2
-  server-direction surface in-process. It ships a deterministic `ScriptedAgent`
-  (no LLM) plus a confirmation-gated `delete_file` tool, and a validating test
-  drives the server through the official `agent-client-protocol` SDK over an
-  `Channel::duplex()` transport — covering embedded-resource prompts,
-  image/audio multimodal prompts, the permission bridge (allow/deny), a
-  `session/load` replay-ordering check, and `UsageUpdate` / `ToolCallUpdate`
-  surfacing — so Phase 2 regressions are caught without a subprocess or model
-  credentials.
-- **adk-acp: session modes and configuration options.** A new `SessionControls`
-  provider trait lets an agent declare session modes (e.g. "ask" / "code") and
-  configuration options (selects, toggles), wired through
-  `AcpServerConfigBuilder::session_controls`. The server advertises the declared
-  modes and options — and only those — in `session/new`, `session/load`,
-  `session/resume`, and `session/fork` responses, and implements `session/set_mode`
-  and `session/set_config_option`: a known value is validated, recorded, and
-  echoed back as a `CurrentModeUpdate` / `ConfigOptionUpdate` notification, while
-  an unknown mode, unknown option, or invalid value is rejected and leaves state
-  unchanged. Selections persist in ADK session state (`acp:mode`,
-  `acp:config:<id>`) so they survive load / resume / fork. An agent that declares
-  no controls advertises no modes and no options, preserving capability accuracy.
-- **adk-acp: `session/fork`.** The server implements `session/fork`, branching a
-  persisted session into a new session id whose stored history is a copy of the
-  source's, carrying over the relevant state (`cwd`, additional directories,
-  mode, config) while leaving the source session's persisted history unchanged.
-  A fork for an unknown session returns a session-not-found error. The server
-  advertises the `session.fork` capability.
-- **adk-acp: available-commands and session-info updates.** On session
-  activation (create / load / resume / fork) the server emits a
-  `SessionUpdate::AvailableCommandsUpdate` for any commands the agent's
-  `SessionControls` declares (and none when it declares none), and a
-  `SessionUpdate::SessionInfoUpdate` carrying the session title when one is
-  recorded (`acp:title`, set via `set_session_title`). A `Plan` `SessionUpdate`
-  mapping exists but stays dormant until an ADK plan primitive surfaces plan
-  entries, so no plan update is emitted today.
-
-### Fixed
-
-- **adk-realtime: preserve split PCM16 samples in the LiveKit audio bridge.**
-  Incomplete channel frames are retained only for the matching response item and cleared at
-  response and error boundaries, preventing malformed samples, stereo channel-phase shifts,
-  data loss, and cross-item audio contamination.
-
-- **adk-model: preserve whitespace-only text deltas when streaming through OpenAI-compatible providers.**
-  Whitespace-only stream deltas and boundary whitespace are no longer dropped, so concatenating
-  the emitted `Part::Text` reconstructs the source byte-exactly (Markdown, indentation, tables,
-  and prose spacing are preserved). (`#441`)
-
-## [2.0.0] - 2026-07-16
+## [2.0.0] - 2026-07-25
 
 ### Security
 
@@ -157,7 +45,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   new public enum variants in `adk-anthropic` (`ContentBlock::WebFetchToolResult`,
   `ToolUnionParam::WebFetch20250910`, `ServerTool::WebFetch20250910`) and a new
   public field on `adk-graph`'s `StateGraph` (`deferred_configs`), which require
-  a major release under semver.
+  a major release under semver. The list also includes the new `adk-core`
+  `Part::EmbeddedResource` variant: `Part` is not `#[non_exhaustive]`, so
+  downstream code that matches on it exhaustively must add an arm for the new
+  variant.
 
 ### Added
 
@@ -314,6 +205,102 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **New example: `streaming_bash`** — an `LlmAgent` with a web UI (Axum + WebSocket)
   that renders live `bash` output and one-shot tool results (`read_file`, `grep`,
   `glob`) from a single event feed. Also runs as a console demo (`-- cli`).
+
+- **adk-core: embedded-resource content part (issue #400).** New
+  `Part::EmbeddedResource` variant carries a complete resource — a source URI
+  plus inline text or binary contents — mirroring the MCP / ACP embedded-resource
+  block. Adds `EmbeddedResource` (untagged `Text` | `Blob`),
+  `TextResourceContents`, `BlobResourceContents`, and the
+  `Content::with_embedded_resource(..)` helper. `BlobResourceContents::new(..)`
+  is a checked constructor that rejects payloads larger than
+  `MAX_INLINE_DATA_SIZE` instead of truncating. The variant is additive: older
+  serialized `Content` values continue to deserialize unchanged, and existing
+  `Part::InlineData` construction sites are untouched.
+- **adk-acp: embedded-resource prompt content.** A new shared `content` module
+  (`block_to_part` / `part_to_block`) maps ACP `ContentBlock`s to `adk_core::Part`
+  in both directions. The server prompt parser and streamer route through it, so
+  `@`-mentioned file context arrives as a `Part::EmbeddedResource` and ADK
+  embedded-resource content streams back as an ACP embedded-resource block. Text
+  resources are preserved verbatim; binary resources are base64-encoded on the
+  wire and decoded to raw bytes internally. The server now advertises the
+  `embedded_context` prompt capability.
+- **adk-acp: usage updates.** The server emits a `SessionUpdate::UsageUpdate`
+  derived from ADK usage metadata (token counts, and cost in USD when reported).
+  Events without usage metadata produce no update, and counts are never
+  fabricated.
+- **adk-acp: richer tool-call updates.** `ToolCallUpdate` now carries the tool
+  result `content`, affected file `locations` (from a reported `path` string or
+  `paths`/`locations` arrays), and a tool `kind` inferred from the tool name,
+  while preserving the existing tool-call identifier correlation between a
+  `ToolCall` and its later `ToolCallUpdate`.
+- **adk-acp: `session/load` with history replay.** The server implements
+  `session/load`: it reactivates a persisted session (validating the supplied
+  `cwd` like `session/resume`), then reads the stored events and replays each
+  user, agent, thought, and tool event as an ordered `session/update`
+  notification in original chronological order before completing the request.
+  The server advertises the `load_session` capability. A load for an unknown
+  session returns a session-not-found error, and a mismatched working directory
+  is rejected rather than reattached.
+- **adk-acp: multimodal prompt content.** The server accepts image and audio
+  prompt content blocks, mapping each to a `Part::InlineData` that preserves the
+  MIME type and decoded bytes, and advertises the corresponding `image` and
+  `audio` prompt capabilities alongside `embedded_context`. Prompt content of a
+  type the server has not advertised is rejected with a descriptive error. The
+  client prompt path now transmits non-text ADK content (embedded-resource,
+  image, audio) as the matching ACP content block rather than dropping it.
+- **adk-acp: server-side permission bridge.** When the ADK Runner pauses on a
+  `ToolConfirmationRequest` during a prompt turn, the server now maps it to an
+  ACP `session/request_permission` request describing the tool and its
+  arguments, awaits the client's outcome, and resumes execution with the mapped
+  decision fed back through `RunConfig::tool_confirmation_decisions`, correlated
+  by function-call id (allow → approve, deny/cancel → deny). The nested request
+  is issued from the spawned prompt task, so the outer prompt response still
+  completes — the earlier concern that the official Rust SDK loses the outer
+  response after a nested request does not reproduce with this pause/resume
+  flow, and the stale limitation note has been removed.
+- **adk-acp: client-direction tool-update and usage fidelity.** The client
+  streaming surface (`OutputChunk`) now surfaces an External_Agent's
+  `ToolCallUpdate` as `OutputChunk::ToolUpdate` (id-correlated, with status,
+  kind, title, extracted content text, and affected file locations) and its
+  `UsageUpdate` as `OutputChunk::Usage` (tokens used/size, plus cost and
+  currency when reported), in addition to the existing text, thought, and
+  tool-call surfaces. Agent message text is surfaced unchanged.
+- **adk-acp: `examples/acp_full_protocol` reference crate.** A new no-API-key,
+  `Runner`-backed `AcpServer` reference example that exercises the full Phase 2
+  server-direction surface in-process. It ships a deterministic `ScriptedAgent`
+  (no LLM) plus a confirmation-gated `delete_file` tool, and a validating test
+  drives the server through the official `agent-client-protocol` SDK over an
+  `Channel::duplex()` transport — covering embedded-resource prompts,
+  image/audio multimodal prompts, the permission bridge (allow/deny), a
+  `session/load` replay-ordering check, and `UsageUpdate` / `ToolCallUpdate`
+  surfacing — so Phase 2 regressions are caught without a subprocess or model
+  credentials.
+- **adk-acp: session modes and configuration options.** A new `SessionControls`
+  provider trait lets an agent declare session modes (e.g. "ask" / "code") and
+  configuration options (selects, toggles), wired through
+  `AcpServerConfigBuilder::session_controls`. The server advertises the declared
+  modes and options — and only those — in `session/new`, `session/load`,
+  `session/resume`, and `session/fork` responses, and implements `session/set_mode`
+  and `session/set_config_option`: a known value is validated, recorded, and
+  echoed back as a `CurrentModeUpdate` / `ConfigOptionUpdate` notification, while
+  an unknown mode, unknown option, or invalid value is rejected and leaves state
+  unchanged. Selections persist in ADK session state (`acp:mode`,
+  `acp:config:<id>`) so they survive load / resume / fork. An agent that declares
+  no controls advertises no modes and no options, preserving capability accuracy.
+- **adk-acp: `session/fork`.** The server implements `session/fork`, branching a
+  persisted session into a new session id whose stored history is a copy of the
+  source's, carrying over the relevant state (`cwd`, additional directories,
+  mode, config) while leaving the source session's persisted history unchanged.
+  A fork for an unknown session returns a session-not-found error. The server
+  advertises the `session.fork` capability.
+- **adk-acp: available-commands and session-info updates.** On session
+  activation (create / load / resume / fork) the server emits a
+  `SessionUpdate::AvailableCommandsUpdate` for any commands the agent's
+  `SessionControls` declares (and none when it declares none), and a
+  `SessionUpdate::SessionInfoUpdate` carrying the session title when one is
+  recorded (`acp:title`, set via `set_session_title`). A `Plan` `SessionUpdate`
+  mapping exists but stays dormant until an ADK plan primitive surfaces plan
+  entries, so no plan update is emitted today.
 
 ### Fixed
 
@@ -507,6 +494,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Event.provider_metadata` is now serialized as `"event_metadata"` to avoid collision
   with `LlmResponse.provider_metadata` (which is flattened into the same JSON object).
   Regression test added. (`#414`)
+
+- **adk-realtime: preserve split PCM16 samples in the LiveKit audio bridge.**
+  Incomplete channel frames are retained only for the matching response item and cleared at
+  response and error boundaries, preventing malformed samples, stereo channel-phase shifts,
+  data loss, and cross-item audio contamination.
+
+- **adk-model: preserve whitespace-only text deltas when streaming through OpenAI-compatible providers.**
+  Whitespace-only stream deltas and boundary whitespace are no longer dropped, so concatenating
+  the emitted `Part::Text` reconstructs the source byte-exactly (Markdown, indentation, tables,
+  and prose spacing are preserved). (`#441`)
 
 ## [1.0.0] - 2026-06-07
 


### PR DESCRIPTION
## Summary

Turns the `## [2.0.0]` draft into the actual 2.0.0 release entry. `CHANGELOG.md` is the only file touched — no version numbers change anywhere.

`2.0.0` has never been tagged or published: the highest tag is `v1.0.0`, the latest GitHub release is `v1.0.0`, and crates.io tops out at `1.0.0` for `adk-core` / `adk-rust` / `adk-acp` / `adk-realtime`. So `## [2.0.0] - 2026-07-16` was an unreleased draft, and the `[Unreleased]` entries belong inside it rather than in a new version. This is the same fold the repo has done twice before: `2620f6ce` (`[1.1.0]` → `[2.0.0]`) and `5f3dec97` (`[1.0.1]` → `[1.1.0]`, which noted the prior version "was never published").

## What changed

- **Folded `[Unreleased]` into `[2.0.0]`**, merging by category:
  - Its `### Added` block (adk-core `Part::EmbeddedResource`; adk-acp embedded-resource prompt content, usage updates, richer tool-call updates, `session/load` with history replay, multimodal prompt content, server-side permission bridge, client-direction tool-update/usage fidelity, `examples/acp_full_protocol`, session modes and config options, `session/fork`, available-commands and session-info updates) joins `[2.0.0]`'s existing `### Added`.
  - Its `### Fixed` block (LiveKit PCM16 split-sample retention; adk-model whitespace-only stream deltas, `#441`) joins `[2.0.0]`'s existing `### Fixed`.
- **Refreshed the heading date** to the actual release date: `## [2.0.0] - 2026-07-25` (was the stale `2026-07-16`).
- **Extended the existing Breaking bullet** to also name the new `adk-core` `Part::EmbeddedResource` variant, noting that `Part` is not `#[non_exhaustive]`, so downstream exhaustive `match` arms must be updated. The bullet's original wording is unchanged; the note is appended.
- No new empty `## [Unreleased]` heading, matching what `2620f6ce` and `5f3dec97` did.

Every existing entry is preserved verbatim. A line-level comparison against `origin/main` confirms the only differences are: the three removed headings (`## [Unreleased]`, the duplicate `### Added`, the duplicate `### Fixed`) plus three blank lines, the heading date, and the four appended lines on the Breaking bullet. Nothing was reworded, deduplicated, or dropped.

## Not in scope

No tag, no `cargo publish`, no GitHub release — those remain separate decisions. The version stays `2.0.0`; the workspace and all internal pins already say `2.0.0`, so `bump-version.sh` was deliberately not run.

## Verification

- `bash scripts/check-doc-versions.sh` → `OK (version 2.0.0, 114 features)`
- `bash scripts/check-doc-examples.sh` → `validated documented Cargo examples for 93 markdown files`

`scripts/check-doc-versions.py` explicitly skips `CHANGELOG.md`, and the version is unchanged, so no doc snippets are affected.
