### PR TITLE
fix(anthropic): validate base URL on the default client

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -15,9 +15,22 @@ paths-ignore:
   # Test fixtures
   - "**/test_data/**"
   - "**/fixtures/**"
+  # Example crates. These are `publish = false` demo binaries whose whole job is
+  # printing to stdout, so every finding raised in them so far has been a
+  # `println!` false positive (rust/cleartext-logging). Path scoping is the only
+  # way to express this: `query-filters` match on query metadata (id, tags,
+  # problem.severity) and have no path predicate, so excluding a single query for
+  # a single directory is not expressible.
+  - "examples/**"
 
-# Query filters to reduce false positives
+# Query filters to reduce false positives.
+# These match on query metadata only (id, tags, problem.severity, ...) — there is
+# no path predicate available here, so anything path-scoped belongs in
+# `paths-ignore` above.
 query-filters:
-  # Exclude low-severity alerts from minified files
+  # Exclude alerts raised by queries tagged for minified/generated sources.
+  # The key is `tags contain` (a single key with a space), per the CodeQL query
+  # suite syntax; the previous `tags: contain:` form was not valid YAML, which
+  # made the whole config file unparseable.
   - exclude:
-      tags: contain: /minified/
+      tags contain: minified

--- a/adk-anthropic/examples/custom_base_url.rs
+++ b/adk-anthropic/examples/custom_base_url.rs
@@ -12,8 +12,12 @@
 //! | Enterprise      | https://your-proxy.internal.com/anthropic   |
 //!
 //! Two ways to set the base URL:
-//! 1. Builder: `Anthropic::new(key)?.with_base_url(url)`
+//! 1. Builder: `Anthropic::new(key)?.with_base_url(url)?`
 //! 2. Env var: `ANTHROPIC_BASE_URL=https://...`
+//!
+//! The builder rejects base URLs that would send the API key in cleartext: only
+//! `https://`, or `http://` bound to loopback (localhost, 127.0.0.1, [::1]), is
+//! accepted.
 //!
 //! Run: `ANTHROPIC_API_KEY=sk-... cargo run -p adk-anthropic --example anthropic_custom_base_url`
 
@@ -47,7 +51,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("Using base URL: {custom_url}");
 
-    let client = Anthropic::new(None)?.with_base_url(custom_url);
+    let client = Anthropic::new(None)?.with_base_url(custom_url)?;
 
     let r = client
         .send(MessageCreateParams::simple(
@@ -66,7 +70,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\n=== Ollama (localhost:11434) ===\n");
 
     let ollama_client = Anthropic::new(Some("ollama".to_string()))?
-        .with_base_url("http://localhost:11434".to_string());
+        .with_base_url("http://localhost:11434".to_string())?;
 
     match ollama_client
         .send(MessageCreateParams::simple(

--- a/adk-anthropic/src/base_url.rs
+++ b/adk-anthropic/src/base_url.rs
@@ -1,0 +1,90 @@
+//! Base URL validation shared by every client in this crate.
+//!
+//! Each client attaches the Anthropic API key to every outbound request, so a
+//! base URL that is not encrypted would transmit the credential in cleartext.
+//! The validator lives here — outside any feature gate — so the default
+//! [`crate::Anthropic`] client and the feature-gated Managed Agents client
+//! enforce exactly the same rule.
+
+use crate::error::{Error, Result};
+
+/// Reject base URLs that would transmit the API key in cleartext.
+///
+/// Accepts `https://` unconditionally and `http://` only when the host is
+/// loopback (`localhost`, `127.0.0.0/8`, `[::1]`) for local development.
+/// Everything else — other schemes, unparseable input — is a validation error
+/// naming the offending scheme.
+pub(crate) fn validate_base_url(base_url: &str) -> Result<()> {
+    let parsed = url::Url::parse(base_url).map_err(|e| {
+        Error::validation(
+            format!(
+                "base URL '{base_url}' is not a valid absolute URL ({e}). \
+                 Provide a full URL such as https://api.anthropic.com."
+            ),
+            Some("base_url".to_string()),
+        )
+    })?;
+
+    if parsed.scheme().eq_ignore_ascii_case("https") {
+        return Ok(());
+    }
+
+    if parsed.scheme().eq_ignore_ascii_case("http") && is_loopback_host(&parsed) {
+        return Ok(());
+    }
+
+    Err(Error::validation(
+        format!(
+            "base URL '{base_url}' uses scheme '{}', which would send the Anthropic API key \
+             over an unencrypted connection. Use https://, or http:// with a loopback host \
+             (localhost, 127.0.0.1, [::1]) for local development.",
+            parsed.scheme()
+        ),
+        Some("base_url".to_string()),
+    ))
+}
+
+/// True when the URL host is a loopback address or `localhost`.
+fn is_loopback_host(url: &url::Url) -> bool {
+    match url.host() {
+        Some(url::Host::Domain(domain)) => domain.eq_ignore_ascii_case("localhost"),
+        Some(url::Host::Ipv4(addr)) => addr.is_loopback(),
+        Some(url::Host::Ipv6(addr)) => addr.is_loopback(),
+        None => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_base_url_accepts_https() {
+        assert!(validate_base_url("https://api.anthropic.com").is_ok());
+    }
+
+    #[test]
+    fn test_validate_base_url_accepts_loopback_http() {
+        for url in ["http://localhost:8080", "http://127.0.0.1:8080", "http://[::1]:8080"] {
+            assert!(validate_base_url(url).is_ok(), "loopback url {url} should be accepted");
+        }
+    }
+
+    #[test]
+    fn test_validate_base_url_rejects_non_loopback_http() {
+        let err = validate_base_url("http://gateway.internal.example.com")
+            .expect_err("non-loopback http must be rejected");
+        assert!(err.is_validation(), "expected a validation error, got {err}");
+        let message = err.to_string();
+        assert!(message.contains("unencrypted"), "should explain the risk, got: {message}");
+        assert!(message.contains("'http'"), "should name the scheme, got: {message}");
+    }
+
+    #[test]
+    fn test_validate_base_url_rejects_other_schemes_and_garbage() {
+        for url in ["ftp://files.example.com", "ws://gateway.example.com", "not-a-url"] {
+            let err = validate_base_url(url).expect_err("{url} must be rejected");
+            assert!(err.is_validation(), "expected a validation error for {url}, got {err}");
+        }
+    }
+}

--- a/adk-anthropic/src/client.rs
+++ b/adk-anthropic/src/client.rs
@@ -13,6 +13,7 @@ use tokio::time::sleep;
 
 use crate::AccumulatingStream;
 use crate::backoff::ExponentialBackoff;
+use crate::base_url::validate_base_url;
 use crate::client_logger::ClientLogger;
 use crate::error::{Error, Result};
 use crate::observability::{
@@ -181,26 +182,34 @@ impl Anthropic {
     /// The base URL should be the root URL without the `/v1/` suffix - this will
     /// be added automatically when constructing request URLs.
     ///
+    /// # Errors
+    ///
+    /// Every request made by this client attaches the Anthropic API key, so the
+    /// base URL must be encrypted. Returns a validation error unless the URL uses
+    /// `https://`, or `http://` with a loopback host (`localhost`, `127.0.0.1`,
+    /// `[::1]`) for local development.
+    ///
     /// # Examples
     ///
     /// ```
     /// # use adk_anthropic::Anthropic;
     /// // For Anthropic's API (default)
-    /// let client = Anthropic::new(Some("api-key".to_string()))?
-    ///     .with_base_url("https://api.anthropic.com".to_string());
+    /// let client = Anthropic::new(Some("placeholder-api-key".to_string()))?
+    ///     .with_base_url("https://api.anthropic.com".to_string())?;
     ///
     /// // For Minimax (international)
-    /// let client = Anthropic::new(Some("api-key".to_string()))?
-    ///     .with_base_url("https://api.minimax.io/anthropic".to_string());
+    /// let client = Anthropic::new(Some("placeholder-api-key".to_string()))?
+    ///     .with_base_url("https://api.minimax.io/anthropic".to_string())?;
     ///
     /// // For Minimax (China)
-    /// let client = Anthropic::new(Some("api-key".to_string()))?
-    ///     .with_base_url("https://api.minimaxi.com/anthropic".to_string());
+    /// let client = Anthropic::new(Some("placeholder-api-key".to_string()))?
+    ///     .with_base_url("https://api.minimaxi.com/anthropic".to_string())?;
     /// # Ok::<(), adk_anthropic::Error>(())
     /// ```
-    pub fn with_base_url(mut self, base_url: String) -> Self {
+    pub fn with_base_url(mut self, base_url: String) -> Result<Self> {
+        validate_base_url(&base_url)?;
         self.base_url = base_url;
-        self
+        Ok(self)
     }
 
     /// Return the effective API base URL used for message requests.
@@ -258,7 +267,7 @@ impl Anthropic {
     ///
     /// This is a convenience method that chains with_base_url and with_timeout.
     pub fn with_base_url_and_timeout(self, base_url: String, timeout: Duration) -> Result<Self> {
-        self.with_base_url(base_url).with_timeout(timeout)
+        self.with_base_url(base_url)?.with_timeout(timeout)
     }
 
     /// Build default headers for API requests (static method for initialization).
@@ -1410,6 +1419,7 @@ mod tests {
         // Test builder pattern methods
         let configured_client = client
             .with_base_url("https://custom.api.com".to_string())
+            .unwrap()
             .with_max_retries(5)
             .with_backoff_params(2.0, 1.0);
 
@@ -1435,7 +1445,8 @@ mod tests {
     fn build_url_custom_base_without_trailing_slash() {
         let client = Anthropic::new(Some("test_key".to_string()))
             .unwrap()
-            .with_base_url("https://api.minimax.io/anthropic".to_string());
+            .with_base_url("https://api.minimax.io/anthropic".to_string())
+            .unwrap();
         assert_eq!(client.build_url("messages"), "https://api.minimax.io/anthropic/v1/messages");
     }
 
@@ -1443,7 +1454,8 @@ mod tests {
     fn build_url_custom_base_with_trailing_slash() {
         let client = Anthropic::new(Some("test_key".to_string()))
             .unwrap()
-            .with_base_url("https://api.minimax.io/anthropic/".to_string());
+            .with_base_url("https://api.minimax.io/anthropic/".to_string())
+            .unwrap();
         assert_eq!(client.build_url("messages"), "https://api.minimax.io/anthropic/v1/messages");
     }
 
@@ -1451,12 +1463,72 @@ mod tests {
     fn build_url_minimax_china() {
         let client = Anthropic::new(Some("test_key".to_string()))
             .unwrap()
-            .with_base_url("https://api.minimaxi.com/anthropic".to_string());
+            .with_base_url("https://api.minimaxi.com/anthropic".to_string())
+            .unwrap();
         assert_eq!(client.build_url("messages"), "https://api.minimaxi.com/anthropic/v1/messages");
         assert_eq!(
             client.build_url(&format!("models/{}", "claude-3-opus")),
             "https://api.minimaxi.com/anthropic/v1/models/claude-3-opus"
         );
+    }
+
+    #[test]
+    fn with_base_url_accepts_https() {
+        let client = Anthropic::new(Some("placeholder-api-key".to_string()))
+            .unwrap()
+            .with_base_url("https://gateway.example.com/anthropic".to_string())
+            .unwrap();
+        assert_eq!(client.base_url, "https://gateway.example.com/anthropic");
+    }
+
+    #[test]
+    fn with_base_url_allows_loopback_http_for_local_dev() {
+        for url in ["http://localhost:8080", "http://127.0.0.1:8080", "http://[::1]:8080"] {
+            let client = Anthropic::new(Some("placeholder-api-key".to_string()))
+                .unwrap()
+                .with_base_url(url.to_string())
+                .unwrap_or_else(|e| panic!("loopback url {url} should be accepted: {e}"));
+            assert_eq!(client.base_url, url);
+        }
+    }
+
+    #[test]
+    fn with_base_url_rejects_cleartext_http() {
+        let err = Anthropic::new(Some("placeholder-api-key".to_string()))
+            .unwrap()
+            .with_base_url("http://gateway.internal.example.com".to_string())
+            .expect_err("a non-loopback http base URL must be rejected");
+
+        assert!(err.is_validation(), "expected a validation error, got {err}");
+        let message = err.to_string();
+        assert!(
+            message.contains("unencrypted"),
+            "error should explain the cleartext risk, got: {message}"
+        );
+        assert!(message.contains("'http'"), "error should name the scheme, got: {message}");
+    }
+
+    #[test]
+    fn with_base_url_rejects_non_http_schemes_and_garbage() {
+        for url in ["ftp://files.example.com", "ws://gateway.example.com", "not-a-url"] {
+            let err = Anthropic::new(Some("placeholder-api-key".to_string()))
+                .unwrap()
+                .with_base_url(url.to_string())
+                .expect_err("non-https, non-loopback base URL must be rejected");
+            assert!(err.is_validation(), "expected a validation error for {url}, got {err}");
+        }
+    }
+
+    #[test]
+    fn with_base_url_and_timeout_rejects_cleartext_http() {
+        let err = Anthropic::new(Some("placeholder-api-key".to_string()))
+            .unwrap()
+            .with_base_url_and_timeout(
+                "http://gateway.internal.example.com".to_string(),
+                Duration::from_secs(5),
+            )
+            .expect_err("a non-loopback http base URL must be rejected");
+        assert!(err.is_validation(), "expected a validation error, got {err}");
     }
 
     #[test]

--- a/adk-anthropic/src/lib.rs
+++ b/adk-anthropic/src/lib.rs
@@ -9,6 +9,7 @@
 
 mod accumulating_stream;
 mod backoff;
+mod base_url;
 mod cache_control;
 mod client;
 mod client_logger;

--- a/adk-anthropic/src/managed_agents/client.rs
+++ b/adk-anthropic/src/managed_agents/client.rs
@@ -25,6 +25,7 @@ use super::vaults::{
     CreateCredentialParams, CreateVaultParams, Credential, CredentialValidation,
     UpdateCredentialParams, Vault, VaultListResponse,
 };
+use crate::base_url::validate_base_url;
 use crate::{Error, Result};
 
 /// Default base URL for the Anthropic API.
@@ -1688,50 +1689,6 @@ fn parse_error_body(body: &str) -> (String, String) {
         (error_type, message)
     } else {
         ("api_error".to_string(), body.to_string())
-    }
-}
-
-/// Reject base URLs that would transmit the API key in cleartext.
-///
-/// Every Managed Agents request attaches `x-api-key`, so the only acceptable
-/// schemes are `https` or — for local development — `http` bound to loopback.
-fn validate_base_url(base_url: &str) -> Result<()> {
-    let parsed = url::Url::parse(base_url).map_err(|e| {
-        Error::validation(
-            format!(
-                "managed-agents base URL '{base_url}' is not a valid absolute URL ({e}). \
-                 Provide a full URL such as https://api.anthropic.com."
-            ),
-            Some("base_url".to_string()),
-        )
-    })?;
-
-    if parsed.scheme().eq_ignore_ascii_case("https") {
-        return Ok(());
-    }
-
-    if parsed.scheme().eq_ignore_ascii_case("http") && is_loopback_host(&parsed) {
-        return Ok(());
-    }
-
-    Err(Error::validation(
-        format!(
-            "managed-agents base URL '{base_url}' uses scheme '{}', which would send the \
-             Anthropic API key over an unencrypted connection. Use https://, or http:// with a \
-             loopback host (localhost, 127.0.0.1, [::1]) for local development.",
-            parsed.scheme()
-        ),
-        Some("base_url".to_string()),
-    ))
-}
-
-/// True when the URL host is a loopback address or `localhost`.
-fn is_loopback_host(url: &url::Url) -> bool {
-    match url.host() {
-        Some(url::Host::Domain(domain)) => domain.eq_ignore_ascii_case("localhost"),
-        Some(url::Host::Ipv4(addr)) => addr.is_loopback(),
-        Some(url::Host::Ipv6(addr)) => addr.is_loopback(),
-        None => false,
     }
 }
 

--- a/adk-model/src/anthropic/client.rs
+++ b/adk-model/src/anthropic/client.rs
@@ -40,7 +40,9 @@ impl AnthropicClient {
         let mut client = Anthropic::new(Some(config.api_key.clone()))
             .map_err(|e| AdkError::model(format!("Failed to create Anthropic client: {e}")))?;
         if let Some(base_url) = &config.base_url {
-            client = client.with_base_url(base_url.clone());
+            client = client.with_base_url(base_url.clone()).map_err(|e| {
+                AdkError::model(format!("Invalid Anthropic base URL '{base_url}': {e}"))
+            })?;
         }
 
         Ok(Self {

--- a/docs/official_docs/models/anthropic.md
+++ b/docs/official_docs/models/anthropic.md
@@ -76,11 +76,18 @@ with `base_url()`:
 use adk_anthropic::Anthropic;
 
 let client = Anthropic::new(Some(api_key))?
-    .with_base_url("https://api.minimax.io/anthropic".to_string());
+    .with_base_url("https://api.minimax.io/anthropic".to_string())?;
 assert_eq!(client.base_url(), "https://api.minimax.io/anthropic");
 ```
 
 When unset, the client uses Anthropic's public API (`https://api.anthropic.com`).
+
+`with_base_url` returns `Result` because the client attaches the Anthropic API key
+to every request. Only `https://`, or `http://` with a loopback host
+(`localhost`, `127.0.0.1`, `[::1]`) for local development, is accepted — anything
+else is rejected as a validation error rather than silently sending the key in
+cleartext. The same rule applies to `AnthropicConfig::with_base_url`, which is
+validated when `AnthropicClient::new` builds the underlying client.
 
 ## Key Features
 


### PR DESCRIPTION
## Summary

Two pre-publish fixes.

### 1. `Anthropic::with_base_url` accepted cleartext base URLs

`adk-anthropic`'s default client attaches the Anthropic API key (`x-api-key`) to
every request, but `with_base_url` took any `String` with no scheme validation.
An `http://` base URL therefore transmitted the credential in cleartext. This is
the same defect as CodeQL alert #103, which we fixed in the Managed Agents
client — except this one sits on the **default** feature set and no alert was
filed against it.

The validator (`validate_base_url` / `is_loopback_host`) previously lived in
`adk-anthropic/src/managed_agents/client.rs`, behind the non-default
`managed-agents` feature. It now lives in a new crate-private module
`adk-anthropic/src/base_url.rs`, compiled unconditionally, and both clients call
it. A dedicated module keeps the rule in one place without adding public API
surface, and `client.rs` is already ~1,500 lines. `url` was already a
non-optional dependency of `adk-anthropic`, so no `Cargo.toml` change was
needed.

Behavior is unchanged from the managed-agents implementation:

| Base URL | Result |
|---|---|
| `https://...` | accepted |
| `http://localhost`, `http://127.0.0.1`, `http://[::1]` | accepted (local dev) |
| `http://` any other host | rejected — `Error::validation`, names the scheme |
| `ftp://`, `ws://`, ... | rejected |
| unparseable | rejected |

**Breaking change (semver-visible, default feature set):**
`Anthropic::with_base_url(String) -> Self` becomes
`Anthropic::with_base_url(String) -> Result<Self>`. Callers need `?`. This is
acceptable because 2.0.0 has not published yet — crates.io tops out at 1.0.0 —
but it is a hard break for anyone building against `main`.

Callers updated:
- `Anthropic::with_base_url_and_timeout` (now `self.with_base_url(base_url)?`)
- `adk_model::anthropic::AnthropicClient::new` — maps the validation error into
  `AdkError::model`, so an invalid `AnthropicConfig::base_url` now fails client
  construction instead of being silently applied
- the three rustdoc examples on `with_base_url` (Anthropic, MiniMax
  international, MiniMax China) — these are compiled doctests
- `adk-anthropic/examples/custom_base_url.rs` (both call sites)
- four existing unit tests in `adk-anthropic/src/client.rs`
- `docs/official_docs/models/anthropic.md`

`with_base_url` on `adk-model`'s config types, `adk-server`, `adk-gemini`,
`adk-audio`, `adk-realtime`, and `adk-enterprise` are different methods on
different types and were not touched.

### 2. CodeQL: stop scanning example crates

Added `examples/**` to `paths-ignore` in `.github/codeql-config.yml`. Every
CodeQL finding raised in example code so far has been a
`rust/cleartext-logging` false positive on a `println!` — these are
`publish = false` demo binaries whose entire purpose is printing to stdout.

A path-scoped query filter is not expressible. `query-filters` match on query
metadata only (`id`, `tags`, `problem.severity`, `query filename`,
`query path` — the last two refer to the *query* file inside its CodeQL pack,
not the analyzed source), so there is no way to say "exclude
`rust/cleartext-logging`, but only under `examples/`". Path scoping is
`paths`/`paths-ignore`, and `paths-ignore` is supported for Rust when analyzing
without building. Sources:
[Customizing your advanced setup for code scanning](https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning),
[Creating CodeQL query suites](https://docs.github.com/en/code-security/tutorials/customize-code-scanning/creating-codeql-query-suites).
(Content rephrased for compliance with licensing restrictions.)

**Coverage trade-off, stated explicitly:** this removes example code from *all*
CodeQL queries, not just the noisy one. A genuine vulnerability in an example
would no longer be reported. The one genuine finding to date (#103) was in a
published crate (`adk-anthropic`), and published crates remain fully covered.

Note that `**/examples/**` was not added — crate-local example directories such
as `adk-anthropic/examples/` are still scanned. Only the top-level `examples/`
workspace members are excluded.

**Also fixed in the same file:** the existing `query-filters` entry read
`tags: contain: /minified/`, which is not valid YAML (`mapping values are not
allowed here`). The whole config file failed to parse, which means
`paths-ignore` was not being applied either. The correct query suite syntax is
the single key `tags contain`. Corrected to `tags contain: minified`; the file
now parses.

## Tests

New in `adk-anthropic/src/base_url.rs` (validator level, 4 tests) and
`adk-anthropic/src/client.rs` (client level, 5 tests): https accepted, all three
loopback `http://` forms accepted, non-loopback `http://` rejected with a
message naming the scheme, non-HTTP schemes and unparseable input rejected, and
`with_base_url_and_timeout` propagating the rejection. Fixtures use
`placeholder-api-key`, never a credential-shaped string.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all` | clean |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo clippy -p adk-model --all-targets --features anthropic -- -D warnings` | clean (the workspace run does not compile `adk-model`'s anthropic module) |
| `cargo nextest run --workspace --no-fail-fast` | 3733 run: 3731 passed, 2 failed, 83 skipped |
| `cargo clippy -p adk-anthropic --lib --all-targets --features managed-agents,files -- -D warnings` | lib clean; 5 pre-existing `collapsible_if` denials in feature-gated integration test targets |
| `cargo nextest run -p adk-anthropic --features managed-agents,files` | 444 run: 444 passed, 35 skipped |
| `cargo test -p adk-anthropic --doc` | 7 passed, 3 ignored |

Pre-existing failures, not caused by this change and not chased:
`adk-code::rust_sandbox_property_tests::test_timeout_during_execution_phase` and
`test_timeout_produces_timeout_failure_short` (they give a real `rustc` compile a
100 ms budget and are machine-sensitive). The 5 clippy denials are all in
`adk-anthropic/tests/managed_agents_*integration.rs`, untouched here.

## CHANGELOG wording (not applied — for the release editor)

```markdown
### Fixed

- **`adk-anthropic`**: `Anthropic::with_base_url` now validates the URL scheme.
  The client attaches the Anthropic API key to every request, so a cleartext
  base URL leaked the credential. `https://` is accepted, `http://` only for
  loopback hosts (`localhost`, `127.0.0.0/8`, `[::1]`) for local development,
  and everything else is rejected with a validation error. The validator is now
  shared with the `managed-agents` client instead of being duplicated behind
  that feature flag.

### Breaking

- **`adk-anthropic`**: `Anthropic::with_base_url` returns `Result<Self>` instead
  of `Self`, so it can reject base URLs that would transmit the API key in
  cleartext. Add `?` at the call site:
  `Anthropic::new(key)?.with_base_url(url)?`. `AnthropicConfig::with_base_url`
  in `adk-model` is unchanged, but an invalid value now surfaces as an error from
  `AnthropicClient::new`.
```

## Known gap not addressed

`Anthropic::new` still reads `ANTHROPIC_BASE_URL` from the environment without
validating it, so the same cleartext path remains reachable via env var. Fixing
that would make `new()` fail for configurations that previously worked, which is
a separate decision — flagging rather than folding it in.
