### PR TITLE
docs: add adk-rag lancedb feature-coverage to required checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -329,6 +329,7 @@ name is the job name (matrix jobs include the matrix value in parentheses):
 | `feature-coverage (adk-model, openrouter)` | `ci.yml` | `feature-coverage` (matrix) |
 | `feature-coverage (adk-sandbox, wasm)` | `ci.yml` | `feature-coverage` (matrix) |
 | `feature-coverage (adk-audio, fx)` | `ci.yml` | `feature-coverage` (matrix) |
+| `feature-coverage (adk-rag, lancedb)` | `ci.yml` | `feature-coverage` (matrix) |
 | `docs` | `ci.yml` | `docs` |
 | `templates` | `ci.yml` | `templates` |
 | `macos` | `ci.yml` | `macos` (compile-only build) |
@@ -338,8 +339,9 @@ name is the job name (matrix jobs include the matrix value in parentheses):
 Notes:
 - `feature-coverage` is a matrix job; its context includes the matrix value, so
   add each entry that exists. Today the entries are `adk-agent, codeact`,
-  `adk-model, openrouter`, `adk-sandbox, wasm`, and `adk-audio, fx`. If you
-  append matrix entries, add their contexts here and to branch protection.
+  `adk-model, openrouter`, `adk-sandbox, wasm`, `adk-audio, fx`, and
+  `adk-rag, lancedb`. If you append matrix entries, add their contexts here and
+  to branch protection.
 - `semver` is a single job that runs the strict stable-crate check (which can fail
   the job) and a warn-only beta/experimental check (which never fails). Requiring
   the `semver` job therefore requires only the stable-tier semver gate, keeping the
@@ -381,6 +383,7 @@ gh api -X PUT repos/zavora-ai/adk-rust/branches/main/protection \
       { "context": "feature-coverage (adk-model, openrouter)" },
       { "context": "feature-coverage (adk-sandbox, wasm)" },
       { "context": "feature-coverage (adk-audio, fx)" },
+      { "context": "feature-coverage (adk-rag, lancedb)" },
       { "context": "docs" },
       { "context": "templates" },
       { "context": "macos" },


### PR DESCRIPTION
## What

`CONTRIBUTING.md` now lists `feature-coverage (adk-rag, lancedb)` in three places:

| Location | Change |
|----------|--------|
| "Required on PRs" table | New row after `feature-coverage (adk-audio, fx)` |
| `feature-coverage` note | Fifth matrix entry added to the enumerated list |
| Branch-protection `gh api` example | New `{ "context": ... }` entry, in matrix order |

## Why

The `feature-coverage` matrix in `ci.yml` gained an `adk-rag` / `lancedb` entry in #459.
`CONTRIBUTING.md` documents the authoritative required-status-check set, and that set no
longer matched the matrix.

> **Important:** A maintainer with admin rights must add the
> `feature-coverage (adk-rag, lancedb)` context to branch protection for `main`. Until that
> is applied, the job runs on every PR but is not merge-blocking — a regression in the
> LanceDB backend can still land.

## How

Documentation only. The context name is the job name plus the matrix value, matching the
existing four `feature-coverage` rows. No workflow or code changes.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

Markdown-only change; no Rust sources touched. `cargo check --workspace` ran as the
`pre-push` hook and passes.

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

Documentation-only change; no Rust code is added, so the test and rustdoc items are vacuous.

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed
- [x] Examples added or updated for new features

No user-facing crate change, so `CHANGELOG.md`, crate READMEs, and examples are unaffected.
