### PR TITLE
chore: v2 release readiness — advisories, doctests, and CI gates

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -9,6 +9,15 @@
 
 [advisories]
 ignore = [
+    # quick-xml 0.26: memory-exhaustion and quadratic-parse DoS. Reached only as
+    # lancedb -> lance-testing -> pprof -> inferno, behind the optional
+    # `adk-rag/lancedb` feature; lancedb declares `lance-testing` as a normal
+    # dependency so the path cannot be dropped downstream. Crates this workspace
+    # declares directly are on the patched line (adk-eval requires 0.41), and
+    # deny.toml bans quick-xml < 0.41 outside the inferno path.
+    "RUSTSEC-2026-0195",
+    "RUSTSEC-2026-0194",
+
     # rsa: Marvin timing side-channel (no upstream fix, accepted risk)
     "RUSTSEC-2023-0071",
 

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -46,19 +46,26 @@ jobs:
   # design.md §5 (audio ONNX, realtime `full`, GPU compile-checks). Default CI
   # (ci.yml clippy/test) only ever builds default features, so a regression in a
   # non-default feature combination is invisible on the PR and merge tiers. This
-  # job compiles each notable combo on the appropriate runner.
+  # job lints each notable combo on the appropriate runner.
   #
-  # GPU features cannot RUN on GitHub runners (no GPU), so they are compile-only
-  # via `cargo check`; the Metal combo runs on macOS where the Metal toolchain is
-  # available even without a discrete GPU. Feature names below were verified
-  # against the real Cargo.toml manifests:
+  # These run `cargo clippy -- -D warnings`, not `cargo check`. Compiling proved
+  # too weak: the 2.0.0 release review found 15 clippy errors sitting in
+  # feature-gated modules (adk-audio ONNX, adk-graph `functional` and
+  # `action-full`, adk-server `background`, adk-anthropic `managed-agents`) that
+  # no gate had ever linted. GPU combos stay compile-only because their
+  # toolchains are not fully available on hosted runners.
+  #
+  # Feature names below were verified against the real Cargo.toml manifests:
   #   • adk-realtime  `full`  = openai + gemini + vertex-live + livekit
-  #   • adk-audio     `whisper-onnx`, `moonshine` = ONNX STT backends (imply `onnx`)
+  #   • adk-audio     `all-onnx` = every ONNX backend (implies `onnx`)
+  #   • adk-graph     `functional`, `action-full` = functional API, action nodes
+  #   • adk-server    `background` = background runs + cron scheduling
   #   • adk-mistralrs `metal` = mistralrs/metal (macOS GPU acceleration)
   #
   # EXTENSION POINT: to cover another feature combination, append one matrix
-  # entry with { name, os, neutralize-wild, command }. Keep GPU/hardware combos
-  # compile-only (`cargo check`) and on a runner whose toolchain supports them.
+  # entry with { name, os, neutralize-wild, command }. Prefer clippy with
+  # `-D warnings`; keep GPU/hardware combos compile-only (`cargo check`) on a
+  # runner whose toolchain supports them.
   feature-combinations:
     name: features (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
@@ -71,14 +78,38 @@ jobs:
           - name: realtime-full
             os: ubuntu-latest
             neutralize-wild: 'true'
-            command: cargo check -p adk-realtime --features full --all-targets
-          # audio ONNX speech-to-text backends (whisper + moonshine). Both imply
-          # the `onnx` feature; neither pulls the espeak-ng system dep that
-          # `kokoro` requires, so this compiles on a plain runner.
-          - name: audio-onnx-stt
+            command: cargo clippy -p adk-realtime --features full --all-targets -- -D warnings
+          # Every audio ONNX backend. `kokoro` pulls the espeak-ng system dep,
+          # installed in the step below.
+          - name: audio-all-onnx
             os: ubuntu-latest
             neutralize-wild: 'true'
-            command: cargo check -p adk-audio --features whisper-onnx,moonshine --all-targets
+            command: cargo clippy -p adk-audio --features all-onnx --all-targets -- -D warnings
+          # Functional graph API (#[entrypoint]/#[task] macros, typed reducers).
+          - name: graph-functional
+            os: ubuntu-latest
+            neutralize-wild: 'true'
+            command: cargo clippy -p adk-graph --features functional --all-targets -- -D warnings
+          # Every action-node executor (http, db, code, email, rss, trigger).
+          - name: graph-action-full
+            os: ubuntu-latest
+            neutralize-wild: 'true'
+            command: cargo clippy -p adk-graph --features action-full --all-targets -- -D warnings
+          # Background runs + cron scheduling REST surface.
+          - name: server-background
+            os: ubuntu-latest
+            neutralize-wild: 'true'
+            command: cargo clippy -p adk-server --features background --all-targets -- -D warnings
+          # Anthropic Managed Agents + Files APIs.
+          - name: anthropic-managed-agents
+            os: ubuntu-latest
+            neutralize-wild: 'true'
+            command: cargo clippy -p adk-anthropic --features managed-agents,files --all-targets -- -D warnings
+          # Every provider in the model facade.
+          - name: model-all-providers
+            os: ubuntu-latest
+            neutralize-wild: 'true'
+            command: cargo clippy -p adk-model --features all-providers --all-targets -- -D warnings
           # GPU compile-check: Metal acceleration for adk-mistralrs. Compile-only
           # (`cargo check`) on macOS, where the Metal toolchain is present even
           # though the runner has no discrete GPU to execute against.
@@ -92,26 +123,30 @@ jobs:
     - name: Setup Rust
       uses: ./.github/actions/setup-rust
       with:
+        components: clippy
         cache-key: features-${{ matrix.name }}
         neutralize-wild: ${{ matrix.neutralize-wild }}
 
+    # espeak-ng is required by `espeak-rs`, pulled in by adk-audio's `kokoro`
+    # backend (part of `all-onnx`). Installed unconditionally so adding a matrix
+    # entry stays a one-line change.
     - name: Install system dependencies (Linux)
       if: runner.os == 'Linux'
       run: |
         sudo apt-get update
-        sudo apt-get install -y cmake protobuf-compiler
+        sudo apt-get install -y cmake protobuf-compiler libespeak-ng-dev
 
     - name: Install system dependencies (macOS)
       if: runner.os == 'macOS'
-      run: brew install cmake protobuf
+      run: brew install cmake protobuf espeak-ng
 
-    - name: Compile feature combination
+    - name: Lint feature combination
       run: ${{ matrix.command }}
 
     - name: Feature-combination summary
       if: always()
       shell: bash
-      run: echo "### 🧩 feature combo '${{ matrix.name }}' compiled" >> "$GITHUB_STEP_SUMMARY"
+      run: echo "### 🧩 feature combo '${{ matrix.name }}' checked" >> "$GITHUB_STEP_SUMMARY"
 
   # ── Supply-chain: advisory + policy checks ─────────────────────
   # Requirement 2.3 (supply-chain checks on a scheduled trigger). Two tools:
@@ -120,11 +155,10 @@ jobs:
   #     accepted there (see docs/security/DEPENDENCY-ADVISORIES.md) are skipped
   #     while NEW advisories surface as failures. This is the ENFORCING gate.
   #   • cargo-deny — broader supply-chain policy (bans, sources, licenses,
-  #     advisories). The repo has NO root deny.toml today, so cargo-deny runs with
-  #     built-in defaults and is ADVISORY (continue-on-error) to avoid spurious
-  #     nightly failures on advisories already accepted in .cargo/audit.toml
-  #     (which cargo-deny does not read) and on the default license policy.
-  #     Add a root deny.toml to make this an enforcing gate.
+  #     advisories) configured by the root `deny.toml`. Its accepted-advisory list
+  #     mirrors `.cargo/audit.toml` (cargo-deny does not read that file), and it
+  #     additionally enforces the license allow-list, the registry allow-list, and
+  #     the `quick-xml` version floor. Both gates are ENFORCING.
   supply-chain:
     runs-on: ubuntu-latest
     steps:
@@ -145,15 +179,53 @@ jobs:
     - name: cargo audit
       run: cargo audit
 
-    # Advisory until a root deny.toml exists (see job comment above).
+    # Enforcing: reads the root deny.toml.
     - name: cargo deny check
-      continue-on-error: true
       run: cargo deny check
 
     - name: Supply-chain summary
       if: always()
       shell: bash
       run: echo "### 🔐 supply-chain checks (cargo audit + cargo deny) completed" >> "$GITHUB_STEP_SUMMARY"
+
+  # ── Standalone examples: compile every examples/* crate ────────
+  # Each example under examples/ is its own workspace with its own Cargo.lock and
+  # path dependencies back into this repo. Nothing else in CI compiles them:
+  # `cargo check --workspace` cannot see them (they are in the root manifest's
+  # `exclude`/outside `members`), and scripts/check-doc-examples.sh only validates
+  # that documented commands resolve in cargo metadata. A public API change can
+  # therefore break the adoption surface silently.
+  #
+  # Nightly tier because this is ~96 separate crate graphs. Sharded so each job
+  # stays within a sensible runtime; the script shares one CARGO_TARGET_DIR per
+  # shard so the ADK crates compile once per shard rather than once per example.
+  examples-compile:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Setup Rust
+      uses: ./.github/actions/setup-rust
+      with:
+        cache-key: examples-compile-${{ matrix.shard }}
+        neutralize-wild: 'true'
+
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake protobuf-compiler
+
+    - name: Compile standalone examples (shard ${{ matrix.shard }} of 4)
+      run: bash scripts/check-examples-compile.sh ${{ matrix.shard }} 4
+
+    - name: Examples summary
+      if: always()
+      shell: bash
+      run: echo "### 📦 standalone example compile, shard ${{ matrix.shard }} of 4" >> "$GITHUB_STEP_SUMMARY"
 
   # ── Integration tests: #[ignore]d tests gated on secrets ───────
   # Requirement 2.3 (scheduled integration coverage). The workspace marks tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,25 @@ jobs:
           exit 1
         fi
 
+    # Doctests: nextest cannot run them, so `ws-test` never touches a single doc
+    # example. Without this step a documented snippet can stop compiling and no
+    # job notices — that is how five broken examples reached the 2.0.0 review in
+    # `adk-rust`'s crate-level docs.
+    #
+    # `adk-rust` is excluded from the workspace pass and run separately under
+    # `full`: its crate-level docs cover the whole API surface, so the examples
+    # only resolve when the optional modules they reference are compiled in. That
+    # matches the feature set docs.rs renders (see adk-rust's
+    # [package.metadata.docs.rs]).
+    - name: Run doctests
+      run: |
+        CI=true devenv shell cargo test --workspace --doc --exclude adk-rust
+        CI=true devenv shell cargo test -p adk-rust --features full --doc
+
+    - name: Doctest summary
+      if: always()
+      run: echo "### 🧪 doctests (workspace + adk-rust --features full) completed" >> "$GITHUB_STEP_SUMMARY"
+
   # ── Scaffolds: cargo-adk generated projects compile ────────────
   templates:
     needs: fmt

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -39,19 +39,13 @@ jobs:
       run: |
         echo "### Stable-tier crates (fail on breakage)" >> "$GITHUB_STEP_SUMMARY"
         FAILED=0
-        # Pre-1.0 crates where new public fields/variants are allowed in minor bumps
-        PRE1_ALLOWED="adk-gemini adk-server"
         for crate in adk-core adk-agent adk-model adk-gemini adk-tool adk-runner adk-session adk-server adk-graph adk-memory adk-anthropic; do
           echo "Checking $crate..."
           if cargo semver-checks check-release -p "$crate" --default-features; then
             echo "✅ $crate" >> "$GITHUB_STEP_SUMMARY"
           else
-            if echo "$PRE1_ALLOWED" | grep -qw "$crate"; then
-              echo "⚠️ $crate — new public API (allowed pre-1.0)" >> "$GITHUB_STEP_SUMMARY"
-            else
-              echo "❌ $crate — BREAKING" >> "$GITHUB_STEP_SUMMARY"
-              FAILED=1
-            fi
+            echo "❌ $crate — BREAKING" >> "$GITHUB_STEP_SUMMARY"
+            FAILED=1
           fi
         done
         if [ "$FAILED" -ne 0 ]; then
@@ -59,12 +53,22 @@ jobs:
           exit 1
         fi
 
+    # Every other published crate. Warn-only because these tiers do not carry the
+    # Stable API commitment (see STABILITY.md).
+    #
+    # Absent on purpose: `adk-computer-use` and `adk-devtools` are new in 2.0.0 and
+    # have no published baseline to diff against, and `adk-rust-macros` exposes no
+    # library target for cargo-semver-checks to read. Add the first two here once
+    # 2.0.0 is on crates.io.
     - name: Semver checks — Beta/Experimental (warn only)
       run: |
         echo "### Beta/Experimental crates (warn only)" >> "$GITHUB_STEP_SUMMARY"
         for crate in adk-artifact adk-auth \
           adk-telemetry adk-guardrail adk-plugin adk-skill \
-          adk-cli adk-realtime adk-browser adk-eval adk-audio; do
+          adk-cli adk-realtime adk-browser adk-eval adk-audio \
+          adk-acp adk-awp awp-types adk-action adk-code adk-deploy \
+          adk-managed adk-enterprise adk-payments adk-rag adk-sandbox \
+          adk-retry-reflect adk-mistralrs adk-bench cargo-adk; do
           echo "Checking $crate..."
           if cargo semver-checks check-release -p "$crate" --default-features; then
             echo "✅ $crate" >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,16 +29,18 @@ is preserved (see the `ci-pipeline-restructure` spec). No coverage is dropped �
 expensive axes move to a later tier.
 
 - **PR tier** (`ci.yml` + `semver.yml`, on pull requests) — the merge-blocking
-  set: `fmt` (prerequisite gate), `clippy --workspace -D warnings`,
+  set: `fmt` (prerequisite gate), `clippy --workspace --all-targets -D warnings`,
   `nextest --workspace` (Linux, runs at most once), `feature-coverage` for
   feature-gated modules default builds skip (e.g. `adk-agent --features codeact`),
-  `docs` (single `cargo doc --workspace --no-deps`), `templates`, compile-only
-  `macos`/`windows` builds, and `semver` (stable strict, beta warn-only).
+  `docs` (`cargo doc --workspace --no-deps` plus doctests), `templates`,
+  compile-only `macos`/`windows` builds, and `semver` (stable strict, everything
+  else warn-only).
 - **Merge tier** (`ci-merge.yml`, on `push: main`) — cross-platform
   `nextest --workspace` on macOS/Windows, the out-of-workspace Monty build, and
   doc-example compilation. Runs post-merge; not branch-protection-required.
 - **Nightly tier** (`ci-nightly.yml`, on `schedule`) — the feature-combination
-  matrix, `cargo-audit`/`cargo-deny` supply-chain checks, and `#[ignore]`
+  matrix (clippy with `-D warnings`), `cargo-audit`/`cargo-deny` supply-chain
+  checks, standalone `examples/*` compilation (4 shards), and `#[ignore]`
   integration tests gated on available secrets. Not branch-protection-required.
 
 Only the PR tier gates merges. See CONTRIBUTING.md ("Branch Protection — Required
@@ -97,7 +99,7 @@ adk-anthropic/   Dedicated Anthropic API client: streaming, adaptive thinking, p
                  multiagent orchestration, file mounting, self-hosted environments.
                  Files API (`files` feature): upload, download, list, get, delete.
 adk-tool/        Tool system: FunctionTool, StatefulTool, SimpleToolContext, MCP integration
-                 (rmcp 1.2), McpServerManager (lifecycle, health, auto-restart), MCP Resource
+                 (rmcp 2.2), McpServerManager (lifecycle, health, auto-restart), MCP Resource
                  API, MCP Elicitation, Google Search, built-in tool wrappers (Gemini/OpenAI/
                  Anthropic), Slack/BigQuery/Spanner toolsets
 adk-runner/      Agent execution runtime with event streaming, RunnerConfigBuilder (typestate),
@@ -204,7 +206,7 @@ adk-ui/          Dynamic UI generation (forms, cards, tables, charts) — extrac
 ### Examples and docs
 
 ```
-examples/              60 standalone example crates (each with own Cargo.toml) covering all major
+examples/              97 standalone example crates (each with own Cargo.toml) covering all major
                        features. Additional 120+ examples in the adk-playground repo.
 docs/official_docs/    Comprehensive documentation site content
 ```
@@ -630,20 +632,29 @@ Always verify builds during publish — never use `--no-verify`. Verification en
 
 ### Publish order
 
-Crates must be published in dependency order. Wait for each crate to be indexed before publishing dependents.
+Crates must be published in dependency order. `cargo xtask publish` (via
+`./publish.sh`) computes the order from the workspace graph, so this list is
+documentation rather than configuration — `scripts/check-publish-order.sh` is the
+gate that keeps it satisfiable. The current 8 tiers over 41 publishable crates:
 
 ```
-Tier 1: adk-core
-Tier 2: adk-telemetry, adk-memory, adk-artifact, adk-plugin, adk-skill, adk-auth, adk-guardrail,
-        adk-gemini, adk-anthropic, adk-rust-macros, awp-types
-Tier 3: adk-session, adk-action
-Tier 4: adk-tool, adk-model, adk-browser, adk-audio
-Tier 5: adk-agent, adk-graph, adk-awp, adk-acp
-Tier 6: adk-runner, adk-realtime, adk-eval, adk-rag, adk-retry-reflect
-Tier 7: adk-server, adk-cli, adk-deploy, adk-payments
-Tier 8: cargo-adk
-Tier 9: adk-rust (umbrella — always last)
+Tier 1: adk-core, adk-anthropic, adk-deploy, adk-enterprise, adk-rust-macros,
+        adk-telemetry, awp-types
+Tier 2: adk-action, adk-artifact, adk-awp, adk-browser, adk-devtools, adk-gemini,
+        adk-guardrail, adk-memory, adk-mistralrs, adk-plugin, adk-sandbox,
+        adk-session
+Tier 3: adk-code, adk-graph, adk-model, adk-rag, adk-realtime, adk-retry-reflect,
+        adk-skill
+Tier 4: adk-agent, adk-audio, adk-runner, adk-tool
+Tier 5: adk-acp, adk-eval, adk-managed, adk-server
+Tier 6: adk-auth, adk-bench, adk-cli
+Tier 7: adk-computer-use, adk-payments, cargo-adk
+Tier 8: adk-rust (umbrella — always last)
 ```
+
+> **Note:** internal **dev**-dependencies are declared path-only (no version) so
+> they do not constrain this order. Adding a versioned internal dev-dependency can
+> deadlock the release; `check-publish-order.sh` warns when one appears.
 
 ### Publish workflow
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,14 +41,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **ADK agent tool confirmation can be resolved live.** `RunConfig` accepts an
   asynchronous `ToolConfirmationHandler`, and allow-once decisions are keyed by
   exact function-call ID rather than tool name.
-- **Breaking:** major version bump. Accumulated API changes since 1.0.0 include
-  new public enum variants in `adk-anthropic` (`ContentBlock::WebFetchToolResult`,
-  `ToolUnionParam::WebFetch20250910`, `ServerTool::WebFetch20250910`) and a new
-  public field on `adk-graph`'s `StateGraph` (`deferred_configs`), which require
-  a major release under semver. The list also includes the new `adk-core`
-  `Part::EmbeddedResource` variant: `Part` is not `#[non_exhaustive]`, so
-  downstream code that matches on it exhaustively must add an arm for the new
-  variant.
+- **Breaking:** major version bump. The complete list of public API breakage since
+  1.0.0, as reported by `cargo semver-checks check-release --release-type minor`
+  against the published 1.0.0 baseline, is below. A migration guide with
+  before/after code is in
+  [docs/official_docs/migration/1.0-to-2.0.md](docs/official_docs/migration/1.0-to-2.0.md).
+
+  | Crate | Change | Downstream impact |
+  |---|---|---|
+  | `adk-acp` | `PermissionDecision::Allow` **removed**, replaced by `Select(String)`, `AllowOnce`, and `AllowAlways` | Code constructing or matching `Allow` must pick the intended variant |
+  | `adk-acp` | New public fields: `PermissionRequest::{session_id, tool_call_id, kind, raw_input}`, `AcpAgentConfig::{mcp_servers, filesystem, terminal}`, `PermissionOption::kind` | Struct literals must add the fields; prefer `..Default::default()` |
+  | `adk-acp` | New variants: `OutputChunk::{ToolUpdate, Usage}`, `PermissionPolicy::AsyncCustom` | Exhaustive `match` must add arms |
+  | `adk-acp` | `AcpAgentConfig` no longer `UnwindSafe`/`RefUnwindSafe` | Affects code storing it across `catch_unwind` |
+  | `adk-anthropic` | New variants: `ContentBlock::WebFetchToolResult`, `ToolUnionParam::WebFetch20250910`, `ServerTool::WebFetch20250910` | Exhaustive `match` must add arms |
+  | `adk-core` | New public fields: `RunConfig::{tool_confirmation_handler, runtime_toolsets}` | Struct literals must add the fields; prefer `RunConfig::builder()` |
+  | `adk-core` | New variant `Part::EmbeddedResource` (`Part` is not `#[non_exhaustive]`) | Exhaustive `match` must add an arm |
+  | `adk-core` | `RunConfig` and `RunConfigBuilder` no longer `UnwindSafe`/`RefUnwindSafe` | Affects code holding them across `catch_unwind` |
+  | `adk-graph` | New public field `StateGraph::deferred_configs` | Struct literals must add the field |
+  | `adk-realtime` | `ClientEvent` and `ServerEvent` are now `#[non_exhaustive]` | Downstream `match` needs a wildcard arm; the enums can no longer be constructed exhaustively outside the crate |
+  | `adk-realtime` | `ServerEvent::Unknown` discriminant changed 21 → 23 | Affects code depending on the numeric discriminant |
+  | `adk-realtime` | New public field `RealtimeConfig::affective_dialog` | Struct literals must add the field |
+  | `adk-telemetry` | `AdkSpanLayer::new` now takes one generic type parameter instead of none | Call sites passing explicit generics must be updated |
+  | `adk-telemetry` | `AdkSpanLayer` no longer `UnwindSafe`/`RefUnwindSafe` | Affects code holding it across `catch_unwind` |
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,7 +469,7 @@ dependencies = [
  "chrono",
  "futures",
  "proptest",
- "quick-xml 0.37.5",
+ "quick-xml 0.41.0",
  "serde",
  "serde_json",
  "statrs",
@@ -1237,14 +1237,13 @@ checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
 
 [[package]]
 name = "ammonia"
-version = "4.1.2"
+version = "4.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17e913097e1a2124b46746c980134e8c954bc17a6a59bb3fde96f088d126dde6"
+checksum = "dc6d763210e2eb7670d1a5183a08bebefa3f97db2a738a684f2ce00bd49f681d"
 dependencies = [
- "cssparser 0.35.0",
- "html5ever 0.35.0",
+ "cssparser 0.37.0",
+ "html5ever 0.39.0",
  "maplit",
- "tendril 0.4.3",
  "url",
 ]
 
@@ -4756,9 +4755,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -4853,19 +4852,6 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e901edd733a1472f944a45116df3f846f54d37e67e68640ac8bb69689aca2aa"
-dependencies = [
- "cssparser-macros",
- "dtoa-short",
- "itoa",
- "phf 0.11.3",
- "smallvec 1.15.1",
-]
-
-[[package]]
-name = "cssparser"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
@@ -4874,6 +4860,17 @@ dependencies = [
  "dtoa-short",
  "itoa",
  "phf 0.13.1",
+ "smallvec 1.15.1",
+]
+
+[[package]]
+name = "cssparser"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
+dependencies = [
+ "dtoa-short",
+ "itoa",
  "smallvec 1.15.1",
 ]
 
@@ -8860,17 +8857,6 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
-dependencies = [
- "log",
- "markup5ever 0.35.0",
- "match_token",
-]
-
-[[package]]
-name = "html5ever"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6452c4751a24e1b99c3260d505eaeee76a050573e61f30ac2c924ddc7236f01e"
@@ -8887,6 +8873,16 @@ checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
 dependencies = [
  "log",
  "markup5ever 0.38.0",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
+dependencies = [
+ "log",
+ "markup5ever 0.39.0",
 ]
 
 [[package]]
@@ -11469,24 +11465,13 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "markup5ever"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
-dependencies = [
- "log",
- "tendril 0.4.3",
- "web_atoms 0.1.3",
-]
-
-[[package]]
-name = "markup5ever"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c3294c4d74d0742910f8c7b466f44dda9eb2d5742c1e430138df290a1e8451c"
 dependencies = [
  "log",
  "tendril 0.4.3",
- "web_atoms 0.2.4",
+ "web_atoms",
 ]
 
 [[package]]
@@ -11497,18 +11482,18 @@ checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
 dependencies = [
  "log",
  "tendril 0.5.0",
- "web_atoms 0.2.4",
+ "web_atoms",
 ]
 
 [[package]]
-name = "match_token"
-version = "0.35.0"
+name = "markup5ever"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "log",
+ "tendril 0.5.0",
+ "web_atoms",
 ]
 
 [[package]]
@@ -14336,9 +14321,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -17237,19 +17222,6 @@ checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "string_cache"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
-dependencies = [
- "new_debug_unreachable",
- "parking_lot",
- "phf_shared 0.11.3",
- "precomputed-hash",
- "serde",
-]
-
-[[package]]
-name = "string_cache"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
@@ -17258,18 +17230,6 @@ dependencies = [
  "parking_lot",
  "phf_shared 0.13.1",
  "precomputed-hash",
-]
-
-[[package]]
-name = "string_cache_codegen"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
 ]
 
 [[package]]
@@ -20177,26 +20137,14 @@ dependencies = [
 
 [[package]]
 name = "web_atoms"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
-dependencies = [
- "phf 0.11.3",
- "phf_codegen 0.11.3",
- "string_cache 0.8.9",
- "string_cache_codegen 0.5.4",
-]
-
-[[package]]
-name = "web_atoms"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
 dependencies = [
  "phf 0.13.1",
  "phf_codegen 0.13.1",
- "string_cache 0.9.0",
- "string_cache_codegen 0.6.1",
+ "string_cache",
+ "string_cache_codegen",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ![Rust](https://img.shields.io/badge/rust-1.94%2B-orange.svg)
 [![GitHub Discussions](https://img.shields.io/github/discussions/zavora-ai/adk-rust?style=flat&logo=github&color=5865F2)](https://github.com/zavora-ai/adk-rust/discussions)
 
-> **🚀 v1.0.0 Released!** First stable release — 39 crates, 130K+ downloads in 6 months, semver stability commitment, all former Beta crates promoted to Stable. Plus: `adk-bench` benchmarking framework (4.6× faster cold start vs Python), authoritative `ROADMAP.md`, and security hardening. See [CHANGELOG](CHANGELOG.md) for full details.
+> **🚀 v2.0.0 Released!** 41 published crates. Official `rmcp 2.2` MCP SDK (protocol `2025-11-25`) with effective HTTP configuration, official `agent-client-protocol` 1.2 for ACP with exact capability publication, the new `adk-computer-use` governed desktop-automation layer, `adk-devtools` coding-agent tools, live async tool confirmation keyed by function-call ID, and resolved dependency advisories. See the [migration guide](docs/official_docs/migration/1.0-to-2.0.md) for the complete breaking-change list and [CHANGELOG](CHANGELOG.md) for full details.
 >
 > **Contributors:** Many thanks to [@mikefaille](https://github.com/mikefaille) — AdkIdentity design, realtime audio, LiveKit bridge, skill system. [@rohan-panickar](https://github.com/rohan-panickar) — OpenAI-compatible providers, xAI, multimodal content. [@dhruv-pant](https://github.com/dhruv-pant) — Gemini service account auth. [@tomtom215](https://github.com/tomtom215) — A2A Protocol v1.0.0 types crate ([a2a-protocol-types](https://crates.io/crates/a2a-protocol-types)), Foundation-verified wire types powering our A2A v1 layer. [@danielsan](https://github.com/danielsan) — Google deps issue & PR (#181, #203), RAG crash report (#205). [@CodingFlow](https://github.com/CodingFlow) — Gemini 3 thinking level, global endpoint, citationSources (#177, #178, #179). [@ctylx](https://github.com/ctylx) — skill discovery fix (#204). [@poborin](https://github.com/poborin) — project config proposal (#176). [@chillin-capybara](https://github.com/chillin-capybara) — ACP integration, adk-acp crate. [@baotao2006](https://github.com/baotao2006) — UTF-8 boundary audit, CJK search/skill/eval fixes (#349, #357). [Get started →](https://github.com/zavora-ai/adk-rust/wiki/quickstart)
 >
@@ -100,7 +100,7 @@ ADK-Rust provides a comprehensive framework for building AI agents in Rust, feat
 - **Agentic commerce**: ACP and AP2 payment orchestration with durable transaction journals and evidence-backed recall
 - **Agentic Web Protocol (AWP)**: Make websites agent-native with discovery, capability manifests, trust levels, rate limiting, consent, and health monitoring
 - **Production features**: Session management, artifact storage, memory systems with project-scoped isolation, REST/A2A APIs
-- **Developer experience**: Interactive CLI, 75+ in-repo examples (120+ in the [playground](https://github.com/zavora-ai/adk-playground)), comprehensive documentation
+- **Developer experience**: Interactive CLI, 97 standalone example crates plus in-crate examples (120+ more in the [playground](https://github.com/zavora-ai/adk-playground)), comprehensive documentation
 
 **Status**: Production-ready, actively maintained
 
@@ -1157,15 +1157,13 @@ Contributions welcome! Please open an issue or pull request on GitHub.
 
 </details>
 
-**Planned** (see [docs/roadmap/](docs/roadmap/)):
+**Planned** (see [ROADMAP.md](ROADMAP.md) for the authoritative roadmap):
 
 | Priority | Feature | Target | Status |
 |----------|---------|--------|--------|
-| 🔴 P0 | [ADK-UI vNext (A2UI + Generative UI)](docs/roadmap/adk-ui.md) | Q2-Q4 2026 | Planned |
-| 🟡 P1 | [Cloud Integrations](docs/roadmap/cloud-integrations.md) | Q2-Q3 2026 | Planned |
-| 🟢 P2 | [Enterprise Features](docs/roadmap/enterprise.md) | Q4 2026 | Planned |
-
-## Star History
+| 🔴 P0 | [ADK-UI vNext (A2UI + Generative UI)](https://github.com/zavora-ai/adk-ui) | Q2-Q4 2026 | Planned |
+| 🟡 P1 | Cloud Integrations | Q2-Q3 2026 | Planned |
+| 🟢 P2 | Enterprise Features | Q4 2026 | Planned |
 
 ## Star History
 

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -52,22 +52,27 @@ The table below assigns one stability tier to every public `adk-*` crate in the 
 | `adk-sandbox` | **Stable** | Sandboxed execution environments |
 | `adk-audio` | **Stable** | Audio processing and STT/TTS providers |
 | `adk-mistralrs` | **Stable** | Native local LLM inference via mistral.rs |
+| `adk-acp` | **Beta** | Agent Client Protocol client and server (tracks the upstream ACP spec) |
+| `adk-awp` | **Beta** | Agentic Web Protocol implementation (tracks the upstream AWP spec) |
+| `awp-types` | **Beta** | AWP protocol types, zero `adk-*` dependencies |
+| `adk-devtools` | **Beta** | Coding-agent dev tools scoped to a `Workspace` (new in 2.0.0) |
+| `adk-computer-use` | **Beta** | Governed orchestration for the `computer-use-mcp` server (new in 2.0.0) |
 | `adk-enterprise` | **Experimental** | Enterprise client SDK for ADK-Rust Managed Agent Service |
 | `adk-managed` | **Experimental** | Managed agent runtime engine |
 
 ### Beta Crate Rationale
 
-These crates are fully functional but remain Beta at 1.0 because their APIs depend on rapidly evolving external specifications or hardware capabilities:
+The crates listed as Beta in the table above are fully functional but track
+external specifications that are still moving, so their public API may change in a
+minor release. Every other crate was promoted to Stable in 1.0.0.
 
 | Crate | Reason for Beta | Path to Stable |
 |-------|----------------|----------------|
-| `adk-realtime` | WebRTC and Live API specs are evolving (OpenAI, Gemini, LiveKit) | Stabilize after upstream APIs settle |
-| `adk-browser` | WebDriver protocol and browser automation patterns still changing | Stabilize when WebDriver BiDi adoption matures |
-| `adk-eval` | Evaluation methodology is an active research area; API surface may expand | Promote after 1-2 release cycles without breaking changes |
-| `adk-code` | Code execution security model under active development | Stabilize alongside `adk-sandbox` |
-| `adk-sandbox` | OS-level sandboxing APIs differ across platforms; API may evolve | Stabilize after cross-platform testing at scale |
-| `adk-audio` | ONNX model ecosystem and audio format support expanding rapidly | Promote when model selection stabilizes |
-| `adk-mistralrs` | Upstream mistral.rs releases new model architectures frequently | Track upstream stability |
+| `adk-acp` | Agent Client Protocol is evolving upstream; capability negotiation follows the SDK | Stabilize once the ACP wire spec settles past v1 |
+| `adk-awp` | Agentic Web Protocol is a young specification | Stabilize when the AWP spec reaches a versioned release |
+| `awp-types` | Mirrors the AWP wire format, so it moves with the spec | Stabilize alongside `adk-awp` |
+| `adk-devtools` | New in 2.0.0; the coding-agent tool surface is still being shaped by use | Promote after 1-2 release cycles without breaking changes |
+| `adk-computer-use` | New in 2.0.0; tracks the `computer-use-mcp` wire contracts | Stabilize when the upstream contracts are versioned |
 
 ### Excluded from Workspace
 
@@ -134,4 +139,40 @@ ADK-Rust 1.0.0 was released on June 7, 2026. All Stable-tier crates commit to lo
 
 - Breaking changes to Stable-tier crates require a 2.0.0 release
 - Beta crates may have breaking changes in 1.x minor releases (with migration guides)
+- Experimental crates may change without notice
+
+## 2.0 Milestone
+
+ADK-Rust 2.0.0 is the second major release. It keeps the Stable-tier commitment and
+spends the major version on the breakage that had accumulated since 1.0.0.
+
+### What the major version bought
+
+| Area | Change |
+|---|---|
+| MCP | Official `rmcp 2.2` SDK, protocol `2025-11-25` |
+| ACP | Official `agent-client-protocol` 1.2; `PermissionDecision::Allow` split into `AllowOnce`/`AllowAlways`/`Select` |
+| Tool authorization | `RunConfig` gained an async `ToolConfirmationHandler`; decisions key on function-call ID |
+| Realtime | `ClientEvent`/`ServerEvent` became `#[non_exhaustive]` so future protocol events are additive |
+| New crates | `adk-devtools`, `adk-computer-use` (both Beta) |
+
+The complete breaking-change list, generated with `cargo semver-checks`, is in
+[`CHANGELOG.md`](CHANGELOG.md) and the
+[1.0 → 2.0 migration guide](docs/official_docs/migration/1.0-to-2.0.md).
+
+### Criteria Status
+
+| Criterion | Status | Notes |
+|-----------|--------|-------|
+| **Semver compliance** | ✅ Met | `cargo semver-checks check-release` accepts the 1.0.0 → 2.0.0 bump for every published crate. Because a major bump permits any change, the breaking-change inventory is generated separately with `--release-type minor` and recorded in the changelog. |
+| **Migration guide** | ✅ Met | [docs/official_docs/migration/1.0-to-2.0.md](docs/official_docs/migration/1.0-to-2.0.md) covers every breakage with before/after code. |
+| **Test coverage** | ✅ Met | 3700+ workspace tests plus 300+ doctests, all gated in CI. |
+| **CI enforcement** | ✅ Met | `fmt`, `clippy --all-targets -D warnings`, `nextest --workspace`, doctests, doc build, template scaffolding, and semver run per PR; supply-chain (`cargo audit` + `cargo deny`) and standalone-example compilation run nightly. |
+| **Supply chain** | ✅ Met | `cargo audit` and `cargo deny check` both pass. Accepted advisories and non-OSI dependency licenses are documented in [docs/security/DEPENDENCY-ADVISORIES.md](docs/security/DEPENDENCY-ADVISORIES.md). |
+| **Documentation coverage** | 🔲 In progress | Public API coverage is high; formal 90% audit pending tooling automation. |
+
+### Post-2.0 Contract
+
+- Breaking changes to Stable-tier crates require a 3.0.0 release
+- Beta crates may have breaking changes in 2.x minor releases (with migration guides)
 - Experimental crates may change without notice

--- a/V2_GAPS.md
+++ b/V2_GAPS.md
@@ -1,0 +1,1582 @@
+# ADK-Rust v2 Gaps
+
+## Document status
+
+**Review date:** 2026-07-22
+**Repository snapshot:** branch `feat/cooperative-cancellation`, commit `0c653af6ca76328a3f540018ba8ad4892bdedd26` (`2026-07-21T07:50:46+03:00`, `feat(acp): add full ACP v1 protocol support`)
+**Landscape cutoff for the wider review:** 2026-07-21
+**Purpose:** detailed technical record of shortcomings verified in the repository snapshot above
+**Implementation changes by this review:** none; this report is the only file created by this review
+
+This is a source and execution-evidence report, not a release announcement and not a complete audit of every crate. Each material statement below is tied to current repository source, a locally executed probe, or an explicit mismatch between source and repository documentation. Areas that were not completed are listed under [Pending review areas](#pending-review-areas) rather than presented as findings.
+
+## Release-baseline limitation
+
+The workspace declares version `2.0.0` in `Cargo.toml`, `CHANGELOG.md` contains a `2.0.0` entry dated 2026-07-16, and `README.md` calls v2 current. However, the inspected local repository has no `v2.0.0` tag. There is therefore no authoritative local Git object that identifies the exact source published as v2.0.0. Commit `2a4a85bec8c5b41a59b94d580a5c9e1684d8e2b3` is retained only as a provisional date-based comparison point; it is not treated as a release tag.
+
+Unless a finding explicitly says otherwise, its release attribution is **current HEAD only**. A current-HEAD finding must not be read as proof that the same behavior exists in a particular crates.io package or released source archive.
+
+## Evidence classification
+
+- **Probe-confirmed:** behavior was reproduced by an executable local probe. Source was also inspected to identify the mechanism.
+- **Source-confirmed:** the behavior follows directly from the inspected implementation. No claim is made about an external service beyond the repository boundary.
+- **Documentation mismatch:** repository documentation promises or describes behavior that the inspected implementation does not provide.
+- **Qualified absence:** no implementation was found within a stated search scope. This does not assert repository-wide or ecosystem-wide absence outside that scope.
+- **Pending review:** insufficient inspection has been completed; the topic is intentionally not reported as a finding.
+
+Unless a narrower scope is stated, each test-coverage-gap claim is limited to tests in the cited crate or subsystem plus repository-wide searches for the relevant symbols in this checkout. It does not describe downstream or external test suites.
+
+A prior attempt to obtain independent source confirmation from reviewer agents was blocked because those agents had no filesystem or search tools. Their output is not used as evidence in this document.
+
+## Severity definitions
+
+- **Critical:** directly enables broad unauthorized control or disclosure under ordinary deployment assumptions, or predictably causes unrecoverable system-wide corruption.
+- **High:** can violate isolation or authorization, execute an operation more than once, lose durable control state, report failed work as successful, or defeat a major runtime contract.
+- **Medium:** materially reduces correctness, reliability, operability, or compatibility but generally needs a narrower trigger or has a bounded workaround.
+- **Low:** localized API or documentation defect with limited operational impact.
+
+Severity describes plausible impact of the repository behavior, not exploitability in every deployment. Conditional impacts are identified explicitly.
+
+## Executive technical conclusion
+
+The snapshot contains substantial implemented functionality, but several advertised runtime boundaries are not yet dependable enough to treat as uniform contracts. The highest-priority problems are:
+
+1. execution paths that replay or execute work more than once;
+2. context wrappers and adapters that remove cancellation, secrets, identity, or authorization data;
+3. background and managed execution surfaces whose durability or execution is process-local or simulated;
+4. unauthenticated UI bridge mutation routes when server authentication is configured;
+5. coding and sandbox surfaces whose isolation is weaker than their public description;
+6. realtime tool paths that are disconnected from the standard control pipeline; and
+7. adapters that trust security-relevant remote objects without local binding checks.
+
+The report does **not** conclude that every ADK-Rust feature is unsafe or unusable. It identifies concrete paths where the implementation does not meet its own local contract or where safe behavior depends on application wiring that the public surface does not enforce.
+
+---
+
+## 1. Execution correctness and runtime identity
+
+### EX-01 — `ParallelAgent` starts sub-agents concurrently but drains their lazy streams serially
+
+**Severity:** High
+**Affected capability:** parallel workflow execution and latency
+**Evidence:** Probe-confirmed
+**Affected code:** `adk-agent/src/workflow/parallel_agent.rs` — `ParallelAgent::run`
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+`ParallelAgent::run` inserts futures that call `agent.run(ctx).await` into `FuturesUnordered`. An ADK agent run returns a lazy `EventStream`; obtaining that stream does not necessarily execute its contents. After one run future resolves, `ParallelAgent` enters an inner loop and drains that stream to completion before polling `FuturesUnordered` for another resolved stream.
+
+#### Failure mechanism
+
+Concurrency covers stream construction, not stream consumption. If two sub-agents each return a stream whose work happens while it is polled, only one stream is polled at a time. The second stream is dormant until the first completes. This is especially visible for LLM streams, tool streams, and custom agents implemented with `async_stream`.
+
+#### Impact
+
+Nominally parallel branches can have approximately additive latency and suffer head-of-line blocking. A slow or stalled first stream delays all other branch events. This also changes timing assumptions for agents coordinating through `SharedState`.
+
+#### Evidence
+
+A local probe used two lazy streams that each waited 300 ms. Total elapsed time was `604 ms`, rather than approximately 300 ms. Source inspection identifies the nested drain loop as the cause.
+
+#### Test coverage gap
+
+Existing tests do not assert overlap of lazy stream execution or interleaving of events from multiple sub-agents.
+
+#### Required correction
+
+Poll all returned streams concurrently. One approach is to map each sub-agent stream into a tagged stream and merge them with `SelectAll` or equivalent bounded fan-in. Preserve deterministic error policy explicitly rather than achieving ordering by serial drain.
+
+#### Regression tests
+
+Add a timing-independent barrier test proving both streams are polled before either can complete, an event-interleaving test, and a failure test showing one branch error does not leave other streams unpolled.
+
+### EX-02 — Workflow context wrappers remove cancellation, secret access, and shared state
+
+**Severity:** High
+**Affected capability:** cooperative cancellation, secret-backed tools, authenticated metadata, and workflow composition
+**Evidence:** Probe-confirmed
+**Affected code:** `adk-agent/src/workflow/loop_agent.rs` — `HistoryTrackingContext`; `adk-agent/src/workflow/skill_context.rs` — `UserContentOverrideContext`; `adk-agent/src/workflow/shared_state_context.rs` — `SharedStateContext`; `adk-core/src/context.rs` — `InvocationContext` defaults
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+The wrappers reimplement `InvocationContext` and delegate only selected methods. Methods not explicitly delegated fall back to trait defaults: `is_cancelled()` becomes `false`, `get_secret()` becomes `Ok(None)`, `shared_state()` becomes `None`, scopes become empty where not delegated, and request metadata becomes empty where not delegated.
+
+`HistoryTrackingContext` delegates scopes and request metadata but not cancellation, secrets, or shared state. `UserContentOverrideContext` delegates none of those optional capabilities. `SharedStateContext` injects shared state and delegates scopes and metadata, but still does not delegate cancellation or secrets.
+
+#### Failure mechanism
+
+Rust trait default methods make a partial wrapper compile successfully. Adding a new context capability therefore does not force every wrapper to forward it. Composition silently changes behavior according to which wrapper happens to be outermost.
+
+#### Impact
+
+A direct agent can stop when interrupted and retrieve a configured secret, while the same agent nested in `LoopAgent` or `SequentialAgent` can continue running and observe no secret provider. Parallel shared-state mode keeps shared state but removes cancellation and secrets. Security and lifecycle behavior therefore changes with workflow topology.
+
+#### Evidence
+
+The local probe reported:
+
+- direct context: cancellation `true`, secret present, shared state present;
+- loop/sequential context: cancellation `false`, secret absent, shared state absent;
+- parallel shared context: cancellation `false`, secret absent, shared state present.
+
+#### Test coverage gap
+
+There is no context-capability conformance test that runs the same sentinel context through every workflow wrapper and compares all extension methods.
+
+#### Required correction
+
+Introduce a reusable delegating context adapter that forwards every capability by default and overrides only the intended field. Alternatively, make capabilities an owned inner object rather than default trait methods. Audit every context wrapper when new methods are added.
+
+#### Regression tests
+
+Create a sentinel context with non-default values for artifacts, memory, shared state, scopes, metadata, cancellation, and secrets. Verify direct, skill, loop, sequential, and parallel paths preserve all values except explicitly documented overrides.
+
+### EX-03 — `LlmAgent` discards provider terminal error fields
+
+**Severity:** High
+**Affected capability:** model failure propagation and truthful event status
+**Evidence:** Probe-confirmed
+**Affected code:** `adk-core/src/model.rs` — `LlmResponse`; `adk-agent/src/llm_agent.rs` — `LlmAgent::run`; `adk-model/src/anthropic/convert.rs` — `from_stream_error`
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+`LlmResponse` carries `interrupted`, `error_code`, and `error_message`. Provider conversion code can return a successful stream item containing those fields; Anthropic's stream-error converter is one concrete source. `LlmAgent::run` copies content, partial/turn status, finish reason, usage, provider metadata, and interaction ID into events, but it does not copy or turn the three terminal error fields into an `Err`.
+
+#### Failure mechanism
+
+The agent distinguishes transport-level `Err` items from response-level error envelopes, but only handles the former. A terminal provider error encoded as `Ok(LlmResponse { error_code: ... })` passes through accumulation and can end as an apparently successful, often empty turn.
+
+#### Impact
+
+Callers, persistence backends, retry logic, and user interfaces can record a failed provider turn as success. Retry and alerting policy cannot react to the lost code. Empty output may be misdiagnosed as model behavior rather than provider failure.
+
+#### Evidence
+
+A local mock-provider probe emitted terminal error fields. The agent stream produced `stream_errors=[]`, and emitted event error fields were absent.
+
+#### Test coverage gap
+
+No cross-provider contract test requires response-level errors to survive the `Llm` → `LlmAgent` → `EventStream` boundary.
+
+#### Required correction
+
+Define one canonical rule: either provider adapters must emit `Err(AdkError)` for terminal errors, or `LlmAgent` must detect `error_code`, preserve the fields on an event, and terminate with a structured error. Apply the same rule to callback-provided responses.
+
+#### Regression tests
+
+Cover streaming and non-streaming modes, a terminal error with no content, an error after partial content, and `interrupted=true`. Assert persistence and telemetry receive an unambiguous failed outcome.
+
+### EX-04 — Runner cancellation is keyed only by raw session ID and is unsafe for concurrent runs
+
+**Severity:** High
+**Affected capability:** run isolation and interruption
+**Evidence:** Source-confirmed
+**Affected code:** `adk-runner/src/runner.rs` — `Runner::run`, `Runner::interrupt`, `Runner::active_session_ids`
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+`Runner` stores active cancellation tokens in `HashMap<String, CancellationToken>` keyed by `session_id` only. The app and user dimensions used to retrieve the session are not part of the key. Starting another run with the same raw session ID replaces the prior token. Each stream's drop guard later removes the key unconditionally.
+
+#### Failure mechanism
+
+Two identities such as `(app-a, user-a, shared-id)` and `(app-b, user-b, shared-id)` collide inside one Runner. Two concurrent runs for one session also collide: the second insert hides the first token, and completion of the first can remove the second run's registration.
+
+#### Impact
+
+`interrupt("shared-id")` can target the wrong active execution, fail to reach an older execution, or report no active run while one is still running. This is an isolation defect when a Runner is shared across users or applications and a correctness defect under same-session concurrency.
+
+#### Test coverage gap
+
+No test starts colliding IDs across users/apps or overlaps two runs with the same identity while exercising cleanup order.
+
+#### Required correction
+
+Key active runs by full `AdkIdentity` plus a unique invocation/run ID. Define whether interrupt-by-session cancels all runs or requires an exact run ID. Make cleanup conditional on removing the same token/run entry that was inserted.
+
+#### Regression tests
+
+Cover duplicate raw IDs across identities, two overlapping runs for one identity, reverse completion order, targeted cancellation by run ID, and session-wide cancellation semantics.
+
+### EX-05 — Runner persistence bypasses the full session identity API
+
+**Severity:** High
+**Affected capability:** tenant-safe session persistence
+**Evidence:** Source-confirmed
+**Affected code:** `adk-runner/src/runner.rs` — event append call sites in `Runner::run`; `adk-session/src/service.rs` — `SessionService::append_event`, `append_event_for_identity`, `AppendEventRequest`
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+The Runner retrieves a session with `(app_name, user_id, session_id)` but persists user and agent events through `session_service.append_event(ctx.session_id(), event)`. The session trait now exposes `append_event_for_identity`, explicitly described as the preferred unambiguous API, but the Runner does not call it.
+
+#### Failure mechanism
+
+The full identity is available in the context and then discarded at the write boundary. A backend whose natural key is composite cannot use its identity-aware override because the Runner chooses the legacy raw-ID method directly.
+
+#### Impact
+
+Impact is backend-dependent. If session IDs are not globally unique, events can be appended to the wrong app/user session or rejected ambiguously. Even backends that currently impose global IDs cannot enforce tenant binding at this call site.
+
+#### Test coverage gap
+
+There is no Runner integration test using a backend that deliberately creates the same session ID under two identities and rejects raw-ID appends.
+
+#### Required correction
+
+Construct `AdkIdentity` once and use `append_event_for_identity` for every persistence write. Consider deprecating the raw append method or making the identity-aware method required for composite backends.
+
+#### Regression tests
+
+Use a strict composite-key fake backend and assert every user, model, plugin, transfer, and tool event is appended with the exact identity.
+
+### EX-06 — Static tool approvals are keyed by tool name rather than exact call identity
+
+**Severity:** High
+**Affected capability:** human authorization for side-effecting tools
+**Evidence:** Source-confirmed
+**Affected code:** `adk-core/src/context.rs` — `RunConfig::tool_confirmation_decisions`, `ToolConfirmationRequest`; `adk-agent/src/llm_agent.rs` — tool confirmation pre-check in `LlmAgent::run`
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+The confirmation request includes `function_call_id` and arguments. Live decisions from a `ToolConfirmationHandler` are tracked by call ID. In contrast, static decisions supplied through `RunConfig::tool_confirmation_decisions` are looked up by `fc_name`.
+
+#### Failure mechanism
+
+An approval entry for `delete_file` authorizes every matching call evaluated against that map, independent of path, arguments, provider call ID, or a digest of the request. Multiple calls with the same tool name cannot receive distinct static decisions.
+
+#### Impact
+
+A decision intended for one exact action can be replayed onto a materially different invocation. This weakens the authorization boundary in resumed/web-driven confirmation flows that use the static map rather than the live handler.
+
+#### Test coverage gap
+
+No test presents two same-name calls with different arguments and proves that approving one leaves the other pending or denied.
+
+#### Required correction
+
+Key decisions by stable function-call ID and bind them to a canonical digest of tool name plus arguments. Reject missing or mismatched IDs. If name-wide policy is desired, expose it as a separately named, explicit policy.
+
+#### Regression tests
+
+Cover two same-name calls, changed arguments under a reused ID, reordered calls, duplicate provider IDs, and one-shot consumption of an approval.
+
+### EX-07 — Tool progress uses an unbounded in-process channel
+
+**Severity:** Medium
+**Affected capability:** resource bounds during long-running tools
+**Evidence:** Source-confirmed
+**Affected code:** `adk-agent/src/llm_agent.rs` — `AgentToolContext::with_progress`, `AgentToolContext::emit_progress`, progress channel creation in `LlmAgent::run`
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+Each tool batch creates `tokio::sync::mpsc::unbounded_channel::<Event>()`. Every call to `emit_progress` allocates and sends an event without backpressure or an aggregate byte/event limit.
+
+#### Failure mechanism
+
+A verbose tool can produce progress faster than the agent stream or client consumes it. The sender never waits, so queued events retain strings and metadata until drained or the process exhausts memory.
+
+#### Impact
+
+Large compiler logs, shell output, or a faulty tool can cause unbounded memory growth. The risk is amplified when the downstream SSE client is slow. This is separate from any final-output truncation a tool applies after collecting output.
+
+#### Test coverage gap
+
+There is no stress test for a stalled consumer, queue depth, dropped/coalesced progress, or cancellation under sustained output.
+
+#### Required correction
+
+Use a bounded channel with explicit backpressure or a documented lossy/coalescing policy. Enforce per-call byte and event budgets and propagate cancellation when the receiver closes.
+
+#### Regression tests
+
+Flood progress with a non-reading receiver and assert bounded memory/queue size, deterministic truncation markers, and prompt producer termination after cancellation.
+
+---
+
+## 2. Context caching, memory, and provider contracts
+
+### MC-01 — Automatic context cache state is Runner-global and built from incomplete inputs
+
+**Severity:** High
+**Affected capability:** prompt correctness and provider context caching
+**Evidence:** Source-confirmed
+**Affected code:** `adk-runner/src/cache.rs` — `CacheManager`; `adk-runner/src/runner.rs` — context-cache lifecycle in `Runner::run`; `adk-agent/src/llm_agent.rs` — cached-content propagation
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+A Runner owns one `CacheManager` with one `active_cache_name` and invocation counter. That cache is reused across sessions and whichever sub-agent `find_agent_to_run` selects. Cache creation uses `agent_to_run.description()` as the system instruction and an empty tool map. The real static/dynamic global instruction, agent instruction, selected skill content, history, and resolved tools are constructed later inside `LlmAgent`.
+
+#### Failure mechanism
+
+Cache identity is neither per agent nor keyed by the actual cacheable request material. A cache made for one selected agent can be attached to a later request for another agent. Refresh occurs by Runner-wide invocation count rather than content change. The cache therefore does not reliably represent the request to which its name is attached.
+
+#### Impact
+
+Provider behavior can include stale or wrong cached instructions, cache misses disguised as reuse, or provider-side validation failures. The current cache input contains descriptions rather than user history, so this finding does not claim cross-user prompt disclosure; it does establish cross-session/agent correctness coupling.
+
+#### Test coverage gap
+
+Tests cover `CacheManager` counters in isolation, not multiple users, agent transfers, dynamic instructions, toolset changes, or the actual `create_cache` arguments.
+
+#### Required correction
+
+Compute a canonical cache key from the exact provider-normalized system/tool material, scope entries by model/provider and agent, and maintain a bounded map rather than one global name. Invalidate on any material change. Do not substitute description for instruction.
+
+#### Regression tests
+
+Capture cache creation requests for two agents and two dynamic instruction values; assert distinct cache entries, correct tools, no cross-session name reuse when content differs, and reuse only for byte-equivalent normalized material.
+
+### MC-02 — Project-aware memory defaults silently fall back to global operations
+
+**Severity:** High
+**Affected capability:** project isolation in memory backends
+**Evidence:** Source-confirmed
+**Affected code:** `adk-memory/src/service.rs` — default project methods on `MemoryService`; `adk-core/src/context.rs` — default project methods on `Memory`; `adk-memory/src/adapter.rs` — `MemoryServiceAdapter`
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+Default implementations of `add_session_to_project`, `add_entry_to_project`, and `delete_entries_in_project` discard `project_id` and call their global equivalents. Core `Memory::search_in_project` and `add_to_project` likewise discard the project and delegate globally. `MemoryServiceAdapter::with_project_id` relies on those project methods.
+
+#### Failure mechanism
+
+A backend can compile as project-aware without overriding every project method. Calls carrying a project identifier then succeed while operating in global scope. The type system and return value provide no indication that isolation was not implemented.
+
+#### Impact
+
+For a custom or incomplete backend, data intended for one project can become globally visible to the same app/user, and project-scoped deletion can affect global entries. Inspected built-in backends may override these methods; this finding is about the unsafe trait fallback and does not assert that every backend collapses scope.
+
+#### Test coverage gap
+
+There is no conformance suite that requires every advertised project-aware backend to preserve project boundaries across add, search, and delete.
+
+#### Required correction
+
+Make project methods return `not implemented` by default, or split project-aware behavior into a separate required trait. Expose capability discovery so callers cannot mistake fallback behavior for isolation.
+
+#### Regression tests
+
+Run a shared backend conformance suite with two project IDs plus global entries. Verify visibility and deletion boundaries and assert incomplete implementations fail explicitly.
+
+### PR-01 — DeepSeek advertises structured JSON output but hardcodes `response_format` to `None`
+
+**Severity:** Medium
+**Affected capability:** native structured output
+**Evidence:** Source-confirmed and documentation mismatch
+**Affected code:** `adk-model/src/deepseek/client.rs` — `DeepSeekClient::build_request`; `adk-model/src/deepseek/convert.rs` — `ChatCompletionRequest`; `adk-model/src/deepseek/mod.rs` — provider feature documentation
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+The request type contains `response_format`, and the provider module advertises “JSON Output: Structured JSON responses via `response_format`.” `DeepSeekClient::build_request` reads temperature, top-p, token limits, tools, thinking, and reasoning effort, but always sets `response_format: None`, even when `GenerateContentConfig.response_schema` is present.
+
+#### Failure mechanism
+
+The unified schema setting is dropped at the provider adapter. `LlmAgent` still injects a textual schema instruction and validates the eventual text, so callers may see retries rather than complete loss; native provider enforcement is nevertheless not requested.
+
+#### Impact
+
+Structured output is less reliable and can cost extra turns. Behavior differs from Gemini, OpenAI-compatible, OpenRouter, and Gemini Interactions adapters that explicitly map response schemas.
+
+#### Test coverage gap
+
+There is no provider request-serialization test asserting a DeepSeek response format when `response_schema` is supplied.
+
+#### Required correction
+
+Map supported schema intent to the exact DeepSeek response-format contract, validate model compatibility, and return an explicit unsupported-capability error where native schema mode is unavailable.
+
+#### Regression tests
+
+Serialize chat and reasoning-model requests with and without schemas and assert the expected wire field, plus an end-to-end fake-server test for invalid structured output handling.
+
+### PR-02 — Provider converters silently drop or downgrade some content parts
+
+**Severity:** Medium
+**Affected capability:** multimodal fidelity and provider portability
+**Evidence:** Source-confirmed
+**Affected code:** `adk-model/src/bedrock/convert.rs` — `adk_parts_to_bedrock`; `adk-model/src/gemini/client.rs` — `GeminiModel::generate_content_internal`; `adk-model/src/anthropic/convert.rs` — `content_to_message`; `adk-model/src/openrouter/convert_chat.rs` — `adk_contents_to_chat_messages`
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+Conversion policy is inconsistent. Bedrock silently returns `None` for unsupported inline MIME types, some file references, embedded blobs, and Gemini-specific server-tool parts. Gemini generateContent turns user `FileData` into attachment-description text rather than a native file part. Anthropic also textualizes unsupported attachments, while OpenRouter has broader file-part mappings.
+
+#### Failure mechanism
+
+The common `Content` type can express more than a given transport. Adapters choose unrelated fallback policies—drop, textualize, or encode—without a common capability result or warning event visible to the caller.
+
+#### Impact
+
+A request can reach a provider without material the caller supplied. The model may answer as if it saw a document or media object when it only saw a URI description, or no part at all. This is a portability defect, not a claim that every provider supports every MIME type.
+
+#### Test coverage gap
+
+Provider tests focus on supported examples. There is no matrix requiring every `Part` variant to be accepted, explicitly downgraded, or rejected with a structured error.
+
+#### Required correction
+
+Add provider capability negotiation and a normalized conversion outcome. Unsupported material should fail before network dispatch unless the caller explicitly opts into a documented textual fallback. Emit diagnostics listing every transformed or omitted part.
+
+#### Regression tests
+
+Build a cross-provider table covering inline/file image, audio, video, PDF, text, arbitrary binary, embedded resources, and server-tool parts. Assert no silent omission.
+
+---
+
+## 3. Graph execution and checkpointing
+
+### GR-01 — Checkpoints save already-executed nodes as pending, so resume replays them
+
+**Severity:** High
+**Affected capability:** durable resume and side-effect safety
+**Evidence:** Probe-confirmed
+**Affected code:** `adk-graph/src/executor.rs` — `PregelExecutor::run`, `try_resume_from_checkpoint`, `save_checkpoint`
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+After `execute_super_step`, `run` calls `save_checkpoint` before calculating and assigning the next nodes. `save_checkpoint` serializes `self.pending_nodes`, which still contains the nodes just executed. Resume restores that vector and executes those nodes again.
+
+#### Failure mechanism
+
+The checkpoint represents the scheduler state from before the completed super-step but the data state from after it. State and control position are inconsistent. Automatic loading of the latest checkpoint has the same issue as explicit `resume_from`.
+
+#### Impact
+
+Completed LLM calls, HTTP calls, database writes, desktop actions, payments, or other non-idempotent nodes can run twice after restart/resume. State reducers can also apply updates twice. External idempotency may reduce effects for a specific integration, but it is not a graph-level guarantee.
+
+#### Evidence
+
+A local probe invoked a one-node graph twice with the same checkpoint thread. It reported `first_count=1 second_count=2`, proving the completed node ran again.
+
+#### Test coverage gap
+
+Current graph tests do not assert that a completed side-effect node is skipped on a second invocation using the same thread.
+
+#### Required correction
+
+Compute the next scheduler state first and checkpoint state plus the **next** pending nodes atomically. Define terminal checkpoints explicitly. Include deferred/fan-in scheduler state if required for exact recovery.
+
+#### Regression tests
+
+Use a non-idempotent counter node, multi-step graph, parallel fan-out, deferred join, interrupt-before/after, and terminal checkpoint. Resume at every boundary and assert each completed node executes exactly once.
+
+### GR-02 — Streaming graph execution never saves checkpoints
+
+**Severity:** High
+**Affected capability:** durable streaming, crash recovery, and streamed interrupts
+**Evidence:** Source-confirmed
+**Affected code:** `adk-graph/src/executor.rs` — `PregelExecutor::run_stream`, `save_checkpoint`
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+`save_checkpoint` is called only by non-streaming `run`. `run_stream` has no call to it in Values, Updates, Debug, Custom, or Messages mode. On a streamed interrupt, it emits `StreamEvent::interrupted` and returns without persisting the interrupt state.
+
+#### Failure mechanism
+
+The streaming implementation duplicates the scheduling loop but omits the persistence steps present in `run`.
+
+#### Impact
+
+A graph advertised as checkpointed is not durable when consumed through the streaming API. A crash restarts from an older checkpoint or from the beginning. Human-in-the-loop consumers cannot rely on a streamed interrupt having a resumable checkpoint.
+
+#### Test coverage gap
+
+There is no test comparing final/latest checkpoint state between `invoke` and every stream mode, or resuming after dropping a stream mid-run.
+
+#### Required correction
+
+Unify streaming and non-streaming execution around one state-transition engine. Persistence should occur once per committed transition independent of output mode, and streamed interrupt events should carry the saved checkpoint ID.
+
+#### Regression tests
+
+For every stream mode, drop after each step and resume; verify no replay, correct next nodes, and a durable interrupt checkpoint.
+
+### GR-03 — Messages stream mode executes each node twice
+
+**Severity:** High
+**Affected capability:** graph message streaming and exactly-once execution
+**Evidence:** Source-confirmed
+**Affected code:** `adk-graph/src/executor.rs` — Messages branch of `PregelExecutor::run_stream`; `adk-graph/src/node.rs` — `Node::execute_stream`, `AgentNode::execute_stream`, `AgentNode::execute`
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+Messages mode first drains `node.execute_stream(&ctx)`. It then calls `node.execute(&ctx)` to obtain state updates. The default `Node::execute_stream` already calls `execute`. `AgentNode::execute_stream` independently invokes the wrapped agent, and `AgentNode::execute` invokes it again.
+
+#### Failure mechanism
+
+The stream contract returns events but not the final `NodeOutput`, so the executor reruns the node to reconstruct updates instead of collecting one execution's result.
+
+#### Impact
+
+Every Messages-mode node can perform side effects twice, incur two model calls, produce inconsistent output, and charge twice. The second execution supplies state updates that may not correspond to the first execution's streamed messages.
+
+#### Test coverage gap
+
+There is no invocation-count assertion for Messages mode or consistency test tying streamed messages to committed state.
+
+#### Required correction
+
+Change the streaming node contract to yield events and return/emit one final output, or run `execute` once and stream events from that execution. Never invoke a node solely to recover state already produced by another invocation.
+
+#### Regression tests
+
+Count calls for default `FunctionNode` and `AgentNode`, verify one call per node, and assert state is derived from the same execution whose messages were emitted.
+
+### GR-04 — `AgentNode` replaces runtime identity and services with a synthetic context
+
+**Severity:** High
+**Affected capability:** agents embedded in graphs
+**Evidence:** Source-confirmed
+**Affected code:** `adk-graph/src/node.rs` — `AgentNode`, `GraphInvocationContext`, `GraphSession`
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+`AgentNode` creates a new `GraphInvocationContext` for each run. It hardcodes `user_id="graph_user"`, `app_name="graph_app"`, and branch `main`; creates a fresh in-memory `GraphSession`; uses default `RunConfig`; and returns no artifacts or memory. Optional invocation methods fall back to empty scopes/metadata, no secrets, no shared state, and no cancellation.
+
+#### Failure mechanism
+
+The graph node API receives `NodeContext`, not the parent ADK `InvocationContext`, so the adapter fabricates the minimum context needed to call an agent. No bridge carries authenticated/runtime capabilities into the graph.
+
+#### Impact
+
+An agent behaves differently inside a graph: identity-dependent tools see synthetic principals, session history/state is detached, secret and memory access disappear, scope checks cannot use the caller's grants, and Runner interruption is not visible.
+
+#### Test coverage gap
+
+No integration test compares one agent run directly and through `AgentNode` with a capability-rich context.
+
+#### Required correction
+
+Allow graph execution to carry a parent invocation capability bundle and derive a child context while preserving identity, services, request context, cancellation, and session semantics. Make synthetic standalone execution an explicit mode.
+
+#### Regression tests
+
+Pass sentinel identity, scopes, metadata, secret service, memory, artifacts, cancellation, shared state, and history through an `AgentNode`; assert exact preservation and intentional branch/session derivation.
+
+### GR-05 — `TimeTravelHandle::replay` lists checkpoints instead of replaying execution
+
+**Severity:** Medium
+**Affected capability:** graph time travel and reproducibility
+**Evidence:** Source-confirmed and documentation mismatch
+**Affected code:** `adk-graph/src/time_travel.rs` — `TimeTravelHandle::replay`
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+Rustdoc says `replay` “re-executes the graph” between steps. The implementation lists checkpoints, sorts and filters them, and returns stored `(step, state)` pairs. It never invokes a node or the compiled graph.
+
+#### Failure mechanism
+
+Historical state retrieval and deterministic re-execution are represented by one method name and description, but only retrieval is implemented.
+
+#### Impact
+
+Callers cannot use this API to reproduce decisions, regenerate intermediate events, or validate deterministic behavior. They may incorrectly treat stored snapshots as a fresh replay.
+
+#### Test coverage gap
+
+Tests assert returned checkpoint ranges, which reinforces snapshot listing but does not test node execution counts or regenerated events.
+
+#### Required correction
+
+Either rename/document the method as checkpoint-range retrieval or implement real replay in an isolated branch with explicit side-effect policy and deterministic inputs.
+
+#### Regression tests
+
+For real replay, use deterministic nodes and counters to prove re-execution and state equivalence; reject or sandbox side-effecting nodes. For retrieval-only behavior, update names and docs and test that no execution occurs.
+
+### GR-06 — Functional `TaskContext::interrupt` cannot resume with a typed value
+
+**Severity:** High
+**Affected capability:** functional graph human-in-the-loop control
+**Evidence:** Source-confirmed
+**Affected code:** `adk-graph/src/functional/context.rs` — `TaskContext::interrupt`; `adk-graph/src/functional/error.rs` — `FunctionalError::InterruptTypeMismatch`
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+`interrupt<T>` emits an event, saves a checkpoint, records an `__interrupt__` task, and then always returns `InterruptTypeMismatch` with “workflow interrupted.” A repository-wide source search found no code outside this method that consumes a resume value or handles `__interrupt__` to return `T`.
+
+#### Failure mechanism
+
+The API signature and rustdoc describe suspension followed by typed resumption, but the implementation has no resume-value channel. The source comment explicitly labels the runtime behavior as future work.
+
+#### Impact
+
+Functional workflows cannot use this method as documented for approval or external input. Applications must interpret an error as control flow and build their own resume machinery, with no typed value delivered to the interrupted call.
+
+#### Test coverage gap
+
+There is no end-to-end test that interrupts a functional entrypoint, supplies a value, resumes, and observes that value at the call site.
+
+#### Required correction
+
+Represent interruption as a distinct suspended outcome, persist a stable continuation key, accept a typed resume payload, and make the generated entrypoint restore execution at the interrupt boundary without misclassifying normal suspension as a type mismatch.
+
+#### Regression tests
+
+Cover bool and structured payload resumption, wrong-type rejection, repeated resume, crash between interrupt and resume, and idempotent continuation.
+
+### GR-07 — Several advertised action executors are validated placeholders
+
+**Severity:** Medium
+**Affected capability:** graph action nodes
+**Evidence:** Source-confirmed and documentation mismatch
+**Affected code:** `adk-graph/src/action/database.rs` — `execute_database`; `adk-graph/src/action/email.rs` — `execute_email`; `adk-graph/src/action/code.rs` — JavaScript/TypeScript execution; `adk-graph/src/action/transform.rs` — builtin transforms
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+Database actions validate configuration and return an error explaining that drivers are not integrated. Email monitor/send modes validate then return “not yet available.” JavaScript/TypeScript code execution is a placeholder. Builtin transforms log that operations are not implemented.
+
+#### Failure mechanism
+
+Feature flags and action types expose configuration surfaces before execution backends exist.
+
+#### Impact
+
+A workflow can deserialize, validate, and compile yet fail only when the node executes. This is operationally different from an unsupported feature rejected during graph construction.
+
+#### Test coverage gap
+
+Tests largely verify validation and placeholder messages rather than executable behavior or build-time capability rejection.
+
+#### Required correction
+
+Either implement each backend with explicit security/resource controls or remove/reserve the executable variants until ready. Graph compilation should reject unavailable action capabilities before a run starts.
+
+#### Regression tests
+
+Add real backend integration tests behind feature flags, plus negative compile/build tests proving unavailable executors fail during validation rather than mid-workflow.
+
+---
+
+## 4. Background, ambient, and managed runtimes
+
+### BG-01 — Background runs report success without resolving or executing a workflow
+
+**Severity:** High
+**Affected capability:** asynchronous workflow execution, timeout, retry, and durability
+**Evidence:** Source-confirmed and documentation mismatch
+**Affected code:** `adk-server/src/background/mod.rs` — `BackgroundRunner::execute`, `run_with_timeout`, `RunStore`
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+A submitted run stores `workflow_id` and input, but `BackgroundRunner::run_with_timeout` receives neither. It checks cancellation and immediately returns `RunOutcome::Completed` with an empty JSON object. `RunStore` is an in-memory `HashMap`. Documentation says retry re-enqueues from the last checkpoint, but no workflow checkpoint is loaded or stored.
+
+#### Failure mechanism
+
+The REST lifecycle and status model are implemented around a placeholder work future. Since the placeholder cannot return `Failed`, normal retry behavior is not exercised by actual workflow failures.
+
+#### Impact
+
+Clients receive a completed status for work that never ran. Process restart loses all run records. Timeout and retry configuration give a false signal of execution guarantees.
+
+#### Test coverage gap
+
+There is no registered-workflow integration test asserting input reaches a workflow, output is returned, failure retries, or restart resumes from a checkpoint.
+
+#### Required correction
+
+Require a workflow registry/executor dependency, resolve `workflow_id`, pass input and cancellation, persist run/control state in a durable store, and define checkpoint-aware retry semantics. Reject unknown workflows before queuing.
+
+#### Regression tests
+
+Exercise a real test workflow for success, failure, timeout, cancellation, retry from a known checkpoint, unknown ID, and process reconstruction from durable state.
+
+### BG-02 — Cron `Queue` policy duplicates overdue occurrences and then loses queue monitoring
+
+**Severity:** High
+**Affected capability:** scheduled-run concurrency control
+**Evidence:** Source-confirmed
+**Affected code:** `adk-server/src/background/cron.rs` — `CronJobStore::get_due_jobs`, `start_cron_scheduler`, `trigger_run`
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+Due calculation uses `last_execution.unwrap_or(created_at)`. Under `Queue`, when a run is active, every one-second scheduler poll appends a new UUID but does not advance `last_execution`. The same overdue occurrence is therefore enqueued repeatedly. When the active run completes, its monitor dequeues and starts one queued run, but it does not create a monitor for that new run.
+
+#### Failure mechanism
+
+Queued occurrences have no schedule-occurrence identity, and queue progression is coupled to a monitor spawned only by `trigger_run`. A run started from the queue bypasses that monitor setup.
+
+#### Impact
+
+One scheduled occurrence can become many queued runs. After the first queued run starts, `active_run_count` can remain nonzero after it finishes, so later queue items are not drained and `Skip`/`Queue` decisions remain stuck.
+
+#### Test coverage gap
+
+There is no test with a long-running job, multiple scheduler ticks, and more than one queued occurrence through completion.
+
+#### Required correction
+
+Track the exact scheduled timestamp and atomically claim it once. Advance scheduling state when an occurrence is queued, not only when execution starts. Route every queued run through the same monitored execution function and reconcile active counts from durable run state.
+
+#### Regression tests
+
+Use a controllable clock to prove one queue entry per occurrence, FIFO draining across three runs, active-count recovery after failure/cancel, and restart behavior.
+
+### BG-03 — The documented cron detail endpoint is not mounted
+
+**Severity:** Low
+**Affected capability:** cron REST API completeness
+**Evidence:** Source-confirmed and documentation mismatch
+**Affected code:** `adk-server/src/background/mod.rs` — module endpoint list; `adk-server/src/background/cron.rs` — `cron_jobs_router_with_state`
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+Module documentation advertises `GET /cron/{job_id}`. The router mounts only PATCH and DELETE on that path. A store `get` method exists, but no GET handler is attached.
+
+#### Failure mechanism
+
+The endpoint list and the Axum route table are maintained separately. The documented detail read was not connected to a handler in `cron_jobs_router_with_state`.
+
+#### Impact
+
+Clients cannot retrieve one job by ID as documented and must list all jobs and filter locally.
+
+#### Test coverage gap
+
+No router test asserts the documented method/path table.
+
+#### Required correction
+
+Add the detail handler or remove the endpoint claim. Generate endpoint documentation from the router where practical.
+
+#### Regression tests
+
+Assert GET returns 200 for an existing ID and 404 for a missing ID, and maintain a route-table conformance test.
+
+### AM-01 — `AmbientAgent` is an event-loop shell, not a self-contained ambient runtime
+
+**Severity:** High
+**Affected capability:** background trigger execution and delivery
+**Evidence:** Source-confirmed
+**Affected code:** `adk-agent/src/ambient/agent.rs` — `AmbientAgent::start`, `TriggerHandler`; `adk-agent/src/ambient/event_source.rs` — `EventSource`
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+Without a `TriggerHandler`, trigger events are only logged. The handler must create/drive a Runner and choose identity/session behavior itself. The event loop reads one event, awaits the handler, and fully drains its returned stream before polling the source again. Produced events are logged rather than delivered through an AmbientAgent output API.
+
+#### Failure mechanism
+
+Execution, persistence, identity selection, retry, acknowledgement, output delivery, and failure policy are delegated to application code. Serial drain creates head-of-line blocking.
+
+#### Impact
+
+Using `AmbientAgent::new(...).start()` alone does not run the wrapped agent. A slow trigger blocks later triggers. There are no built-in durable offsets, dead letters, per-user session mapping, or ownership guarantees in the inspected ambient module.
+
+#### Test coverage gap
+
+No end-to-end test proves default construction invokes an agent, survives restart, retries a failed event, or processes independent triggers concurrently under a bound.
+
+#### Required correction
+
+Make execution policy explicit in the type: require a handler/Runner binding at construction, define identity/session strategy, expose output delivery, and add bounded concurrency plus acknowledgement/retry hooks. Keep a clearly named low-level event-loop type if application-managed behavior is desired.
+
+#### Regression tests
+
+Cover missing handler rejection, two overlapping triggers, bounded queueing, handler failure retry/dead-letter behavior, output delivery, and stop/cancel semantics.
+
+### AM-02 — `WebhookTrigger` has no trust boundary and its listener outlives the ambient consumer
+
+**Severity:** High
+**Affected capability:** externally triggered agents and lifecycle control
+**Evidence:** Source-confirmed
+**Affected code:** `adk-agent/src/ambient/webhook_trigger.rs` — `WebhookTrigger::subscribe`; `adk-agent/src/ambient/agent.rs` — `AmbientAgent::stop`
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+The webhook binds `0.0.0.0:<port>`, accepts every POST on the configured path, and converts invalid JSON to a string event. There is no signature/authentication hook, replay protection, principal mapping, authorization decision, body-specific rate limit, or source timestamp check. The HTTP server is spawned without retaining its join/shutdown handle. Stopping `AmbientAgent` aborts only the consumer task.
+
+#### Failure mechanism
+
+The event source has no request context interface and no owned server lifecycle. When the receiver is dropped, handlers log that the listener is stopping, but they only return a response; no shutdown signal reaches `axum::serve`.
+
+#### Impact
+
+If the bound port is reachable, any caller can trigger application-defined agent work. After stop/drop, the listener can remain bound and continue accepting requests that cannot be delivered, preventing clean restart on the same port. This finding covers only `WebhookTrigger`; it does not claim anything about uninspected channel integrations.
+
+#### Test coverage gap
+
+No tests send unsigned/replayed requests, stop and rebind the port, or verify listener shutdown when the subscriber disappears.
+
+#### Required correction
+
+Require or expose an authentication/verifier interface, support provider signatures and replay windows, map a verified principal into the trigger event, and own a graceful-shutdown token plus join handle. Reject malformed content according to configured policy.
+
+#### Regression tests
+
+Cover missing/invalid signatures, replay, body limits, malformed JSON, stop-and-rebind, receiver drop, and principal propagation.
+
+### MR-01 — Managed checkpoints and registries are process-local, not crash-durable
+
+**Severity:** High
+**Affected capability:** managed runtime durability and replay
+**Evidence:** Source-confirmed and documentation mismatch
+**Affected code:** `adk-managed/src/checkpoint.rs` — `CheckpointManager`; `adk-managed/src/default_runtime.rs` — `DefaultManagedAgentRuntime`, `ActiveSession`
+**Release attribution:** current HEAD; released-v2 attribution unverified; crate is marked experimental
+
+#### Current behavior
+
+`CheckpointManager` stores `Vec<SessionEvent>` and `RunState` in memory. Agent and active-session registries are in-memory maps. Replay reads the same live manager. The module itself notes that persistent `SessionService` integration is a platform concern.
+
+#### Failure mechanism
+
+“Atomic” checkpointing is an assignment within one process. There is no transaction with the injected `SessionService`, no load of managed checkpoint state on startup, and no reconstruction of active sessions or registered agents after process loss.
+
+#### Impact
+
+A crash loses managed event replay, parked-tool state, sequence position, lifecycle status, and registry handles even if conversation events were written by the nested Runner. A new process cannot resume from the managed checkpoint advertised by the crate description.
+
+#### Test coverage gap
+
+Tests instantiate one manager/runtime and do not destroy/recreate it against a persistent backend.
+
+#### Required correction
+
+Define a durable managed-state store with transactional event/run-state writes, stable agent definitions, and startup reconstruction. Treat in-memory storage as an explicitly named test backend.
+
+#### Regression tests
+
+Persist state, drop the runtime, recreate it, resume sequence and parked tools, and verify no event loss/duplication under failure injection between event and state commits.
+
+### MR-02 — Managed session environment is ignored and identity is hardcoded
+
+**Severity:** High
+**Affected capability:** tenant isolation and environment provisioning
+**Evidence:** Source-confirmed
+**Affected code:** `adk-managed/src/default_runtime.rs` — `DefaultManagedAgentRuntime::start_session`; `adk-managed/src/session_loop.rs` — `SessionLoop::build_runner`, `process_turn`
+**Release attribution:** current HEAD; released-v2 attribution unverified; crate is marked experimental
+
+#### Current behavior
+
+`start_session` names its environment argument `_env` and never reads it. Every persisted session uses app `managed` and user `managed_user`; every Runner call repeats that identity. The public session handle contains only a generated session ID.
+
+#### Failure mechanism
+
+The managed API accepts environment configuration without applying it and has no caller identity parameter. The runtime substitutes constants to satisfy the underlying Runner/SessionService contract.
+
+#### Impact
+
+Environment-specific isolation/configuration is absent. All managed sessions share one logical app/user namespace, reducing auditability and preventing caller-level ownership enforcement at the session layer. Random session IDs reduce direct collisions but do not restore user identity.
+
+#### Test coverage gap
+
+No test supplies two environment/tenant configurations and verifies different provisioned settings and persistence identities.
+
+#### Required correction
+
+Make authenticated owner/app identity and environment resolution required inputs, validate them at session creation, persist them with the managed session, and build the Runner from those values.
+
+#### Regression tests
+
+Start sessions for two principals/environments and assert isolation across session lookup, memory, sandbox configuration, event streams, and deletion.
+
+### MR-03 — Public managed status is disconnected from normal session-loop transitions
+
+**Severity:** Medium
+**Affected capability:** managed lifecycle observability
+**Evidence:** Source-confirmed
+**Affected code:** `adk-managed/src/default_runtime.rs` — `ActiveSession::status`, `ManagedAgentRuntime::status`; `adk-managed/src/session_loop.rs` — `SessionLoop::status`, `process_turn`, `emit_idle`
+**Release attribution:** current HEAD; released-v2 attribution unverified; crate is marked experimental
+
+#### Current behavior
+
+`ActiveSession` owns `Arc<RwLock<SessionStatus>>`, which `status()` reads. `SessionLoop` owns a separate plain `SessionStatus`. Normal queued → running → idle transitions update only the loop field and checkpoint. The public lock changes only through pause, resume, archive, or deletion control methods.
+
+#### Failure mechanism
+
+The comment says the status is shared with the loop, but the constructor does not pass the `Arc<RwLock<_>>` into `SessionLoop`.
+
+#### Impact
+
+A normally executing or idle session can continue to report `Queued`. Control-plane decisions and clients can act on stale lifecycle information.
+
+#### Test coverage gap
+
+No lifecycle test polls public status while a turn moves through running and idle.
+
+#### Required correction
+
+Use one shared status source, update it atomically with checkpointed status events, and define terminal/error transitions.
+
+#### Regression tests
+
+Observe status at each transition, including pause during work, interrupt, tool parking, error, idle, and archive.
+
+### MR-04 — Managed deletion removes only the active handle, not persisted session data
+
+**Severity:** High
+**Affected capability:** data deletion and lifecycle cleanup
+**Evidence:** Source-confirmed
+**Affected code:** `adk-managed/src/default_runtime.rs` — `DefaultManagedAgentRuntime::delete_session`; `adk-session/src/service.rs` — `SessionService::delete`
+**Release attribution:** current HEAD; released-v2 attribution unverified; crate is marked experimental
+
+#### Current behavior
+
+`delete_session` archives/cancels the active session and removes it from the in-memory map. It never calls the injected `SessionService::delete`, even though `start_session` seeded a persistent session and the Runner appended events to it.
+
+#### Failure mechanism
+
+Control-plane deletion and data-plane deletion are implemented as one method but only the former occurs.
+
+#### Impact
+
+The API reports deletion while conversation events remain in the configured backend. This can violate retention expectations and allows the orphaned data to survive process restart.
+
+#### Test coverage gap
+
+No test queries the session backend after managed deletion.
+
+#### Required correction
+
+Persist owner identity, invoke identity-aware session deletion, remove managed checkpoints/memory/artifacts according to documented policy, and return partial-failure details if cleanup cannot complete atomically.
+
+#### Regression tests
+
+Delete a session backed by persistent storage and assert session, events, checkpoint, parked state, and configured related data are removed or explicitly retained according to policy.
+
+---
+
+## 5. Server UI bridge and secrets
+
+### SV-01 — UI bridge and resource routes bypass configured server authentication
+
+**Severity:** High
+**Affected capability:** authenticated UI state and resource ownership
+**Evidence:** Source-confirmed
+**Affected code:** `adk-server/src/rest/mod.rs` — `ui_api_router` and router layering; `adk-server/src/rest/controllers/ui.rs` — bridge handlers, `MCP_UI_BRIDGE_REGISTRY`, `UI_RESOURCE_REGISTRY`
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+Session, artifact, and debug routers receive `auth_layer`; `ui_api_router` is merged without it. UI bridge request bodies carry caller-supplied `app_name`, `user_id`, and `session_id`, and handlers key a process-global registry by that tuple without deriving identity from `RequestContext`. Resource list/read/register endpoints share a global URI-keyed registry. Registration accepts arbitrary text with MIME type `text/html;profile=mcp-app` and overwrites an existing URI.
+
+Runtime run routes also lack the shared middleware layer, but their handlers explicitly call `extract_request_context`, return 401 on missing/invalid configured auth, and override the supplied user with the authenticated user. They are therefore **not** included in this bypass finding.
+
+#### Failure mechanism
+
+UI routes have neither middleware extraction nor equivalent handler-level extraction. Registries do not store an authenticated owner or tenant.
+
+#### Impact
+
+When server authentication is configured, an unauthenticated caller can create or mutate bridge state under a chosen identity tuple, poll notifications, list/read globally registered resources, and replace HTML resource text. Cross-user state mutation is confirmed by source. Whether a particular UI renders that HTML as executable content was not assessed here.
+
+#### Test coverage gap
+
+No route test configures a rejecting auth extractor and asserts every `/api/ui/*` mutation/read is protected and identity-bound.
+
+#### Required correction
+
+Apply authentication to all non-public UI endpoints, derive user/tenant identity from `RequestContext`, store ownership with resources, authorize every read/write, namespace registries, and define safe HTML/CSP handling. Keep capability discovery public only if explicitly intended.
+
+#### Regression tests
+
+Enumerate the UI route table under configured auth; test missing/invalid tokens, body identity spoofing, cross-user resource access, overwrite authorization, and process-global registry isolation.
+
+### SC-01 — Secret retrieval has no per-tool authorization or audit boundary
+
+**Severity:** High
+**Affected capability:** secret access from agent tools
+**Evidence:** Source-confirmed
+**Affected code:** `adk-core/src/context.rs` — `SecretService`, `InvocationContext::get_secret`; `adk-core/src/tool.rs` — `ToolContext::get_secret`; `adk-auth/src/secrets/provider.rs` — `SecretProvider`, `SecretServiceAdapter`
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+A tool with a context can request any secret name string. `SecretService` and `SecretProvider` receive only that name. Their interfaces carry no tool identity, caller principal, namespace, declared allowlist, access decision, purpose, or audit sink.
+
+#### Failure mechanism
+
+Once a secret provider is attached to an invocation, policy is reduced to whatever names the backing cloud credentials can read. The ADK layer cannot distinguish a weather tool requesting its own API key from the same tool requesting a payment or database secret.
+
+#### Impact
+
+A compromised or model-influenced tool can attempt broad secret discovery. Cloud-provider IAM may still prevent access; this finding does not claim those providers leak values. It establishes that ADK supplies no finer per-tool boundary or access audit in the inspected interface.
+
+#### Test coverage gap
+
+Tests cover provider errors/cache behavior, not tool-specific allow/deny decisions or audit records.
+
+#### Required correction
+
+Use a request object containing principal, app/session, tool identity, requested secret/namespace, and purpose. Enforce declarative per-tool grants before provider access and emit a value-free audit event for allow/deny.
+
+#### Regression tests
+
+Verify a tool can retrieve only declared names, spoofed tool identity is rejected, denied names never reach the provider, and audit output contains no secret value.
+
+### SC-02 — Secret cache has no revocation, capacity, purge, or memory-clearing controls
+
+**Severity:** Medium
+**Affected capability:** secret lifecycle in process memory
+**Evidence:** Source-confirmed
+**Affected code:** `adk-auth/src/secrets/cached.rs` — `CachedSecretProvider`, `CachedEntry`
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+The cache stores secret `String` values in an unbounded `HashMap`. TTL is checked only when the same name is read. Expired entries are not proactively removed, there is no invalidate/revoke API, no size limit or eviction policy, and values are not zeroized on replacement/drop.
+
+#### Failure mechanism
+
+TTL controls return behavior, not memory residency. Names requested once can remain allocated for the process lifetime.
+
+#### Impact
+
+Revoked/expired material remains recoverable from process memory longer than its TTL, and many unique names can grow the cache without bound. This does not imply normal logs expose values.
+
+#### Test coverage gap
+
+No tests assert purge after time advance, bounded cardinality, explicit invalidation, or memory-clearing behavior.
+
+#### Required correction
+
+Add explicit invalidate/all purge, bounded LRU/size policy, periodic expired-entry removal, and a secrecy-aware value container with zeroization where practical. Document the residual process-memory threat model.
+
+#### Regression tests
+
+Use a controllable clock to test expiry purge, revocation before TTL, capacity eviction, concurrent refresh, and absence of values from Debug/log output.
+
+---
+
+## 6. Coding tools and optional sandbox
+
+### CA-01 — Developer-tool path containment is bypassable through workspace symlinks
+
+**Severity:** High
+**Affected capability:** coding-agent filesystem containment
+**Evidence:** Source-confirmed
+**Affected code:** `adk-devtools/src/workspace.rs` — `Workspace::new`, `Workspace::resolve`; `adk-devtools/src/tools/read.rs` — `ReadFileTool::execute`; `adk-devtools/src/tools/write.rs` — `WriteFileTool::execute`
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+The workspace root is canonicalized once. Each requested path is then normalized lexically and checked with `starts_with(root)`. Existing target paths and parent components are not canonicalized or opened with no-follow/dirfd-safe operations.
+
+#### Failure mechanism
+
+A symlink located lexically under the root can point outside it. The resolved path still starts with the root, but ordinary file I/O follows the symlink. A symlinked parent directory similarly redirects creation/writes.
+
+#### Impact
+
+Read/write/edit tools can access host files outside the advertised workspace. The shell tool already has broader host access; this finding shows that even nominally scoped file tools do not provide a containment boundary.
+
+#### Test coverage gap
+
+The containment test covers `..` traversal but not final-component or parent-directory symlinks and replacement races.
+
+#### Required correction
+
+Use descriptor-relative traversal from an opened root, reject symlinks for each component, and create/open with platform no-follow semantics. If symlinks are intentionally allowed, canonicalize and recheck the actual target immediately before access while addressing TOCTOU risk.
+
+#### Regression tests
+
+Create inside-root symlinks to outside files/directories and assert read, write, edit, glob, and grep cannot escape; include a symlink-swap race test where supported.
+
+### CA-02 — Coding modes execute unrestricted host shells while describing the workspace as sandboxed
+
+**Severity:** High
+**Affected capability:** coding-agent host isolation
+**Evidence:** Source-confirmed and documentation mismatch
+**Affected code:** `adk-devtools/src/workspace.rs` — `Workspace::new`; `adk-devtools/src/tools/bash.rs` — `BashTool::execute`; `adk-cli/src/main.rs` — code/goal workspace construction and `run_check`; `adk-cli/src/ultra.rs` — ultracode workspace construction; `adk-cli/src/cli.rs` — help text
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+`Workspace::new` enables writes and bash by default. `BashTool` runs host-local `sh -c`, sets only `current_dir`, inherits the parent environment because it does not call `env_clear`, has no network restriction, and can use absolute paths. Timeout calls `start_kill` on the direct child rather than a Unix process group. CLI code mode uses this workspace unless `--read-only`; goal mode and ultracode use it by default. Goal success checks independently run host `sh -c`.
+
+#### Failure mechanism
+
+A working directory is treated as a security boundary even though the OS does not enforce it. The CLI wires the permissive configuration as the ordinary path and labels it sandboxed.
+
+#### Impact
+
+Model-directed commands can read/write outside the project, access the network, inspect inherited API keys and credentials, and leave descendant processes after a timeout. Users may grant trust based on stronger help/README wording than the implementation supports.
+
+#### Test coverage gap
+
+No adversarial tests attempt absolute-path access, environment-secret reads, network access, or descendant survival through the CLI coding modes.
+
+#### Required correction
+
+Rename this surface as a host workspace unless backed by a real sandbox. Default to an environment-cleared, network-denied, filesystem-confined execution backend with explicit capability grants and confirmation for shell. Use process-group/job-object termination. Run goal checks through the same boundary.
+
+#### Regression tests
+
+Assert default code/goal/ultracode cannot read a sentinel outside root, cannot see an injected parent secret, cannot reach a test listener, and kills child/grandchild processes on timeout.
+
+### SB-01 — `ProcessBackend` defaults to no OS enforcer, and Rust compilation bypasses configured enforcement
+
+**Severity:** High
+**Affected capability:** optional code-execution sandbox
+**Evidence:** Source-confirmed
+**Affected code:** `adk-sandbox/src/process.rs` — `ProcessBackend::default`, `execute_rust`, `run_command`; `adk-sandbox/src/sandbox/mod.rs` — `SandboxPolicy`
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+`ProcessBackend::default()` has no enforcer, so Python, JavaScript, and command execution are subprocess isolation only. When an enforcer is explicitly configured, runtime commands pass through it. Rust source is first compiled with a direct `rustc` command outside `run_command`; this compile phase has no sandbox wrapper, request timeout, or memory enforcement. `SandboxPolicy.env` is never applied by `ProcessBackend`; only `ExecRequest.env` is used.
+
+#### Failure mechanism
+
+Enforcement is optional and attached at the runtime-command helper, while compilation uses a separate path. Rust compile-time features such as `include_str!` can read host files before the resulting binary enters the runtime boundary.
+
+#### Impact
+
+Default process execution has host filesystem/network access (with a cleared environment). Even a configured OS policy does not constrain Rust compilation, and a compiler can hang beyond the requested execution timeout. Policy environment settings can give callers a false expectation about supplied variables.
+
+#### Test coverage gap
+
+No test compiles Rust that attempts an outside read, blocks in a procedural/build-time operation, or asserts policy env reaches the child.
+
+#### Required correction
+
+Make isolation class explicit at construction, require an enforcer for any API described as sandboxed, and run compilation through the same wrapper and resource limits. Merge/validate policy and request environments under one documented precedence rule.
+
+#### Regression tests
+
+Attempt compile-time outside reads, network access, and timeout; test default capability reporting, policy-env propagation, and configured-enforcer coverage of both compiler and binary.
+
+### SB-02 — macOS filesystem isolation blocks writes but permits global host reads
+
+**Severity:** High
+**Affected capability:** macOS Seatbelt confidentiality boundary
+**Evidence:** Source-confirmed and documentation mismatch
+**Affected code:** `adk-sandbox/src/sandbox/macos.rs` — `MacOsEnforcer::generate_profile_from_paths`; `adk-sandbox/src/process.rs` — `ProcessBackend::capabilities`
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+The generated profile contains both `(deny default)` and `(allow default)`, then selectively denies network, process fork, and all file writes before re-allowing writes to configured paths. It does not deny file reads outside `allowed_paths`; read-only path entries are effectively documentation under the global allow. `ProcessBackend::capabilities` nevertheless marks `filesystem_isolation: true` whenever any enforcer is configured.
+
+#### Failure mechanism
+
+The policy uses a “deny dangerous operations” model rather than an allowed-path read boundary, while capability language and examples describe allowed paths as filesystem access controls.
+
+#### Impact
+
+Sandboxed code can read host files outside configured paths on macOS, even though writes/network/fork may be constrained. This is not a claim that Seatbelt is absent; the profile provides meaningful write and network restrictions but not read isolation.
+
+#### Test coverage gap
+
+Profile tests inspect strings but do not execute a sandboxed process that reads an outside sentinel and writes inside/outside allowed paths.
+
+#### Required correction
+
+Either implement read allowlisting with the system/runtime paths required to launch interpreters, or report the capability as write isolation and document global reads prominently. Capability fields should distinguish read and write isolation.
+
+#### Regression tests
+
+On macOS CI, verify outside reads are denied if full isolation is claimed, allowed writes work, outside writes fail, network policy works, and capability reporting matches observed behavior.
+
+### SB-03 — Windows AppContainer enforcement is structurally present but not implemented
+
+**Severity:** High
+**Affected capability:** Windows sandbox availability
+**Evidence:** Source-confirmed and documentation mismatch
+**Affected code:** `adk-sandbox/src/sandbox/windows.rs` — `WindowsEnforcer::probe`, `wrap_command`, `configure_command`; `README.md` and `examples/sandbox_agent/README.md` — platform support descriptions
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+On Windows, `probe` checks that the AppContainer API symbol is available. `wrap_command` returns the original executable and arguments. `configure_command` returns `EnforcerFailed` stating that AppContainer configuration is not yet implemented.
+
+#### Failure mechanism
+
+Availability probing validates the platform API, not a usable enforcement implementation. The execution path fails closed when configuration is attempted; it does not silently run sandboxed requests without restrictions.
+
+#### Impact
+
+Windows callers cannot use the advertised AppContainer backend. Cross-platform applications that require the sandbox fail at execution despite successful platform probing and documentation that presents AppContainer as a supported OS profile.
+
+#### Test coverage gap
+
+No Windows integration test creates a restricted process and verifies filesystem/network denial.
+
+#### Required correction
+
+Implement restricted token/AppContainer profile creation, ACLs, capabilities, process startup, cleanup, and job-object termination; make `probe` exercise a restricted child. Until then, mark the backend unavailable in capability/docs.
+
+#### Regression tests
+
+On Windows CI, execute a child that can access only allowed paths, cannot use denied network, receives the intended environment, and is terminated with descendants.
+
+---
+
+## 7. Computer-use adapter
+
+### CU-01 — Security-relevant MCP response objects are not rebound to the requested action locally
+
+**Severity:** High
+**Affected capability:** defense-in-depth for governed desktop actions
+**Evidence:** Source-confirmed
+**Affected code:** `adk-computer-use/src/runtime/mcp.rs` — `ComputerUseMcpRuntime::acquire_lease`, `reserve_target`, `execute_action`; `adk-computer-use/src/contracts/lease.rs` — `ControlLease`, `TargetReservation`; `adk-computer-use/src/contracts/receipt.rs` — `ExecutionReceipt`
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+The adapter positively checks session/principal on previews and follow-ups. It does not perform equivalent checks after lease acquisition or target reservation. It deserializes and returns those objects without comparing session, principal, agent, mode, active state, budget, or app/window boundaries to the envelope. After execution, it logs and returns the receipt without checking receipt session, action ID, or action digest against the requested envelope.
+
+#### Failure mechanism
+
+Typed deserialization validates shape but most of these structs have no invariant-enforcing constructor/deserializer. The adapter trusts the remote runtime to bind each returned object correctly.
+
+#### Impact
+
+If the MCP boundary returns stale, confused, or mismatched data, graph state accepts it and can proceed. This is a missing local defense, not evidence that `computer-use-mcp` itself is unsafe; the external runtime remains authoritative and was not independently audited here.
+
+#### Test coverage gap
+
+No adapter test injects a well-formed lease/reservation/receipt for another session, principal, action, mode, or target and expects rejection.
+
+#### Required correction
+
+Add explicit validators that bind every response to the configured principal/session and exact action envelope, including target boundaries, active state, expiry, remaining budget, action ID, and digest. Reject before storing in graph state.
+
+#### Regression tests
+
+Use a fake MCP toolset to return one mismatched field at a time and assert `IdentityMismatch` or a dedicated binding error; include expired and exhausted leases.
+
+### CU-02 — Verification equates “committed” with a verified postcondition
+
+**Severity:** High
+**Affected capability:** post-action verification
+**Evidence:** Source-confirmed and documentation mismatch
+**Affected code:** `adk-computer-use/src/runtime/mcp.rs` — `ComputerUseMcpRuntime::verify`; `adk-computer-use/src/graph.rs` — `verify` node; `adk-computer-use/src/contracts/action.rs` — `ActionPostcondition`
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+`verify()` returns only `receipt.status == ReceiptStatus::Committed`. It does not query the desktop, filesystem, registry, process, or window state and does not evaluate the envelope's digest-only `ActionPostcondition` in the ADK adapter.
+
+#### Failure mechanism
+
+Execution acknowledgement and independent postcondition verification are collapsed into one boolean. The reference graph labels the resulting node and output as verification.
+
+#### Impact
+
+A committed action whose intended effect did not occur is reported as completed. The external runtime may already perform verification before issuing a receipt, but that contract is not rechecked or made explicit in this adapter.
+
+#### Test coverage gap
+
+No test returns a committed receipt with a failed/missing postcondition observation and expects `verified=false`.
+
+#### Required correction
+
+Define whether the receipt includes cryptographic/structured verification evidence or call a dedicated read-only verification endpoint. Bind the evidence to action/postcondition digest and freshness before returning true.
+
+#### Regression tests
+
+Cover committed-but-postcondition-failed, stale observation, wrong target/digest, indeterminate receipt, and successful independent verification.
+
+---
+
+## 8. Realtime execution
+
+### RT-01 — Integrated realtime continuity loads history and memory but does not inject them
+
+**Severity:** High
+**Affected capability:** session continuity, memory grounding, and plugin lifecycle
+**Evidence:** Source-confirmed and documentation mismatch
+**Affected code:** `adk-realtime/src/integration/mod.rs` — `IntegratedRealtimeRunner::connect`, `handle_aggregated_event`; `adk-session/src/service.rs` — identity-aware append API
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+`connect` retrieves the prior session into `_session` and discards it. Memory search results are logged; a source comment says actual system-instruction injection is a future enhancement. Completed transcripts are persisted through raw `append_event(session_id, ...)`, and plugin `on_event` is skipped because no `InvocationContext` is available.
+
+#### Failure mechanism
+
+The integration layer performs service calls but has no bridge from returned context into `RealtimeConfig` and no full invocation context for plugins/persistence identity.
+
+#### Impact
+
+A resumed realtime session starts without the history and memory the builder/documentation implies it will use. Transcript writes inherit raw-session ambiguity, and configured event plugins do not run.
+
+#### Test coverage gap
+
+Tests cover persistence mechanics but not provider configuration containing prior turns/memory or plugin event invocation.
+
+#### Required correction
+
+Construct a bounded, policy-controlled context injection from session history and memory before connect; use full identity append; and create a realtime invocation context suitable for lifecycle plugins.
+
+#### Regression tests
+
+Inspect the provider connect config for prior context, verify identity-aware persistence with duplicate raw IDs, and assert plugin `on_event` runs for user/assistant/tool events.
+
+### RT-02 — The active integrated tool bridge bypasses the configured plugin and control pipeline
+
+**Severity:** High
+**Affected capability:** realtime tool authorization, confirmation, retries, and plugins
+**Evidence:** Source-confirmed
+**Affected code:** `adk-realtime/src/integration/builder.rs` — ADK tool registration; `adk-realtime/src/integration/tool_bridge.rs` — `ToolBridgeAdapter::execute`; `adk-realtime/src/integration/mod.rs` — `next_event`, `execute_tool_with_plugins`; `adk-realtime/src/runner.rs` — `dispatch_tool_call`
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+The builder wraps each ADK tool in `ToolBridgeAdapter`, and the active event path calls `RealtimeRunner::dispatch_tool_call`, which invokes that adapter directly. The adapter creates a context and calls `tool.execute`. It does not add confirmation, timeout, retry/circuit-breaker policy, before/after callbacks, or plugin hooks. The richer `execute_tool_with_plugins` method is not connected to this path. Its own before-plugin error branch would log and execute the tool directly.
+
+Pre-wrapped tools such as `ScopeGuard` can still enforce their own wrapper logic; the bridge itself does not inspect `Tool::required_scopes`, and its default context carries no authenticated scopes.
+
+#### Failure mechanism
+
+Tool metadata, services, and a plugin manager are collected by the integration builder but execution is delegated to a lower-level handler interface that lacks those policies.
+
+#### Impact
+
+A tool that is controlled in the standard agent loop can run in realtime without equivalent confirmation/callback/plugin policy. A security plugin failure would be fail-open in the unused helper if it were wired unchanged.
+
+#### Test coverage gap
+
+No parity test runs one protected tool through standard and integrated realtime paths and compares authorization, callbacks, confirmation, timeout, retry, and audit outcomes.
+
+#### Required correction
+
+Route all realtime ADK tools through one policy executor shared with the standard agent path. Security plugin errors must fail closed by default. Carry authenticated scopes/secrets/cancellation into the realtime context and make native-handler bypass explicit.
+
+#### Regression tests
+
+Cover denied scopes, confirmation required, before-plugin deny/error, timeout, retry, after-plugin modification, cancellation, and an explicitly trusted native handler.
+
+### RT-03 — Direct `RealtimeAgent` ignores before-tool callback errors and lacks context capabilities
+
+**Severity:** High
+**Affected capability:** direct realtime agent tool safety
+**Evidence:** Source-confirmed
+**Affected code:** `adk-realtime/src/agent.rs` — `RealtimeAgent::run`, `RealtimeToolContext`
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+In the active `FunctionCallDone` branch, a before-tool callback error constructs an `(error_result, EventActions::default())` tuple inside the loop but discards it; execution then continues to `tool.execute`. After-tool callback errors are explicitly ignored. `RealtimeToolContext` delegates identity and memory search but not shared state, `user_scopes`, or `get_secret`, so those methods use empty/none defaults. Direct dispatch also has no confirmation or tool timeout.
+
+#### Failure mechanism
+
+The callback loop does not store a denial/error result or branch around execution. The context wrapper implements only required methods and inherits permissive/empty defaults.
+
+#### Impact
+
+A callback intended to block a tool cannot do so by returning an error in this path. Tools depending on scopes/secrets/shared coordination behave differently or fail closed unpredictably compared with the standard agent context.
+
+#### Test coverage gap
+
+No test configures a before-tool callback that errors and asserts the tool's execution counter remains zero; no context sentinel test covers scopes/secrets/shared state.
+
+#### Required correction
+
+Use the standard callback semantics: a deny/error must prevent execution, after-callback failures must follow an explicit policy, and context capabilities must delegate to the parent. Add confirmation, timeout, cancellation, and protected-tool handling through a shared executor.
+
+#### Regression tests
+
+Assert zero execution on callback deny/error, exact callback order, after-error behavior, and preservation of scopes, secret access, shared state, artifacts, and identity.
+
+### RT-04 — Realtime tool concurrency is configured but not enforced, and transport loss is not automatically recovered
+
+**Severity:** Medium
+**Affected capability:** realtime latency and connection resilience
+**Evidence:** Source-confirmed
+**Affected code:** `adk-realtime/src/runner.rs` — `RunnerConfig::max_concurrent_tools`, `RealtimeRunner::run`, `handle_event`, `execute_tool_call`, resumption state machine
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+`max_concurrent_tools` defaults to four, but the only source references are the field and default; no semaphore or scheduler consumes it. `FunctionCallDone` is handled inline and awaits tool completion before the event loop reads another event. On a real disconnect, `run` exits successfully after distinguishing it from a concurrently installed session. Reconnection logic is used for deliberate context mutation (“phantom reconnect”), with process-local pending state and three attempts, not for unexpected transport loss.
+
+#### Failure mechanism
+
+Configuration and comments describe concurrency/resumption capabilities that are not connected to the event dispatch loop.
+
+#### Impact
+
+Multiple provider tool calls execute serially and block audio/event processing. Transient network loss ends the session rather than reconnecting with retained context, while callers may infer broader reconnect behavior from the state-machine documentation.
+
+#### Test coverage gap
+
+No test measures overlapping tool handlers under `max_concurrent_tools > 1` or simulates unexpected disconnect and recovery.
+
+#### Required correction
+
+Implement bounded task dispatch with ordered response aggregation and event-loop responsiveness. Define explicit reconnect policy for transport loss, persist/restore provider resume tokens where supported, and surface terminal disconnect distinctly.
+
+#### Regression tests
+
+Use barriers to prove the configured concurrency bound, ensure audio events continue during tools, and test recoverable/unrecoverable disconnects plus retry-budget exhaustion.
+
+### RT-05 — OpenAI realtime schema-drift logs can contain raw user/provider content
+
+**Severity:** Medium
+**Affected capability:** telemetry privacy
+**Evidence:** Source-confirmed
+**Affected code:** `adk-realtime/src/openai/session.rs` — `OpenAIRealtimeSession::receive_raw`
+**Release attribution:** current HEAD; released-v2 attribution unverified
+
+#### Current behavior
+
+When a recognized event type fails deserialization, the warning logs the first 300 bytes of the raw WebSocket text. This path is not conditioned on a payload-recording opt-in or redaction policy.
+
+#### Failure mechanism
+
+Schema diagnostics capture the raw frame rather than a field-safe summary. Realtime frames can contain transcripts, tool arguments/results, identifiers, or other user/provider content.
+
+#### Impact
+
+Sensitive conversation content can enter warning logs during provider schema drift—the exact moment operators may raise log collection/retention. The finding does not claim such a drift event was observed in a live provider session.
+
+#### Test coverage gap
+
+No test sends a malformed recognized event containing a sentinel secret and inspects captured logs for redaction.
+
+#### Required correction
+
+Log event type, parse error, payload size, and a digest by default. Gate bounded raw payload recording behind the existing explicit telemetry payload policy and apply structured redaction.
+
+#### Regression tests
+
+Capture tracing output for malformed frames and assert sensitive sentinel text is absent by default and only appears under an explicit, documented opt-in.
+
+---
+
+## 9. Release and documentation controls
+
+### DOC-01 — Version metadata does not provide a reproducible local v2 source baseline, while capability claims exceed implementation
+
+**Severity:** Medium
+**Affected capability:** release provenance and user decision-making
+**Evidence:** Source-confirmed and documentation mismatch
+**Affected code:** `Cargo.toml` — workspace version; `CHANGELOG.md` — `2.0.0` entry; `README.md` — release/current-status, graph, background, coding, sandbox, and managed-runtime claims; `adk-graph/README.md` — durable-resume claim
+**Release attribution:** metadata finding applies to the inspected repository; exact packaged-source attribution is unresolved
+
+#### Current behavior
+
+The workspace and installation snippets use `2.0.0`, the changelog dates 2.0.0, the README banner still announces v1, and the roadmap calls v2 current. No local `v2.0.0` tag identifies the exact release source. Separately, documentation says graph durable resume skips completed nodes, background runs execute workflows, coding workspaces are sandboxed, OS profiles include AppContainer, and managed execution is durable; the findings above establish narrower or placeholder behavior at current HEAD.
+
+#### Failure mechanism
+
+Version, release, and capability statements are maintained in multiple files without one machine-verifiable release object or capability test that gates the claims.
+
+#### Impact
+
+Reviewers cannot reliably attribute a current defect to the published v2 artifact from the local repository alone. Users can select features based on guarantees that the implementation only partially provides.
+
+#### Test coverage gap
+
+Existing documentation checks validate many command/feature references, but not semantic capability claims or correspondence between version/changelog/tag/source archive.
+
+#### Required correction
+
+Create and verify an immutable release tag/source manifest, record crate checksums/commit ID, and generate version statements from one source. Gate strong capability wording on executable conformance tests; label experimental/placeholders at the first public mention.
+
+#### Regression tests
+
+Add a release-metadata check requiring workspace version, changelog heading, README current version, and tag/manifest to agree. Maintain claim-to-test mappings for durable resume, background execution, sandbox isolation, and managed recovery.
+
+---
+
+## Cross-cutting correction sequence
+
+The ordering below is based on dependency and risk, not release attribution.
+
+1. **Restore exact execution semantics.** Fix graph checkpoint ordering, graph streaming persistence, Messages-mode double execution, and `ParallelAgent` stream polling before building additional orchestration features on them.
+2. **Make context capabilities structurally preservable.** Introduce a complete delegating context mechanism and migrate workflow, graph, realtime, and plugin adapters. Include full identity and cancellation in every long-running path.
+3. **Unify tool policy execution.** Route standard and realtime tools through one executor for scope wrappers, confirmation, callbacks/plugins, timeout, retry, cancellation, and audit. Bind approvals to exact calls.
+4. **Close externally reachable trust gaps.** Authenticate/authorize UI bridge routes and webhook triggers; namespace state by verified identity; add secret access policy.
+5. **Separate host workspaces from enforced sandboxes.** Correct naming immediately, then implement no-follow file containment, environment/network isolation, compiler confinement, and platform-accurate capability reporting.
+6. **Make asynchronous runtimes truthful.** Do not report background completion until a registered workflow ran. Add durable stores and restart reconstruction for background, cron, and managed execution.
+7. **Harden external adapters.** Locally validate computer-use leases/reservations/receipts and perform or verify postcondition evidence.
+8. **Normalize provider contracts.** Require explicit accept/downgrade/reject outcomes for schemas and every content-part class.
+9. **Repair release provenance and claims.** Establish one immutable v2 baseline and tie strong documentation statements to conformance tests.
+
+## Required regression-test program
+
+A minimal release gate for the corrected behavior should include:
+
+- **Exactly-once graph suite:** invoke, every stream mode, interrupt, resume, deferred fan-in, and terminal checkpoint with non-idempotent counters.
+- **Context conformance suite:** sentinel values for identity, scopes, metadata, secrets, artifacts, memory, shared state, and cancellation through every wrapper/adapter.
+- **Session identity suite:** duplicate raw session IDs across app/user dimensions for read, append, interrupt, realtime transcript, and deletion paths.
+- **Tool policy suite:** identical protected tool through `LlmAgent`, direct `RealtimeAgent`, and `IntegratedRealtimeRunner`, including exact-call approval binding.
+- **Background recovery suite:** real workflow resolution, timeout/cancel/retry, cron occurrence claiming/queue draining, and restart reconstruction.
+- **Filesystem/sandbox adversarial suite:** traversal, symlink escape, environment leakage, network, compile-time reads, child-process escape, and platform capability checks.
+- **External object-binding suite:** malformed/mismatched computer-use lease, reservation, receipt, and postcondition evidence.
+- **Provider conversion matrix:** schema and every `Part` variant for each provider adapter, with no silent loss.
+- **Route authorization inventory:** automatically enumerate every stateful/read-sensitive route and assert configured auth plus owner binding.
+- **Telemetry privacy suite:** sentinel secrets in malformed provider events, errors, tool arguments, and traces with payload recording disabled.
+
+## Pending review areas
+
+The following areas were not reviewed deeply enough to support absence or correctness claims in this document:
+
+- complete deployment/cloud integration behavior and production topology;
+- full telemetry pipeline, exporter defaults, retention, and redaction outside the realtime schema-drift path;
+- evaluation framework correctness and benchmark methodology;
+- complete CI, feature-matrix, semver, packaging, and crates.io artifact verification;
+- the full documentation site and every example/template;
+- Slack, email channel integrations, and notification systems beyond the inspected `WebhookTrigger` and graph email placeholder;
+- all session and memory backend implementations under fault injection;
+- external `computer-use-mcp` server implementation and its own validation/idempotency guarantees;
+- browser automation and A2A/ACP/AWP protocol security as complete subsystems;
+- standard server/CLI end-user memory management controls outside the inspected route/command assembly.
+
+No conclusion should be drawn from this list other than that review is pending. In particular, this document does not claim that channel integrations or memory APIs are absent repository-wide.
+
+## Evidence appendix
+
+### Executed probe outputs
+
+The following outputs were recorded from local probes against the inspected source:
+
+```text
+Graph checkpoint replay:
+first_count=1 second_count=2
+
+Parallel lazy streams (two 300 ms streams):
+elapsed=604 ms
+
+Context capability propagation:
+direct: cancellation=true, secret=present, shared_state=present
+loop/sequential: cancellation=false, secret=absent, shared_state=absent
+parallel shared: cancellation=false, secret=absent, shared_state=present
+
+Provider terminal response errors through LlmAgent:
+stream_errors=[]
+emitted event error fields=absent
+```
+
+Temporary probe files were kept outside the repository under `/tmp/adk-parallel-timing-probe`; implementation source was not changed.
+
+### Scoped source searches used for qualified claims
+
+- Context wrappers and optional `InvocationContext` methods were searched across `adk-core`, `adk-runner`, `adk-agent`, and graph/realtime adapters.
+- Graph checkpoint writes were searched across `adk-graph/src`; only non-streaming `PregelExecutor::run` calls `save_checkpoint`.
+- Response-schema propagation was searched across `adk-model/src`; explicit mappings were found in Gemini, Gemini Interactions, OpenAI-compatible, and OpenRouter paths, while DeepSeek hardcodes `None` in its request builder.
+- Computer-use response checks were inspected within `adk-computer-use/src/runtime/mcp.rs`; this scope does not include the external MCP server.
+- Realtime `max_concurrent_tools` references were searched across `adk-realtime/src`; only the field and its default were found.
+- Functional interrupt handling was searched repository-wide for `InterruptTypeMismatch`, `__interrupt__`, and the emitted interruption message; no separate resume-value handler was found.
+
+### Important interpretation limits
+
+- Source-confirmed behavior can still be mitigated by deployment controls outside this repository.
+- Documentation alone was not used to infer runtime behavior.
+- A missing use within an explicitly named search scope is not a claim of universal absence.
+- External providers and servers were not declared insecure based solely on missing local defense-in-depth.
+- No Linux bubblewrap effectiveness or network-permissiveness finding is made in this report.
+- macOS Seatbelt is not described as absent: the inspected policy restricts writes, network, and process fork but permits broad reads.
+- Windows AppContainer configuration fails closed as unimplemented; this report does not claim it silently executes an allegedly sandboxed command.

--- a/adk-anthropic/examples/managed_agents_multiagent.rs
+++ b/adk-anthropic/examples/managed_agents_multiagent.rs
@@ -139,10 +139,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let tool_name = name.as_deref().unwrap_or("unknown");
                 // Agent delegation shows up as tool use
                 eprintln!("  ⚙️  Tool: {tool_name}");
-                if let Some(inp) = &input {
-                    if let Some(agent_name) = inp.get("agent_name").and_then(|v| v.as_str()) {
-                        eprintln!("    → Delegating to: {agent_name}");
-                    }
+                if let Some(inp) = &input
+                    && let Some(agent_name) = inp.get("agent_name").and_then(|v| v.as_str())
+                {
+                    eprintln!("    → Delegating to: {agent_name}");
                 }
             }
             SessionEvent::StatusIdle { stop_reason } => {

--- a/adk-anthropic/tests/files_integration.rs
+++ b/adk-anthropic/tests/files_integration.rs
@@ -141,10 +141,13 @@ async fn test_download_uploaded_file_fails() {
     // Attempt to download (should fail — only code execution outputs are downloadable)
     let result = client.download_file(&file.id).await;
     // The API may return 403 or 400 for non-downloadable files
-    if result.is_err() {
-        eprintln!("Expected: download of uploaded file failed: {:?}", result.unwrap_err());
-    } else {
-        eprintln!("Note: download succeeded (API behavior may have changed)");
+    match result {
+        Err(error) => {
+            eprintln!("Expected: download of uploaded file failed: {error:?}");
+        }
+        Ok(_) => {
+            eprintln!("Note: download succeeded (API behavior may have changed)");
+        }
     }
 
     // Clean up
@@ -161,14 +164,13 @@ async fn test_cleanup_test_files() {
     let mut deleted = 0;
     for file in &files {
         let name = file.filename.as_deref().unwrap_or("");
-        if name.starts_with("test")
+        if (name.starts_with("test")
             || name.starts_with("list_test")
-            || name.starts_with("no_download")
+            || name.starts_with("no_download"))
+            && client.delete_file(&file.id).await.is_ok()
         {
-            if client.delete_file(&file.id).await.is_ok() {
-                deleted += 1;
-                eprintln!("Deleted file: {} ({})", file.id, name);
-            }
+            deleted += 1;
+            eprintln!("Deleted file: {} ({})", file.id, name);
         }
     }
     eprintln!("Cleaned up {deleted} test files out of {} total", files.len());

--- a/adk-anthropic/tests/managed_agents_integration.rs
+++ b/adk-anthropic/tests/managed_agents_integration.rs
@@ -335,15 +335,13 @@ async fn test_custom_tool_flow() {
             }
             Ok(SessionEvent::StatusIdle { stop_reason, .. }) => {
                 // Check if it's requires_action
-                if let Some(reason) = &stop_reason {
-                    if reason.get("type").and_then(|v| v.as_str()) == Some("requires_action") {
-                        if let Some(ids) = reason.get("event_ids").and_then(|v| v.as_array()) {
-                            if let Some(first_id) = ids.first().and_then(|v| v.as_str()) {
-                                custom_tool_event_id = first_id.to_string();
-                                received_custom_tool_use = true;
-                            }
-                        }
-                    }
+                if let Some(reason) = &stop_reason
+                    && reason.get("type").and_then(|v| v.as_str()) == Some("requires_action")
+                    && let Some(ids) = reason.get("event_ids").and_then(|v| v.as_array())
+                    && let Some(first_id) = ids.first().and_then(|v| v.as_str())
+                {
+                    custom_tool_event_id = first_id.to_string();
+                    received_custom_tool_use = true;
                 }
                 break;
             }

--- a/adk-anthropic/tests/managed_agents_memory_integration.rs
+++ b/adk-anthropic/tests/managed_agents_memory_integration.rs
@@ -256,11 +256,11 @@ async fn test_cleanup_test_memory_stores() {
     let mut cleaned = 0;
     for store in &stores {
         let name = store.name.as_deref().unwrap_or("");
-        if name.contains("Test") || name.contains("ADK") {
-            if client.delete_memory_store(&store.id).await.is_ok() {
-                cleaned += 1;
-                eprintln!("Deleted store: {} ({})", store.id, name);
-            }
+        if (name.contains("Test") || name.contains("ADK"))
+            && client.delete_memory_store(&store.id).await.is_ok()
+        {
+            cleaned += 1;
+            eprintln!("Deleted store: {} ({})", store.id, name);
         }
     }
     eprintln!("Cleaned up {cleaned} test stores");

--- a/adk-anthropic/tests/managed_agents_vaults_integration.rs
+++ b/adk-anthropic/tests/managed_agents_vaults_integration.rs
@@ -222,11 +222,11 @@ async fn test_cleanup_test_vaults() {
     let mut cleaned = 0;
     for vault in &vaults {
         let name = vault.display_name.as_deref().unwrap_or("");
-        if name.contains("Test") || name.contains("ADK") {
-            if client.archive_vault(&vault.id).await.is_ok() {
-                cleaned += 1;
-                eprintln!("Archived vault: {} ({})", vault.id, name);
-            }
+        if (name.contains("Test") || name.contains("ADK"))
+            && client.archive_vault(&vault.id).await.is_ok()
+        {
+            cleaned += 1;
+            eprintln!("Archived vault: {} ({})", vault.id, name);
         }
     }
     eprintln!("Cleaned up {cleaned} test vaults");

--- a/adk-audio/src/onnx/chatterbox.rs
+++ b/adk-audio/src/onnx/chatterbox.rs
@@ -189,50 +189,50 @@ impl ChatterboxTtsProvider {
             "loading chatterbox models"
         );
 
-        eprintln!("[chatterbox] loading speech_encoder.onnx ...");
+        tracing::debug!(model = "speech_encoder.onnx", "loading onnx model");
         let mut speech_encoder =
             Self::create_session(&onnx_dir.join("speech_encoder.onnx"), &config)?;
-        eprintln!("[chatterbox] speech_encoder loaded OK");
+        tracing::debug!(model = "speech_encoder.onnx", "onnx model loaded");
 
-        eprintln!("[chatterbox] loading embed_tokens.onnx ...");
+        tracing::debug!(model = "embed_tokens.onnx", "loading onnx model");
         let embed_tokens = Self::create_session(&onnx_dir.join("embed_tokens.onnx"), &config)?;
-        eprintln!("[chatterbox] embed_tokens loaded OK");
+        tracing::debug!(model = "embed_tokens.onnx", "onnx model loaded");
 
-        eprintln!("[chatterbox] loading conditional_decoder.onnx ...");
+        tracing::debug!(model = "conditional_decoder.onnx", "loading onnx model");
         let conditional_decoder =
             Self::create_session(&onnx_dir.join("conditional_decoder.onnx"), &config)?;
-        eprintln!("[chatterbox] conditional_decoder loaded OK");
+        tracing::debug!(model = "conditional_decoder.onnx", "onnx model loaded");
 
-        eprintln!("[chatterbox] loading {} ...", config.variant.language_model_filename());
+        tracing::debug!(model = %config.variant.language_model_filename(), "loading onnx model");
         let language_model = Self::create_session(
             &onnx_dir.join(config.variant.language_model_filename()),
             &config,
         )?;
-        eprintln!("[chatterbox] language_model loaded OK");
+        tracing::debug!(model = "language_model", "onnx model loaded");
 
         let tokenizer_path = model_dir.join("tokenizer.json");
-        eprintln!("[chatterbox] loading tokenizer from {} ...", tokenizer_path.display());
+        tracing::debug!(path = %tokenizer_path.display(), "loading tokenizer");
         let tokenizer =
             tokenizers::Tokenizer::from_file(&tokenizer_path).map_err(|e| AudioError::Tts {
                 provider: "Chatterbox".into(),
                 message: format!("failed to load tokenizer from {}: {e}", tokenizer_path.display()),
             })?;
-        eprintln!("[chatterbox] tokenizer loaded OK");
+        tracing::debug!("tokenizer loaded");
 
         // Pre-encode reference voice
-        eprintln!("[chatterbox] pre-encoding reference voice ...");
+        tracing::debug!("pre-encoding reference voice");
         let cached_encoder_output = if let Some(ref wav_path) = config.reference_wav {
-            eprintln!("[chatterbox] running speech encoder on {} ...", wav_path.display());
+            tracing::debug!(path = %wav_path.display(), "running speech encoder");
             Some(Self::run_speech_encoder(&mut speech_encoder, wav_path)?)
         } else if let Some(ref default_wav) = default_voice_path {
             tracing::info!(path = %default_wav.display(), "using default_voice.wav as reference");
-            eprintln!("[chatterbox] running speech encoder on default_voice.wav ...");
+            tracing::debug!(path = "default_voice.wav", "running speech encoder");
             Some(Self::run_speech_encoder(&mut speech_encoder, default_wav)?)
         } else {
-            eprintln!("[chatterbox] no reference voice, skipping pre-encode");
+            tracing::debug!("no reference voice, skipping pre-encode");
             None
         };
-        eprintln!("[chatterbox] reference voice encoding done");
+        tracing::debug!("reference voice encoding done");
 
         Ok(Self {
             config,
@@ -476,15 +476,15 @@ impl ChatterboxTtsProvider {
         &self,
         voice_wav: Option<&Path>,
     ) -> AudioResult<SpeechEncoderOutput> {
-        if voice_wav.is_none() {
-            if let Some(ref out) = self.cached_encoder_output {
-                return Ok(SpeechEncoderOutput {
-                    cond_emb: out.cond_emb.clone(),
-                    prompt_token: out.prompt_token.clone(),
-                    ref_x_vector: out.ref_x_vector.clone(),
-                    prompt_feat: out.prompt_feat.clone(),
-                });
-            }
+        if voice_wav.is_none()
+            && let Some(ref out) = self.cached_encoder_output
+        {
+            return Ok(SpeechEncoderOutput {
+                cond_emb: out.cond_emb.clone(),
+                prompt_token: out.prompt_token.clone(),
+                ref_x_vector: out.ref_x_vector.clone(),
+                prompt_feat: out.prompt_feat.clone(),
+            });
         }
 
         let wav_path = voice_wav
@@ -650,18 +650,16 @@ impl ChatterboxTtsProvider {
         let text_seq_len = input_ids.len();
         let total_seq_len = cond_seq_len + text_seq_len;
 
-        eprintln!(
-            "[chatterbox] input_ids ({} tokens): {:?}",
-            input_ids.len(),
-            &input_ids[..input_ids.len().min(20)]
-        );
-        eprintln!("[chatterbox] position_ids: {:?}", &position_ids[..position_ids.len().min(20)]);
-        eprintln!(
-            "[chatterbox] cond_emb shape: {:?}, hidden_dim={hidden_dim}, cond_seq_len={cond_seq_len}",
-            cond_shape
-        );
-        eprintln!(
-            "[chatterbox] total_seq_len={total_seq_len} (cond={cond_seq_len} + text={text_seq_len})"
+        tracing::trace!(
+            token.count = input_ids.len(),
+            input_ids = ?&input_ids[..input_ids.len().min(20)],
+            position_ids = ?&position_ids[..position_ids.len().min(20)],
+            cond_emb.shape = ?cond_shape,
+            hidden_dim,
+            seq_len.cond = cond_seq_len,
+            seq_len.text = text_seq_len,
+            seq_len.total = total_seq_len,
+            "prefill inputs prepared"
         );
 
         let mut prefill_embeds = Vec::with_capacity(total_seq_len * hidden_dim);
@@ -686,18 +684,24 @@ impl ChatterboxTtsProvider {
             total_seq_len, // attention_mask length
         )?;
 
-        eprintln!("[chatterbox] prefill logits len={}, top5: {:?}", first_output.logits.len(), {
+        if tracing::enabled!(tracing::Level::TRACE) {
             let mut indexed: Vec<(usize, f32)> =
                 first_output.logits.iter().copied().enumerate().collect();
-            indexed.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
-            indexed.iter().take(5).map(|(i, v)| (*i, *v)).collect::<Vec<_>>()
-        });
+            indexed.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+            tracing::trace!(
+                logits.len = first_output.logits.len(),
+                logits.top5 = ?indexed.iter().take(5).collect::<Vec<_>>(),
+                "prefill logits"
+            );
+        }
 
         let mut next_token = self.sample_token(&first_output.logits, &generate_tokens);
-        eprintln!("[chatterbox] prefill → next_token={next_token} (STOP={})", STOP_SPEECH_TOKEN);
-        eprintln!(
-            "[chatterbox] prefill KV cache: layer0 key shape={:?}, value shape={:?}",
-            first_output.kv_cache.keys[0].shape, first_output.kv_cache.values[0].shape,
+        tracing::trace!(
+            next_token,
+            stop_token = STOP_SPEECH_TOKEN,
+            kv_cache.key.shape = ?first_output.kv_cache.keys[0].shape,
+            kv_cache.value.shape = ?first_output.kv_cache.values[0].shape,
+            "prefill complete"
         );
         generate_tokens.push(next_token);
         let mut kv_cache = first_output.kv_cache;
@@ -726,9 +730,12 @@ impl ChatterboxTtsProvider {
 
             next_token = self.sample_token(&output.logits, &generate_tokens);
             if step <= 10 {
-                eprintln!(
-                    "[chatterbox] step {step} → next_token={next_token}, kv_shape={:?}, attn_len={attn_len}",
-                    output.kv_cache.keys[0].shape
+                tracing::trace!(
+                    step,
+                    next_token,
+                    kv_cache.shape = ?output.kv_cache.keys[0].shape,
+                    attn_len,
+                    "decode step"
                 );
             }
             generate_tokens.push(next_token);
@@ -1044,14 +1051,12 @@ impl TtsProvider for ChatterboxTtsProvider {
 
         let encoder_output = self.get_encoder_output(voice_wav.as_deref()).await?;
 
-        eprintln!(
-            "[chatterbox] encoder output: cond_emb shape={:?} len={}, prompt_token shape={:?} len={}, xvec shape={:?}, pfeat shape={:?}",
-            encoder_output.cond_emb.0,
-            encoder_output.cond_emb.1.len(),
-            encoder_output.prompt_token.0,
-            encoder_output.prompt_token.1.len(),
-            encoder_output.ref_x_vector.0,
-            encoder_output.prompt_feat.0,
+        tracing::trace!(
+            cond_emb.shape = ?encoder_output.cond_emb.0,
+            cond_emb.len = encoder_output.cond_emb.1.len(),
+            prompt_token.shape = ?encoder_output.prompt_token.0,
+            prompt_token.len = encoder_output.prompt_token.1.len(),
+            "encoder output"
         );
 
         tracing::info!(text_len = request.text.len(), "starting chatterbox synthesis");

--- a/adk-audio/src/onnx/stt/whisper.rs
+++ b/adk-audio/src/onnx/stt/whisper.rs
@@ -566,19 +566,19 @@ impl WhisperDecoder {
         }
 
         // Flush remaining tokens without a closing timestamp
-        if !current_word_tokens.is_empty() {
-            if let Ok(text) = self.tokenizer.decode(&current_word_tokens, true) {
-                let text = text.trim().to_string();
-                if !text.is_empty() {
-                    let start = current_start_ms.unwrap_or(0);
-                    words.push(Word {
-                        text,
-                        start_ms: start,
-                        end_ms: start, // Unknown end
-                        confidence: 0.5,
-                        speaker: None,
-                    });
-                }
+        if !current_word_tokens.is_empty()
+            && let Ok(text) = self.tokenizer.decode(&current_word_tokens, true)
+        {
+            let text = text.trim().to_string();
+            if !text.is_empty() {
+                let start = current_start_ms.unwrap_or(0);
+                words.push(Word {
+                    text,
+                    start_ms: start,
+                    end_ms: start, // Unknown end
+                    confidence: 0.5,
+                    speaker: None,
+                });
             }
         }
 

--- a/adk-code/Cargo.toml
+++ b/adk-code/Cargo.toml
@@ -34,4 +34,7 @@ docker = ["dep:bollard", "dep:rand", "dep:futures"]
 
 [dev-dependencies]
 proptest = "1.5"
-tokio = { workspace = true, features = ["rt", "macros", "test-util"] }
+# rt-multi-thread: the property tests build a runtime with `Runtime::new()`, which
+# is gated on it. Without this the crate only compiles as part of a workspace
+# build that happens to unify the feature in from another member.
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "test-util"] }

--- a/adk-computer-use/Cargo.toml
+++ b/adk-computer-use/Cargo.toml
@@ -31,10 +31,14 @@ tracing.workspace = true
 [dev-dependencies]
 proptest = "1.5"
 chrono.workspace = true
-adk-agent.workspace = true
-adk-model = { workspace = true, features = ["gemini"] }
-adk-runner.workspace = true
-adk-session.workspace = true
+# Path-only (no version) on purpose: a versioned internal dev-dependency has to be
+# published before this crate can be, which constrains — and can deadlock — the
+# release order. Cargo strips path-only dev-dependencies when packaging.
+# See scripts/check-publish-order.py.
+adk-agent = { path = "../adk-agent" }
+adk-model = { path = "../adk-model", features = ["gemini"] }
+adk-runner = { path = "../adk-runner" }
+adk-session = { path = "../adk-session" }
 futures.workspace = true
 tokio = { workspace = true, features = ["macros", "process", "rt-multi-thread", "sync", "time"] }
 

--- a/adk-enterprise/Cargo.toml
+++ b/adk-enterprise/Cargo.toml
@@ -8,6 +8,8 @@ authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
 description = "Native Rust SDK for ADK-Rust Enterprise Managed Agent Service"
+keywords = ["ai", "agent", "sdk", "enterprise", "llm"]
+categories = ["api-bindings", "asynchronous"]
 
 [dependencies]
 reqwest = { workspace = true }

--- a/adk-eval/Cargo.toml
+++ b/adk-eval/Cargo.toml
@@ -27,7 +27,7 @@ uuid.workspace = true
 chrono.workspace = true
 futures.workspace = true
 tracing.workspace = true
-quick-xml = { version = "0.37", optional = true }
+quick-xml = { version = "0.41", optional = true }
 statrs = { version = "0.18", optional = true }
 
 [features]

--- a/adk-graph/src/action/file.rs
+++ b/adk-graph/src/action/file.rs
@@ -128,18 +128,16 @@ async fn execute_write(
     })?;
 
     // Create parent directories if configured
-    if write_cfg.create_dirs {
-        if let Some(parent) = std::path::Path::new(path).parent() {
-            tokio::fs::create_dir_all(parent).await.map_err(|e| {
-                GraphError::NodeExecutionFailed {
-                    node: node_id.to_string(),
-                    message: ActionError::FileWrite(format!(
-                        "failed to create directories for '{path}': {e}"
-                    ))
-                    .to_string(),
-                }
-            })?;
-        }
+    if write_cfg.create_dirs
+        && let Some(parent) = std::path::Path::new(path).parent()
+    {
+        tokio::fs::create_dir_all(parent).await.map_err(|e| GraphError::NodeExecutionFailed {
+            node: node_id.to_string(),
+            message: ActionError::FileWrite(format!(
+                "failed to create directories for '{path}': {e}"
+            ))
+            .to_string(),
+        })?;
     }
 
     let content_str = match &write_cfg.content {

--- a/adk-graph/src/action/http.rs
+++ b/adk-graph/src/action/http.rs
@@ -55,15 +55,13 @@ pub async fn execute_http(config: &HttpNodeConfig, ctx: &NodeContext) -> Result<
     let status = response.status().as_u16();
 
     // Validate status code
-    if let Some(pattern) = &config.response.status_validation {
-        if !validate_status(status, pattern) {
-            return Err(GraphError::NodeExecutionFailed {
-                node: node_id.clone(),
-                message: format!(
-                    "HTTP status {status} does not match validation pattern '{pattern}'"
-                ),
-            });
-        }
+    if let Some(pattern) = &config.response.status_validation
+        && !validate_status(status, pattern)
+    {
+        return Err(GraphError::NodeExecutionFailed {
+            node: node_id.clone(),
+            message: format!("HTTP status {status} does not match validation pattern '{pattern}'"),
+        });
     }
 
     // Parse response
@@ -188,15 +186,15 @@ fn validate_status(status: u16, pattern: &str) -> bool {
         if let Some((start_str, end_str)) = part.split_once('-') {
             if let (Ok(start), Ok(end)) =
                 (start_str.trim().parse::<u16>(), end_str.trim().parse::<u16>())
+                && status >= start
+                && status <= end
             {
-                if status >= start && status <= end {
-                    return true;
-                }
-            }
-        } else if let Ok(code) = part.parse::<u16>() {
-            if status == code {
                 return true;
             }
+        } else if let Ok(code) = part.parse::<u16>()
+            && status == code
+        {
+            return true;
         }
     }
     false

--- a/adk-graph/src/action/rss.rs
+++ b/adk-graph/src/action/rss.rs
@@ -58,20 +58,20 @@ pub async fn execute_rss(config: &RssNodeConfig, ctx: &NodeContext) -> Result<No
         .into_iter()
         .filter(|item| {
             // Skip seen items
-            if let Some(link) = item["link"].as_str() {
-                if seen_ids.contains(link) {
-                    return false;
-                }
+            if let Some(link) = item["link"].as_str()
+                && seen_ids.contains(link)
+            {
+                return false;
             }
             // Apply keyword filter
-            if let Some(filter) = &config.filter {
-                if !filter.keywords.is_empty() {
-                    let title = item["title"].as_str().unwrap_or("");
-                    let description = item["description"].as_str().unwrap_or("");
-                    let text = format!("{title} {description}").to_lowercase();
-                    if !filter.keywords.iter().any(|kw| text.contains(&kw.to_lowercase())) {
-                        return false;
-                    }
+            if let Some(filter) = &config.filter
+                && !filter.keywords.is_empty()
+            {
+                let title = item["title"].as_str().unwrap_or("");
+                let description = item["description"].as_str().unwrap_or("");
+                let text = format!("{title} {description}").to_lowercase();
+                if !filter.keywords.iter().any(|kw| text.contains(&kw.to_lowercase())) {
+                    return false;
                 }
             }
             true
@@ -80,23 +80,23 @@ pub async fn execute_rss(config: &RssNodeConfig, ctx: &NodeContext) -> Result<No
 
     // Update seen items
     let mut output = NodeOutput::new();
-    if let Some(tracking) = &config.seen_tracking {
-        if tracking.enabled {
-            for item in &filtered {
-                if let Some(link) = item["link"].as_str() {
-                    seen_ids.insert(link.to_string());
-                }
+    if let Some(tracking) = &config.seen_tracking
+        && tracking.enabled
+    {
+        for item in &filtered {
+            if let Some(link) = item["link"].as_str() {
+                seen_ids.insert(link.to_string());
             }
-            // Cap at max_items
-            let max = tracking.max_items.unwrap_or(1000) as usize;
-            let seen_vec: Vec<String> = if seen_ids.len() > max {
-                seen_ids.into_iter().take(max).collect()
-            } else {
-                seen_ids.into_iter().collect()
-            };
-            let state_key = tracking.state_key.as_deref().unwrap_or("rss_seen_items");
-            output = output.with_update(state_key, json!(seen_vec));
         }
+        // Cap at max_items
+        let max = tracking.max_items.unwrap_or(1000) as usize;
+        let seen_vec: Vec<String> = if seen_ids.len() > max {
+            seen_ids.into_iter().take(max).collect()
+        } else {
+            seen_ids.into_iter().collect()
+        };
+        let state_key = tracking.state_key.as_deref().unwrap_or("rss_seen_items");
+        output = output.with_update(state_key, json!(seen_vec));
     }
 
     let result = json!({
@@ -115,14 +115,14 @@ fn load_seen_ids(
     state: &std::collections::HashMap<String, Value>,
 ) -> HashSet<String> {
     let mut seen = HashSet::new();
-    if let Some(tracking) = &config.seen_tracking {
-        if tracking.enabled {
-            let state_key = tracking.state_key.as_deref().unwrap_or("rss_seen_items");
-            if let Some(Value::Array(arr)) = state.get(state_key) {
-                for v in arr {
-                    if let Some(s) = v.as_str() {
-                        seen.insert(s.to_string());
-                    }
+    if let Some(tracking) = &config.seen_tracking
+        && tracking.enabled
+    {
+        let state_key = tracking.state_key.as_deref().unwrap_or("rss_seen_items");
+        if let Some(Value::Array(arr)) = state.get(state_key) {
+            for v in arr {
+                if let Some(s) = v.as_str() {
+                    seen.insert(s.to_string());
                 }
             }
         }

--- a/adk-graph/src/action/set.rs
+++ b/adk-graph/src/action/set.rs
@@ -19,18 +19,18 @@ pub async fn execute_set(config: &SetNodeConfig, ctx: &NodeContext) -> Result<No
     let mut output = NodeOutput::new();
 
     // Load environment variables if configured
-    if let Some(env_cfg) = &config.env_vars {
-        if env_cfg.load_from_env {
-            for key in &env_cfg.keys {
-                let env_key = if let Some(prefix) = &env_cfg.prefix {
-                    format!("{prefix}{key}")
-                } else {
-                    key.clone()
-                };
-                if let Ok(val) = std::env::var(&env_key) {
-                    output = output.with_update(key, Value::String(val));
-                    tracing::debug!(key = %key, "loaded env var");
-                }
+    if let Some(env_cfg) = &config.env_vars
+        && env_cfg.load_from_env
+    {
+        for key in &env_cfg.keys {
+            let env_key = if let Some(prefix) = &env_cfg.prefix {
+                format!("{prefix}{key}")
+            } else {
+                key.clone()
+            };
+            if let Ok(val) = std::env::var(&env_key) {
+                output = output.with_update(key, Value::String(val));
+                tracing::debug!(key = %key, "loaded env var");
             }
         }
     }
@@ -83,10 +83,10 @@ fn resolve_variable_value(value: &Value, state: &HashMap<String, Value>) -> Valu
             if s.contains("{{") {
                 // If the entire string was a single variable reference that resolved to
                 // a non-string JSON value, try to parse it back
-                if let Ok(parsed) = serde_json::from_str::<Value>(&interpolated) {
-                    if !parsed.is_string() {
-                        return parsed;
-                    }
+                if let Ok(parsed) = serde_json::from_str::<Value>(&interpolated)
+                    && !parsed.is_string()
+                {
+                    return parsed;
                 }
             }
             Value::String(interpolated)

--- a/adk-graph/src/action/trigger_runtime.rs
+++ b/adk-graph/src/action/trigger_runtime.rs
@@ -120,15 +120,15 @@ impl TriggerRuntime {
         }
 
         // Spawn event listener (single task handles all event configs)
-        if !event_configs.is_empty() {
-            if let Some(event_rx) = self.event_rx.take() {
-                let graph = Arc::clone(&self.graph);
-                let shutdown_rx = self.shutdown_rx.clone();
-                let handle = tokio::spawn(async move {
-                    run_event_trigger(graph, event_configs, event_rx, shutdown_rx).await;
-                });
-                handles.push(handle);
-            }
+        if !event_configs.is_empty()
+            && let Some(event_rx) = self.event_rx.take()
+        {
+            let graph = Arc::clone(&self.graph);
+            let shutdown_rx = self.shutdown_rx.clone();
+            let handle = tokio::spawn(async move {
+                run_event_trigger(graph, event_configs, event_rx, shutdown_rx).await;
+            });
+            handles.push(handle);
         }
 
         handles

--- a/adk-graph/src/functional/messages.rs
+++ b/adk-graph/src/functional/messages.rs
@@ -296,7 +296,7 @@ mod tests {
         assert_eq!(assistant_msgs.len(), 1);
 
         let system_msgs = mv.by_role(MessageRole::System);
-        assert_eq!(system_msgs.is_empty(), true);
+        assert!(system_msgs.is_empty());
     }
 
     #[test]

--- a/adk-graph/src/functional/schema.rs
+++ b/adk-graph/src/functional/schema.rs
@@ -195,14 +195,14 @@ impl StateSchemaValidator {
 
         // Check type expectations for present fields.
         for (field, expected_type) in &self.type_expectations {
-            if let Some(value) = state.get(field) {
-                if !expected_type.matches(value) {
-                    return Err(FunctionalError::SchemaValidation {
-                        field: field.clone(),
-                        expected: expected_type.type_name().to_string(),
-                        actual: value_type_name(value).to_string(),
-                    });
-                }
+            if let Some(value) = state.get(field)
+                && !expected_type.matches(value)
+            {
+                return Err(FunctionalError::SchemaValidation {
+                    field: field.clone(),
+                    expected: expected_type.type_name().to_string(),
+                    actual: value_type_name(value).to_string(),
+                });
             }
         }
 
@@ -225,14 +225,14 @@ impl StateSchemaValidator {
     /// has a value that does not match its declared expected type.
     pub fn validate_task_output(&self, output: &State) -> Result<(), FunctionalError> {
         for (field, value) in output {
-            if let Some(expected_type) = self.type_expectations.get(field) {
-                if !expected_type.matches(value) {
-                    return Err(FunctionalError::SchemaValidation {
-                        field: field.clone(),
-                        expected: expected_type.type_name().to_string(),
-                        actual: value_type_name(value).to_string(),
-                    });
-                }
+            if let Some(expected_type) = self.type_expectations.get(field)
+                && !expected_type.matches(value)
+            {
+                return Err(FunctionalError::SchemaValidation {
+                    field: field.clone(),
+                    expected: expected_type.type_name().to_string(),
+                    actual: value_type_name(value).to_string(),
+                });
             }
         }
 
@@ -371,7 +371,7 @@ mod tests {
         assert!(ExpectedType::Null.matches(&json!(null)));
         assert!(ExpectedType::Boolean.matches(&json!(true)));
         assert!(ExpectedType::Number.matches(&json!(42)));
-        assert!(ExpectedType::Number.matches(&json!(3.14)));
+        assert!(ExpectedType::Number.matches(&json!(1.5)));
         assert!(ExpectedType::String.matches(&json!("hello")));
         assert!(ExpectedType::Array.matches(&json!([1, 2, 3])));
         assert!(ExpectedType::Object.matches(&json!({"key": "value"})));

--- a/adk-graph/src/functional/typed_reducer.rs
+++ b/adk-graph/src/functional/typed_reducer.rs
@@ -3,9 +3,9 @@
 //! This module provides the [`TypedReducer`] trait for defining custom merge
 //! strategies on typed state values, along with built-in implementations:
 //!
-//! - [`ReplaceReducer`]: Last-write-wins (returns incoming value)
-//! - [`AppendReducer`]: Vec concatenation (extends current with incoming)
-//! - [`MergeReducer`]: Deep merge for JSON-like structures
+//! - [`ReplaceReducer`] — Last-write-wins (returns incoming value)
+//! - [`AppendReducer`] — Vec concatenation (extends current with incoming)
+//! - [`MergeReducer`] — Deep merge for JSON-like structures
 //!
 //! # Example
 //!

--- a/adk-graph/tests/action_switch_property_tests.rs
+++ b/adk-graph/tests/action_switch_property_tests.rs
@@ -56,7 +56,7 @@ fn arb_state_value() -> impl Strategy<Value = Value> {
         Just(json!(42)),
         Just(json!(100)),
         Just(json!(-1)),
-        Just(json!(3.14)),
+        Just(json!(1.5)),
         Just(json!(true)),
         Just(json!(false)),
         Just(json!([])),

--- a/adk-graph/tests/workflow_schema_property_tests.rs
+++ b/adk-graph/tests/workflow_schema_property_tests.rs
@@ -211,7 +211,7 @@ fn arb_variable_value() -> impl Strategy<Value = Value> {
     prop_oneof![
         Just(json!("hello")),
         Just(json!(42)),
-        Just(json!(3.14)),
+        Just(json!(1.5)),
         Just(json!(true)),
         Just(json!(false)),
         Just(json!(null)),

--- a/adk-rust/src/lib.rs
+++ b/adk-rust/src/lib.rs
@@ -73,7 +73,9 @@
 //!
 //! ### LlmAgent - AI-Powered Reasoning
 //!
-//! The core agent type that uses Large Language Models for intelligent reasoning:
+//! The core agent type that uses Large Language Models for intelligent
+//! reasoning. `GoogleSearchTool` below requires the `tools` feature (included in
+//! `standard` and above); the agent itself needs only the default tier:
 //!
 //! ```no_run
 //! use adk_rust::prelude::*;
@@ -152,7 +154,8 @@
 //!
 //! ## Tools
 //!
-//! Give your agents capabilities beyond conversation:
+//! Give your agents capabilities beyond conversation. The tool types below
+//! require the `tools` feature (included in `standard` and above):
 //!
 //! ### Function Tools - Custom Operations
 //!
@@ -280,7 +283,8 @@
 //!
 //! ## Artifacts
 //!
-//! Store and retrieve binary data (images, files, etc.):
+//! Store and retrieve binary data (images, files, etc.). Requires the
+//! `artifacts` feature (included in `standard` and above):
 //!
 //! ```no_run
 //! use adk_rust::prelude::*;
@@ -342,7 +346,8 @@
 //!
 //! ### Agent-to-Agent (A2A) Protocol
 //!
-//! Expose your agent for inter-agent communication:
+//! Expose your agent for inter-agent communication. Requires the `server`
+//! feature (included in `standard` and above):
 //!
 //! ```no_run
 //! use adk_rust::server::{create_app_with_a2a, ServerConfig};
@@ -364,17 +369,19 @@
 //!
 //! ## Observability
 //!
-//! Built-in OpenTelemetry support for production monitoring:
+//! Built-in OpenTelemetry support for production monitoring. Requires the
+//! `telemetry` feature (included in `standard` and above); OTLP export adds
+//! `telemetry-otlp`:
 //!
 //! ```no_run
-//! use adk_rust::telemetry::{init_telemetry, init_with_otlp};
+//! use adk_rust::telemetry::init_telemetry;
 //!
 //! # fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! // Basic telemetry with console logging
 //! init_telemetry("my-agent-service")?;
 //!
-//! // Or with OTLP export for distributed tracing
-//! // init_with_otlp("my-agent-service", "http://localhost:4317")?;
+//! // With `features = ["telemetry-otlp"]`, export spans to a collector instead:
+//! // adk_rust::telemetry::init_with_otlp("my-agent-service", "http://localhost:4317")?;
 //!
 //! // All agent operations now emit traces and metrics
 //! # Ok(())

--- a/adk-server/src/background/cron.rs
+++ b/adk-server/src/background/cron.rs
@@ -216,10 +216,10 @@ impl CronJobStore {
 
     /// Dequeue the next pending run for a cron job (for `Queue` policy).
     pub async fn dequeue_run(&self, job_id: &str) -> Option<String> {
-        if let Some(job) = self.jobs.write().await.get_mut(job_id) {
-            if !job.queued_runs.is_empty() {
-                return Some(job.queued_runs.remove(0));
-            }
+        if let Some(job) = self.jobs.write().await.get_mut(job_id)
+            && !job.queued_runs.is_empty()
+        {
+            return Some(job.queued_runs.remove(0));
         }
         None
     }
@@ -443,30 +443,29 @@ async fn trigger_run(state: &CronState, job: &CronJob) {
                         cron_store.decrement_active_runs(&job_id).await;
 
                         // If queue policy, check for queued runs
-                        if let Some(job) = cron_store.get(&job_id).await {
-                            if job.concurrency_policy == ConcurrencyPolicy::Queue {
-                                if let Some(queued_run_id) = cron_store.dequeue_run(&job_id).await {
-                                    // Create and execute the queued run
-                                    let now = Utc::now();
-                                    let queued_run = super::BackgroundRun {
-                                        run_id: queued_run_id.clone(),
-                                        workflow_id: job.workflow_id.clone(),
-                                        status: RunStatus::Queued,
-                                        input: job.input.clone().unwrap_or_default(),
-                                        result: None,
-                                        error: None,
-                                        created_at: now,
-                                        updated_at: now,
-                                        timeout: Some(Duration::from_secs(3600)),
-                                        max_retries: 0,
-                                        retry_count: 0,
-                                        cancel_token: CancellationToken::new(),
-                                    };
-                                    bg_store.insert(queued_run).await;
-                                    cron_store.increment_active_runs(&job_id).await;
-                                    bg_runner.execute(queued_run_id);
-                                }
-                            }
+                        if let Some(job) = cron_store.get(&job_id).await
+                            && job.concurrency_policy == ConcurrencyPolicy::Queue
+                            && let Some(queued_run_id) = cron_store.dequeue_run(&job_id).await
+                        {
+                            // Create and execute the queued run
+                            let now = Utc::now();
+                            let queued_run = super::BackgroundRun {
+                                run_id: queued_run_id.clone(),
+                                workflow_id: job.workflow_id.clone(),
+                                status: RunStatus::Queued,
+                                input: job.input.clone().unwrap_or_default(),
+                                result: None,
+                                error: None,
+                                created_at: now,
+                                updated_at: now,
+                                timeout: Some(Duration::from_secs(3600)),
+                                max_retries: 0,
+                                retry_count: 0,
+                                cancel_token: CancellationToken::new(),
+                            };
+                            bg_store.insert(queued_run).await;
+                            cron_store.increment_active_runs(&job_id).await;
+                            bg_runner.execute(queued_run_id);
                         }
                         break;
                     }

--- a/adk-server/src/background/mod.rs
+++ b/adk-server/src/background/mod.rs
@@ -197,14 +197,14 @@ impl RunStore {
 
     /// Increment the retry count and re-queue the run.
     pub async fn retry(&self, run_id: &str) -> bool {
-        if let Some(run) = self.runs.write().await.get_mut(run_id) {
-            if run.retry_count < run.max_retries {
-                run.retry_count += 1;
-                run.status = RunStatus::Queued;
-                run.error = None;
-                run.updated_at = Utc::now();
-                return true;
-            }
+        if let Some(run) = self.runs.write().await.get_mut(run_id)
+            && run.retry_count < run.max_retries
+        {
+            run.retry_count += 1;
+            run.status = RunStatus::Queued;
+            run.error = None;
+            run.updated_at = Utc::now();
+            return true;
         }
         false
     }

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,171 @@
+# cargo-deny configuration — supply-chain policy for the ADK-Rust workspace.
+#
+# Enforced by the nightly `supply-chain` job (`.github/workflows/ci-nightly.yml`)
+# alongside `cargo audit`. Run locally with `cargo deny check`.
+#
+# The accepted-advisory list mirrors `.cargo/audit.toml` so both tools agree.
+# Every entry is justified in `docs/security/DEPENDENCY-ADVISORIES.md`; add the
+# rationale there before adding an ID here.
+
+[graph]
+# Optional backends (surrealdb, lancedb, the ONNX audio models, mistral.rs,
+# LiveKit) carry most of the dependency surface. Resolving every feature keeps
+# the crates a production deployment actually enables under the gate.
+all-features = true
+
+[output]
+feature-depth = 1
+
+[advisories]
+# Unmaintained advisories are actionable only for dependencies this workspace
+# declares. A transitive crate going unmaintained deep in the graph is upstream's
+# to replace; failing the build on it turns the gate into noise. Vulnerabilities
+# and unsoundness remain errors at any depth.
+unmaintained = "workspace"
+
+ignore = [
+    # --- Vulnerabilities: reviewed and accepted, see the security doc ---
+
+    # quick-xml 0.26 — memory-exhaustion and quadratic-parse DoS.
+    # Reached only as lancedb -> lance-testing -> pprof -> inferno, behind the
+    # optional `adk-rag/lancedb` feature. lancedb declares `lance-testing` as a
+    # normal (not dev) dependency with `default = []`, so the path cannot be
+    # dropped downstream. The crates this workspace declares directly are on the
+    # patched line (`adk-eval` requires quick-xml 0.41), and the `[[bans.deny]]`
+    # entry below keeps that floor enforced.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
+
+    # rsa — Marvin timing side-channel. No upstream fix exists.
+    "RUSTSEC-2023-0071",
+
+    # rustls-webpki < 0.103.12 — CRL and name-constraint handling. The old line
+    # is pinned inside the AWS SDK's own HTTP client stack.
+    "RUSTSEC-2026-0098",
+    "RUSTSEC-2026-0099",
+    "RUSTSEC-2026-0104",
+
+    # --- Unsoundness and notices: reviewed, no ADK-reachable path ---
+    "RUSTSEC-2026-0190", # anyhow: Error::downcast_mut
+    "RUSTSEC-2026-0202", # cxx
+    "RUSTSEC-2026-0186", # memmap2
+    "RUSTSEC-2026-0097", # rand
+    "RUSTSEC-2026-0174", # http-types: ASCII invariant in Authorization value
+
+    # --- Unmaintained crates carried by upstream dependencies ---
+    "RUSTSEC-2023-0089", # atomic-polyfill
+    "RUSTSEC-2024-0384", # instant
+    "RUSTSEC-2024-0436", # paste
+    "RUSTSEC-2025-0012", # backoff
+    "RUSTSEC-2025-0052", # async-std
+    "RUSTSEC-2025-0057", # fxhash
+    "RUSTSEC-2025-0119", # number_prefix
+    "RUSTSEC-2025-0134", # rustls-pemfile
+    "RUSTSEC-2025-0141", # bincode
+    "RUSTSEC-2026-0150", # audiopus_sys
+    "RUSTSEC-2026-0173", # proc-macro-error2
+]
+
+[licenses]
+# Permissive licenses plus MPL-2.0. MPL-2.0 is file-level copyleft, satisfied by
+# linking without relicensing this workspace; it arrives through the `symphonia`
+# audio decoders and the `cssparser`/`selectors` sanitizer stack.
+allow = [
+    "0BSD",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "CC0-1.0",
+    "CDLA-Permissive-2.0",
+    "ISC",
+    "MIT",
+    "MIT-0",
+    "MPL-2.0",
+    "NCSA",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+]
+confidence-threshold = 0.8
+
+# `intel-mkl-src` ships the Intel Simplified Software License, which has no SPDX
+# identifier, so the expression is stated explicitly. Every other license-file
+# crate is detected from the file it publishes.
+[[licenses.clarify]]
+crate = "intel-mkl-src"
+expression = "LicenseRef-Intel-Simplified-Software-License"
+license-files = [{ path = "License.txt", hash = 0x3bf8c2d0 }]
+
+# Non-OSI licenses, reached only through opt-in features. Allowed per-crate so
+# that enabling those features is a visible decision rather than a silent one:
+#   * surrealdb and its sub-crates (Business Source License 1.1)
+#     — `adk-rag/surrealdb`
+#   * intel-mkl-src (Intel Simplified Software License) — `adk-mistralrs/mkl`
+# See docs/security/DEPENDENCY-ADVISORIES.md ("Non-OSI dependency licenses").
+[[licenses.exceptions]]
+crate = "surrealdb"
+allow = ["BUSL-1.1"]
+
+[[licenses.exceptions]]
+crate = "surrealdb-core"
+allow = ["BUSL-1.1"]
+
+[[licenses.exceptions]]
+crate = "surrealdb-types"
+allow = ["BUSL-1.1"]
+
+[[licenses.exceptions]]
+crate = "surrealdb-types-derive"
+allow = ["BUSL-1.1"]
+
+[[licenses.exceptions]]
+crate = "surrealdb-strand"
+allow = ["BUSL-1.1"]
+
+[[licenses.exceptions]]
+crate = "surrealdb-collections"
+allow = ["BUSL-1.1"]
+
+[[licenses.exceptions]]
+crate = "surrealdb-protocol"
+allow = ["BUSL-1.1"]
+
+# `inferno` renders flamegraph SVG inside lance-testing's profiler, reached only
+# through the optional `adk-rag/lancedb` feature. CDDL-1.0 is OSI-approved,
+# file-level copyleft and imposes no obligation on this workspace's own sources.
+[[licenses.exceptions]]
+crate = "inferno"
+allow = ["CDDL-1.0"]
+
+[[licenses.exceptions]]
+crate = "intel-mkl-src"
+allow = ["LicenseRef-Intel-Simplified-Software-License"]
+
+[licenses.private]
+# `xtask` is the repo-internal task runner (`publish = false`) and carries no
+# license field.
+ignore = true
+
+[bans]
+# Duplicate transitive versions are tolerated: the arrow/lance, opentelemetry,
+# and rustls stacks each pin their own line.
+multiple-versions = "allow"
+wildcards = "deny"
+# Internal dev-dependencies are declared path-only (no version) so publish order
+# cannot deadlock — see scripts/check-publish-order.py. Those resolve as
+# wildcards and are expected.
+allow-wildcard-paths = true
+
+[[bans.deny]]
+# Keep declared quick-xml usage on the patched line. `inferno` is the sole
+# permitted wrapper, matching the documented advisory ignore above.
+crate = "quick-xml:<0.41"
+wrappers = ["inferno"]
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/devenv.nix
+++ b/devenv.nix
@@ -120,7 +120,7 @@
   tasks = {
     "ci:test" = {
       description = "Run full workspace quality gates.";
-      exec = "cargo fmt --all -- --check && cargo clippy --workspace -- -D warnings && cargo nextest run --workspace";
+      exec = "cargo fmt --all -- --check && cargo clippy --workspace --all-targets -- -D warnings && cargo nextest run --workspace";
     };
   };
 
@@ -130,7 +130,10 @@
     ws-test.exec = "RUSTC_WRAPPER=sccache cargo nextest run --workspace $@";
     ws-test-ci.exec = "RUSTC_WRAPPER=sccache cargo nextest run --workspace --profile ci $@";
     ws-test-slow.exec = "RUSTC_WRAPPER=sccache cargo test --workspace $@";
-    ws-clippy.exec = "RUSTC_WRAPPER=sccache cargo clippy --workspace $@ -- -D warnings";
+    # --all-targets so tests, examples, and benches are linted too. Without it the
+    # PR-tier clippy gate silently skipped every non-lib target, contradicting the
+    # command documented in AGENTS.md and CONTRIBUTING.md.
+    ws-clippy.exec = "RUSTC_WRAPPER=sccache cargo clippy --workspace --all-targets $@ -- -D warnings";
     ws-summary.exec = ''
       if [ -n "$GITHUB_STEP_SUMMARY" ]; then
         echo "## 🚀 CI Summary" >> "$GITHUB_STEP_SUMMARY"

--- a/docs/official_docs/index.md
+++ b/docs/official_docs/index.md
@@ -7,6 +7,7 @@ Welcome to the official documentation for ADK-Rust (Agent Development Kit for Ru
 - [Introduction](introduction.md) - Overview of ADK-Rust, its architecture, and key concepts
 - [Quickstart](quickstart.md) - Build your first agent in under 10 minutes
 - [A2UI Quickstart](quickstart-a2ui.md) - Emit A2UI JSONL and render it in React
+- [Migrating 1.0 → 2.0](migration/1.0-to-2.0.md) - Complete breaking-change list with before/after code
 
 ## Core
 

--- a/docs/official_docs/migration/1.0-to-2.0.md
+++ b/docs/official_docs/migration/1.0-to-2.0.md
@@ -1,0 +1,192 @@
+# Migrating from ADK-Rust 1.0 to 2.0
+
+2.0.0 is a major release. Most 1.0 code compiles unchanged; the breakages below are
+the complete set reported by `cargo semver-checks check-release --release-type minor`
+against the published 1.0.0 baseline, plus the two SDK upgrades that change types
+you may name directly.
+
+Update every `adk-*` dependency together — the crates are versioned in lockstep:
+
+```toml
+[dependencies]
+adk-rust = { version = "2.0.0", features = ["standard"] }
+```
+
+## Quick reference
+
+| If your code… | Do this |
+|---|---|
+| matches on `PermissionDecision::Allow` | choose `AllowOnce`, `AllowAlways`, or `Select(id)` |
+| builds `RunConfig` with a struct literal | switch to `RunConfig::builder()` |
+| matches exhaustively on `Part` | add an arm for `Part::EmbeddedResource` |
+| matches exhaustively on `ClientEvent`/`ServerEvent` | add a `_ => {}` arm |
+| builds `StateGraph`/`RealtimeConfig`/`PermissionRequest` with struct literals | add the new fields or spread `..Default::default()` |
+| names `rmcp` types directly | import them from `adk_tool::mcp::rmcp` |
+| depends on `ServerEvent::Unknown`'s numeric value | stop relying on the discriminant |
+
+## adk-acp
+
+### `PermissionDecision::Allow` was removed
+
+1.0 had a single `Allow`. ACP agents distinguish one-time from persistent
+approval, so 2.0 returns the caller's actual intent.
+
+```rust
+// 1.0
+PermissionDecision::Allow
+
+// 2.0 — pick the intent
+PermissionDecision::AllowOnce      // approve this call only
+PermissionDecision::AllowAlways    // approve for the rest of the session
+PermissionDecision::Select(option_id)  // choose an exact option the agent offered
+```
+
+`PermissionDecision::allow_once()` is available as a constructor, and `Deny` is
+unchanged. When matching, note the enum now has four variants:
+
+```rust
+match decision {
+    PermissionDecision::AllowOnce | PermissionDecision::AllowAlways => approve(),
+    PermissionDecision::Select(option_id) => choose(option_id),
+    PermissionDecision::Deny => reject(),
+}
+```
+
+### `PermissionRequest` and `PermissionOption` carry the real operation
+
+Custom policies now receive the tool operation instead of a display label. New
+public fields: `PermissionRequest::{session_id, tool_call_id, kind, raw_input}` and
+`PermissionOption::kind`. Policies that read fields need no change; code that
+*constructs* these structs (typically tests) must supply them.
+
+### `AcpAgentConfig` gained host-integration fields
+
+New public fields: `mcp_servers`, `filesystem`, `terminal`. Build with the
+constructor rather than a struct literal:
+
+```rust
+// 2.0
+let config = AcpAgentConfig::new("claude-code")
+    .working_dir("/path/to/project")
+    .auto_approve(false);
+```
+
+`AcpAgentConfig` also no longer implements `UnwindSafe`/`RefUnwindSafe`, because it
+now holds `Arc<dyn AcpFileSystem>`/`Arc<dyn AcpTerminal>` trait objects. This only
+affects code holding the config across `catch_unwind`.
+
+### New enum variants
+
+`OutputChunk::{ToolUpdate, Usage}` and `PermissionPolicy::AsyncCustom` are new.
+Exhaustive `match` statements over those enums need arms.
+
+## adk-core
+
+### `RunConfig` gained two public fields
+
+`tool_confirmation_handler` (live async tool approval) and `runtime_toolsets`.
+Struct literals break; the builder does not:
+
+```rust
+// 1.0 — struct literal naming every field
+let config = RunConfig { streaming_mode: StreamingMode::SSE, /* … */ };
+
+// 2.0 — builder
+let config = RunConfig::builder().streaming_mode(StreamingMode::SSE).build();
+```
+
+Struct literals that already spread `..RunConfig::default()` keep compiling; only
+literals that name every field break.
+
+`RunConfig` and `RunConfigBuilder` no longer implement `UnwindSafe`/`RefUnwindSafe`
+because the confirmation handler is a boxed async callback.
+
+### `Part::EmbeddedResource`
+
+`Part` is not `#[non_exhaustive]`, so exhaustive matches must add an arm:
+
+```rust
+match part {
+    Part::Text { text } => …,
+    Part::InlineData { mime_type, data } => …,
+    Part::EmbeddedResource { .. } => …,  // new in 2.0
+    // …
+}
+```
+
+## adk-graph
+
+`StateGraph` gained the public field `deferred_configs` (fan-in node
+configuration). Use the constructor:
+
+```rust
+// 2.0
+let graph = StateGraph::new(schema);              // or
+let graph = StateGraph::with_channels(&["input", "output"]);
+```
+
+## adk-realtime
+
+- `ClientEvent` and `ServerEvent` are now `#[non_exhaustive]`. Add a wildcard arm
+  to `match` statements; the enums can no longer be constructed exhaustively from
+  outside the crate. This makes future protocol events non-breaking.
+- `ServerEvent::Unknown`'s discriminant changed from 21 to 23. Match on the variant,
+  not the number.
+- `RealtimeConfig` gained `affective_dialog`. Set it through the builder helper:
+
+```rust
+let config = RealtimeConfig::default().with_affective_dialog(true);
+```
+
+## adk-telemetry
+
+`AdkSpanLayer::new` is now generic over the sink so it accepts any `SpanSink`
+(in-memory, SQLite, or custom) rather than only the built-in exporter:
+
+```rust
+// signature in 2.0
+pub fn new<S: SpanSink + 'static>(exporter: Arc<S>) -> Self
+```
+
+Inferred call sites such as `AdkSpanLayer::new(exporter.clone())` compile
+unchanged. Only call sites that passed explicit generics need updating.
+`AdkSpanLayer` no longer implements `UnwindSafe`/`RefUnwindSafe`.
+
+## MCP: rmcp 1.2 → 2.2
+
+ADK-Rust now uses the official `rmcp 2.2` SDK and MCP protocol `2025-11-25`.
+Code that names `rmcp` content, elicitation, or service types directly must import
+them through the re-export so the version cannot drift:
+
+```rust
+use adk_tool::mcp::rmcp;
+```
+
+MCP sampling remains available as an opt-in deprecated-compatibility feature under
+upstream SEP-2577.
+
+## ACP: agent-client-protocol 1.2
+
+`adk-acp` now uses the official `agent-client-protocol` 1.2 SDK while negotiating
+stable wire protocol v1. Capability publication is exact: unsupported media,
+remote transports, and optional protocol features are no longer advertised.
+
+## Feature tiers
+
+Tier composition is unchanged (`minimal` → `standard` → `enterprise` → `full`).
+OTLP telemetry export remains a separate opt-in:
+
+```toml
+adk-rust = { version = "2.0.0", features = ["standard", "telemetry-otlp"] }
+```
+
+## Verifying your upgrade
+
+```bash
+cargo update
+cargo check --all-targets
+cargo test
+```
+
+If a break is not listed here, please open an issue — the list is generated from
+`cargo semver-checks` and should be exhaustive for the published API.

--- a/docs/security/DEPENDENCY-ADVISORIES.md
+++ b/docs/security/DEPENDENCY-ADVISORIES.md
@@ -8,11 +8,37 @@ The purpose of this file is to provide transparency to consumers about the secur
 
 These accepted advisories are also configured in [`.cargo/audit.toml`](../../.cargo/audit.toml) so that `cargo audit` passes in CI while still surfacing new, unreviewed advisories.
 
-**Last reviewed:** 2026-06-07
+**Last reviewed:** 2026-07-26 (2.0.0 release review)
+
+---
+
+## Resolved in 2.0.0
+
+| Advisory | Crate | Resolution |
+|---|---|---|
+| RUSTSEC-2026-0193, RUSTSEC-2026-0213 | `ammonia` | Lockfile updated to 4.1.4. |
+| RUSTSEC-2026-0204 | `crossbeam-epoch` | Lockfile updated to 0.9.20. |
+| RUSTSEC-2026-0194, RUSTSEC-2026-0195 | `quick-xml` (declared) | `adk-eval` now requires quick-xml 0.41. The transitive 0.26 copy is covered below. |
 
 ---
 
 ## Active Advisories
+
+### RUSTSEC-2026-0194, RUSTSEC-2026-0195 — quick-xml 0.26: parser denial of service
+
+- **Crate:** `quick-xml` (0.26.0)
+- **Severity:** High (7.5) — availability only
+- **Advisories:**
+  - [RUSTSEC-2026-0194](https://rustsec.org/advisories/RUSTSEC-2026-0194) — quadratic run time checking a start tag for duplicate attribute names
+  - [RUSTSEC-2026-0195](https://rustsec.org/advisories/RUSTSEC-2026-0195) — unbounded namespace-declaration allocation in `NsReader`
+- **ADK Impact:** `adk-rag` → `lancedb` → `lance-testing` → `pprof` → `inferno` → `quick-xml 0.26`, behind the optional `adk-rag/lancedb` feature.
+- **Status:** Patched upstream in quick-xml ≥ 0.41. The 0.26 copy cannot be updated from this workspace: `lancedb` declares `lance-testing` as a normal (not dev) dependency with `default = []`, so no feature selection removes the path. It needs a `lancedb` release that moves `lance-testing` to dev-dependencies.
+- **Disposition:** Accepted risk — no ADK-reachable path
+- **Conditions:** Both advisories require the attacker to control XML fed to the parser.
+- **ADK-Specific Context:** `inferno` parses only the flamegraph SVG that `pprof` generates in-process during profiling. No ADK-Rust request, document, or tool input reaches this parser, and the profiler is not invoked by the RAG backend at runtime.
+- **Mitigation:** The crates this workspace declares directly are on the patched line — `adk-eval` requires quick-xml 0.41. `deny.toml` bans `quick-xml < 0.41` with `inferno` as the sole permitted wrapper, so a direct regression cannot hide behind this exception.
+
+---
 
 ### RUSTSEC-2023-0071 — rsa: Marvin Attack (Timing Side-Channel)
 
@@ -106,16 +132,33 @@ The following crates are flagged by `cargo audit` as unmaintained. Each has been
 
 ---
 
+## Non-OSI dependency licenses
+
+Two optional backends link code under licenses that are not OSI-approved. They are
+allowed per-crate in [`deny.toml`](../../deny.toml) rather than through the global
+allow-list, so enabling the feature is a visible decision.
+
+| Crate | License | Reached through | Note |
+|---|---|---|---|
+| `surrealdb`, `surrealdb-core`, `surrealdb-types`, `surrealdb-types-derive`, `surrealdb-strand`, `surrealdb-collections`, `surrealdb-protocol` | Business Source License 1.1 | `adk-rag/surrealdb` | BSL restricts production use of the licensed work until its change date. Review before enabling the SurrealDB vector backend in a commercial deployment. |
+| `intel-mkl-src` | Intel Simplified Software License | `adk-mistralrs/mkl` | Intel's redistribution terms apply to the bundled MKL binaries. |
+| `inferno` | CDDL-1.0 (OSI-approved, file-level copyleft) | `adk-rag/lancedb` → `lance-testing` → `pprof` | No obligation on this workspace's own sources. |
+
+Neither `surrealdb` nor `intel-mkl-src` is enabled by any default, `standard`,
+`enterprise`, or `full` feature tier.
+
+---
+
 ## Review Cadence
 
-This document is reviewed at each minor release. Run `cargo audit` to check for new advisories:
+This document is reviewed at each minor release. Run both supply-chain gates:
 
 ```bash
 cargo audit
+cargo deny check
 ```
 
-To check for outdated dependencies:
-
-```bash
-cargo audit --deny warnings
-```
+`cargo audit` scans `Cargo.lock`; `cargo deny check` additionally enforces the
+license allow-list, the registry allow-list, and the `quick-xml` version floor.
+The accepted-advisory lists in [`.cargo/audit.toml`](../../.cargo/audit.toml) and
+[`deny.toml`](../../deny.toml) are kept in sync — add the rationale here first.

--- a/examples/ambient_cron_agent/README.md
+++ b/examples/ambient_cron_agent/README.md
@@ -1,0 +1,20 @@
+# Ambient Cron Agent Example
+
+Runs an ambient agent on a `CronTrigger`, wrapping a Gemini-powered quote generator with the full trigger lifecycle.
+
+## What This Shows
+
+- **`AmbientAgent`** — wraps an agent with an event-source lifecycle (`start`/`stop`)
+- **`CronTrigger`** — fires trigger events on a cron schedule
+- **`TriggerHandler`** — receives each trigger event and drives the agent through a `Runner`
+
+## Prerequisites
+
+- **Rust 1.94+** (edition 2024)
+- **`GOOGLE_API_KEY`** environment variable set
+
+## Run
+
+```bash
+cargo run --manifest-path examples/ambient_cron_agent/Cargo.toml
+```

--- a/examples/background_runs/README.md
+++ b/examples/background_runs/README.md
@@ -1,0 +1,20 @@
+# Background Runs Example
+
+Exercises the Background Runs REST API from `adk-server`: submit a run, poll its status, and cancel it.
+
+## What This Shows
+
+- **`BackgroundState` / `BackgroundRunner`** — the shared state and executor behind the REST surface
+- **`POST/GET/DELETE /runs`** — submit, inspect, and cancel asynchronous runs
+- **Timeout and retry configuration** — per-run limits carried on the run record
+
+## Prerequisites
+
+- **Rust 1.94+** (edition 2024)
+- Built with the adk-server `background` feature (already enabled in this example's manifest)
+
+## Run
+
+```bash
+cargo run --manifest-path examples/background_runs/Cargo.toml
+```

--- a/examples/bedrock_test/README.md
+++ b/examples/bedrock_test/README.md
@@ -1,0 +1,24 @@
+# Amazon Bedrock Smoke Test Example
+
+Drives the Amazon Bedrock provider through the ADK stack, including prompt caching.
+
+## What This Shows
+
+- **`BedrockClient`** — the Converse API provider in `adk-model`
+- **Prompt caching** — toggled with `BEDROCK_PROMPT_CACHING`
+- **Model selection** — overridden with `BEDROCK_MODEL_ID`
+
+## Prerequisites
+
+- **Rust 1.94+** (edition 2024)
+- **`AWS_REGION (or AWS_DEFAULT_REGION)`** environment variable set
+
+Authentication uses the standard AWS credential chain — run `aws configure` first.
+
+Optional: `BEDROCK_MODEL_ID`, `BEDROCK_PROMPT_CACHING`.
+
+## Run
+
+```bash
+cargo run --manifest-path examples/bedrock_test/Cargo.toml
+```

--- a/examples/competitive_ergonomics/README.md
+++ b/examples/competitive_ergonomics/README.md
@@ -1,0 +1,20 @@
+# Ergonomics and Encrypted Sessions Example
+
+Validation example for the convenience APIs and encrypted session storage.
+
+## What This Shows
+
+- **`provider_from_env()`** — provider auto-detection across the compiled provider features
+- **`Runner::run_str()`** — string-based convenience entry point
+- **`EncryptedSession`** — AES-256-GCM session storage with key rotation
+
+## Prerequisites
+
+- **Rust 1.94+** (edition 2024)
+- **`One of ANTHROPIC_API_KEY, OPENAI_API_KEY, or GOOGLE_API_KEY`** environment variable set
+
+## Run
+
+```bash
+cargo run --manifest-path examples/competitive_ergonomics/Cargo.toml
+```

--- a/examples/competitive_graph_resume/README.md
+++ b/examples/competitive_graph_resume/README.md
@@ -1,0 +1,20 @@
+# Graph Durable Resume Example
+
+Validation example for resume-from-checkpoint in `adk-graph`.
+
+## What This Shows
+
+- **`MemoryCheckpointer`** — save/load round-trip for graph state
+- **Durable resume** — restoring state, pending nodes, and step from the last checkpoint
+- **`StreamEvent::Resumed`** — emitted when execution restarts from a checkpoint
+
+## Prerequisites
+
+- **Rust 1.94+** (edition 2024)
+- No API key required
+
+## Run
+
+```bash
+cargo run --manifest-path examples/competitive_graph_resume/Cargo.toml
+```

--- a/examples/competitive_tool_search/README.md
+++ b/examples/competitive_tool_search/README.md
@@ -1,0 +1,19 @@
+# Tool Search and Interruption Detection Example
+
+Validation example for `ToolSearchConfig` filtering and realtime interruption modes.
+
+## What This Shows
+
+- **`ToolSearchConfig`** — regex-based tool filtering for the Anthropic provider
+- **`InterruptionDetection`** — `Manual` versus `Automatic` VAD-based interruption
+
+## Prerequisites
+
+- **Rust 1.94+** (edition 2024)
+- No API key required
+
+## Run
+
+```bash
+cargo run --manifest-path examples/competitive_tool_search/Cargo.toml
+```

--- a/examples/cron_scheduling/README.md
+++ b/examples/cron_scheduling/README.md
@@ -1,0 +1,20 @@
+# Cron Scheduling Example
+
+Exercises the cron scheduling API from `adk-server`: create jobs, list them, and pause or delete them.
+
+## What This Shows
+
+- **`CronState` / `CronJobStore`** — job storage and the scheduling loop
+- **Concurrency policies** — `skip`, `allow`, and `queue`
+- **`POST/GET/PATCH/DELETE /cron`** — the job management surface
+
+## Prerequisites
+
+- **Rust 1.94+** (edition 2024)
+- Built with the adk-server `background` feature (already enabled in this example's manifest)
+
+## Run
+
+```bash
+cargo run --manifest-path examples/cron_scheduling/Cargo.toml
+```

--- a/examples/desktop_agent/README.md
+++ b/examples/desktop_agent/README.md
@@ -1,0 +1,38 @@
+# Desktop Agent Example
+
+Controls a macOS desktop with a Gemini-powered agent driving the
+`computer-use-mcp` server over MCP.
+
+## What This Shows
+
+- **MCP toolset over stdio** — the agent consumes `computer-use-mcp` tools through `adk-tool`
+- **Full JSON Schema pass-through** — MCP schemas using `exclusiveMinimum`, tuple `items`, and similar keywords are forwarded via Gemini's `parametersJsonSchema` field instead of being lossily normalized
+- **Task-driven automation** — the desktop task is supplied as a command-line argument
+
+## Prerequisites
+
+- **Rust 1.94+** (edition 2024)
+- **`GOOGLE_API_KEY`** (or `GEMINI_API_KEY`) environment variable set
+- **`computer-use-mcp`** installed: `npm install -g @zavora-ai/computer-use-mcp`
+- **macOS**, with the accessibility and screen-recording permissions the MCP server requests
+
+```bash
+cp examples/desktop_agent/.env.example examples/desktop_agent/.env
+# Edit .env and add your GOOGLE_API_KEY
+```
+
+## Run
+
+```bash
+cargo run --manifest-path examples/desktop_agent/Cargo.toml
+```
+
+With a custom task:
+
+```bash
+cargo run --manifest-path examples/desktop_agent/Cargo.toml -- "Open Safari and go to google.com"
+```
+
+> **Note:** this example actuates a real desktop. For the governed orchestration
+> layer — approval interrupts, single-executor mutation, and verification — see
+> the [`adk-computer-use`](../../adk-computer-use) crate.

--- a/examples/eval_showcase/Cargo.lock
+++ b/examples/eval_showcase/Cargo.lock
@@ -671,9 +671,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]

--- a/examples/functional_workflow/README.md
+++ b/examples/functional_workflow/README.md
@@ -1,0 +1,21 @@
+# Functional Workflow Example
+
+Demonstrates the Functional API from `adk-graph`: write a workflow as async functions instead of assembling a graph.
+
+## What This Shows
+
+- **`TaskContext`** — the handle passed to each `#[task]`
+- **`ReducedValue` / `UntrackedValue` / `MessagesValue`** — typed state reducers
+- **`StateSchemaValidator`** — type expectations enforced on state and task output
+- **`ExecutionLog`** — the per-run record of task execution
+
+## Prerequisites
+
+- **Rust 1.94+** (edition 2024)
+- Built with the adk-graph `functional` feature (already enabled in this example's manifest)
+
+## Run
+
+```bash
+cargo run --manifest-path examples/functional_workflow/Cargo.toml
+```

--- a/examples/gemini_search_bug/README.md
+++ b/examples/gemini_search_bug/README.md
@@ -1,0 +1,19 @@
+# Gemini Search Tool Coexistence (Issue #224) Example
+
+Reproduction for GitHub issue #224: a built-in Google Search tool and a function tool used by the same agent.
+
+## What This Shows
+
+- **Built-in and function tool coexistence** — both declared on one `LlmAgent`
+- **`ServerToolCall` / `ServerToolResponse`** — full provider-side tool tracing through the Runner
+
+## Prerequisites
+
+- **Rust 1.94+** (edition 2024)
+- **`GOOGLE_API_KEY`** environment variable set
+
+## Run
+
+```bash
+cargo run --manifest-path examples/gemini_search_bug/Cargo.toml
+```

--- a/examples/managed_runtime_hello/README.md
+++ b/examples/managed_runtime_hello/README.md
@@ -1,0 +1,20 @@
+# Managed Agent Runtime — Hello World Example
+
+End-to-end smoke test of the managed agent runtime against a scripted LLM, so it needs no API key.
+
+## What This Shows
+
+- **`DefaultManagedAgentRuntime`** — register an agent, start a session, stream events
+- **`ScriptedLlm`** — deterministic test double standing in for a provider
+- **Session lifecycle** — send an event, observe status transitions, archive
+
+## Prerequisites
+
+- **Rust 1.94+** (edition 2024)
+- Built with the adk-rust `managed-runtime` feature (already enabled in this example's manifest)
+
+## Run
+
+```bash
+cargo run --manifest-path examples/managed_runtime_hello/Cargo.toml
+```

--- a/examples/openai_responses/README.md
+++ b/examples/openai_responses/README.md
@@ -1,0 +1,20 @@
+# OpenAI Responses API Example
+
+Drives `OpenAIResponsesClient` through the full ADK stack (Runner → LlmAgent → session service).
+
+## What This Shows
+
+- **`OpenAIResponsesClient`** — the `/v1/responses` provider, recommended for reasoning models
+- **`OpenAIResponsesConfig`** — model and endpoint configuration
+- **Multi-turn sessions** — history preserved across turns
+
+## Prerequisites
+
+- **Rust 1.94+** (edition 2024)
+- **`OPENAI_API_KEY`** environment variable set
+
+## Run
+
+```bash
+cargo run --manifest-path examples/openai_responses/Cargo.toml
+```

--- a/examples/openrouter/README.md
+++ b/examples/openrouter/README.md
@@ -1,0 +1,21 @@
+# OpenRouter Example
+
+Live integration example for the native OpenRouter provider and its discovery APIs.
+
+## What This Shows
+
+- **`OpenRouterClient`** — native chat and responses transports
+- **Routing and discovery** — model listing and credit APIs
+- **Full agent stack** — Runner → LlmAgent → OpenRouterClient
+
+## Prerequisites
+
+- **Rust 1.94+** (edition 2024)
+- **`OPENROUTER_API_KEY`** environment variable set
+- Built with the adk-model `openrouter` feature (already enabled in this example's manifest)
+
+## Run
+
+```bash
+cargo run --manifest-path examples/openrouter/Cargo.toml
+```

--- a/examples/output_schema_agent/README.md
+++ b/examples/output_schema_agent/README.md
@@ -1,0 +1,20 @@
+# Output Schema Agent Example
+
+Demonstrates structured-output enforcement on an `LlmAgent`.
+
+## What This Shows
+
+- **`output_type::<T>()`** — declare the expected response type
+- **Schema enforcement** — the response is validated against the generated JSON schema
+- **Typed extraction** — parse the final event straight into a Rust struct
+
+## Prerequisites
+
+- **Rust 1.94+** (edition 2024)
+- **`GOOGLE_API_KEY`** environment variable set
+
+## Run
+
+```bash
+cargo run --manifest-path examples/output_schema_agent/Cargo.toml
+```

--- a/examples/skill_memory_improvements/README.md
+++ b/examples/skill_memory_improvements/README.md
@@ -1,0 +1,20 @@
+# Skill and Memory Improvements Example
+
+Validation example covering the skill-discovery and memory APIs added by the skill-memory-improvements spec.
+
+## What This Shows
+
+- **`Memory::add()` / `delete()`** — direct memory mutation from `adk-core`
+- **Skill discovery** — `.skills` indexing and lexical matching
+- **Prompt injection helpers** — compact skill blocks injected into instructions
+
+## Prerequisites
+
+- **Rust 1.94+** (edition 2024)
+- No API key required
+
+## Run
+
+```bash
+cargo run --manifest-path examples/skill_memory_improvements/Cargo.toml
+```

--- a/examples/telemetry_sqlite_export/README.md
+++ b/examples/telemetry_sqlite_export/README.md
@@ -1,0 +1,21 @@
+# Telemetry SQLite Export Example
+
+Traces an agent run end-to-end into a local SQLite file — no OTLP collector or backend to deploy.
+
+## What This Shows
+
+- **`AdkSpanLayer`** — tracing layer that forwards spans to a `SpanSink`
+- **SQLite span sink** — spans written to a local file for offline inspection
+- **Zero-infrastructure tracing** — query the run with plain SQL afterwards
+
+## Prerequisites
+
+- **Rust 1.94+** (edition 2024)
+- **`GOOGLE_API_KEY`** environment variable set
+- Built with the adk-telemetry `sqlite` feature (already enabled in this example's manifest)
+
+## Run
+
+```bash
+cargo run --manifest-path examples/telemetry_sqlite_export/Cargo.toml
+```

--- a/scripts/check-examples-compile.sh
+++ b/scripts/check-examples-compile.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Compile every standalone example crate under examples/.
+#
+# Each example is its own workspace with its own Cargo.lock and path
+# dependencies back into this repo, so nothing in the root workspace build
+# covers them: `cargo check --workspace` cannot see them and
+# scripts/check-doc-examples.sh only validates that documented commands resolve
+# in cargo metadata. Without this gate an example can stop compiling against a
+# changed public API and no CI job notices.
+#
+# Usage:
+#   scripts/check-examples-compile.sh              # every example
+#   scripts/check-examples-compile.sh 0 4          # shard 0 of 4 (CI matrix)
+#
+# A shared CARGO_TARGET_DIR is used so the ADK crates and common dependencies
+# are built once and reused across examples.
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT" || exit 1
+
+SHARD_INDEX="${1:-0}"
+SHARD_TOTAL="${2:-1}"
+
+# adk-codeact-monty requires rustc 1.95 (the workspace is pinned to 1.94), so
+# examples/codeact_monty_agent is built by its own workflow on that toolchain.
+SKIP_EXAMPLES=("examples/codeact_monty_agent")
+
+export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$ROOT/target/examples-check}"
+
+mapfile -t MANIFESTS < <(find examples -maxdepth 2 -name Cargo.toml | sort)
+
+declare -a failed=()
+declare -i checked=0 skipped=0 index=0
+
+for manifest in "${MANIFESTS[@]}"; do
+    dir="$(dirname "$manifest")"
+
+    skip=0
+    for excluded in "${SKIP_EXAMPLES[@]}"; do
+        if [[ "$dir" == "$excluded" ]]; then skip=1; fi
+    done
+    if (( skip )); then
+        printf 'skip     %s (own toolchain/workflow)\n' "$dir"
+        skipped+=1
+        continue
+    fi
+
+    if (( index % SHARD_TOTAL != SHARD_INDEX )); then
+        index+=1
+        continue
+    fi
+    index+=1
+
+    # --locked also catches a lockfile that no longer matches its manifest.
+    if cargo check --manifest-path "$manifest" --locked --quiet 2>/tmp/example-check-err; then
+        printf 'ok       %s\n' "$dir"
+    else
+        printf 'FAILED   %s\n' "$dir"
+        sed 's/^/         /' /tmp/example-check-err | head -20
+        failed+=("$dir")
+    fi
+    checked+=1
+done
+
+printf '\nexamples checked: %d, skipped: %d, failed: %d' "$checked" "$skipped" "${#failed[@]}"
+if (( SHARD_TOTAL > 1 )); then
+    printf ' (shard %d of %d)' "$SHARD_INDEX" "$SHARD_TOTAL"
+fi
+printf '\n'
+
+if (( ${#failed[@]} > 0 )); then
+    printf '\nfailing examples:\n'
+    printf '  %s\n' "${failed[@]}"
+    exit 1
+fi


### PR DESCRIPTION
## What

Closes the release blockers found in an end-to-end 2.0.0 readiness review, and adds the CI gates that would have caught them.

| Commit | Change |
|---|---|
| `fix(deps)` | Resolve dependency advisories; add a root `deny.toml` policy |
| `fix` | Clear 15 clippy errors in feature-gated code; unbreak `adk-code` standalone tests |
| `fix(adk-rust)` | Make the umbrella crate's doc examples compile; tidy publish metadata |
| `ci` | Gate doctests, standalone examples, and feature-gated lints |
| `docs` | Complete the 2.0.0 breaking-change record; add the 1.0→2.0 migration guide |
| `docs` | Add the v2 gap analysis report |

## Why

No issue — findings came from a full readiness review of the 2.0.0 candidate. Each fix pairs with the gate that let it through:

- **`cargo audit` reported 7 vulnerabilities and `cargo deny check` failed outright.** The nightly `cargo deny` step was `continue-on-error` because no root `deny.toml` existed.
- **Five doctests failed in `adk-rust`**, the flagship published crate. One failed even under `full` — the feature set docs.rs renders — because a doc example imported `adk_rust::telemetry::init_with_otlp`, which needs `telemetry-otlp`, a feature no advertised tier enables. **No CI job ran doctests at all.**
- **15 clippy errors sat in feature-gated modules.** The nightly feature matrix ran `cargo check`, not clippy, so nothing ever linted `adk-audio` ONNX, `adk-graph` `functional`/`action-full`, `adk-server` `background`, or `adk-anthropic` `managed-agents`.
- **`adk-code`'s tests only compiled inside a workspace build** that unified tokio's `rt-multi-thread` in from another member.
- **The CHANGELOG's Breaking section listed 3 of 14 breaking changes.** It omitted the `adk-acp` `PermissionDecision::Allow` removal, the `adk-telemetry` `AdkSpanLayer::new` signature change, the `adk-core` auto-trait losses and new public fields, and the `adk-realtime` `non_exhaustive` and discriminant changes.
- **Nothing compiled the 97 standalone example crates.** They sit outside the workspace, and `check-doc-examples.sh` only validates metadata references.

## How

**Supply chain.** `ammonia` → 4.1.4 and `crossbeam-epoch` → 0.9.20 by lockfile; `adk-eval` now requires `quick-xml` 0.41 (RUSTSEC-2026-0194/-0195). The remaining `quick-xml` 0.26 copy is transitive-only through `lancedb → lance-testing → pprof → inferno` and cannot be dropped downstream, so it is an accepted exception documented in `docs/security/DEPENDENCY-ADVISORIES.md`, with a `[[bans.deny]]` rule keeping declared usage on the patched line. `deny.toml` also carries the license allow-list; non-OSI licenses reached only through opt-in features (surrealdb BSL-1.1, intel-mkl-src Intel ISSL) are allowed per-crate rather than globally, so enabling those features stays a visible decision.

**Breaking-change inventory.** Generated with `cargo semver-checks check-release --release-type minor` against the published 1.0.0 baseline, because a major bump makes `check-release` skip all 253 checks and yield zero signal. Recorded as a 14-row table in the CHANGELOG plus `docs/official_docs/migration/1.0-to-2.0.md` with before/after code.

**New gates.** Doctests in the PR-tier `docs` job (`--workspace --exclude adk-rust`, plus `adk-rust` under `full` to match docs.rs). `ws-clippy` gains `--all-targets`, which AGENTS.md and CONTRIBUTING.md already claimed. The nightly feature matrix moves to `cargo clippy -- -D warnings` and grows 3 → 8 entries. A new 4-shard nightly `examples-compile` job runs `scripts/check-examples-compile.sh`. `cargo deny check` becomes enforcing. Semver coverage goes 22 → 37 published crates and drops the stale `PRE1_ALLOWED` downgrade, which post-1.0 would have masked real breakage in `adk-gemini` and `adk-server`.

**Verification** (local, macOS, rustc 1.94.0, rebased onto `e0687bda`):

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo nextest run --workspace --profile ci` | 3738 passed, 83 skipped |
| doctests (workspace + `adk-rust --features full`) | 316 + 11 passed |
| `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps` | exit 0 |
| `cargo audit` / `cargo deny check` | exit 0 / all four checks ok |
| `cargo metadata --locked` | exit 0 |
| guard scripts (name-collisions, doc-examples, doc-versions, publish-order) | exit 0 |
| `scripts/check-examples-compile.sh` | 96 checked, 1 skipped, 0 failed |
| feature-coverage matrix (5 PR-tier entries) | clippy 0 / tests 0 |
| nightly feature matrix (7 Linux entries) | exit 0 |

Not verified locally: Linux and Windows builds (macOS only), the 83 `#[ignore]` tests needing secrets, and the new nightly jobs as GitHub Actions runs — this PR is their first real execution.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed
- [x] Examples added or updated for new features

## Notes for review

Two items need a decision rather than a code review:

1. **Non-OSI license exceptions.** `deny.toml` allows BSL-1.1 (surrealdb, via `adk-rag/surrealdb`) and the Intel Simplified Software License (intel-mkl-src, via `adk-mistralrs/mkl`) per-crate. Neither is in any default, `standard`, `enterprise`, or `full` tier, but BSL restricts production use until its change date — worth confirming this is acceptable.
2. **`V2_GAPS.md`** is isolated in its own commit (`8c05fe20`) so it can be dropped independently. Its snapshot header records a commit that is now behind main; the findings were re-verified against current source, but the header and its README-banner clause are stale.

Separately, `adk-devtools` and `adk-computer-use` are new in 2.0.0 and unpublished, so they have no semver baseline and are deliberately absent from the semver matrix. Add them once 2.0.0 is on crates.io.