### PR TITLE
docs: add writing style guidance for agent-authored text

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -503,12 +503,104 @@ refactor(ui): extract validation into per-type trait impls
 test(eval): add trajectory property tests
 ```
 
+Subject line only, unless the change is not self-evident from the subject. See
+[Writing style](#writing-style) for body, register, and issue-reference rules.
+
+## Writing style
+
+This guideline governs every text artefact an agent commits or posts: commit messages, code
+comments, rustdoc, PR bodies, issue comments, and review replies. `CONTRIBUTING.md` and
+`docs/official_docs/` are the reference corpus — match their register.
+
+The register rules below govern text committed to or posted on the repository. They do not govern
+`AGENTS.md` itself, which is instruction addressed to the agent and uses the second-person
+imperative.
+
+Committed and posted text is project documentation, not a contributor's voice. Do not adopt a
+maintainer's tone, do not offer personal preferences or recommendations in committed artefacts,
+and keep analysis, discovery narrative, and reasoning in the conversation with the human rather
+than in the repository.
+
+The house register:
+
+- **Structure over prose**: enumerations become tables, procedures become numbered headed steps,
+  definitions become bold-lead bullets.
+- **Present tense, stating what the system does**: "The gate fails the build when a feature-gated
+  module stops compiling."
+- **"You" for the reader, "we" only for project-level decisions**: "We follow an issue-first
+  workflow."
+- **Rationale is a single clause, not a paragraph**: "Excluded so `--all-features` works without
+  CUDA toolkit."
+- **Code blocks are complete**, with full imports, not fragments.
+- **Callouts** are `> **Note:**` blockquotes or inline `**Important:**`.
+- **Em dashes are house style** — use them where they read naturally.
+
+### Commit messages
+
+- Conventional-commit subject, imperative, under ~70 characters:
+  `fix(rag): upgrade lancedb to 0.31, unbreak and cover the backend`.
+- Body only when the change is not self-evident from the subject. When present, keep it short and
+  factual, prefer bullets over paragraphs, and state what changed and why in as few lines as
+  possible.
+- Reference issues as `Fixes #123` or `Closes #123`.
+- No discovery narrative, no first person, no essay-length bodies.
+
+### Code comments
+
+- Explain **why**, not **what** — the code already states what it does.
+- Single line where possible. A multi-line block earns its length by recording a non-obvious
+  constraint, invariant, or upstream quirk.
+- Do not restate the code. Do not write changelog entries or migration history in comments.
+
+```rust
+// All arrow types come from lancedb's own re-exports, so the arrow version is
+// stated exactly once, by lancedb, and cannot drift between crates.
+use lancedb::arrow::arrow_schema::{DataType, Field, Schema};
+```
+
+### Rustdoc
+
+Follow the pattern in `CONTRIBUTING.md` ("Documentation"): brief one-line summary, more detail if
+needed, `# Example` where practical, `# Errors` when the function returns `Result`. Present tense,
+third person, no "we" or "I".
+
+```rust
+/// Swaps the active LoRA adapter without reloading the base model.
+///
+/// # Errors
+///
+/// Returns `MistralRsError::AdapterNotFound` when `adapter_name` is not among the loaded adapters.
+pub async fn swap_adapter(&self, adapter_name: &str) -> Result<()> { ... }
+```
+
+### PR bodies, issue comments, and review replies
+
+- Lead with what changed, then use the PR template's headed sections (`## What`, `## Why`,
+  `## How`) and complete its checklist.
+- Prefer tables and bullets over paragraphs.
+- State verification results as facts: "`cargo nextest run --workspace` passes; three regression
+  tests added in `adk-rag/tests/`."
+- No narration of the authoring process, no opinions framed as personal preference, no persuasion.
+
+### Do and don't
+
+| Don't | Do |
+|-------|----|
+| "Root cause was lancedb sitting four breaking releases stale, not arrow drifting up." | "lancedb 0.28 and later re-export every arrow crate they depend on." |
+| "I verified the workspace compiles and my recommendation is the PR tier." | "`cargo check --workspace` passes. `feature-coverage` runs in the PR tier." |
+| "This gate fails loudly, which is strictly better than the negligent silence it replaced." | "The gate fails the build when a feature-gated module stops compiling." |
+| "Worth noting, one sequencing consequence is that two things are left." | A `### Remaining work` heading followed by a list. |
+| A 20-line narrative commit body recounting the investigation. | `fix(realtime): drop session guard before provider await` |
+| "I'd put the arrow pin in adk-rag since that's where it hurts most." | "`adk-rag` takes arrow types from `lancedb::arrow`, so the version is stated once, by lancedb." |
+| A paragraph listing four authorization mechanisms and their tradeoffs. | A `\| Mechanism \| Use Case \| Granularity \| Runtime \|` table. |
+
 ## PR workflow
 
 - **Branch naming**: Use `prefix/short-description`. Allowed prefixes: `feat/`, `fix/`, `docs/`, `refactor/`, `test/`, `chore/`.
 - **Reference**: Include `Fixes #123` or similar in the PR description.
 - **Scope**: Keep PRs focused — one logical change per PR. Don't mix unrelated changes.
-- **Quality Gates**: All four gates must pass before merge: `fmt`, `clippy`, `test`, `check` (via `devenv shell`).
+- **Local gates before pushing**: Run `fmt`, `clippy`, `test`, and `check` via `devenv shell`. These are local shorthand, not CI job names — `check` has no CI job at all.
+- **CI gates that block merge**: The PR tier only (see [CI cost tiers](#ci-cost-tiers)). CONTRIBUTING.md ("Branch Protection — Required Status Checks") is authoritative for the required-check set.
 
 ### PR Checklist requirements
 


### PR DESCRIPTION
## What

`AGENTS.md` gains a `## Writing style` section and the `## PR workflow` quality-gates line is
split in two.

| Change | Detail |
|--------|--------|
| New `## Writing style` section | House register plus per-artefact rules for commit messages, code comments, rustdoc, and PR/issue/review text, closing with a do/don't table |
| Scope statement | The register applies to text committed to or posted on the repository, not to `AGENTS.md` itself, which is instruction addressed to the agent |
| `## Commit messages` | Now points at `## Writing style` for body, register, and issue-reference rules |
| `## PR workflow` | The single "all four gates must pass before merge" bullet becomes two: local `devenv shell` gates, and the CI-enforced set |

## Why

Agent-authored commit messages, comments, and PR text drifted from the register used by
`CONTRIBUTING.md` and `docs/official_docs/` — first person, discovery narrative, and
recommendations framed as personal preference. The section states the target register and gives
paired counterexamples.

The old quality-gates line contradicted `### CI cost tiers` in the same file, which states that
only the PR tier gates merges. `fmt`, `clippy`, `test`, and `check` are `devenv shell` shorthand
for local runs; `check` has no CI job. The replacement bullets keep the local list and defer to
CONTRIBUTING.md ("Branch Protection — Required Status Checks") as the authoritative
required-check set, so the enumeration lives in exactly one file.

> **Note:** Two `.kiro/steering/` files cross-reference the new section. `.kiro/` is gitignored,
> so those references are local-only and are not part of this change.

## How

Documentation only. The rustdoc example in the new section uses the real signature of
`MistralRsAdapterModel::swap_adapter` (`adapter_name`, `adk-mistralrs/src/adapter.rs`), and the
`MistralRsError::AdapterNotFound` variant it names exists in `adk-mistralrs/src/error.rs`.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

Markdown-only change; no Rust sources touched. `cargo check --workspace` ran as the `pre-push`
hook and passes.

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

Documentation-only change; no Rust code is added, so the test and rustdoc items are vacuous.

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed
- [x] Examples added or updated for new features

No user-facing crate change, so `CHANGELOG.md`, crate READMEs, and examples are unaffected.
