### PR TITLE
fix(agent): surface provider errors instead of silent successful turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -318,6 +318,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **adk-agent: provider errors are no longer reported as successful turns.**
+  `LlmResponse` carries `interrupted`, `error_code`, and `error_message`, and a
+  provider adapter can report a terminal failure inside an otherwise successful
+  stream item — `adk-anthropic`'s `from_stream_error`, the OpenAI Responses error
+  event, and the OpenAI websocket transport all do. `LlmAgent` copied content,
+  finish reason, usage, and provider metadata onto its events but not those three
+  fields, and never inspected them, so a failed turn arrived as an ordinary event
+  with no content and the run completed successfully. Callers, persistence, retry
+  policy, and telemetry could not distinguish a provider failure from a model that
+  simply said nothing.
+
+  Those fields now travel with both partial and final events, and a terminal
+  `error_code` ends the run with an `AdkError` coded `model.provider_error`,
+  carrying the provider's own code in the error details under
+  `provider_error_code`. The event is emitted *before* the failure so the failed
+  turn stays observable and persisted rather than vanishing into an error.
+  `interrupted` is recorded but is not treated as terminal, and truncation is
+  unaffected: a response cut short by a token limit reports
+  `finish_reason: MaxTokens` and no error code.
+
 - **adk-agent/adk-tool: workflow context wrappers no longer drop cancellation,
   secrets, and shared state.** Each wrapper re-implements `InvocationContext` and
   delegates to an inner context, but most capability methods have permissive trait

--- a/adk-agent/src/llm_agent.rs
+++ b/adk-agent/src/llm_agent.rs
@@ -1830,6 +1830,12 @@ impl Agent for LlmAgent {
                             partial_event.llm_response.content = chunk.content.clone();
                             partial_event.llm_response.provider_metadata = chunk.provider_metadata.clone();
                             partial_event.llm_response.interaction_id = chunk.interaction_id.clone();
+                            // Terminal error fields travel with the event. Without this a
+                            // provider failure delivered as `Ok(LlmResponse { error_code, .. })`
+                            // reached the caller as an ordinary, apparently successful turn.
+                            partial_event.llm_response.interrupted = chunk.interrupted;
+                            partial_event.llm_response.error_code = chunk.error_code.clone();
+                            partial_event.llm_response.error_message = chunk.error_message.clone();
 
                             // Populate long_running_tool_ids
                             if let Some(ref content) = chunk.content {
@@ -1884,6 +1890,9 @@ impl Agent for LlmAgent {
                             final_event.llm_response.usage_metadata = last.usage_metadata.clone();
                             final_event.llm_response.provider_metadata = last.provider_metadata.clone();
                             final_event.llm_response.interaction_id = last.interaction_id.clone();
+                            final_event.llm_response.interrupted = last.interrupted;
+                            final_event.llm_response.error_code = last.error_code.clone();
+                            final_event.llm_response.error_message = last.error_message.clone();
                             final_provider_metadata = last.provider_metadata.clone();
                             final_event.provider_metadata.insert("gcp.vertex.agent.llm_response".to_string(), serde_json::to_string(last).unwrap_or_default());
                         }
@@ -1894,6 +1903,50 @@ impl Agent for LlmAgent {
                         }
 
                         yield Ok(final_event);
+                    }
+
+                    // A provider that reports a terminal error inside an `Ok`
+                    // response ends the turn. The event above already carries the
+                    // error fields so the failure is observable and persisted;
+                    // this converts it into a `Result` failure so callers, retry
+                    // policy, and telemetry see it rather than reading an empty
+                    // turn as success.
+                    //
+                    // In this workspace `error_code` marks a genuine failure —
+                    // truncation is reported through `finish_reason`
+                    // (`FinishReason::MaxTokens`), not through `error_code`.
+                    if let Some(ref last) = last_chunk
+                        && let Some(ref code) = last.error_code
+                    {
+                        let message = last
+                            .error_message
+                            .clone()
+                            .unwrap_or_else(|| "provider reported a terminal error".to_string());
+                        tracing::error!(
+                            error.code = %code,
+                            error.message = %message,
+                            agent = %agent_name,
+                            "model reported a terminal error"
+                        );
+                        // The provider's own code is preserved in the ADK error code
+                        // so retry policy and telemetry can key on it.
+                        // Built before the yield point: a borrow may not cross it.
+                        // `AdkError::code` is `&'static str`, so the provider's own
+                        // code travels in the details metadata instead, where retry
+                        // policy and telemetry can read it.
+                        let mut details = adk_core::ErrorDetails::default();
+                        details
+                            .metadata
+                            .insert("provider_error_code".to_string(), serde_json::json!(code));
+                        let provider_error = adk_core::AdkError::new(
+                            adk_core::ErrorComponent::Model,
+                            adk_core::ErrorCategory::Internal,
+                            "model.provider_error",
+                            format!("{code}: {message}"),
+                        )
+                        .with_details(details);
+                        yield Err(provider_error);
+                        return;
                     }
 
                     // Record LLM response to span before guard drops

--- a/adk-agent/tests/provider_error_tests.rs
+++ b/adk-agent/tests/provider_error_tests.rs
@@ -1,0 +1,260 @@
+//! Provider errors delivered inside an `Ok` response must not read as success.
+//!
+//! `LlmResponse` carries `interrupted`, `error_code`, and `error_message`. A
+//! provider adapter can report a terminal failure that way — `adk-anthropic`'s
+//! `from_stream_error`, the OpenAI Responses error event, and the OpenAI
+//! websocket transport all do. `LlmAgent` previously copied content, finish
+//! reason, usage, and provider metadata onto its events but not those three
+//! fields, and never inspected them, so a failed turn arrived as an ordinary
+//! event with no content and the run completed successfully.
+
+use adk_agent::LlmAgentBuilder;
+use adk_core::{
+    Agent, Content, FinishReason, InvocationContext, Llm, LlmRequest, LlmResponse,
+    LlmResponseStream, Part, Result, RunConfig, Session, State,
+};
+use async_trait::async_trait;
+use futures::StreamExt;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+// ── Mocks ─────────────────────────────────────────────────────────────
+
+struct MockModel {
+    response: LlmResponse,
+}
+
+impl MockModel {
+    /// An ordinary successful text turn.
+    fn new_text(text: &str) -> Self {
+        Self { response: base(Some(text), Some(FinishReason::Stop), false, None, None) }
+    }
+
+    /// A provider reporting a terminal error inside a successful stream item,
+    /// with no content — the shape `from_stream_error` produces.
+    fn new_provider_error(code: &str, message: &str) -> Self {
+        Self { response: base(None, None, false, Some(code), Some(message)) }
+    }
+
+    /// A provider reporting an interruption mid-turn.
+    fn new_interrupted() -> Self {
+        Self { response: base(Some("partial answer"), None, true, None, None) }
+    }
+}
+
+fn base(
+    text: Option<&str>,
+    finish_reason: Option<FinishReason>,
+    interrupted: bool,
+    error_code: Option<&str>,
+    error_message: Option<&str>,
+) -> LlmResponse {
+    LlmResponse {
+        content: text.map(|t| Content {
+            role: "model".to_string(),
+            parts: vec![Part::Text { text: t.to_string() }],
+        }),
+        usage_metadata: None,
+        finish_reason,
+        citation_metadata: None,
+        partial: false,
+        turn_complete: true,
+        interrupted,
+        error_code: error_code.map(str::to_string),
+        error_message: error_message.map(str::to_string),
+        provider_metadata: None,
+        interaction_id: None,
+    }
+}
+
+#[async_trait]
+impl Llm for MockModel {
+    fn name(&self) -> &str {
+        "mock-model"
+    }
+
+    async fn generate_content(&self, _req: LlmRequest, _stream: bool) -> Result<LlmResponseStream> {
+        let response = self.response.clone();
+        let s = async_stream::stream! {
+            yield Ok(response);
+        };
+        Ok(Box::pin(s))
+    }
+}
+
+struct MockState;
+
+impl State for MockState {
+    fn get(&self, _key: &str) -> Option<Value> {
+        None
+    }
+    fn set(&mut self, _key: String, _value: Value) {}
+    fn all(&self) -> HashMap<String, Value> {
+        HashMap::new()
+    }
+}
+
+struct MockSession;
+
+impl Session for MockSession {
+    fn id(&self) -> &str {
+        "session-1"
+    }
+    fn app_name(&self) -> &str {
+        "test-app"
+    }
+    fn user_id(&self) -> &str {
+        "user-1"
+    }
+    fn state(&self) -> &dyn State {
+        &MockState
+    }
+    fn conversation_history(&self) -> Vec<Content> {
+        Vec::new()
+    }
+}
+
+struct MockContext {
+    session: MockSession,
+    user_content: Content,
+}
+
+impl MockContext {
+    fn new() -> Self {
+        Self {
+            session: MockSession,
+            user_content: Content {
+                role: "user".to_string(),
+                parts: vec![Part::Text { text: "start".to_string() }],
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl adk_core::ReadonlyContext for MockContext {
+    fn invocation_id(&self) -> &str {
+        "inv-1"
+    }
+    fn agent_name(&self) -> &str {
+        "test-agent"
+    }
+    fn user_id(&self) -> &str {
+        "user-1"
+    }
+    fn app_name(&self) -> &str {
+        "test-app"
+    }
+    fn session_id(&self) -> &str {
+        "session-1"
+    }
+    fn branch(&self) -> &str {
+        "main"
+    }
+    fn user_content(&self) -> &Content {
+        &self.user_content
+    }
+}
+
+#[async_trait]
+impl adk_core::CallbackContext for MockContext {
+    fn artifacts(&self) -> Option<Arc<dyn adk_core::Artifacts>> {
+        None
+    }
+}
+
+#[async_trait]
+impl InvocationContext for MockContext {
+    fn agent(&self) -> Arc<dyn Agent> {
+        unimplemented!("not exercised by these tests")
+    }
+    fn memory(&self) -> Option<Arc<dyn adk_core::Memory>> {
+        None
+    }
+    fn session(&self) -> &dyn Session {
+        &self.session
+    }
+    fn run_config(&self) -> &RunConfig {
+        static RUN_CONFIG: std::sync::OnceLock<RunConfig> = std::sync::OnceLock::new();
+        RUN_CONFIG.get_or_init(RunConfig::default)
+    }
+    fn end_invocation(&self) {}
+    fn ended(&self) -> bool {
+        false
+    }
+}
+
+/// Drain an agent run into (events, errors).
+async fn run(model: MockModel) -> (Vec<adk_core::Event>, Vec<adk_core::AdkError>) {
+    let agent = LlmAgentBuilder::new("test-agent").model(Arc::new(model)).build().unwrap();
+    let mut stream = agent.run(Arc::new(MockContext::new())).await.unwrap();
+    let (mut events, mut errors) = (Vec::new(), Vec::new());
+    while let Some(result) = stream.next().await {
+        match result {
+            Ok(event) => events.push(event),
+            Err(e) => errors.push(e),
+        }
+    }
+    (events, errors)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn a_provider_error_ends_the_turn_with_an_error() {
+    let (_events, errors) =
+        run(MockModel::new_provider_error("overloaded_error", "the model is overloaded")).await;
+
+    assert_eq!(errors.len(), 1, "the run must fail, not complete successfully");
+    let rendered = errors[0].to_string();
+    assert!(
+        rendered.contains("overloaded_error"),
+        "the provider's code must survive into the error: {rendered}"
+    );
+    assert!(
+        rendered.contains("the model is overloaded"),
+        "the provider's message must survive into the error: {rendered}"
+    );
+}
+
+#[tokio::test]
+async fn the_emitted_event_records_the_provider_error() {
+    // The event is emitted before the failure, so the turn stays observable and
+    // persistable rather than vanishing into an error.
+    let (events, _errors) =
+        run(MockModel::new_provider_error("rate_limit_error", "slow down")).await;
+
+    let carrying = events
+        .iter()
+        .find(|e| e.llm_response.error_code.is_some())
+        .expect("an event must carry the provider error fields");
+    assert_eq!(carrying.llm_response.error_code.as_deref(), Some("rate_limit_error"));
+    assert_eq!(carrying.llm_response.error_message.as_deref(), Some("slow down"));
+}
+
+#[tokio::test]
+async fn an_interruption_is_recorded_on_the_event() {
+    // `interrupted` is not a failure, so the run still succeeds — but the flag
+    // must reach the caller instead of being dropped.
+    let (events, errors) = run(MockModel::new_interrupted()).await;
+
+    assert!(errors.is_empty(), "an interruption alone is not a terminal error");
+    assert!(
+        events.iter().any(|e| e.llm_response.interrupted),
+        "the interrupted flag must be recorded on an event"
+    );
+}
+
+#[tokio::test]
+async fn a_healthy_turn_still_succeeds() {
+    // Guards against the error path firing on ordinary responses.
+    let (events, errors) = run(MockModel::new_text("a perfectly ordinary answer")).await;
+
+    assert!(errors.is_empty(), "a healthy turn must not fail");
+    assert!(!events.is_empty());
+    assert!(
+        events.iter().all(|e| e.llm_response.error_code.is_none()),
+        "a healthy turn must not carry an error code"
+    );
+}

--- a/docs/official_docs/agents/workflow-agents.md
+++ b/docs/official_docs/agents/workflow-agents.md
@@ -153,6 +153,21 @@ fan-out but not what its siblings produced, so concurrent branches cannot
 contaminate each other's context. Use `ParallelAgent::with_shared_state()` when
 you *want* sub-agents to coordinate.
 
+Branches are polled together, so wall-clock cost is roughly the slowest branch
+rather than the sum of all of them, and a slow branch does not hold up the
+others. Two consequences worth designing around:
+
+- **Events interleave.** Events arrive in the order branches produce them, not
+  grouped per sub-agent. Use `event.author` (or `event.branch`) to attribute a
+  chunk to its branch. Ordering across branches is not guaranteed.
+- **One error ends the run, chosen deterministically.** Every branch still runs
+  to completion, and a single terminal error is surfaced afterwards. When more
+  than one branch fails, the error reported is the one from the earliest
+  sub-agent in declaration order — not whichever failed first in wall-clock
+  terms, which concurrency would make a race.
+
+Dropping the event stream early tears down branches that are still in flight.
+
 ### When to Use
 
 - Multiple perspectives on the same topic

--- a/docs/official_docs/core/core.md
+++ b/docs/official_docs/core/core.md
@@ -437,23 +437,59 @@ Full context for agent execution (extends CallbackContext):
 pub trait InvocationContext: CallbackContext {
     /// The agent being executed
     fn agent(&self) -> Arc<dyn Agent>;
-    
+
     /// Memory service (if configured)
     fn memory(&self) -> Option<Arc<dyn Memory>>;
-    
+
     /// Current session with state and history
     fn session(&self) -> &dyn Session;
-    
+
     /// Execution configuration
     fn run_config(&self) -> &RunConfig;
-    
+
     /// Signal that this invocation should end
     fn end_invocation(&self);
-    
+
     /// Check if invocation has been ended
     fn ended(&self) -> bool;
+
+    // Capability methods — all have defaults, so an implementation may omit them.
+
+    /// Whether the run has been cancelled, e.g. by `Runner::interrupt`.
+    /// Default: `false`.
+    fn is_cancelled(&self) -> bool;
+
+    /// Authenticated scopes for the caller. Default: empty.
+    fn user_scopes(&self) -> Vec<String>;
+
+    /// Request-scoped metadata. Default: empty.
+    fn request_metadata(&self) -> HashMap<String, serde_json::Value>;
+
+    /// Resolve a secret through the configured provider. Default: `Ok(None)`.
+    async fn get_secret(&self, name: &str) -> Result<Option<String>>;
 }
 ```
+
+#### Capability preservation in derived contexts
+
+The capability methods above, plus `shared_state()` and `artifacts()` on
+`CallbackContext`, all have permissive defaults — `false`, empty, or `None`. That
+matters when a context is *derived*: workflow agents wrap the caller's context to
+change one thing (a branch, the user content, the session), and a wrapper that
+does not forward a capability method silently falls back to its default rather
+than failing to compile.
+
+Every wrapper in the workspace forwards all of them, and a conformance suite
+enforces it by pushing a context with non-default values for each capability
+through each wrapper, including a composed stack. Practically this means
+cancellation, secrets, scopes, request metadata, shared state, artifacts, and
+memory reach a sub-agent regardless of whether it runs directly, under a
+`LoopAgent`, under a `ParallelAgent`, or with skills injected.
+
+> **Note:** if you implement `InvocationContext` yourself by wrapping another
+> context, forward every method above. `ToolContext` does not expose
+> `is_cancelled` or `request_metadata`, so an agent invoked *as a tool* does not
+> currently observe cancellation.
 
 ---
 

--- a/docs/official_docs/events/events.md
+++ b/docs/official_docs/events/events.md
@@ -63,7 +63,7 @@ if let Some(content) = &event.llm_response.content {
 
 - **invocation_id**: Groups events that belong to the same agent invocation. When an agent processes a message, all events generated (agent response, tool calls, sub-agent calls) share the same invocation_id.
 
-- **branch**: Reserved for future branching functionality. Currently unused but allows for conversation branching in future versions.
+- **branch**: The conversation branch the event was produced on. `ParallelAgent` places each sub-agent on its own branch (`{parent}.{parallel_agent}.{sub_agent}`) and stamps the events it emits, so history reads scoped to a branch exclude what sibling branches produced. An event is visible from a branch when its own branch equals that branch or is an *ancestor* of it; siblings and nested descendants are not. An empty branch means "unscoped" and stays visible everywhere, so events written without one are unaffected. See [Workflow Agents](../agents/workflow-agents.md#parallelagent).
 
 - **author**: Identifies who created the event:
   - User messages: typically "user" or a user identifier
@@ -72,6 +72,20 @@ if let Some(content) = &event.llm_response.content {
   - System events: "system"
 
 - **llm_response**: Contains the message content and LLM metadata. Access content via `event.llm_response.content`. The `Content` type can contain text, multimodal parts (images, audio), or structured data. Some events (like pure state updates) may have `content: None`.
+
+- **llm_response.error_code / error_message**: Set when the provider reported a terminal failure for the turn. Providers can report a failure inside an otherwise successful stream item — `adk-anthropic`'s stream errors, the OpenAI Responses error event, and the OpenAI websocket transport all do — so these fields are how a failed turn is distinguished from an empty one. `LlmAgent` emits the event carrying them *and then* ends the run with an `AdkError` whose code is `model.provider_error`, with the provider's own code in the error details under `provider_error_code`. The event is emitted first so the failed turn is still observable and persisted rather than disappearing into an error.
+
+  Truncation is **not** reported this way: a response cut short by a token limit carries `finish_reason: FinishReason::MaxTokens` and no error code.
+
+- **llm_response.interrupted**: The generation was interrupted (for example a realtime turn cut off by the user, or a tool confirmation pausing the turn). This is recorded on the event but is **not** a terminal error on its own, so the run does not fail.
+
+```rust
+// Distinguishing a failed turn from an empty one
+if let Some(code) = &event.llm_response.error_code {
+    let detail = event.llm_response.error_message.as_deref().unwrap_or("no message");
+    eprintln!("provider reported {code}: {detail}");
+}
+```
 
 ## EventActions
 


### PR DESCRIPTION
## What

A provider failure delivered inside an `Ok(LlmResponse)` now ends the run with a structured error, and the error fields reach the event. Docs for this and the two preceding agent fixes (#464, #465), which shipped code-only.

## Why

`LlmResponse` carries `interrupted`, `error_code`, and `error_message`. Adapters report terminal failures that way — `adk-anthropic`'s `from_stream_error`, the OpenAI Responses error event, and the OpenAI websocket transport all do. `LlmAgent` copied content, finish reason, usage, and provider metadata onto its events but **not** those three fields, and never inspected them.

A failed turn therefore arrived as an ordinary event with no content and the run completed successfully. Callers, persistence, retry policy, and telemetry could not distinguish a provider failure from a model that simply said nothing.

## How

- The three fields travel with both partial and final events.
- A terminal `error_code` ends the run with `AdkError` coded `model.provider_error`, with the provider's own code in details under `provider_error_code`.
- The event is emitted **before** the failure, so the failed turn stays observable and persisted rather than vanishing into an error.
- `interrupted` is recorded but not treated as terminal.

### Why raising is right here but wrong upstream

The reference implementations point the other way, and that is worth stating: **ADK Python carries the error fields onto the event and never raises.** It can't raise, because it overloads `error_code` with mapped finish reasons including `MAX_TOKENS` (`lite_llm.py:2125`), so failing the run on any error code would break legitimate truncated responses.

Our adapters do not do that. `error_code` here is set only for genuine failures (Anthropic stream errors, OpenAI cancellation, Responses error events, ws transport errors), while truncation is reported via `finish_reason: FinishReason::MaxTokens`. That difference is recorded in a code comment so the behaviour is not later "corrected" toward Python.

## Documentation

`events/events.md` was actively wrong and is corrected:

- **`branch`** was documented as *"reserved for future branching functionality. Currently unused"*. #464 made it load-bearing. It now describes per-sub-agent branch derivation and the ancestor visibility rule.
- **`error_code` / `error_message` / `interrupted`** were listed in the struct but never explained. Now documented, including that truncation is *not* reported through them.

`agents/workflow-agents.md` records the observable consequences of #464 that a user has to design around: branches are polled together, **events interleave** and should be attributed via `event.author`, a single error is surfaced chosen by declaration order, and dropping the stream tears down in-flight branches.

`core/core.md` documents the capability methods on `InvocationContext` — absent from the trait listing entirely — plus the preservation guarantee from #465 and the `ToolContext` limitation that leaves an agent-as-tool blind to cancellation.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo nextest run --workspace --profile ci` | **3769 passed**, 83 skipped |
| `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps` | exit 0 |
| doc-examples / doc-versions guards | exit 0 |
| links in touched docs | none broken |

Four regression tests; **three fail against the previous implementation** (the fourth is a healthy-turn control that must pass both ways).

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed — n/a
- [x] Examples added or updated for new features — n/a