### PR TITLE
fix(anthropic): close remaining cleartext base-URL paths

### DIFF
--- a/adk-anthropic/examples/custom_base_url.rs
+++ b/adk-anthropic/examples/custom_base_url.rs
@@ -15,9 +15,10 @@
 //! 1. Builder: `Anthropic::new(key)?.with_base_url(url)?`
 //! 2. Env var: `ANTHROPIC_BASE_URL=https://...`
 //!
-//! The builder rejects base URLs that would send the API key in cleartext: only
+//! Both paths reject base URLs that would send the API key in cleartext: only
 //! `https://`, or `http://` bound to loopback (localhost, 127.0.0.1, [::1]), is
-//! accepted.
+//! accepted. A rejected `ANTHROPIC_BASE_URL` makes `Anthropic::new` fail rather
+//! than silently falling back to the default endpoint.
 //!
 //! Run: `ANTHROPIC_API_KEY=sk-... cargo run -p adk-anthropic --example anthropic_custom_base_url`
 

--- a/adk-anthropic/src/client.rs
+++ b/adk-anthropic/src/client.rs
@@ -125,6 +125,28 @@ impl Anthropic {
         }
     }
 
+    /// Resolve the effective base URL from an optional `ANTHROPIC_BASE_URL` value.
+    ///
+    /// A value supplied through the environment is held to exactly the same rule
+    /// as one supplied through [`Anthropic::with_base_url`]: every request
+    /// attaches the API key, so an unencrypted endpoint would leak the
+    /// credential. When no value is supplied the default Anthropic API URL is
+    /// used.
+    ///
+    /// # Errors
+    ///
+    /// Returns a validation error when the supplied value is not `https://` and
+    /// not `http://` with a loopback host.
+    fn resolve_base_url(env_value: Option<String>) -> Result<String> {
+        match env_value {
+            Some(value) => {
+                validate_base_url(&value)?;
+                Ok(value)
+            }
+            None => Ok(DEFAULT_API_URL.to_string()),
+        }
+    }
+
     /// Create a new Anthropic client.
     ///
     /// The API key can be provided directly or read from the `ANTHROPIC_API_KEY`
@@ -133,6 +155,14 @@ impl Anthropic {
     ///
     /// The base URL is resolved from the `ANTHROPIC_BASE_URL` environment
     /// variable. If not set, the default Anthropic API URL is used.
+    ///
+    /// # Errors
+    ///
+    /// Returns a validation error when `ANTHROPIC_BASE_URL` is set to an
+    /// endpoint that would transmit the API key in cleartext — anything other
+    /// than `https://`, or `http://` with a loopback host (`localhost`,
+    /// `127.0.0.1`, `[::1]`). A misconfigured environment fails loudly rather
+    /// than silently falling back to the default URL.
     pub fn new(api_key: Option<String>) -> Result<Self> {
         let api_key = match api_key {
             Some(key) => Self::resolve_api_key(&key)?,
@@ -160,9 +190,10 @@ impl Anthropic {
         // Pre-build headers for performance
         let cached_headers = Arc::new(Self::build_default_headers(&api_key)?);
 
-        // Resolve base URL from environment variable, defaulting to the API URL
-        let base_url =
-            env::var("ANTHROPIC_BASE_URL").unwrap_or_else(|_| DEFAULT_API_URL.to_string());
+        // Resolve base URL from environment variable, defaulting to the API URL.
+        // An env-provided value is validated here so the cleartext path closed on
+        // `with_base_url` cannot be reopened through the environment.
+        let base_url = Self::resolve_base_url(env::var("ANTHROPIC_BASE_URL").ok())?;
 
         Ok(Self {
             api_key,
@@ -1515,6 +1546,59 @@ mod tests {
                 .unwrap()
                 .with_base_url(url.to_string())
                 .expect_err("non-https, non-loopback base URL must be rejected");
+            assert!(err.is_validation(), "expected a validation error for {url}, got {err}");
+        }
+    }
+
+    // The `ANTHROPIC_BASE_URL` tests exercise `resolve_base_url` directly instead
+    // of mutating the process environment. The environment is process-global, so
+    // setting an intentionally-rejected value would race against every other test
+    // in this binary that calls `Anthropic::new`. `resolve_base_url` is the exact
+    // code path `Anthropic::new` uses for the env value, so nothing is lost.
+
+    #[test]
+    fn env_base_url_absent_falls_back_to_default() {
+        let resolved = Anthropic::resolve_base_url(None).unwrap();
+        assert_eq!(resolved, DEFAULT_API_URL);
+    }
+
+    #[test]
+    fn env_base_url_accepts_https() {
+        let resolved =
+            Anthropic::resolve_base_url(Some("https://gateway.example.com/anthropic".to_string()))
+                .unwrap();
+        assert_eq!(resolved, "https://gateway.example.com/anthropic");
+    }
+
+    #[test]
+    fn env_base_url_allows_loopback_http_for_local_dev() {
+        for url in ["http://localhost:11434", "http://127.0.0.1:11434", "http://[::1]:11434"] {
+            let resolved = Anthropic::resolve_base_url(Some(url.to_string()))
+                .unwrap_or_else(|e| panic!("loopback url {url} should be accepted: {e}"));
+            assert_eq!(resolved, url);
+        }
+    }
+
+    #[test]
+    fn env_base_url_rejects_cleartext_http() {
+        let err =
+            Anthropic::resolve_base_url(Some("http://gateway.internal.example.com".to_string()))
+                .expect_err("a non-loopback http ANTHROPIC_BASE_URL must be rejected");
+
+        assert!(err.is_validation(), "expected a validation error, got {err}");
+        let message = err.to_string();
+        assert!(
+            message.contains("unencrypted"),
+            "error should explain the cleartext risk, got: {message}"
+        );
+        assert!(message.contains("'http'"), "error should name the scheme, got: {message}");
+    }
+
+    #[test]
+    fn env_base_url_rejects_non_http_schemes_and_garbage() {
+        for url in ["ftp://files.example.com", "ws://gateway.example.com", "not-a-url"] {
+            let err = Anthropic::resolve_base_url(Some(url.to_string()))
+                .expect_err("non-https, non-loopback ANTHROPIC_BASE_URL must be rejected");
             assert!(err.is_validation(), "expected a validation error for {url}, got {err}");
         }
     }

--- a/adk-anthropic/src/files/client.rs
+++ b/adk-anthropic/src/files/client.rs
@@ -6,6 +6,7 @@ use reqwest::header::{CONTENT_TYPE, HeaderMap, HeaderValue};
 use reqwest::multipart;
 
 use super::types::{FileDeleteResponse, FileListResponse, FileObject};
+use crate::base_url::validate_base_url;
 use crate::{Error, Result};
 
 /// Default base URL for the Anthropic API.
@@ -21,7 +22,7 @@ const DEFAULT_BASE_URL: &str = "https://api.anthropic.com";
 /// ```rust,ignore
 /// use adk_anthropic::files::FilesClient;
 ///
-/// let client = FilesClient::new("sk-ant-api03-...")?;
+/// let client = FilesClient::new("placeholder-api-key")?;
 /// let file = client.upload_file("data.csv", csv_bytes).await?;
 /// ```
 #[derive(Debug, Clone)]
@@ -57,9 +58,34 @@ impl FilesClient {
     }
 
     /// Override the base URL.
-    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
-        self.base_url = base_url.into();
-        self
+    ///
+    /// The base URL should be the root URL without the `/v1/` suffix — that is
+    /// added automatically when constructing request URLs.
+    ///
+    /// # Errors
+    ///
+    /// Every request made by this client attaches the Anthropic API key, so the
+    /// base URL must be encrypted. Returns a validation error unless the URL uses
+    /// `https://`, or `http://` with a loopback host (`localhost`, `127.0.0.1`,
+    /// `[::1]`) for local development.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use adk_anthropic::files::FilesClient;
+    ///
+    /// let client = FilesClient::new("placeholder-api-key")?
+    ///     .with_base_url("https://my-proxy.example.com")?;
+    ///
+    /// // Loopback http is allowed for local development
+    /// let local = FilesClient::new("placeholder-api-key")?
+    ///     .with_base_url("http://127.0.0.1:8080")?;
+    /// ```
+    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Result<Self> {
+        let base_url = base_url.into();
+        validate_base_url(&base_url)?;
+        self.base_url = base_url;
+        Ok(self)
     }
 
     fn build_url(&self, endpoint: &str) -> String {
@@ -300,5 +326,73 @@ fn map_api_error(status: reqwest::StatusCode, body: &str) -> Error {
         413 => Error::BadRequest { message: format!("file too large: {message}"), param: None },
         429 => Error::RateLimit { message, retry_after: None },
         code => Error::Api { status_code: code, error_type, message, request_id: None },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_base_url_is_https() {
+        let client = FilesClient::new("placeholder-api-key").unwrap();
+        assert_eq!(client.base_url, DEFAULT_BASE_URL);
+        assert!(validate_base_url(&client.base_url).is_ok());
+    }
+
+    #[test]
+    fn test_with_base_url_accepts_https() {
+        let client = FilesClient::new("placeholder-api-key")
+            .unwrap()
+            .with_base_url("https://gateway.example.com/anthropic")
+            .unwrap();
+        assert_eq!(client.base_url, "https://gateway.example.com/anthropic");
+    }
+
+    #[test]
+    fn test_with_base_url_allows_loopback_http_for_local_dev() {
+        for url in ["http://localhost:8080", "http://127.0.0.1:8080", "http://[::1]:8080"] {
+            let client = FilesClient::new("placeholder-api-key")
+                .unwrap()
+                .with_base_url(url)
+                .unwrap_or_else(|e| panic!("loopback url {url} should be accepted: {e}"));
+            assert_eq!(client.base_url, url);
+        }
+    }
+
+    #[test]
+    fn test_with_base_url_rejects_cleartext_http() {
+        let err = FilesClient::new("placeholder-api-key")
+            .unwrap()
+            .with_base_url("http://files.internal.example.com")
+            .expect_err("a non-loopback http base URL must be rejected");
+
+        assert!(err.is_validation(), "expected a validation error, got {err}");
+        let message = err.to_string();
+        assert!(
+            message.contains("unencrypted"),
+            "error should explain the cleartext risk, got: {message}"
+        );
+        assert!(message.contains("'http'"), "error should name the scheme, got: {message}");
+    }
+
+    #[test]
+    fn test_with_base_url_rejects_non_http_schemes_and_garbage() {
+        for url in ["ftp://files.example.com", "ws://gateway.example.com", "not-a-url"] {
+            let err = FilesClient::new("placeholder-api-key")
+                .unwrap()
+                .with_base_url(url)
+                .expect_err("non-https, non-loopback base URL must be rejected");
+            assert!(err.is_validation(), "expected a validation error for {url}, got {err}");
+        }
+    }
+
+    #[test]
+    fn test_build_url_trims_trailing_slash() {
+        let client = FilesClient::new("placeholder-api-key")
+            .unwrap()
+            .with_base_url("https://api.anthropic.com/")
+            .unwrap();
+        assert_eq!(client.build_url("files"), "https://api.anthropic.com/v1/files");
     }
 }


### PR DESCRIPTION
## Summary

Closes the two remaining paths in `adk-anthropic` where a base URL could send the Anthropic API key over an unencrypted connection.

**`ANTHROPIC_BASE_URL` (real gap).** `Anthropic::with_base_url` already rejected cleartext endpoints, but the same value supplied through the environment was adopted unchecked. `Anthropic::new` now validates it. A rejected value fails construction rather than silently falling back to the default endpoint — a misconfigured environment is reported instead of being papered over.

**`FilesClient::with_base_url` (feature-gated `files`).** Now returns `Result<Self>` and validates its argument.

Both reuse the shared `validate_base_url`, so `Anthropic`, `ManagedAgentsClient`, and `FilesClient` enforce one rule: `https://`, or `http://` bound to a loopback host (`localhost`, `127.0.0.1`, `[::1]`) for local development.

This completes the sweep started in #457 (merged), which covered `Anthropic::with_base_url`. Base-URL setters in `adk-anthropic` are now exhaustively validated:

| Setter | Validation |
|---|---|
| `Anthropic::with_base_url` | `validate_base_url` (#457) |
| `Anthropic::with_base_url_and_timeout` | delegates to `with_base_url` |
| `Anthropic::new` via `ANTHROPIC_BASE_URL` | `validate_base_url` (this PR) |
| `ManagedAgentsClient::with_base_url` | `validate_base_url` (earlier) |
| `FilesClient::with_base_url` | `validate_base_url` (this PR) |

## Breaking change

`FilesClient::with_base_url` (behind the `files` feature) returns `Result<Self>` instead of `Self`. Callers add `?`. No in-tree callers existed outside the module.

`Anthropic::new` gains a new failure mode: it returns a validation error when `ANTHROPIC_BASE_URL` is set to a cleartext endpoint.

## Testing

- `cargo nextest run --workspace` — 3736 passed, 83 skipped. The two `adk-code` sandbox timeout failures are pre-existing and machine-sensitive (they give a real `rustc` compile a 100 ms budget); unrelated to this change.
- `cargo test -p adk-anthropic --lib --features managed-agents,files` — 442 passed.
- `cargo test -p adk-anthropic --doc` — 7 passed, 3 ignored.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo clippy -p adk-anthropic --lib --features managed-agents,files -- -D warnings` — clean.
- `cargo clippy -p adk-model --all-targets --features anthropic -- -D warnings` — clean.
- `cargo fmt --all` — clean.

The `ANTHROPIC_BASE_URL` tests exercise `resolve_base_url` directly instead of mutating the process environment. The environment is process-global, so setting an intentionally-rejected value would race against every other test in the binary that calls `Anthropic::new`; `resolve_base_url` is the exact code path `Anthropic::new` uses for the env value.

## Note

Pre-existing clippy denials surface only when the `managed-agents`/`files` features are enabled (`collapsible_if` in `tests/managed_agents_integration.rs`, `examples/managed_agents_multiagent.rs`, `tests/files_integration.rs`, plus `unnecessary_unwrap` in `tests/files_integration.rs`). They are untouched here and out of scope.
