### PR TITLE
fix(agent): stop context wrappers dropping cancellation and secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -318,6 +318,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **adk-agent/adk-tool: workflow context wrappers no longer drop cancellation,
+  secrets, and shared state.** Each wrapper re-implements `InvocationContext` and
+  delegates to an inner context, but most capability methods have permissive trait
+  defaults — `is_cancelled()` returns `false`, `get_secret()` returns `None`,
+  `shared_state()`/`user_scopes()`/`request_metadata()` return empty — so a
+  wrapper that omitted one still compiled and silently lost it. Capabilities
+  therefore depended on which workflow agent a sub-agent happened to run under:
+  `LoopAgent`'s history wrapper dropped cancellation, secrets, and shared state;
+  the skill-injection wrapper dropped all five; `ParallelAgent`'s shared-state
+  wrapper dropped cancellation and secrets. Most visibly, `Runner::interrupt` did
+  not reach an LLM agent nested under any of them, because the agent's
+  `is_cancelled()` checks read `false` through the wrapper.
+
+  All wrappers now forward every capability. `adk-tool`'s agent-as-tool context
+  additionally forwards `user_scopes`, `get_secret`, and `shared_state`, so a
+  scope-guarded tool invoked by an agent-as-tool sees the caller's grants. A
+  conformance suite pushes a sentinel context with a non-default value for every
+  capability through each wrapper — and through a composed stack, since an inner
+  wrapper that drops a capability defeats a correct outer one.
+
+  Known remaining gap: `is_cancelled` and `request_metadata` are not part of the
+  `ToolContext` surface that the agent-as-tool wrapper is built from, so
+  cancellation still does not reach an agent invoked as a tool. Closing that needs
+  those methods added to `ToolContext`.
+
 - **adk-agent/adk-core/adk-runner: `ParallelAgent` sub-agents no longer read each
   other's output.** Concurrent branches all read the full session history, so an
   analyst in a fan-out could see a sibling's answer before forming its own — while

--- a/adk-agent/src/workflow/loop_agent.rs
+++ b/adk-agent/src/workflow/loop_agent.rs
@@ -257,6 +257,14 @@ impl Session for HistoryTrackingSession {
     }
 }
 
+/// Builds a [`HistoryTrackingContext`] for the wrapper conformance tests.
+#[cfg(test)]
+pub(crate) fn history_tracking_context_for_test(
+    parent: Arc<dyn InvocationContext>,
+) -> Arc<dyn InvocationContext> {
+    Arc::new(HistoryTrackingContext::new(parent))
+}
+
 struct HistoryTrackingContext {
     parent_ctx: Arc<dyn InvocationContext>,
     session: HistoryTrackingSession,
@@ -309,6 +317,10 @@ impl CallbackContext for HistoryTrackingContext {
     fn artifacts(&self) -> Option<Arc<dyn adk_core::Artifacts>> {
         self.parent_ctx.artifacts()
     }
+
+    fn shared_state(&self) -> Option<Arc<adk_core::SharedState>> {
+        self.parent_ctx.shared_state()
+    }
 }
 
 #[async_trait]
@@ -337,12 +349,20 @@ impl InvocationContext for HistoryTrackingContext {
         self.parent_ctx.ended()
     }
 
+    fn is_cancelled(&self) -> bool {
+        self.parent_ctx.is_cancelled()
+    }
+
     fn user_scopes(&self) -> Vec<String> {
         self.parent_ctx.user_scopes()
     }
 
     fn request_metadata(&self) -> HashMap<String, serde_json::Value> {
         self.parent_ctx.request_metadata()
+    }
+
+    async fn get_secret(&self, name: &str) -> adk_core::Result<Option<String>> {
+        self.parent_ctx.get_secret(name).await
     }
 }
 

--- a/adk-agent/src/workflow/mod.rs
+++ b/adk-agent/src/workflow/mod.rs
@@ -6,6 +6,8 @@ mod parallel_agent;
 mod sequential_agent;
 mod shared_state_context;
 mod skill_context;
+#[cfg(test)]
+mod wrapper_conformance_tests;
 
 pub use conditional_agent::ConditionalAgent;
 pub use llm_conditional_agent::{LlmConditionalAgent, LlmConditionalAgentBuilder};

--- a/adk-agent/src/workflow/shared_state_context.rs
+++ b/adk-agent/src/workflow/shared_state_context.rs
@@ -103,11 +103,19 @@ impl InvocationContext for SharedStateContext {
         self.inner.ended()
     }
 
+    fn is_cancelled(&self) -> bool {
+        self.inner.is_cancelled()
+    }
+
     fn user_scopes(&self) -> Vec<String> {
         self.inner.user_scopes()
     }
 
     fn request_metadata(&self) -> HashMap<String, serde_json::Value> {
         self.inner.request_metadata()
+    }
+
+    async fn get_secret(&self, name: &str) -> adk_core::Result<Option<String>> {
+        self.inner.get_secret(name).await
     }
 }

--- a/adk-agent/src/workflow/skill_context.rs
+++ b/adk-agent/src/workflow/skill_context.rs
@@ -79,6 +79,22 @@ impl CallbackContext for UserContentOverrideContext {
     fn artifacts(&self) -> Option<Arc<dyn adk_core::Artifacts>> {
         self.parent.artifacts()
     }
+
+    fn tool_outcome(&self) -> Option<adk_core::ToolOutcome> {
+        self.parent.tool_outcome()
+    }
+
+    fn tool_name(&self) -> Option<&str> {
+        self.parent.tool_name()
+    }
+
+    fn tool_input(&self) -> Option<&serde_json::Value> {
+        self.parent.tool_input()
+    }
+
+    fn shared_state(&self) -> Option<Arc<adk_core::SharedState>> {
+        self.parent.shared_state()
+    }
 }
 
 #[async_trait]
@@ -105,6 +121,22 @@ impl InvocationContext for UserContentOverrideContext {
 
     fn ended(&self) -> bool {
         self.parent.ended()
+    }
+
+    fn is_cancelled(&self) -> bool {
+        self.parent.is_cancelled()
+    }
+
+    fn user_scopes(&self) -> Vec<String> {
+        self.parent.user_scopes()
+    }
+
+    fn request_metadata(&self) -> std::collections::HashMap<String, serde_json::Value> {
+        self.parent.request_metadata()
+    }
+
+    async fn get_secret(&self, name: &str) -> Result<Option<String>> {
+        self.parent.get_secret(name).await
     }
 }
 

--- a/adk-agent/src/workflow/wrapper_conformance_tests.rs
+++ b/adk-agent/src/workflow/wrapper_conformance_tests.rs
@@ -1,0 +1,353 @@
+//! Capability conformance for the workflow context wrappers.
+//!
+//! Every wrapper here re-implements [`InvocationContext`] and delegates to an
+//! inner context. Most of the trait's capability methods have permissive
+//! defaults — `is_cancelled()` returns `false`, `get_secret()` returns `None`,
+//! `shared_state()`/`user_scopes()`/`request_metadata()` return empty — so a
+//! wrapper that forgets one still compiles and silently drops it. That is how
+//! cancellation, secrets, and shared state came to be lost depending on which
+//! workflow agent a sub-agent happened to run under.
+//!
+//! These tests push a sentinel context with a non-default value for every
+//! capability through each wrapper and assert all of them survive. A new wrapper,
+//! or a new capability method, should be added here.
+
+use super::branch_context::BranchContext;
+use super::shared_state_context::SharedStateContext;
+use adk_core::{
+    Agent, CallbackContext, Content, Event, InvocationContext, Memory, Part, ReadonlyContext,
+    Result, RunConfig, Session, SharedState, ToolOutcome,
+};
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+// ── Sentinel context: every capability set to a non-default value ──────
+
+const SENTINEL_SECRET_NAME: &str = "sentinel-secret";
+const SENTINEL_SECRET_VALUE: &str = "sentinel-value";
+const SENTINEL_SCOPE: &str = "sentinel:scope";
+const SENTINEL_METADATA_KEY: &str = "sentinel-metadata";
+const SENTINEL_STATE_KEY: &str = "sentinel-shared-key";
+
+const SENTINEL_ARTIFACT: &str = "sentinel-artifact";
+const SENTINEL_MEMORY_AUTHOR: &str = "sentinel-memory-author";
+
+struct SentinelArtifacts;
+
+#[async_trait]
+impl adk_core::Artifacts for SentinelArtifacts {
+    async fn save(&self, _name: &str, _data: &Part) -> Result<i64> {
+        Ok(1)
+    }
+    async fn load(&self, _name: &str) -> Result<Part> {
+        Ok(Part::Text { text: "sentinel".to_string() })
+    }
+    async fn list(&self) -> Result<Vec<String>> {
+        Ok(vec![SENTINEL_ARTIFACT.to_string()])
+    }
+}
+
+struct SentinelMemory;
+
+#[async_trait]
+impl Memory for SentinelMemory {
+    async fn search(&self, _query: &str) -> Result<Vec<adk_core::MemoryEntry>> {
+        Ok(vec![adk_core::MemoryEntry {
+            content: Content {
+                role: "model".to_string(),
+                parts: vec![Part::Text { text: "sentinel".to_string() }],
+            },
+            author: SENTINEL_MEMORY_AUTHOR.to_string(),
+        }])
+    }
+}
+
+struct SentinelState;
+
+impl adk_core::State for SentinelState {
+    fn get(&self, _key: &str) -> Option<serde_json::Value> {
+        None
+    }
+    fn set(&mut self, _key: String, _value: serde_json::Value) {}
+    fn all(&self) -> HashMap<String, serde_json::Value> {
+        HashMap::new()
+    }
+}
+
+struct SentinelSession {
+    state: SentinelState,
+}
+
+impl Session for SentinelSession {
+    fn id(&self) -> &str {
+        "sentinel-session"
+    }
+    fn app_name(&self) -> &str {
+        "sentinel-app"
+    }
+    fn user_id(&self) -> &str {
+        "sentinel-user"
+    }
+    fn state(&self) -> &dyn adk_core::State {
+        &self.state
+    }
+    fn conversation_history(&self) -> Vec<Content> {
+        Vec::new()
+    }
+}
+
+struct SentinelContext {
+    content: Content,
+    config: RunConfig,
+    session: SentinelSession,
+    shared: Arc<SharedState>,
+}
+
+impl SentinelContext {
+    /// `SharedState` mutation is async, so callers seed it via [`seeded_shared_state`].
+    fn with_shared(shared: Arc<SharedState>) -> Self {
+        Self {
+            content: Content {
+                role: "user".to_string(),
+                parts: vec![Part::Text { text: "sentinel".to_string() }],
+            },
+            config: RunConfig::default(),
+            session: SentinelSession { state: SentinelState },
+            shared,
+        }
+    }
+}
+
+/// A `SharedState` carrying the sentinel key.
+async fn seeded_shared_state(key: &str) -> Arc<SharedState> {
+    let shared = Arc::new(SharedState::new());
+    shared.set_shared(key, serde_json::json!(true)).await.expect("seeding shared state failed");
+    shared
+}
+
+#[async_trait]
+impl ReadonlyContext for SentinelContext {
+    fn invocation_id(&self) -> &str {
+        "sentinel-invocation"
+    }
+    fn agent_name(&self) -> &str {
+        "sentinel-agent"
+    }
+    fn user_id(&self) -> &str {
+        "sentinel-user"
+    }
+    fn app_name(&self) -> &str {
+        "sentinel-app"
+    }
+    fn session_id(&self) -> &str {
+        "sentinel-session"
+    }
+    fn branch(&self) -> &str {
+        "sentinel-branch"
+    }
+    fn user_content(&self) -> &Content {
+        &self.content
+    }
+}
+
+#[async_trait]
+impl CallbackContext for SentinelContext {
+    fn artifacts(&self) -> Option<Arc<dyn adk_core::Artifacts>> {
+        Some(Arc::new(SentinelArtifacts))
+    }
+    fn tool_outcome(&self) -> Option<ToolOutcome> {
+        Some(ToolOutcome {
+            tool_name: "sentinel-tool".to_string(),
+            tool_args: serde_json::json!({}),
+            success: true,
+            duration: std::time::Duration::from_millis(1),
+            error_message: None,
+            attempt: 0,
+        })
+    }
+    fn tool_name(&self) -> Option<&str> {
+        Some("sentinel-tool")
+    }
+    fn shared_state(&self) -> Option<Arc<SharedState>> {
+        Some(self.shared.clone())
+    }
+}
+
+#[async_trait]
+impl InvocationContext for SentinelContext {
+    fn agent(&self) -> Arc<dyn Agent> {
+        unimplemented!("not exercised by wrapper conformance")
+    }
+    fn memory(&self) -> Option<Arc<dyn Memory>> {
+        Some(Arc::new(SentinelMemory))
+    }
+    fn session(&self) -> &dyn Session {
+        &self.session
+    }
+    fn run_config(&self) -> &RunConfig {
+        &self.config
+    }
+    fn end_invocation(&self) {}
+    fn ended(&self) -> bool {
+        false
+    }
+
+    // Non-default values for each capability the wrappers must preserve.
+    fn is_cancelled(&self) -> bool {
+        true
+    }
+    fn user_scopes(&self) -> Vec<String> {
+        vec![SENTINEL_SCOPE.to_string()]
+    }
+    fn request_metadata(&self) -> HashMap<String, serde_json::Value> {
+        HashMap::from([(SENTINEL_METADATA_KEY.to_string(), serde_json::json!(1))])
+    }
+    async fn get_secret(&self, name: &str) -> Result<Option<String>> {
+        Ok(if name == SENTINEL_SECRET_NAME {
+            Some(SENTINEL_SECRET_VALUE.to_string())
+        } else {
+            None
+        })
+    }
+}
+
+// ── Shared assertion ──────────────────────────────────────────────────
+
+/// Assert that every capability set on the sentinel survives `wrapped`.
+async fn assert_capabilities_preserved(label: &str, wrapped: Arc<dyn InvocationContext>) {
+    assert!(wrapped.is_cancelled(), "{label}: cancellation was dropped");
+
+    assert_eq!(
+        wrapped.user_scopes(),
+        vec![SENTINEL_SCOPE.to_string()],
+        "{label}: authenticated scopes were dropped"
+    );
+
+    assert!(
+        wrapped.request_metadata().contains_key(SENTINEL_METADATA_KEY),
+        "{label}: request metadata was dropped"
+    );
+
+    let secret = wrapped.get_secret(SENTINEL_SECRET_NAME).await.expect("secret lookup failed");
+    assert_eq!(
+        secret.as_deref(),
+        Some(SENTINEL_SECRET_VALUE),
+        "{label}: secret access was dropped"
+    );
+
+    let shared =
+        wrapped.shared_state().unwrap_or_else(|| panic!("{label}: shared state was dropped"));
+    assert!(
+        shared.get_shared(SENTINEL_STATE_KEY).await.is_some(),
+        "{label}: shared state was replaced rather than forwarded"
+    );
+
+    let artifacts =
+        wrapped.artifacts().unwrap_or_else(|| panic!("{label}: artifact service was dropped"));
+    assert_eq!(
+        artifacts.list().await.expect("artifact list failed"),
+        vec![SENTINEL_ARTIFACT.to_string()],
+        "{label}: artifact service was replaced rather than forwarded"
+    );
+
+    let memory = wrapped.memory().unwrap_or_else(|| panic!("{label}: memory service was dropped"));
+    let hits = memory.search("sentinel").await.expect("memory search failed");
+    assert_eq!(
+        hits.first().map(|e| e.author.as_str()),
+        Some(SENTINEL_MEMORY_AUTHOR),
+        "{label}: memory service was replaced rather than forwarded"
+    );
+
+    // Identity must survive untouched too.
+    assert_eq!(wrapped.app_name(), "sentinel-app", "{label}: app name was lost");
+    assert_eq!(wrapped.user_id(), "sentinel-user", "{label}: user id was lost");
+    assert_eq!(wrapped.session_id(), "sentinel-session", "{label}: session id was lost");
+}
+
+async fn sentinel() -> Arc<dyn InvocationContext> {
+    Arc::new(SentinelContext::with_shared(seeded_shared_state(SENTINEL_STATE_KEY).await))
+}
+
+// ── Per-wrapper tests ─────────────────────────────────────────────────
+
+#[tokio::test]
+async fn shared_state_context_preserves_capabilities() {
+    // This wrapper deliberately replaces `shared_state`, so it is checked
+    // separately from the shared assertion.
+    let injected = seeded_shared_state("injected").await;
+    let wrapped: Arc<dyn InvocationContext> =
+        Arc::new(SharedStateContext::new(sentinel().await, injected));
+
+    assert!(wrapped.is_cancelled(), "SharedStateContext: cancellation was dropped");
+    assert_eq!(wrapped.user_scopes(), vec![SENTINEL_SCOPE.to_string()]);
+    assert!(wrapped.request_metadata().contains_key(SENTINEL_METADATA_KEY));
+    let secret = wrapped.get_secret(SENTINEL_SECRET_NAME).await.unwrap();
+    assert_eq!(secret.as_deref(), Some(SENTINEL_SECRET_VALUE));
+    let shared = wrapped.shared_state().expect("shared state missing");
+    assert!(
+        shared.get_shared("injected").await.is_some(),
+        "SharedStateContext must expose the state it injects"
+    );
+    assert!(wrapped.artifacts().is_some(), "SharedStateContext: artifacts were dropped");
+    assert!(wrapped.memory().is_some(), "SharedStateContext: memory was dropped");
+}
+
+#[tokio::test]
+async fn branch_context_preserves_capabilities() {
+    let wrapped: Arc<dyn InvocationContext> =
+        Arc::new(BranchContext::new(sentinel().await, "sentinel-branch.child".to_string()));
+    assert_capabilities_preserved("BranchContext", wrapped.clone()).await;
+    assert_eq!(wrapped.branch(), "sentinel-branch.child", "BranchContext must override branch");
+}
+
+#[tokio::test]
+async fn skill_context_preserves_capabilities() {
+    let overridden = Content {
+        role: "user".to_string(),
+        parts: vec![Part::Text { text: "overridden".to_string() }],
+    };
+    let wrapped =
+        super::skill_context::with_user_content_override(sentinel().await, overridden.clone());
+    assert_capabilities_preserved("UserContentOverrideContext", wrapped.clone()).await;
+    assert_eq!(
+        wrapped.user_content().parts.len(),
+        overridden.parts.len(),
+        "UserContentOverrideContext must override user content"
+    );
+}
+
+#[tokio::test]
+async fn loop_history_context_preserves_capabilities() {
+    let wrapped = super::loop_agent::history_tracking_context_for_test(sentinel().await);
+    assert_capabilities_preserved("HistoryTrackingContext", wrapped).await;
+}
+
+/// Wrappers compose, so a capability dropped by an inner wrapper is lost even if
+/// the outer one forwards correctly. `ParallelAgent` builds exactly this stack.
+#[tokio::test]
+async fn composed_wrappers_preserve_capabilities() {
+    let injected = seeded_shared_state(SENTINEL_STATE_KEY).await;
+    let inner: Arc<dyn InvocationContext> =
+        Arc::new(SharedStateContext::new(sentinel().await, injected));
+    let outer: Arc<dyn InvocationContext> =
+        Arc::new(BranchContext::new(inner, "sentinel-branch.parallel.a".to_string()));
+
+    assert_capabilities_preserved("BranchContext(SharedStateContext)", outer.clone()).await;
+    assert_eq!(outer.branch(), "sentinel-branch.parallel.a");
+}
+
+/// An `Event` carries no capabilities, but this pins the sentinel itself: if the
+/// trait gains a capability method, the sentinel must set a non-default value or
+/// these tests silently stop covering it.
+#[tokio::test]
+async fn sentinel_reports_non_default_capabilities() {
+    let ctx = SentinelContext::with_shared(seeded_shared_state(SENTINEL_STATE_KEY).await);
+    assert!(ctx.is_cancelled());
+    assert!(!ctx.user_scopes().is_empty());
+    assert!(!ctx.request_metadata().is_empty());
+    assert!(ctx.shared_state().is_some());
+    assert!(ctx.artifacts().is_some());
+    assert!(ctx.memory().is_some());
+    let _ = Event::new("sentinel-invocation");
+}

--- a/adk-tool/src/agent_tool.rs
+++ b/adk-tool/src/agent_tool.rs
@@ -388,6 +388,10 @@ impl CallbackContext for AgentToolInvocationContext {
     fn artifacts(&self) -> Option<Arc<dyn Artifacts>> {
         if self.forward_artifacts { self.parent_ctx.artifacts() } else { None }
     }
+
+    fn shared_state(&self) -> Option<Arc<adk_core::SharedState>> {
+        self.parent_ctx.shared_state()
+    }
 }
 
 #[async_trait]
@@ -423,6 +427,23 @@ impl InvocationContext for AgentToolInvocationContext {
     fn ended(&self) -> bool {
         self.ended.load(std::sync::atomic::Ordering::SeqCst)
     }
+
+    /// Authenticated scopes are forwarded so a scope-guarded tool used by the
+    /// wrapped agent sees the caller's grants rather than an empty set.
+    fn user_scopes(&self) -> Vec<String> {
+        self.parent_ctx.user_scopes()
+    }
+
+    /// Secret access is forwarded so the wrapped agent's tools can resolve
+    /// secrets through the same provider as the calling agent.
+    async fn get_secret(&self, name: &str) -> adk_core::Result<Option<String>> {
+        self.parent_ctx.get_secret(name).await
+    }
+
+    // `is_cancelled` and `request_metadata` are not forwarded: they are not part
+    // of the `ToolContext` surface this wrapper is constructed from, so there is
+    // nothing to delegate to. Cancellation therefore does not currently reach an
+    // agent invoked as a tool.
 }
 
 // Minimal session for sub-agent execution


### PR DESCRIPTION
## What

Every workflow context wrapper now forwards every capability, and a conformance suite keeps it that way.

| Wrapper | Was dropping |
|---|---|
| `HistoryTrackingContext` (`LoopAgent`) | cancellation, secrets, shared state |
| `UserContentOverrideContext` (skill injection) | **all five** capabilities |
| `SharedStateContext` (`ParallelAgent`) | cancellation, secrets |
| `AgentToolInvocationContext` (`adk-tool`) | every delegatable capability |

## Why

Each wrapper re-implements `InvocationContext` and delegates to an inner context, but most capability methods have permissive trait defaults — `is_cancelled()` is `false`, `get_secret()` is `None`, and `shared_state()`, `user_scopes()`, `request_metadata()` are empty. A wrapper that omitted one still compiled and silently lost it, so what a sub-agent could do depended on which workflow agent it happened to run under.

The most visible consequence: `llm_agent.rs` has three `ctx.is_cancelled()` checks, and all three read `false` through these wrappers. **`Runner::interrupt` did not stop an LLM agent nested under a loop, a skill-injected agent, or a parallel branch.**

`AgentToolInvocationContext` was not part of the original finding; it turned up while auditing every `impl InvocationContext` in the workspace.

## How

The individual delegations are trivial. The durable part is the conformance suite: it pushes a sentinel context with a non-default value for **every** capability — cancellation, secrets, scopes, request metadata, shared state, artifacts, memory, identity — through each wrapper, and through a composed stack, since an inner wrapper that drops a capability defeats a correct outer one. That composed shape is what `ParallelAgent` builds.

Verified the suite catches regressions rather than merely passing:

| Sabotage | Result |
|---|---|
| Remove the delegations from the three workflow wrappers | **4 of 6 tests fail**, each naming the capability (`HistoryTrackingContext: cancellation was dropped`, `BranchContext(SharedStateContext): cancellation was dropped`, …) |
| Make `BranchContext` return `None` for artifacts/memory | fails with `BranchContext: artifact service was dropped` |

That second check exists because the first version of this suite had a hole: the sentinel returned `None` for `artifacts()` and `memory()` with zero assertions on either, so a wrapper dropping them would have passed. Both are now real implementations with assertions.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo nextest run --workspace --profile ci` | **3765 passed**, 83 skipped |
| conformance suite | 6 passed |

Rebased onto `main` after #464 merged; both changelog entries verified present after the rebase.

## Known gaps left open deliberately

**1. Cancellation still does not reach an agent invoked as a tool.** `is_cancelled` and `request_metadata` are not part of the `ToolContext` surface `AgentToolInvocationContext` is constructed from, so there is nothing to delegate to. Closing it means adding those methods to `ToolContext`, which has many implementors (realtime, eval, `SimpleToolContext`) that would each want to forward them. Recorded in a code comment, the commit message, and the changelog rather than expanded into this PR.

**2. The structural fix is not done.** The original finding asked for "a reusable delegating context adapter that forwards every capability by default". This PR hand-delegates and tests instead, so the hazard remains: the next wrapper is still ~20 manual delegations against permissive defaults.

Both reference implementations avoid this class of bug entirely, and neither hand-delegates:

- **ADK Python** never wraps. Derived contexts are pydantic copies — `invocation_context.model_copy()` then mutate `.branch` (`parallel_agent.py:46`), or `model_copy(update={'agent': self})` (`base_agent.py:441`) — so every field carries over by construction. There is no `is_cancelled` on the context at all; cancellation is ambient asyncio task cancellation.
- **ADK Go** has an explicit delta type: `WithDelta` does `res := *c` and applies only the fields present in `InvocationContextDelta{Context, UserContent, Agent, Branch, IsolationScope}`. `InvocationContext` embeds `context.Context`, so cancellation propagates via `ctx.Done()`.

The equivalent here would be delta-style derivation on the runner's concrete context (`with_branch`, `with_user_content`, `with_shared_state`), which would delete all four wrapper types and also fix the graph's synthetic `GraphInvocationContext`. Larger refactor, its own change.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed — n/a, no capability change
- [x] Examples added or updated for new features — n/a