### PR TITLE
test(rag): add runtime integration tests for the LanceDB backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,6 +718,7 @@ dependencies = [
  "sqlx 0.8.6",
  "surrealdb",
  "surrealdb-types",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/adk-rag/Cargo.toml
+++ b/adk-rag/Cargo.toml
@@ -39,6 +39,7 @@ surrealdb-types = { version = "3.0.1", optional = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros", "rt-multi-thread"] }
 proptest = "1.6"
+tempfile = "3"
 
 [features]
 default = []

--- a/adk-rag/tests/lancedb_integration.rs
+++ b/adk-rag/tests/lancedb_integration.rs
@@ -1,0 +1,217 @@
+//! Runtime integration tests for the LanceDB vector store backend.
+//!
+//! LanceDB runs embedded against a local directory, so these tests exercise the
+//! real storage engine with no external service and no API key. Each test gets
+//! its own [`TempDir`] so they stay independent under parallel execution.
+
+#![cfg(feature = "lancedb")]
+
+use std::collections::HashMap;
+
+use adk_rag::document::Chunk;
+use adk_rag::lancedb::LanceDBVectorStore;
+use adk_rag::vectorstore::VectorStore;
+use tempfile::TempDir;
+
+const DIM: usize = 4;
+
+/// Build a store rooted in a fresh temporary directory.
+///
+/// The `TempDir` is returned alongside the store so the caller keeps it alive
+/// for the duration of the test.
+async fn store() -> (TempDir, LanceDBVectorStore) {
+    let dir = TempDir::new().expect("create temp dir");
+    let store = LanceDBVectorStore::new(dir.path().to_str().expect("utf-8 temp path"))
+        .await
+        .expect("connect to embedded lancedb");
+    (dir, store)
+}
+
+fn chunk(id: &str, text: &str, embedding: Vec<f32>, metadata: HashMap<String, String>) -> Chunk {
+    Chunk {
+        id: id.to_string(),
+        text: text.to_string(),
+        embedding,
+        metadata,
+        document_id: "doc_1".to_string(),
+    }
+}
+
+fn plain(id: &str, text: &str, embedding: Vec<f32>) -> Chunk {
+    chunk(id, text, embedding, HashMap::new())
+}
+
+/// `search` never reads the vector column back, so every returned chunk has an
+/// empty embedding. This mirrors a stored chunk into the shape `search` yields.
+fn as_returned(c: &Chunk) -> Chunk {
+    Chunk { embedding: vec![], ..c.clone() }
+}
+
+fn ids(results: &[adk_rag::document::SearchResult]) -> Vec<String> {
+    results.iter().map(|r| r.chunk.id.clone()).collect()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_lancedb_full_round_trip() {
+    let (_dir, store) = store().await;
+    store.create_collection("docs", DIM).await.unwrap();
+
+    let alpha = plain("a", "alpha text", vec![1.0, 0.0, 0.0, 0.0]);
+    let beta = plain("b", "beta text", vec![0.0, 1.0, 0.0, 0.0]);
+    let gamma = plain("c", "gamma text", vec![0.0, 0.0, 1.0, 0.0]);
+    let chunks = vec![alpha.clone(), beta.clone(), gamma.clone()];
+
+    store.upsert("docs", &chunks).await.unwrap();
+
+    let results = store.search("docs", &[0.0, 0.9, 0.0, 0.0], 3).await.unwrap();
+    assert_eq!(results.len(), 3, "expected all three stored rows back");
+    assert_eq!(results[0].chunk, as_returned(&beta), "nearest row should be the beta chunk");
+    assert_eq!(ids(&results)[0], "b");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_lancedb_metadata_round_trip() {
+    let (_dir, store) = store().await;
+    store.create_collection("docs", DIM).await.unwrap();
+
+    let mut metadata = HashMap::new();
+    metadata.insert("source".to_string(), "handbook.pdf".to_string());
+    metadata.insert("page".to_string(), "12".to_string());
+    metadata.insert("quoted".to_string(), r#"he said "hello" \ then left"#.to_string());
+    metadata.insert("unicode".to_string(), "naïve café — 日本語 🚀".to_string());
+    metadata.insert("newlines".to_string(), "line1\nline2\ttabbed".to_string());
+
+    let stored = chunk("meta-1", "metadata carrier", vec![1.0, 0.0, 0.0, 0.0], metadata.clone());
+    store.upsert("docs", std::slice::from_ref(&stored)).await.unwrap();
+
+    let results = store.search("docs", &[1.0, 0.0, 0.0, 0.0], 1).await.unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].chunk.metadata, metadata);
+    assert_eq!(results[0].chunk, as_returned(&stored));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_lancedb_similarity_ordering() {
+    let (_dir, store) = store().await;
+    store.create_collection("docs", DIM).await.unwrap();
+
+    // Query is [0,0,0,0]; each chunk sits at a strictly increasing L2 distance.
+    let chunks = vec![
+        plain("near", "near", vec![1.0, 0.0, 0.0, 0.0]),
+        plain("mid", "mid", vec![3.0, 0.0, 0.0, 0.0]),
+        plain("far", "far", vec![9.0, 0.0, 0.0, 0.0]),
+        plain("farthest", "farthest", vec![27.0, 0.0, 0.0, 0.0]),
+    ];
+    store.upsert("docs", &chunks).await.unwrap();
+
+    let results = store.search("docs", &[0.0, 0.0, 0.0, 0.0], 4).await.unwrap();
+    assert_eq!(ids(&results), vec!["near", "mid", "far", "farthest"]);
+
+    // score = 1.0 - distance, so scores must be monotonically non-increasing.
+    for pair in results.windows(2) {
+        assert!(
+            pair[0].score >= pair[1].score,
+            "scores not non-increasing: {} then {}",
+            pair[0].score,
+            pair[1].score,
+        );
+    }
+    // The scores must actually differ, otherwise the ordering check is vacuous.
+    assert!(
+        results[0].score > results[results.len() - 1].score,
+        "expected distinct scores across distinct distances, got {:?}",
+        results.iter().map(|r| r.score).collect::<Vec<_>>(),
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_lancedb_top_k_bound() {
+    let (_dir, store) = store().await;
+    store.create_collection("docs", DIM).await.unwrap();
+
+    let chunks: Vec<Chunk> =
+        (0..7).map(|i| plain(&format!("id-{i}"), "row", vec![i as f32, 0.0, 0.0, 0.0])).collect();
+    store.upsert("docs", &chunks).await.unwrap();
+
+    let results = store.search("docs", &[0.0, 0.0, 0.0, 0.0], 3).await.unwrap();
+    assert_eq!(results.len(), 3, "top_k must bound the result count");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_lancedb_delete_by_id() {
+    let (_dir, store) = store().await;
+    store.create_collection("docs", DIM).await.unwrap();
+
+    let chunks = vec![
+        plain("keep-1", "keep one", vec![1.0, 0.0, 0.0, 0.0]),
+        plain("drop-1", "drop one", vec![0.0, 1.0, 0.0, 0.0]),
+        plain("keep-2", "keep two", vec![0.0, 0.0, 1.0, 0.0]),
+        plain("drop-2", "drop two", vec![0.0, 0.0, 0.0, 1.0]),
+    ];
+    store.upsert("docs", &chunks).await.unwrap();
+    assert_eq!(store.search("docs", &[0.0, 0.0, 0.0, 0.0], 10).await.unwrap().len(), 4);
+
+    store.delete("docs", &["drop-1", "drop-2"]).await.unwrap();
+
+    let mut remaining = ids(&store.search("docs", &[0.0, 0.0, 0.0, 0.0], 10).await.unwrap());
+    remaining.sort();
+    assert_eq!(remaining, vec!["keep-1".to_string(), "keep-2".to_string()]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_lancedb_create_collection_idempotency() {
+    let (_dir, store) = store().await;
+    store.create_collection("docs", DIM).await.unwrap();
+
+    let stored = plain("only", "survivor", vec![1.0, 0.0, 0.0, 0.0]);
+    store.upsert("docs", std::slice::from_ref(&stored)).await.unwrap();
+
+    // Second call must succeed and must not drop the existing rows.
+    store.create_collection("docs", DIM).await.unwrap();
+
+    let results = store.search("docs", &[1.0, 0.0, 0.0, 0.0], 5).await.unwrap();
+    assert_eq!(results.len(), 1, "existing rows must survive a repeated create_collection");
+    assert_eq!(results[0].chunk, as_returned(&stored));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_lancedb_delete_collection() {
+    let (_dir, store) = store().await;
+    store.create_collection("docs", DIM).await.unwrap();
+    store.upsert("docs", &[plain("a", "alpha", vec![1.0, 0.0, 0.0, 0.0])]).await.unwrap();
+    assert_eq!(store.search("docs", &[1.0, 0.0, 0.0, 0.0], 1).await.unwrap().len(), 1);
+
+    store.delete_collection("docs").await.unwrap();
+
+    // The table is gone, so opening it for a search fails.
+    let err = store.search("docs", &[1.0, 0.0, 0.0, 0.0], 1).await.unwrap_err();
+    assert!(
+        matches!(err, adk_rag::error::RagError::VectorStoreError { .. }),
+        "expected a vector store error after delete_collection, got {err:?}"
+    );
+    // Upsert into the dropped collection also fails.
+    assert!(
+        store.upsert("docs", &[plain("b", "beta", vec![0.0, 1.0, 0.0, 0.0])]).await.is_err(),
+        "upsert into a dropped collection must fail"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_lancedb_empty_input_noops() {
+    let (_dir, store) = store().await;
+    store.create_collection("docs", DIM).await.unwrap();
+
+    let chunks = vec![
+        plain("a", "alpha", vec![1.0, 0.0, 0.0, 0.0]),
+        plain("b", "beta", vec![0.0, 1.0, 0.0, 0.0]),
+    ];
+    store.upsert("docs", &chunks).await.unwrap();
+    let before = ids(&store.search("docs", &[0.0, 0.0, 0.0, 0.0], 10).await.unwrap());
+    assert_eq!(before.len(), 2);
+
+    store.upsert("docs", &[]).await.unwrap();
+    store.delete("docs", &[]).await.unwrap();
+
+    let after = ids(&store.search("docs", &[0.0, 0.0, 0.0, 0.0], 10).await.unwrap());
+    assert_eq!(after, before, "empty-input calls must not change stored rows");
+}


### PR DESCRIPTION
## Summary

Follow-up to #459, which upgraded `lancedb` 0.27 → 0.31 and moved every arrow type to `lancedb::arrow::{arrow_array, arrow_schema}`. That change was **compile-verified only**: none of `adk-rag`'s six existing tests executed a single LanceDB call — five are chunking, one is the in-memory store — so the type alignment across a four-breaking-release jump was proven while the runtime behaviour was not.

This adds eight tests that drive the real embedded engine through the full `VectorStore` contract as implemented by `LanceDBVectorStore`.

## What is covered

| Test | Contract |
|---|---|
| `test_lancedb_full_round_trip` | `create_collection` → `upsert` → nearest-vector `search`; `id`, `text`, `document_id` survive exactly |
| `test_lancedb_metadata_round_trip` | multi-key metadata through the `metadata_json` column, including quotes, backslashes, unicode, and embedded newlines |
| `test_lancedb_similarity_ordering` | nearest-first ordering with monotonically non-increasing `score` over known distances |
| `test_lancedb_top_k_bound` | `top_k` below the stored row count returns exactly `top_k` |
| `test_lancedb_delete_by_id` | deleted ids absent, the rest still present |
| `test_lancedb_create_collection_idempotency` | a second call succeeds and existing rows survive |
| `test_lancedb_delete_collection` | subsequent `search` and `upsert` both fail |
| `test_lancedb_empty_input_noops` | `upsert(&[])` and `delete(&[])` return `Ok` and leave stored rows untouched |

## Runtime findings

**No runtime bug was found.** All eight tests pass against `lancedb` 0.31 with no change to `adk-rag/src/lancedb.rs`, so the upgrade is now behaviourally verified rather than only type-checked. The four candidate breaks specifically probed:

- the `_distance` result column still exists under that name and is still `Float32` — the ordering test asserts the scores are *distinct*, not merely ordered, so a rename or type change would make `column_by_name`/`as_primitive_opt` fall back to `0.0`, flatten every score to `1.0`, and **fail** rather than pass vacuously;
- `FixedSizeList` vector-column handling in `create_empty_table` works, exercised by every test;
- `Table::add` append semantics are intact, exercised by the multi-row and idempotency tests;
- `nearest_to` needs neither an index nor a minimum row count — it returns correct results on tables of 1 to 7 rows with no index built.

The tests also pin down existing documented behaviour: `search` returns chunks with `embedding: vec![]`, because the implementation does not read the vector column back.

## No external dependencies

LanceDB runs embedded against a local directory, so these need **no external service and no API key**. Each test gets its own `TempDir`, keeping them independent under nextest's parallel execution. They are therefore not `#[ignore]`d and run in the `feature-coverage` CI job that #459 added — closing the loop on the blind spot that PR identified, where nothing in CI compiled, let alone executed, the LanceDB backend.

`tempfile` is added as an unconditional dev-dependency. It was already in the dependency graph, so `Cargo.lock` picks up a single edge line and no new package.

## Verification

```
cargo +1.94.0 nextest run -p adk-rag --features lancedb
    Starting 14 tests across 4 binaries
        PASS [   0.055s] ( 6/14) adk-rag::lancedb_integration test_lancedb_create_collection_idempotency
        PASS [   0.055s] ( 7/14) adk-rag::lancedb_integration test_lancedb_delete_collection
        PASS [   0.056s] ( 8/14) adk-rag::lancedb_integration test_lancedb_empty_input_noops
        PASS [   0.045s] ( 9/14) adk-rag::lancedb_integration test_lancedb_metadata_round_trip
        PASS [   0.045s] (10/14) adk-rag::lancedb_integration test_lancedb_top_k_bound
        PASS [   0.046s] (11/14) adk-rag::lancedb_integration test_lancedb_similarity_ordering
        PASS [   0.046s] (12/14) adk-rag::lancedb_integration test_lancedb_full_round_trip
        PASS [   0.063s] (13/14) adk-rag::lancedb_integration test_lancedb_delete_by_id
     Summary [   0.073s] 14 tests run: 14 passed, 0 skipped
```

- `cargo +1.94.0 clippy -p adk-rag --features lancedb --all-targets -- -D warnings` — clean (the new test file is a target)
- `cargo +1.94.0 check -p adk-rag` — no-default-features path unaffected
- `cargo fmt --all -- --check` — clean

## Not verified

Nothing beyond the above. The CI job these tests run in was itself only YAML-parsed when #459 landed, because `actionlint` was unavailable locally; that caveat carries over unchanged and is not addressed here.

Refs #459
