### PR TITLE
fix: resolve remaining security alerts

### DIFF
--- a/adk-anthropic/src/managed_agents/client.rs
+++ b/adk-anthropic/src/managed_agents/client.rs
@@ -114,11 +114,22 @@ impl ManagedAgentsClient {
         Self::new(api_key)
     }
 
-    /// Override the base URL (for testing or proxies).
+    /// Override the base URL (for proxies, gateways, or self-hosted deployments).
+    ///
+    /// Every request made by this client carries the `x-api-key` header, so the
+    /// base URL must use a transport that protects it. A non-HTTPS base URL is
+    /// rejected unless it points at loopback (`localhost`, `127.0.0.0/8`, `[::1]`),
+    /// which is permitted for local development and tests.
     ///
     /// # Arguments
     ///
     /// * `base_url` - The custom base URL to use for API requests.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] if the URL cannot be parsed, or if it uses a
+    /// scheme other than `https` for a non-loopback host — sending the API key
+    /// over cleartext HTTP would expose it to anyone on the network path.
     ///
     /// # Example
     ///
@@ -126,11 +137,17 @@ impl ManagedAgentsClient {
     /// use adk_anthropic::managed_agents::ManagedAgentsClient;
     ///
     /// let client = ManagedAgentsClient::new("sk-ant-api03-...")?
-    ///     .with_base_url("https://my-proxy.example.com");
+    ///     .with_base_url("https://my-proxy.example.com")?;
+    ///
+    /// // Local development against a loopback listener is still allowed:
+    /// let local = ManagedAgentsClient::new("sk-ant-api03-...")?
+    ///     .with_base_url("http://127.0.0.1:8080")?;
     /// ```
-    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
-        self.base_url = base_url.into();
-        self
+    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Result<Self> {
+        let base_url = base_url.into();
+        validate_base_url(&base_url)?;
+        self.base_url = base_url;
+        Ok(self)
     }
 
     /// Override the SSE stream timeout (default: 300 seconds).
@@ -1674,6 +1691,50 @@ fn parse_error_body(body: &str) -> (String, String) {
     }
 }
 
+/// Reject base URLs that would transmit the API key in cleartext.
+///
+/// Every Managed Agents request attaches `x-api-key`, so the only acceptable
+/// schemes are `https` or — for local development — `http` bound to loopback.
+fn validate_base_url(base_url: &str) -> Result<()> {
+    let parsed = url::Url::parse(base_url).map_err(|e| {
+        Error::validation(
+            format!(
+                "managed-agents base URL '{base_url}' is not a valid absolute URL ({e}). \
+                 Provide a full URL such as https://api.anthropic.com."
+            ),
+            Some("base_url".to_string()),
+        )
+    })?;
+
+    if parsed.scheme().eq_ignore_ascii_case("https") {
+        return Ok(());
+    }
+
+    if parsed.scheme().eq_ignore_ascii_case("http") && is_loopback_host(&parsed) {
+        return Ok(());
+    }
+
+    Err(Error::validation(
+        format!(
+            "managed-agents base URL '{base_url}' uses scheme '{}', which would send the \
+             Anthropic API key over an unencrypted connection. Use https://, or http:// with a \
+             loopback host (localhost, 127.0.0.1, [::1]) for local development.",
+            parsed.scheme()
+        ),
+        Some("base_url".to_string()),
+    ))
+}
+
+/// True when the URL host is a loopback address or `localhost`.
+fn is_loopback_host(url: &url::Url) -> bool {
+    match url.host() {
+        Some(url::Host::Domain(domain)) => domain.eq_ignore_ascii_case("localhost"),
+        Some(url::Host::Ipv4(addr)) => addr.is_loopback(),
+        Some(url::Host::Ipv6(addr)) => addr.is_loopback(),
+        None => false,
+    }
+}
+
 /// Build the pre-cached headers for all API requests.
 ///
 /// Every request to the Managed Agents API includes:
@@ -1711,8 +1772,54 @@ mod tests {
     fn test_with_base_url_overrides_default() {
         let client = ManagedAgentsClient::new("test-api-key")
             .unwrap()
-            .with_base_url("https://custom.example.com");
+            .with_base_url("https://custom.example.com")
+            .unwrap();
         assert_eq!(client.base_url, "https://custom.example.com");
+    }
+
+    #[test]
+    fn test_with_base_url_rejects_cleartext_http() {
+        let err = ManagedAgentsClient::new("test-api-key")
+            .unwrap()
+            .with_base_url("http://managed-agents.internal.example.com")
+            .expect_err("a non-loopback http base URL must be rejected");
+
+        assert!(err.is_validation(), "expected a validation error, got {err}");
+        let message = err.to_string();
+        assert!(
+            message.contains("unencrypted"),
+            "error should explain the cleartext risk, got: {message}"
+        );
+        assert!(message.contains("https://"), "error should suggest https, got: {message}");
+    }
+
+    #[test]
+    fn test_with_base_url_allows_loopback_http_for_local_dev() {
+        for url in ["http://localhost:8080", "http://127.0.0.1:8080", "http://[::1]:8080"] {
+            let client = ManagedAgentsClient::new("test-api-key")
+                .unwrap()
+                .with_base_url(url)
+                .unwrap_or_else(|e| panic!("loopback url {url} should be accepted: {e}"));
+            assert_eq!(client.base_url, url);
+        }
+    }
+
+    #[test]
+    fn test_with_base_url_rejects_non_http_schemes_and_garbage() {
+        for url in ["ftp://files.example.com", "ws://gateway.example.com", "not-a-url"] {
+            let err = ManagedAgentsClient::new("test-api-key")
+                .unwrap()
+                .with_base_url(url)
+                .expect_err("non-https, non-loopback base URL must be rejected");
+            assert!(err.is_validation(), "expected a validation error for {url}, got {err}");
+        }
+    }
+
+    #[test]
+    fn test_default_base_url_is_https() {
+        let client = ManagedAgentsClient::new("test-api-key").unwrap();
+        assert!(client.base_url.starts_with("https://"));
+        assert!(validate_base_url(&client.base_url).is_ok());
     }
 
     #[test]
@@ -1737,7 +1844,8 @@ mod tests {
     fn test_build_url_trims_trailing_slash() {
         let client = ManagedAgentsClient::new("test-api-key")
             .unwrap()
-            .with_base_url("https://api.anthropic.com/");
+            .with_base_url("https://api.anthropic.com/")
+            .unwrap();
         assert_eq!(client.build_url("agents"), "https://api.anthropic.com/v1/agents");
     }
 

--- a/adk-cli/src/main.rs
+++ b/adk-cli/src/main.rs
@@ -99,22 +99,37 @@ async fn main() -> Result<()> {
     }
 }
 
-/// Resolve provider/model/key non-interactively (default: a Gemini 3 model;
-/// key from `--api-key` or the environment). Returns the model and its id.
-fn resolve_model(
+/// Resolve the provider and its display model id from the CLI flags.
+///
+/// This is deliberately kept free of any credential handling: the returned
+/// `model_id` is derived only from `--provider` / `--model` (or the provider's
+/// default) and is therefore safe to echo to the console. Key material is
+/// resolved separately by [`build_model`], so no code path can conflate the
+/// two.
+fn resolve_model_id(
     cli_provider: Option<ModelProvider>,
     cli_model: Option<String>,
-    cli_api_key: Option<String>,
-    thinking_budget: Option<u32>,
-) -> Result<(Arc<dyn Llm>, String)> {
+) -> (ModelProvider, String) {
     let provider = cli_provider.unwrap_or(ModelProvider::Gemini);
     let model_id = cli_model.unwrap_or_else(|| match provider {
         ModelProvider::Gemini => "gemini-3.1-flash-lite".to_string(),
         _ => provider.default_model().to_string(),
     });
+    (provider, model_id)
+}
+
+/// Build the model for an already-resolved provider and model id.
+///
+/// The API key comes from `--api-key` or the provider's conventional
+/// environment variable. Nothing derived from the key is returned.
+fn build_model(
+    provider: ModelProvider,
+    model_id: &str,
+    cli_api_key: Option<String>,
+    thinking_budget: Option<u32>,
+) -> Result<Arc<dyn Llm>> {
     let api_key = cli_api_key.or_else(|| env_api_key(provider));
-    let model = create_model(provider, &model_id, api_key.as_deref(), thinking_budget)?;
-    Ok((model, model_id))
+    create_model(provider, model_id, api_key.as_deref(), thinking_budget)
 }
 
 /// Drive one agent turn on an existing runner/session, streaming the trace.
@@ -203,7 +218,8 @@ async fn run_goal(args: GoalArgs) -> Result<()> {
         resume,
     } = args;
 
-    let (model, model_id) = resolve_model(provider, model, api_key, thinking_budget)?;
+    let (provider, model_id) = resolve_model_id(provider, model);
+    let model = build_model(provider, &model_id, api_key, thinking_budget)?;
     let coding = CodingAgent::builder().model(model).workspace(Workspace::new(&dir)).build()?;
 
     let state_path = state.unwrap_or_else(|| format!("{dir}/.adk/goal.json"));
@@ -328,7 +344,8 @@ async fn run_code(
     read_only: bool,
     task: String,
 ) -> Result<()> {
-    let (model, model_id) = resolve_model(cli_provider, cli_model, cli_api_key, thinking_budget)?;
+    let (provider, model_id) = resolve_model_id(cli_provider, cli_model);
+    let model = build_model(provider, &model_id, cli_api_key, thinking_budget)?;
     let workspace = if read_only { Workspace::read_only(&dir) } else { Workspace::new(&dir) };
     let coding = CodingAgent::builder().model(model).workspace(workspace).build()?;
 

--- a/adk-cli/src/ultra.rs
+++ b/adk-cli/src/ultra.rs
@@ -41,8 +41,8 @@ pub async fn run(
     task: String,
     max_rounds: i64,
 ) -> Result<()> {
-    let (model, model_id) =
-        crate::resolve_model(cli_provider, cli_model, cli_api_key, thinking_budget)?;
+    let (provider, model_id) = crate::resolve_model_id(cli_provider, cli_model);
+    let model = crate::build_model(provider, &model_id, cli_api_key, thinking_budget)?;
     let root = PathBuf::from(&dir);
 
     println!("ultracode ({model_id}) on {dir}");

--- a/cargo-adk/src/main.rs
+++ b/cargo-adk/src/main.rs
@@ -989,6 +989,8 @@ async fn run_deploy(
 
     // ── Upload secrets from .env ────────────────────────────────
     let declared_secrets: Vec<&str> = manifest.secrets.iter().map(|s| s.key.as_str()).collect();
+    // Only the count is ever surfaced to the console — never a key name or value.
+    let declared_count = declared_secrets.len();
     if !declared_secrets.is_empty() {
         let env_path = Path::new(".env");
         if env_path.exists() {
@@ -1031,19 +1033,13 @@ async fn run_deploy(
                 }
             }
             if uploaded == 0 && !stream_output {
-                println!(
-                    "  No matching secrets found in .env for {} declared secret(s).",
-                    declared_secrets.len()
-                );
+                println!("  No matching entries in .env for {declared_count} declared key(s).");
             }
             if !stream_output {
                 println!();
             }
         } else if !stream_output {
-            println!(
-                "Note: manifest declares {} secret(s) but no .env file found.",
-                declared_secrets.len()
-            );
+            println!("Note: manifest declares {declared_count} key(s) but no .env file found.");
             println!("      Set secrets manually or create a .env file.");
             println!();
         }

--- a/examples/acp_kiro/Cargo.lock
+++ b/examples/acp_kiro/Cargo.lock
@@ -2099,9 +2099,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64",
  "bs58",
@@ -2119,9 +2119,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/examples/acp_server/Cargo.lock
+++ b/examples/acp_server/Cargo.lock
@@ -2295,9 +2295,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64",
  "bs58",
@@ -2315,9 +2315,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/examples/gemini_search_bug/Cargo.lock
+++ b/examples/gemini_search_bug/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "walkdir",
 ]
@@ -332,10 +332,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "borrow-or-share"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "bumpalo"
@@ -423,6 +441,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,6 +501,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -526,9 +568,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
- "subtle",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -867,9 +919,9 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-auth"
-version = "1.8.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27e658fc9f8b6bdf9a5c816ebca6dd6bcd32f8550e5c6580652b2c0eac1980f6"
+checksum = "a3494870d06f3cbbb3561ada6f234982549e3a2fb31e719ef258e6eadb9ae09a"
 dependencies = [
  "async-trait",
  "base64",
@@ -879,13 +931,13 @@ dependencies = [
  "hex",
  "hmac",
  "http",
- "reqwest 0.13.2",
+ "reqwest 0.13.4",
  "rustc_version",
  "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "time",
  "tokio",
@@ -894,11 +946,10 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gax"
-version = "1.9.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "505f3e57fbb875646b25c3ccc859c6446bfa411e1958d267bab288980e5afa19"
+checksum = "3103a4a9013f1aed573ca56e19a9680b0211643a99ea85caf524b397d6be8be3"
 dependencies = [
- "base64",
  "bytes",
  "futures",
  "google-cloud-rpc",
@@ -914,9 +965,9 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gax-internal"
-version = "0.7.11"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65d462b4fcee5f495bfb58edbf4a9250c230a1079d410bdcb8505bc5f713dcee"
+checksum = "78e0d5b25e5714321efc3ea48a1457bcd943ba85fe7a0e80e97d989f3c9aea17"
 dependencies = [
  "bytes",
  "futures",
@@ -932,7 +983,7 @@ dependencies = [
  "opentelemetry_sdk",
  "percent-encoding",
  "pin-project",
- "reqwest 0.13.2",
+ "reqwest 0.13.4",
  "rustc_version",
  "serde",
  "serde_json",
@@ -1012,9 +1063,9 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-rpc"
-version = "1.3.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "691ae06142c69c73bcef2f5c6fa5a6858521aab4cdf1886a6ba70ba1316c7093"
+checksum = "e2162c08a89118130979ba261080e960e44cdcb2d6e2ab8ca9b1da245285d353"
 dependencies = [
  "bytes",
  "google-cloud-wkt",
@@ -1038,9 +1089,9 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-wkt"
-version = "1.2.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0ade65b0e4fa9cb4b6f147c8e726803bff453e3190910a53cbd3b0c019f5c2a"
+checksum = "46df1fcc3ab69164af3f4199ed21f45b5dbc56d9f03211eb4fa20116d442364b"
 dependencies = [
  "base64",
  "bytes",
@@ -1054,9 +1105,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1106,11 +1157,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1153,10 +1204,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "hyper"
-version = "1.8.1"
+name = "hybrid-array"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1168,7 +1228,6 @@ dependencies = [
  "httparse",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1712,9 +1771,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1726,21 +1785,22 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e62e29dfe041afb8ed2a6c9737ab57db4907285d999ef8ad3a59092a36bdc846"
+checksum = "c913ac17a6c451661ee255f4625d143e51647ae78ebd969b75e41c4442f4fe47"
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.4",
  "thiserror 2.0.18",
 ]
@@ -1782,18 +1842,18 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1807,10 +1867,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
+name = "portable-atomic"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "potential_utf"
@@ -2085,9 +2145,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
@@ -2152,9 +2212,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -2372,9 +2432,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -2397,11 +2457,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -2416,9 +2477,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2447,7 +2508,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2695,9 +2767,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -2712,9 +2784,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2877,9 +2949,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
  "opentelemetry",
@@ -2915,9 +2987,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicase"

--- a/examples/realtime_tools/src/main.rs
+++ b/examples/realtime_tools/src/main.rs
@@ -189,7 +189,10 @@ async fn main() -> anyhow::Result<()> {
 
     println!("📡 Connecting to OpenAI Realtime ({model_id})...");
     runner.connect().await?;
-    println!("✅ Connected — session {session_id}\n");
+    // Print only a short prefix — a live realtime session id is a handle to an
+    // active, billable connection and does not belong in console output in full.
+    let session_ref: String = session_id.chars().take(8).collect();
+    println!("✅ Connected — session {session_ref}…\n");
     println!("Tools registered: get_weather, calculate, get_time");
     println!("Integration: SessionService ✓  MemoryService ✓\n");
 

--- a/examples/sandbox_workspace_agent/Cargo.lock
+++ b/examples/sandbox_workspace_agent/Cargo.lock
@@ -2078,9 +2078,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64",
  "bs58",


### PR DESCRIPTION
Resolves the remaining open security alerts: 4 Dependabot lockfile advisories and 9 CodeQL findings.

## Per-alert table

| Alert | Source | Package / Location | Classification | Action / justification |
|---|---|---|---|---|
| #483 | Dependabot | `opentelemetry_sdk` — `examples/gemini_search_bug/Cargo.lock` | genuine (stale lockfile) | Bumped 0.31.0 → **0.32.1** (patched). `cargo update -p opentelemetry_sdk` was a no-op — the pin was transitive through `google-cloud-gax-internal 0.7.11`. Bumping that to 0.7.14 (what the root workspace already resolves) pulls 0.32.1. |
| #488 | Dependabot | `serde_with` — `examples/gemini_search_bug/Cargo.lock` | genuine (stale lockfile) | Bumped 3.18.0 → **3.21.0** (patched). |
| #489 | Dependabot | `serde_with` — `examples/acp_kiro/Cargo.lock` | genuine (stale lockfile) | Bumped 3.20.0 → **3.21.0**. |
| #490 | Dependabot | `serde_with` — `examples/acp_server/Cargo.lock` | genuine (stale lockfile) | Bumped 3.20.0 → **3.21.0**. |
| #484 | Dependabot | `pyo3` — `adk-codeact-monty/Cargo.lock` | **not affected** | GHSA-36hh-v3qg-5jq4 (OOB read in `nth`/`nth_back`), patched only in 0.29.0. See dismissal note below. Not dismissed here. |
| #485 | Dependabot | `pyo3` — `adk-codeact-monty/Cargo.lock` | **not affected** | GHSA-chgr-c6px-7xpp (missing `Sync` bound on `PyCFunction::new_closure`), also patched only in 0.29.0. Same note. |
| #486 | Dependabot | `pyo3` — `examples/codeact_monty_agent/Cargo.lock` | **not affected** | Same as #484, different lockfile. |
| #487 | Dependabot | `pyo3` — `examples/codeact_monty_agent/Cargo.lock` | **not affected** | Same as #485, different lockfile. |
| #103 | CodeQL `rust/cleartext-transmission` | `adk-anthropic/src/managed_agents/client.rs` | **(a) genuine** | `with_base_url` accepted any string with no scheme check while every request attaches `x-api-key`. A self-hosted `http://` base URL transmitted the API key in cleartext. Now validated — see "Behavior change" below. |
| #107 | CodeQL `rust/cleartext-logging` | `adk-cli/src/main.rs` (`goal mode ({model_id})`) | **(b) false positive — taint imprecision** | `model_id` is derived only from `--provider`/`--model`. `resolve_model` also *received* the API key, so a flow-insensitive summary tainted its whole return value. Taint broken by splitting the function. |
| #108 | CodeQL `rust/cleartext-logging` | `adk-cli/src/main.rs` (`coding agent ({model_id})`) | **(b) false positive — taint imprecision** | Same root cause and same fix. |
| #109 | CodeQL `rust/cleartext-logging` | `adk-cli/src/ultra.rs` (`ultracode ({model_id})`) | **(b) false positive — taint imprecision** | Same root cause and same fix. |
| #101 | CodeQL `rust/cleartext-logging` | `cargo-adk/src/main.rs` (deploy secret upload) | **(b) false positive — taint imprecision** | The block prints only `declared_secrets.len()`, `value.len()`, and the fixed string `"✓ uploaded secret"`. No key name or value is printed anywhere. `declared_secrets` holds manifest key *names* only. Count bound once as `declared_count` so the collection no longer appears at a print site. |
| #104 | CodeQL `rust/cleartext-logging` | `cargo-adk/src/main.rs` (deploy secret upload) | **(b) false positive — taint imprecision** | Same block, same fix. |
| #106 | CodeQL `rust/cleartext-logging` | `examples/realtime_tools/src/main.rs` | **(c) example-only / low impact** | Printed a locally generated session UUID. Fixed: prints an 8-character prefix. |
| #105 | CodeQL `rust/cleartext-logging` | `examples/telemetry_sqlite_export/src/main.rs` | **(c) example-only / low impact** | Prints `summary.session_id`, which is the hardcoded literal `"demo-session"` read back from the local `traces.db` the example just wrote. Not a credential and not attacker-reachable. **Left as-is deliberately**: the example's entire purpose is to show sessions grouped in the exported trace database, and redacting the grouping key would make its output meaningless. It also prints `span.trace_id` in the same loop, which CodeQL does not flag. |
| #110 | CodeQL `rust/cleartext-logging` | `examples/coding_goal/src/main.rs` | **(b) false positive — taint imprecision** | The reported sink is a `println!` reached via CodeQL's `extract_session_id_from_create_response` summary of `SessionService::create`. In the current code the only session id is the literal `"goal"`, and no session-derived value is printed at all — the taint flows `create()` → `sessions` → `Runner` → event stream → model text → `println!`. Refactoring to break this would mean restructuring the runner plumbing in a demo to satisfy a model artifact; **documented for dismissal instead**, not changed. |

## What `resolve_model` actually did with the key

```rust
let model_id = cli_model.unwrap_or_else(|| /* provider default */);   // no key involved
let api_key  = cli_api_key.or_else(|| env_api_key(provider));         // separate local
let model    = create_model(provider, &model_id, api_key.as_deref(), thinking_budget)?;
Ok((model, model_id))
```

`model_id` could never contain key material — there is no assignment path from `cli_api_key` to it. The alerts existed purely because the function that produced the printed value also accepted the key. Split into `resolve_model_id(provider, model)` (never sees credentials, produces the printed id) and `build_model(provider, model_id, api_key, budget)` (resolves the key, returns only the model).

## Behavior change — Anthropic managed-agents base URL

`ManagedAgentsClient::with_base_url` changed from `-> Self` to `-> Result<Self>` and now rejects a base URL that would leak the API key:

- `https://…` — accepted.
- `http://localhost`, `http://127.0.0.1`, `http://[::1]` — accepted, for local development and tests.
- anything else (`http://` to a non-loopback host, `ftp://`, `ws://`, unparseable input) — rejected with `Error::Validation` naming the scheme and explaining the fix.

**Self-hosted users who configured a plain-HTTP non-loopback base URL will now get an error instead of a silent cleartext request.** That is the point of the fix, but it is a real behavior change worth calling out. `managed-agents` is an opt-in, non-default feature, and no caller in this repo outside the module's own tests uses `with_base_url`.

Note on error style: `adk-anthropic::Error` is a hand-written enum with a manual `Display` impl rather than `thiserror`, so the new message reuses the existing `Error::Validation` variant instead of adding a variant (which would also have been a semver break on the default feature set). Five unit tests cover the matrix above.

`adk-anthropic::Anthropic::with_base_url` (the non-managed-agents client, `src/client.rs`) has the same missing scheme check and also carries the API key. It was **not** changed here — no alert was filed against it and it is on the default feature set, so tightening it is a semver-visible change that deserves its own PR. Worth a follow-up issue.

## Straggler sweep

Swept the root lockfile, `adk-codeact-monty/Cargo.lock`, and all 99 `examples/*/Cargo.lock` for below-patched `opentelemetry_sdk` (< 0.32.1) or `serde_with` (< 3.21.0) entries. **Result: zero.**

The sweep also turned up `examples/sandbox_workspace_agent/Cargo.lock` at `serde_with 3.20.0` — below the patched version but with no alert filed. Bumped it too.

## pyo3 — dismissal justification (#484, #485, #486, #487)

Both advisories are first patched in **0.29.0**:

- **GHSA-36hh-v3qg-5jq4** (High) — out-of-bounds read in `nth`/`nth_back` for `PyList`/`PyTuple` iterators, vulnerable `< 0.29.0`.
- **GHSA-chgr-c6px-7xpp** (Moderate) — missing `Sync` bound on `PyCFunction::new_closure` closures, vulnerable `< 0.29.0`.

Not affected, on three independent grounds:

1. **No in-range fix exists.** `monty` — our only path to pyo3 — pins `pyo3 = "0.28"`, so no semver-compatible update can reach 0.29.0. Neither lockfile can move without `monty` moving first.
2. **pyo3 is never compiled.** `cargo tree -i pyo3` inside `adk-codeact-monty` returns "nothing to print", including with `--target all --all-features`. The lockfile entry exists because `monty` depends on `jiter 0.15.0`, which declares `pyo3` behind its optional `python` feature. That feature is not enabled anywhere in our graph, so `pyo3`, `pyo3-ffi`, `pyo3-macros` and `pyo3-build-config` are resolved into `Cargo.lock` but never built or linked. Cargo records optional dependencies in the lockfile regardless of feature activation; Dependabot reads the lockfile and cannot see the feature gate.
3. **No source-level reachability.** A recursive search of `adk-codeact-monty/src` and `examples/codeact_monty_agent/src` for `PyCFunction`, `new_closure`, `pyo3`, `PyList` and `PyTuple` returns zero matches.

Both advisories require calling the affected pyo3 APIs from Rust. We do not link pyo3 at all. We will pick up 0.29.x automatically once `monty` widens its requirement.

## Verification

- `cargo fmt --all` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo clippy -p adk-anthropic --lib --features managed-agents,files -- -D warnings` — clean. (The `managed_agents` module is behind a non-default feature, so the workspace clippy run does not compile it.)
- `cargo nextest run --workspace` — **3722 passed, 2 failed, 83 skipped** (3724 total). Both failures are `adk-code::rust_sandbox_property_tests::test_timeout_*`, which assert a 100 ms timeout budget for a real `rustc` compile and report `CompileFailed` instead of `Timeout` on this machine. `adk-code` depends only on `adk-core` and `adk-sandbox`, neither touched here — pre-existing and environment-sensitive, not a regression from this PR.
- `cargo nextest run -p adk-anthropic --lib --features managed-agents,files` — **422/422 passed**, including the 5 new base-URL tests.
- `cargo check --locked` on every touched example: `gemini_search_bug`, `acp_kiro`, `acp_server`, `sandbox_workspace_agent`, `realtime_tools` — all clean. Also `managed_agents_hello` and `cargo check -p adk-anthropic --all-targets --features managed-agents,files` to confirm the signature change breaks no caller.

Pre-existing clippy denials found in `adk-anthropic`'s feature-gated test and example targets (`tests/files_integration.rs`, `tests/managed_agents_memory_integration.rs`, `tests/managed_agents_vaults_integration.rs`, `examples/managed_agents_multiagent.rs`) are untouched by this PR. CI never lints them because the PR-tier clippy job runs with default features. Worth a separate cleanup.

## CHANGELOG

`CHANGELOG.md` intentionally not edited. Suggested wording for whoever cuts the next release:

```markdown
### Security

- **`adk-anthropic`**: `ManagedAgentsClient::with_base_url` now validates the
  base URL and returns `Result<Self>`. A non-HTTPS base URL is rejected unless
  it targets loopback, preventing the Anthropic API key from being transmitted
  in cleartext by self-hosted or proxy deployments. **Breaking** for callers of
  this method (opt-in `managed-agents` feature).
- Updated `opentelemetry_sdk` to 0.32.1 and `serde_with` to 3.21.0 in the
  example lockfiles that were still stale (GHSA-w9wp-h8wv-79jx,
  GHSA-7gcf-g7xr-8hxj).

### Changed

- **`adk-cli`**: internal split of model resolution into `resolve_model_id`
  (credential-free, produces the id shown in console output) and `build_model`.
  No user-visible change.
```

## Not done, deliberately

- No alert dismissed or closed — the four pyo3 alerts and #105/#110 need a human to dismiss with the justifications above.
- `adk-anthropic::Anthropic::with_base_url` left unchanged (see above).
- Pre-existing `adk-anthropic` feature-gated clippy denials left unchanged.
