### PR TITLE
perf(realtime): borrow aligned PCM16 samples at the audio boundary

### DIFF
--- a/adk-realtime/Cargo.toml
+++ b/adk-realtime/Cargo.toml
@@ -148,6 +148,10 @@ harness = false
 name = "audio_payload_allocations"
 harness = false
 
+[[bench]]
+name = "audio_boundary_decode"
+harness = false
+
 [features]
 default = []
 # Enable ADK services integration (sessions, memory, plugins)

--- a/adk-realtime/benches/audio_boundary_decode.rs
+++ b/adk-realtime/benches/audio_boundary_decode.rs
@@ -1,0 +1,115 @@
+//! Decode boundary benchmark: owned PCM16 decode vs borrowed (zero-copy) decode.
+//!
+//! The payload is one realtime frame: 20 ms of 24 kHz mono PCM16 =
+//! 480 samples = 960 bytes. That is the unit a provider transport actually
+//! hands to the codec, so per-iteration numbers map directly onto per-frame cost.
+//!
+//! This binary measures **latency only**, with Criterion. Criterion batches
+//! iterations and amortizes the timer, so the measurement is not floored by
+//! `Instant::now()` overhead (~20-25 ns), which would swamp a sub-100 ns
+//! operation.
+//!
+//! Allocation counting deliberately lives in
+//! `tests/audio_allocation_tests.rs`, not here. It needs an instrumented
+//! `#[global_allocator]`, which taxes every allocation with an atomic counter
+//! update — and only the owned arm allocates, so keeping it in this binary
+//! would penalize that arm alone and inflate the reported speedup.
+//!
+//! Both latency arms consume the decoded samples identically (a checksum fold
+//! behind `black_box`). Without that, the borrowed arm has no observable effect
+//! and LLVM is free to delete it, which would report a fictional speedup.
+
+use std::borrow::Cow;
+use std::hint::black_box;
+use std::time::Duration;
+
+use adk_realtime::audio::{AudioChunk, AudioFormat};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+
+/// 20 ms at 24 kHz mono.
+const SAMPLES_PER_FRAME: usize = 480;
+/// PCM16 is two bytes per sample.
+const FRAME_BYTES: usize = SAMPLES_PER_FRAME * size_of::<i16>();
+
+/// Build one deterministic frame. The values span positive and negative
+/// amplitudes so the checksum fold cannot be constant-folded away.
+fn frame() -> AudioChunk {
+    let samples: Vec<i16> =
+        (0..SAMPLES_PER_FRAME).map(|i| ((i as i32 * 2617) % 65_536 - 32_768) as i16).collect();
+    let chunk = AudioChunk::from_i16_samples(&samples, AudioFormat::pcm16_24khz());
+    assert_eq!(chunk.data.len(), FRAME_BYTES);
+    chunk
+}
+
+/// The previous `AudioChunk::to_i16_samples` body, kept local to this bench.
+///
+/// Holding a copy here keeps the comparison honest after the production source
+/// changed: the "before" arm is the code that actually shipped, not a
+/// reconstruction that drifts with the crate.
+fn decode_owned(data: &[u8]) -> Vec<i16> {
+    let mut samples = Vec::with_capacity(data.len() / size_of::<i16>());
+    for chunk in data.chunks_exact(size_of::<i16>()) {
+        samples.push(i16::from_le_bytes([chunk[0], chunk[1]]));
+    }
+    samples
+}
+
+/// The current production path.
+fn decode_borrowed(chunk: &AudioChunk) -> Cow<'_, [i16]> {
+    chunk.to_i16_samples().expect("benchmark frame is valid PCM16")
+}
+
+/// Identical consumption for both arms: fold every sample into a checksum.
+///
+/// `i64` accumulation cannot overflow for a frame of `i16` values, so the fold
+/// is total and both arms do exactly the same amount of downstream work.
+fn consume(samples: &[i16]) -> i64 {
+    samples.iter().map(|sample| *sample as i64).sum()
+}
+
+/// Assert the two arms agree, once, outside every measured region.
+fn assert_arms_agree(chunk: &AudioChunk) {
+    let owned = decode_owned(&chunk.data);
+    let borrowed = decode_borrowed(chunk);
+    assert_eq!(
+        owned.as_slice(),
+        borrowed.as_ref(),
+        "owned and borrowed decode disagree; the comparison would be meaningless"
+    );
+    assert_eq!(consume(&owned), consume(borrowed.as_ref()));
+}
+
+fn audio_boundary_decode(criterion: &mut Criterion) {
+    let chunk = frame();
+    assert_arms_agree(&chunk);
+
+    let mut group = criterion.benchmark_group("audio_boundary_decode");
+    group.throughput(Throughput::Bytes(FRAME_BYTES as u64));
+
+    group.bench_function("owned_decode", |bencher| {
+        bencher.iter(|| {
+            let samples = decode_owned(black_box(chunk.data.as_slice()));
+            black_box(consume(samples.as_ref()))
+        });
+    });
+
+    group.bench_function("borrowed_decode", |bencher| {
+        bencher.iter(|| {
+            let samples = decode_borrowed(black_box(&chunk));
+            black_box(consume(samples.as_ref()))
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .warm_up_time(Duration::from_secs(1))
+        .measurement_time(Duration::from_secs(3))
+        .sample_size(100);
+    targets = audio_boundary_decode
+}
+
+criterion_main!(benches);

--- a/adk-realtime/src/audio.rs
+++ b/adk-realtime/src/audio.rs
@@ -1,5 +1,7 @@
 //! Audio format definitions and utilities.
 
+use std::borrow::Cow;
+
 use serde::{Deserialize, Serialize};
 
 /// Audio encoding formats supported by realtime APIs.
@@ -153,34 +155,96 @@ impl AudioChunk {
         Ok(Self::new(data, format))
     }
 
-    /// Create an AudioChunk from i16 samples (converts to PCM16 little-endian bytes).
+    /// Create an `AudioChunk` from i16 samples (converts to PCM16 little-endian bytes).
     ///
     /// This is useful when working with audio APIs (like LiveKit) that provide
     /// samples as `i16` slices rather than raw byte buffers.
+    ///
+    /// On little-endian hosts the samples are reinterpreted and copied in one
+    /// vectorized `memcpy` instead of one `to_le_bytes` call per sample. On
+    /// big-endian hosts each sample is byte-swapped individually, so the emitted
+    /// bytes are little-endian PCM16 on every target.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use adk_realtime::audio::{AudioChunk, AudioFormat};
+    ///
+    /// let chunk = AudioChunk::from_i16_samples(&[1, -1], AudioFormat::pcm16_24khz());
+    /// assert_eq!(chunk.data, vec![0x01, 0x00, 0xff, 0xff]);
+    /// ```
     pub fn from_i16_samples(samples: &[i16], format: AudioFormat) -> Self {
-        let mut data = Vec::with_capacity(samples.len() * 2);
-        for sample in samples {
-            data.extend_from_slice(&sample.to_le_bytes());
-        }
+        // Narrowing the element type to `u8` can never fail an alignment check, so
+        // this is a single bulk copy of the already little-endian sample bytes.
+        #[cfg(target_endian = "little")]
+        let data = bytemuck::cast_slice::<i16, u8>(samples).to_vec();
+
+        #[cfg(target_endian = "big")]
+        let data = {
+            let mut data = Vec::with_capacity(samples.len() * size_of::<i16>());
+            for sample in samples {
+                data.extend_from_slice(&sample.to_le_bytes());
+            }
+            data
+        };
+
         Self::new(data, format)
     }
 
-    /// Convert the audio data to a vector of i16 samples (assuming PCM16 little-endian).
+    /// Interpret the audio data as i16 samples (assuming PCM16 little-endian).
+    ///
+    /// When the buffer is suitably aligned on a little-endian host the samples are
+    /// borrowed directly from `self.data` and no copy is made ([`Cow::Borrowed`]).
+    /// Otherwise — a big-endian host, or a misaligned buffer — the samples are
+    /// decoded into a freshly allocated `Vec` ([`Cow::Owned`]).
+    ///
+    /// # Errors
     ///
     /// Returns an error string if the data length is not even (not valid PCM16).
-    pub fn to_i16_samples(&self) -> Result<Vec<i16>, String> {
-        if !self.data.len().is_multiple_of(2) {
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use adk_realtime::audio::{AudioChunk, AudioFormat};
+    ///
+    /// let chunk = AudioChunk::pcm16_24khz(vec![0x01, 0x00, 0xff, 0xff]);
+    /// let samples = chunk.to_i16_samples().unwrap();
+    /// assert_eq!(samples.as_ref(), &[1, -1]);
+    ///
+    /// // An odd byte count cannot be valid PCM16.
+    /// assert!(AudioChunk::pcm16_24khz(vec![0x01]).to_i16_samples().is_err());
+    /// ```
+    pub fn to_i16_samples(&self) -> Result<Cow<'_, [i16]>, String> {
+        if !self.data.len().is_multiple_of(size_of::<i16>()) {
             return Err(format!(
                 "Invalid data length for PCM16: {} (must be even)",
                 self.data.len()
             ));
         }
-        let mut samples = Vec::with_capacity(self.data.len() / 2);
-        for chunk in self.data.chunks_exact(2) {
-            samples.push(i16::from_le_bytes([chunk[0], chunk[1]]));
-        }
-        Ok(samples)
+        Ok(decode_pcm16_le(&self.data))
     }
+}
+
+/// Decode little-endian PCM16 bytes into i16 samples, borrowing when possible.
+///
+/// Mirrors the idiom used by the LiveKit audio handler: on a little-endian host an
+/// aligned buffer is reinterpreted in place, which is free. The `chunks_exact`
+/// fallback covers both big-endian hosts (where the bytes need swapping) and
+/// misaligned buffers (where `i16` cannot be read directly).
+fn decode_pcm16_le(audio: &[u8]) -> Cow<'_, [i16]> {
+    debug_assert!(audio.len().is_multiple_of(size_of::<i16>()));
+
+    #[cfg(target_endian = "little")]
+    if let Ok(aligned_slice) = bytemuck::try_cast_slice::<u8, i16>(audio) {
+        return Cow::Borrowed(aligned_slice);
+    }
+
+    Cow::Owned(
+        audio
+            .chunks_exact(size_of::<i16>())
+            .map(|chunk| i16::from_le_bytes([chunk[0], chunk[1]]))
+            .collect(),
+    )
 }
 
 /// Buffers audio samples until a target duration is reached.
@@ -308,19 +372,62 @@ mod tests {
         let samples: Vec<i16> = vec![0, 1, -1, 32767, -32768, 1000, -1000];
         let chunk = AudioChunk::from_i16_samples(&samples, AudioFormat::pcm16_24khz());
         let recovered = chunk.to_i16_samples().unwrap();
-        assert_eq!(samples, recovered);
+        assert_eq!(samples.as_slice(), recovered.as_ref());
+    }
+
+    #[test]
+    fn test_from_i16_samples_emits_little_endian_bytes() {
+        let chunk = AudioChunk::from_i16_samples(&[1, -1, 256], AudioFormat::pcm16_24khz());
+        assert_eq!(chunk.data, vec![0x01, 0x00, 0xff, 0xff, 0x00, 0x01]);
     }
 
     #[test]
     fn test_i16_samples_empty() {
         let chunk = AudioChunk::from_i16_samples(&[], AudioFormat::pcm16_24khz());
         assert!(chunk.data.is_empty());
-        assert_eq!(chunk.to_i16_samples().unwrap(), Vec::<i16>::new());
+        assert!(chunk.to_i16_samples().unwrap().is_empty());
     }
 
     #[test]
     fn test_i16_samples_odd_bytes_error() {
         let chunk = AudioChunk::pcm16_24khz(vec![0, 1, 2]); // 3 bytes = invalid PCM16
-        assert!(chunk.to_i16_samples().is_err());
+        assert_eq!(
+            chunk.to_i16_samples().unwrap_err(),
+            "Invalid data length for PCM16: 3 (must be even)"
+        );
+    }
+
+    #[test]
+    #[cfg(target_endian = "little")]
+    fn test_to_i16_samples_borrows_aligned_buffer() {
+        // `AudioChunk::data` is an owned `Vec<u8>`, so its allocation is always
+        // suitably aligned for `i16` and the borrowed fast path applies.
+        let chunk = AudioChunk::from_i16_samples(&[1, -1, 256], AudioFormat::pcm16_24khz());
+        let samples = chunk.to_i16_samples().unwrap();
+        assert!(matches!(samples, Cow::Borrowed(_)));
+        assert_eq!(samples.as_ref(), &[1, -1, 256]);
+    }
+
+    #[test]
+    fn test_decode_pcm16_le_misaligned_buffer_is_owned() {
+        // Build an aligned `[i16]`, view it as bytes, then take an odd-offset
+        // sub-slice so the buffer cannot be reinterpreted as `i16` in place.
+        let aligned_words = [
+            i16::from_ne_bytes([0x00, 0x01]),
+            i16::from_ne_bytes([0x02, 0x03]),
+            i16::from_ne_bytes([0x04, 0x00]),
+        ];
+        let aligned_bytes: &[u8] = bytemuck::cast_slice(&aligned_words);
+        let misaligned = &aligned_bytes[1..5];
+
+        let samples = decode_pcm16_le(misaligned);
+        assert!(matches!(samples, Cow::Owned(_)));
+        assert_eq!(samples.as_ref(), &[0x0201, 0x0403]);
+    }
+
+    #[test]
+    fn test_decode_pcm16_le_empty_input() {
+        let samples = decode_pcm16_le(&[]);
+        assert!(samples.is_empty());
     }
 }

--- a/adk-realtime/src/openai/webrtc.rs
+++ b/adk-realtime/src/openai/webrtc.rs
@@ -652,11 +652,13 @@ impl OpenAITransportLink for OpenAIWebRTCSession {
             return Err(RealtimeError::NotConnected);
         }
 
+        // `to_i16_samples` borrows directly from the chunk when the buffer is
+        // aligned, so the encoder sees the samples without an intermediate copy.
         let pcm_samples = audio
             .to_i16_samples()
             .map_err(|e| RealtimeError::opus(format!("Invalid PCM16 audio data: {e}")))?;
 
-        self.write_audio_to_track(&pcm_samples).await
+        self.write_audio_to_track(pcm_samples.as_ref()).await
     }
 
     /// Send base64-encoded PCM16 audio over the WebRTC audio track.

--- a/adk-realtime/tests/audio_allocation_tests.rs
+++ b/adk-realtime/tests/audio_allocation_tests.rs
@@ -1,0 +1,161 @@
+//! Allocation accounting for the PCM16 decode boundary: owned decode vs
+//! borrowed (zero-copy) decode.
+//!
+//! This lives in its own integration test rather than in
+//! `benches/audio_boundary_decode.rs` on purpose. Counting allocations requires
+//! installing an instrumented `#[global_allocator]`, and every allocation in
+//! that binary then pays for an atomic counter update. Only the owned arm
+//! allocates, so sharing a binary with the Criterion latency arms would tax the
+//! owned arm alone and inflate the reported speedup. A separate test binary
+//! keeps the instrumented allocator away from the timings.
+//!
+//! The payload is one realtime frame: 20 ms of 24 kHz mono PCM16 =
+//! 480 samples = 960 bytes. That is the unit a provider transport actually
+//! hands to the codec, so per-iteration numbers map directly onto per-frame
+//! cost.
+//!
+//! Both arms consume the decoded samples identically (a checksum fold behind
+//! `black_box`). Without that, the borrowed arm has no observable effect and
+//! LLVM is free to delete it, which would report a fictional result.
+
+use std::alloc::System;
+use std::borrow::Cow;
+use std::hint::black_box;
+
+use adk_realtime::audio::{AudioChunk, AudioFormat};
+use stats_alloc::{INSTRUMENTED_SYSTEM, Region, Stats, StatsAlloc};
+
+#[global_allocator]
+static GLOBAL: &StatsAlloc<System> = &INSTRUMENTED_SYSTEM;
+
+/// 20 ms at 24 kHz mono.
+const SAMPLES_PER_FRAME: usize = 480;
+/// PCM16 is two bytes per sample.
+const FRAME_BYTES: usize = SAMPLES_PER_FRAME * size_of::<i16>();
+
+/// Measurement loop lengths. Long enough to make a per-iteration figure
+/// meaningful, short enough to stay instant.
+const WARMUP_ITERATIONS: usize = 1_000;
+const MEASURED_ITERATIONS: usize = 10_000;
+
+/// Build one deterministic frame. The values span positive and negative
+/// amplitudes so the checksum fold cannot be constant-folded away.
+fn frame() -> AudioChunk {
+    let samples: Vec<i16> =
+        (0..SAMPLES_PER_FRAME).map(|i| ((i as i32 * 2617) % 65_536 - 32_768) as i16).collect();
+    let chunk = AudioChunk::from_i16_samples(&samples, AudioFormat::pcm16_24khz());
+    assert_eq!(chunk.data.len(), FRAME_BYTES);
+    chunk
+}
+
+/// The previous `AudioChunk::to_i16_samples` body, kept local to this test.
+///
+/// Holding a copy here keeps the comparison honest after the production source
+/// changed: the "before" arm is the code that actually shipped, not a
+/// reconstruction that drifts with the crate.
+fn decode_owned(data: &[u8]) -> Vec<i16> {
+    let mut samples = Vec::with_capacity(data.len() / size_of::<i16>());
+    for chunk in data.chunks_exact(size_of::<i16>()) {
+        samples.push(i16::from_le_bytes([chunk[0], chunk[1]]));
+    }
+    samples
+}
+
+/// The current production path.
+fn decode_borrowed(chunk: &AudioChunk) -> Cow<'_, [i16]> {
+    chunk.to_i16_samples().expect("test frame is valid PCM16")
+}
+
+/// Identical consumption for both arms: fold every sample into a checksum.
+///
+/// `i64` accumulation cannot overflow for a frame of `i16` values, so the fold
+/// is total and both arms do exactly the same amount of downstream work.
+fn consume(samples: &[i16]) -> i64 {
+    samples.iter().map(|sample| *sample as i64).sum()
+}
+
+/// Assert the two arms agree, once, outside every measured region.
+fn assert_arms_agree(chunk: &AudioChunk) {
+    let owned = decode_owned(&chunk.data);
+    let borrowed = decode_borrowed(chunk);
+    assert_eq!(
+        owned.as_slice(),
+        borrowed.as_ref(),
+        "owned and borrowed decode disagree; the comparison would be meaningless"
+    );
+    assert_eq!(consume(&owned), consume(borrowed.as_ref()));
+}
+
+/// Count allocations for one arm. No timing here at all.
+///
+/// The `Region` is opened only after warm-up, so allocator growth and any
+/// harness setup are excluded. `operation` returns the checksum, which is
+/// black-boxed, so each arm still performs its full work.
+fn measure_allocations<F: FnMut() -> i64>(mut operation: F) -> Stats {
+    for _ in 0..WARMUP_ITERATIONS {
+        black_box(operation());
+    }
+
+    let region = Region::new(GLOBAL);
+    for _ in 0..MEASURED_ITERATIONS {
+        black_box(operation());
+    }
+    region.change()
+}
+
+fn print_table(owned: &Stats, borrowed: &Stats) {
+    println!("audio_boundary_decode allocations");
+    println!("os={},arch={}", std::env::consts::OS, std::env::consts::ARCH);
+    println!("frame_bytes={FRAME_BYTES},samples_per_frame={SAMPLES_PER_FRAME}");
+    println!("warmup_iterations={WARMUP_ITERATIONS},measured_iterations={MEASURED_ITERATIONS}");
+    println!("arm,allocations_per_iter,reallocations_per_iter,allocated_bytes_per_iter");
+    for (arm, stats) in [("owned_decode", owned), ("borrowed_decode", borrowed)] {
+        println!(
+            "{},{},{},{}",
+            arm,
+            stats.allocations / MEASURED_ITERATIONS,
+            stats.reallocations / MEASURED_ITERATIONS,
+            stats.bytes_allocated / MEASURED_ITERATIONS,
+        );
+    }
+}
+
+/// The owned decode allocates exactly one buffer of `FRAME_BYTES` per frame;
+/// the borrowed decode allocates nothing at all.
+///
+/// Assertions are on exact per-iteration integer totals, not averages, so the
+/// invariant is deterministic rather than a threshold that can drift.
+#[test]
+fn pcm16_decode_allocation_invariants() {
+    let chunk = frame();
+    assert_arms_agree(&chunk);
+
+    let owned = measure_allocations(|| {
+        let samples = decode_owned(black_box(chunk.data.as_slice()));
+        consume(samples.as_ref())
+    });
+    let borrowed = measure_allocations(|| {
+        let samples = decode_borrowed(black_box(&chunk));
+        consume(samples.as_ref())
+    });
+
+    print_table(&owned, &borrowed);
+
+    assert_eq!(
+        owned.allocations, MEASURED_ITERATIONS,
+        "owned decode must allocate exactly one buffer per frame"
+    );
+    assert_eq!(
+        owned.reallocations, 0,
+        "owned decode pre-sizes its buffer, so it never reallocates"
+    );
+    assert_eq!(
+        owned.bytes_allocated,
+        MEASURED_ITERATIONS * FRAME_BYTES,
+        "owned decode must allocate exactly {FRAME_BYTES} bytes per frame"
+    );
+
+    assert_eq!(borrowed.allocations, 0, "borrowed decode must not allocate");
+    assert_eq!(borrowed.reallocations, 0, "borrowed decode must not reallocate");
+    assert_eq!(borrowed.bytes_allocated, 0, "borrowed decode must not allocate any bytes");
+}


### PR DESCRIPTION
## Summary

Supersedes #443. Same insight, smaller blast radius.

`AudioChunk::to_i16_samples` now returns `Cow<'_, [i16]>` instead of `Result<Vec<i16>, String>`'s owned vector. On a little-endian host with a suitably aligned buffer the bytes are reinterpreted in place via `bytemuck::try_cast_slice`, so the per-sample `from_le_bytes` loop and its allocation disappear on the hot audio path. Misaligned buffers and big-endian hosts take the previous decode, so decoded values are identical on every target.

`AudioChunk::from_i16_samples` now emits its bytes with a single `bytemuck::cast_slice::<i16, u8>` copy on little-endian instead of one `to_le_bytes` per sample, keeping the byte-swapping path for big-endian. Output is byte-identical PCM16 little-endian either way.

The decode helper (`decode_pcm16_le`) mirrors the idiom the crate already has at `adk-realtime/src/livekit/handler.rs::decode_pcm16` — no hand-rolled pointer alignment arithmetic.

Credit to @mikefaille for the endianness/alignment insight in #443; the original commit is preserved as a `Co-authored-by` trailer.

## What was intentionally dropped from #443, and why

| Dropped | Reason |
| --- | --- |
| `AudioChunk.data: Vec<u8>` → `bytes::Bytes` | No measurable win. The base64 path and `gemini/session.rs` still copy the buffer, so the field change is a breaking API change with nothing to show for it. |
| 3 unrelated file changes | Out of scope for a perf PR; one of them would have reverted commit `0844d63e`. |
| `examples/bench_audio_performance.rs` | It failed `fmt`, contained a `usize` underflow, and its numbers measured the harness's own allocations. The crate already has `livekit_pcm_bench`, `audio_payload_ownership`, `audio_payload_tail_latency`, and `audio_payload_allocations`. |
| `send_audio` rejecting non-`pcm16_24khz` formats | Undocumented behavior change, and asymmetric with `send_audio_base64`, which kept accepting anything. |

## Honest magnitude

Measured on macOS/aarch64 (Apple Silicon) for one 20 ms frame of 24 kHz mono PCM16 — 480 samples, 960 bytes.

**Headline: the allocation goes away.**

| | Allocations / frame | Bytes / frame |
| --- | --- | --- |
| Owned `Vec<i16>` decode (before) | 1 | 960 |
| Borrowed `Cow` decode (after) | 0 | 0 |

At 50 frames/sec that removes roughly **180,000 allocations and ~173 MB of allocator churn per hour of audio, per stream**. These figures are deterministic — they come from counting allocations in `tests/audio_allocation_tests.rs`, not from timing, so they reproduce on any platform where the buffer is aligned and the host is little-endian.

Latency is the secondary effect: **183.73 ns → 24.400 ns, a 7.53x speedup**. In absolute terms that is ~159 ns off a 20 ms frame budget, i.e. about **0.0008%** of the time available per frame. Nobody should adopt this for the throughput. The reason to take it is that the per-frame heap traffic on the hot audio path disappears, which is what matters for jitter and for allocator pressure in long-lived sessions.

To correct the record: the real decode speedup is **7.53x, not the 20.91x quoted in #443**. That number measured the old benchmark harness's own allocations rather than the decode itself.

Latency numbers are single-machine and will vary by host; the allocation numbers will not.

## Breaking change

`to_i16_samples` returns `Result<Cow<'_, [i16]>, String>`. Callers that need an owned vector add `.into_owned()`; callers that just read the samples use `&*samples` / `.as_ref()`. This is acceptable in the unreleased 2.0.0 (crates.io tops out at 1.0.0) and will be documented via the release-notes entry in #447 — no CHANGELOG edit here to avoid conflicting with that PR.

## Tests

- `test_i16_samples_roundtrip` (kept)
- `test_from_i16_samples_emits_little_endian_bytes`
- `test_i16_samples_empty`
- `test_i16_samples_odd_bytes_error` (now asserts the exact message)
- `test_to_i16_samples_borrows_aligned_buffer` (little-endian only, asserts `Cow::Borrowed`)
- `test_decode_pcm16_le_misaligned_buffer_is_owned` — `AudioChunk.data` is an owned `Vec<u8>` so it is effectively always aligned; the fallback is unreachable through the public type, so it is exercised directly with a deliberately misaligned sub-slice, mirroring the existing test in `livekit/handler.rs`
- `test_decode_pcm16_le_empty_input`
- Two rustdoc `# Example` blocks, run as doctests

## Gate results

Run locally on macOS/aarch64:

| Gate | Result |
| --- | --- |
| `cargo fmt --all -- --check` | pass |
| `cargo clippy --workspace --all-targets -- -D warnings` | pass, no warnings |
| `cargo clippy -p adk-realtime --features full --all-targets -- -D warnings` | pass, no warnings |
| `cargo nextest run --workspace` | 3724 passed, 83 skipped, 0 failed |
| `cargo test -p adk-realtime --doc` | 3 passed, 9 ignored — both new `audio.rs` examples run |
| `CMAKE_POLICY_VERSION_MINIMUM=3.5 cargo check -p adk-realtime --features openai-webrtc --all-targets` | pass |

That last one matters: the `full` feature set excludes `openai-webrtc`, so CI never compiles the WebRTC transport this PR touches. It was checked explicitly here.

No `#[allow(...)]` was added, and no hook or lint was bypassed.
