### PR TITLE
fix(graph): checkpoint the frontier that still has to run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -318,6 +318,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **adk-graph: checkpoints recorded finished work as pending, and streamed runs
+  never checkpointed at all.** Three defects in `PregelExecutor`:
+
+  1. `run` saved its checkpoint *before* advancing the frontier, so the stored
+     `pending_nodes` were the nodes that had just completed. Resuming re-executed
+     them and re-applied their updates, which is wrong for any node that is not
+     idempotent — counters, accumulators, appends, and external side effects.
+     Checkpoints are now written after the frontier advances, and a finished run
+     records an empty frontier so resuming a completed thread returns the final
+     state instead of restarting the graph. Interrupts deliberately keep saving
+     the executing frontier, because an interrupted node still owes its updates.
+  2. `run_stream` saved no checkpoints, and its interrupt path returned without
+     saving one — so a streamed run could not be resumed and a streamed
+     human-in-the-loop interrupt was unrecoverable. Streamed runs now checkpoint
+     on the same schedule as blocking runs, including on interrupt.
+  3. In `StreamMode::Messages` the executor drained `execute_stream` for events
+     and then called `execute` again to obtain state updates, running every node
+     twice per super-step. For `AgentNode` that meant two billed model calls per
+     node, and the streamed tokens came from a different execution than the state
+     that was kept. Nodes now report their updates on the stream as
+     `StreamEvent::Updates`, and the executor applies those from the single
+     execution.
+
+  `Node::execute_stream` therefore carries a new contract: an implementation must
+  yield a `StreamEvent::Updates` event with its state updates. The default
+  implementation does this, so nodes built from closures are unaffected. A custom
+  override that does not will stream events but contribute no state in `Messages`
+  mode. `AgentNode::execute_stream` now applies its output mapper, which it
+  previously never did. Timeout policies now apply to the streamed execution
+  itself, where `idle_timeout` means no event was produced within the limit.
+
 - **adk-agent/adk-tool: workflow context wrappers no longer drop cancellation,
   secrets, and shared state.** Each wrapper re-implements `InvocationContext` and
   delegates to an inner context, but most capability methods have permissive trait

--- a/adk-graph/src/executor.rs
+++ b/adk-graph/src/executor.rs
@@ -11,7 +11,7 @@ use crate::interrupt::Interrupt;
 use crate::node::{ExecutionConfig, NodeContext};
 use crate::state::{Checkpoint, State};
 use crate::stream::{StreamEvent, StreamMode};
-use crate::timeout::{ProgressHandle, execute_with_timeout};
+use crate::timeout::{OnTimeout, ProgressHandle, execute_with_timeout, item_timeout_budget};
 use futures::stream::{self, StreamExt};
 use std::collections::HashMap;
 use std::time::Instant;
@@ -129,6 +129,9 @@ impl<'a> PregelExecutor<'a> {
 
             // Handle interrupts
             if let Some(interrupt) = result.interrupt {
+                // The frontier saved here is deliberately the one that was
+                // executing: an interrupted node has not produced its updates,
+                // so resuming must run it again.
                 let checkpoint_id = self.save_checkpoint().await?;
                 return Err(GraphError::Interrupted(Box::new(InterruptedExecution::new(
                     self.config.thread_id.clone(),
@@ -139,22 +142,21 @@ impl<'a> PregelExecutor<'a> {
                 ))));
             }
 
-            // Save checkpoint after each step
-            self.save_checkpoint().await?;
-
-            // Check if we're done (all paths led to END)
-            if self.graph.leads_to_end(&result.executed_nodes, &self.state) {
-                let next = self.graph.get_next_nodes(&result.executed_nodes, &self.state);
-                if next.is_empty() {
-                    break;
-                }
-            }
-
-            // Determine next nodes and apply deferred node filtering
+            // Advance the frontier *before* checkpointing. A checkpoint records
+            // what still has to run, so saving while `pending_nodes` still holds
+            // the nodes that just finished would re-execute them on resume.
             let next_candidates = self.graph.get_next_nodes(&result.executed_nodes, &self.state);
             self.pending_nodes =
                 self.filter_deferred_nodes(next_candidates, &result.executed_nodes)?;
             self.step += 1;
+
+            // An empty frontier is a terminal checkpoint: resuming it re-reads
+            // the final state instead of restarting the graph.
+            self.save_checkpoint().await?;
+
+            if self.pending_nodes.is_empty() {
+                break;
+            }
         }
 
         Ok(self.state.clone())
@@ -228,20 +230,93 @@ impl<'a> PregelExecutor<'a> {
 
                             let start = std::time::Instant::now();
 
-                            let mut node_stream = node.execute_stream(&ctx);
+                            // The timeout policy now applies to the streamed
+                            // execution itself. For a stream, "idle" means no
+                            // event was produced within the idle timeout.
+                            let max_attempts = match policy.as_ref().map(|p| &p.on_timeout) {
+                                Some(OnTimeout::Retry { max_attempts }) => (*max_attempts).max(1),
+                                _ => 1,
+                            };
                             let mut collected_events = Vec::new();
+                            let mut streamed_updates = Vec::new();
+                            let mut timed_out_after;
+                            let mut attempt = 0;
 
-                            while let Some(event_result) = node_stream.next().await {
-                                match event_result {
-                                    Ok(event) => {
-                                        // Yield Message events immediately
-                                        if matches!(event, StreamEvent::Message { .. }) {
-                                            yield Ok(event.clone());
+                            loop {
+                                attempt += 1;
+                                collected_events.clear();
+                                streamed_updates.clear();
+                                timed_out_after = None;
+                                let attempt_start = std::time::Instant::now();
+                                let mut node_stream = node.execute_stream(&ctx);
+                                let mut failure = None;
+
+                                loop {
+                                    let budget = policy
+                                        .as_ref()
+                                        .and_then(|p| item_timeout_budget(p, attempt_start.elapsed()));
+                                    let item = match budget {
+                                        Some(budget) => {
+                                            match tokio::time::timeout(budget, node_stream.next()).await {
+                                                Ok(item) => item,
+                                                Err(_) => {
+                                                    timed_out_after = Some(attempt_start.elapsed());
+                                                    break;
+                                                }
+                                            }
                                         }
-                                        collected_events.push(event);
+                                        None => node_stream.next().await,
+                                    };
+
+                                    match item {
+                                        Some(Ok(event)) => {
+                                            // Yield Message events immediately
+                                            if matches!(event, StreamEvent::Message { .. }) {
+                                                yield Ok(event.clone());
+                                            }
+                                            // The node reports its state updates on the
+                                            // stream, so they are taken from the single
+                                            // execution that produced these events.
+                                            if let StreamEvent::Updates { ref updates, .. } = event {
+                                                streamed_updates.push(updates.clone());
+                                            }
+                                            collected_events.push(event);
+                                        }
+                                        Some(Err(e)) => {
+                                            failure = Some(e);
+                                            break;
+                                        }
+                                        None => break,
                                     }
-                                    Err(e) => {
-                                        yield Err(e);
+                                }
+                                drop(node_stream);
+
+                                if let Some(e) = failure {
+                                    yield Err(e);
+                                    return;
+                                }
+                                if timed_out_after.is_none() || attempt >= max_attempts {
+                                    break;
+                                }
+                            }
+
+                            if let Some(elapsed) = timed_out_after {
+                                let on_timeout =
+                                    policy.as_ref().map(|p| p.on_timeout.clone()).unwrap_or_default();
+                                match on_timeout {
+                                    OnTimeout::Skip => {
+                                        tracing::warn!(
+                                            node = %node_name,
+                                            elapsed = ?elapsed,
+                                            "node timed out while streaming, skipping"
+                                        );
+                                        streamed_updates.clear();
+                                    }
+                                    OnTimeout::Fail | OnTimeout::Retry { .. } => {
+                                        yield Err(GraphError::NodeTimedOut {
+                                            node: node_name.clone(),
+                                            elapsed,
+                                        });
                                         return;
                                     }
                                 }
@@ -252,15 +327,8 @@ impl<'a> PregelExecutor<'a> {
                             result.events.push(StreamEvent::node_end(node_name, self.step, duration_ms));
                             result.events.extend(collected_events);
 
-                            // Get output from execute for state updates, with timeout if configured
-                            let output_result = match policy {
-                                Some(ref timeout_policy) => {
-                                    execute_with_timeout(node.as_ref(), &ctx, timeout_policy).await
-                                }
-                                None => node.execute(&ctx).await,
-                            };
-                            if let Ok(output) = output_result {
-                                for (key, value) in output.updates {
+                            for updates in streamed_updates {
+                                for (key, value) in updates {
                                     self.graph.schema.apply_update(&mut self.state, &key, value);
                                 }
                             }
@@ -324,6 +392,14 @@ impl<'a> PregelExecutor<'a> {
 
                 // Handle interrupts
                 if let Some(interrupt) = result.interrupt {
+                    // Persist before reporting: without this the interrupt is
+                    // unresumable, because resuming loads the checkpoint for the
+                    // thread. The frontier saved is the one that was executing,
+                    // since an interrupted node still owes its updates.
+                    if let Err(e) = self.save_checkpoint().await {
+                        yield Err(e);
+                        return;
+                    }
                     yield Ok(StreamEvent::interrupted(
                         result.executed_nodes.first().map(|s| s.as_str()).unwrap_or("unknown"),
                         &interrupt.to_string(),
@@ -331,14 +407,8 @@ impl<'a> PregelExecutor<'a> {
                     return;
                 }
 
-                // Check if done
-                if self.graph.leads_to_end(&result.executed_nodes, &self.state) {
-                    let next = self.graph.get_next_nodes(&result.executed_nodes, &self.state);
-                    if next.is_empty() {
-                        break;
-                    }
-                }
-
+                // Advance the frontier before checkpointing, so the checkpoint
+                // records what still has to run rather than what just finished.
                 self.pending_nodes = {
                     let next_candidates = self.graph.get_next_nodes(&result.executed_nodes, &self.state);
                     match self.filter_deferred_nodes(next_candidates, &result.executed_nodes) {
@@ -350,6 +420,11 @@ impl<'a> PregelExecutor<'a> {
                     }
                 };
                 self.step += 1;
+
+                if let Err(e) = self.save_checkpoint().await {
+                    yield Err(e);
+                    return;
+                }
             }
 
             yield Ok(StreamEvent::done(self.state.clone(), self.step + 1));

--- a/adk-graph/src/node.rs
+++ b/adk-graph/src/node.rs
@@ -190,18 +190,24 @@ pub trait Node: Send + Sync {
     /// Execute the node and return state updates
     async fn execute(&self, ctx: &NodeContext) -> Result<NodeOutput>;
 
-    /// Stream execution events (default: wraps execute)
+    /// Streams execution events for this node.
+    ///
+    /// An implementation must report the node's state updates by yielding a
+    /// [`StreamEvent::Updates`] event, because a streaming executor takes the
+    /// updates from this stream rather than executing the node a second time.
+    /// The default implementation wraps [`Node::execute`] and does so.
     fn execute_stream<'a>(
         &'a self,
         ctx: &'a NodeContext,
     ) -> Pin<Box<dyn futures::Stream<Item = Result<StreamEvent>> + Send + 'a>> {
-        let _name = self.name().to_string();
+        let name = self.name().to_string();
         Box::pin(async_stream::stream! {
             match self.execute(ctx).await {
                 Ok(output) => {
                     for event in output.events {
                         yield Ok(event);
                     }
+                    yield Ok(StreamEvent::Updates { node: name, updates: output.updates });
                 }
                 Err(e) => yield Err(e),
             }
@@ -419,6 +425,7 @@ impl Node for AgentNode {
         let name = self.name.clone();
         let agent = self.agent.clone();
         let input_mapper = &self.input_mapper;
+        let output_mapper = &self.output_mapper;
         let thread_id = ctx.config.thread_id.clone();
         let content = (input_mapper)(&ctx.state);
 
@@ -476,6 +483,14 @@ impl Node for AgentNode {
                     yield Ok(StreamEvent::custom(&name, "agent_event", json));
                 }
             }
+
+            // Report state updates from this run. Without this the streaming
+            // executor has no updates to apply and would have to run the agent
+            // a second time to obtain them.
+            yield Ok(StreamEvent::Updates {
+                node: name.clone(),
+                updates: (output_mapper)(&all_events),
+            });
         })
     }
 }

--- a/adk-graph/src/timeout.rs
+++ b/adk-graph/src/timeout.rs
@@ -288,6 +288,22 @@ fn current_time_ms() -> u64 {
         .as_millis() as u64
 }
 
+/// Returns how long a streaming node may take to produce its next event.
+///
+/// The budget is the smaller of the remaining run timeout and the idle timeout.
+/// For a stream, "idle" means no event was produced within `idle_timeout`, which
+/// is the streaming analogue of a node that never calls `report_progress()`.
+/// Returns `None` when the policy sets no applicable limit.
+pub fn item_timeout_budget(policy: &TimeoutPolicy, elapsed: Duration) -> Option<Duration> {
+    let remaining_run = policy.run_timeout.map(|limit| limit.saturating_sub(elapsed));
+    match (remaining_run, policy.idle_timeout) {
+        (Some(run), Some(idle)) => Some(run.min(idle)),
+        (Some(run), None) => Some(run),
+        (None, Some(idle)) => Some(idle),
+        (None, None) => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/adk-graph/tests/checkpoint_correctness_tests.rs
+++ b/adk-graph/tests/checkpoint_correctness_tests.rs
@@ -1,0 +1,199 @@
+//! Checkpoints must record what still has to run, and a streamed run must
+//! checkpoint at all.
+//!
+//! Three defects motivated these tests:
+//!
+//! 1. `run` saved the checkpoint *before* advancing the frontier, so the saved
+//!    `pending_nodes` were the nodes that had just finished. Resuming re-executed
+//!    them, double-applying any non-idempotent update.
+//! 2. `run_stream` never saved a checkpoint at all, and its interrupt path
+//!    returned without saving one, so a streamed run could not be resumed and a
+//!    streamed human-in-the-loop interrupt was unrecoverable.
+//! 3. In `StreamMode::Messages` the executor drained `execute_stream` for events
+//!    and then called `execute` again for state updates, running every node — and
+//!    every agent behind an `AgentNode` — twice per super-step.
+
+use adk_graph::checkpoint::{Checkpointer, MemoryCheckpointer};
+use adk_graph::edge::{END, START};
+use adk_graph::graph::StateGraph;
+use adk_graph::node::{ExecutionConfig, NodeOutput};
+use adk_graph::state::State;
+use adk_graph::stream::StreamMode;
+use futures::StreamExt;
+use serde_json::json;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// A counter shared with node closures so executions can be counted.
+fn counter() -> Arc<AtomicUsize> {
+    Arc::new(AtomicUsize::new(0))
+}
+
+#[tokio::test]
+async fn a_checkpoint_records_the_nodes_that_still_have_to_run() {
+    let checkpointer = Arc::new(MemoryCheckpointer::new());
+    let graph = StateGraph::with_channels(&["value"])
+        .add_node_fn("first", |ctx| async move {
+            let value = ctx.get("value").and_then(|v| v.as_i64()).unwrap_or(0);
+            Ok(NodeOutput::new().with_update("value", json!(value + 1)))
+        })
+        .add_node_fn("second", |ctx| async move {
+            let value = ctx.get("value").and_then(|v| v.as_i64()).unwrap_or(0);
+            Ok(NodeOutput::new().with_update("value", json!(value + 10)))
+        })
+        .add_edge(START, "first")
+        .add_edge("first", "second")
+        .add_edge("second", END)
+        .compile()
+        .unwrap()
+        .with_checkpointer_arc(checkpointer.clone() as Arc<dyn Checkpointer>);
+
+    let mut input = State::new();
+    input.insert("value".to_string(), json!(0));
+    let result = graph.invoke(input, ExecutionConfig::new("thread-order")).await.unwrap();
+    assert_eq!(result.get("value"), Some(&json!(11)));
+
+    // The final checkpoint must not name a node that already ran.
+    let cp = checkpointer.load("thread-order").await.unwrap().expect("a checkpoint was saved");
+    assert!(
+        cp.pending_nodes.is_empty(),
+        "a finished run must checkpoint an empty frontier, got {:?}",
+        cp.pending_nodes
+    );
+}
+
+#[tokio::test]
+async fn resuming_a_finished_run_does_not_re_execute_it() {
+    let checkpointer = Arc::new(MemoryCheckpointer::new());
+    let runs = counter();
+    let runs_in_node = runs.clone();
+
+    let graph = StateGraph::with_channels(&["value"])
+        .add_node_fn("accumulate", move |ctx| {
+            let runs = runs_in_node.clone();
+            async move {
+                runs.fetch_add(1, Ordering::SeqCst);
+                let value = ctx.get("value").and_then(|v| v.as_i64()).unwrap_or(0);
+                Ok(NodeOutput::new().with_update("value", json!(value + 1)))
+            }
+        })
+        .add_edge(START, "accumulate")
+        .add_edge("accumulate", END)
+        .compile()
+        .unwrap()
+        .with_checkpointer_arc(checkpointer.clone() as Arc<dyn Checkpointer>);
+
+    let mut input = State::new();
+    input.insert("value".to_string(), json!(0));
+    let first = graph.invoke(input, ExecutionConfig::new("thread-resume")).await.unwrap();
+    assert_eq!(first.get("value"), Some(&json!(1)));
+    assert_eq!(runs.load(Ordering::SeqCst), 1);
+
+    // Re-invoking the same thread resumes from the terminal checkpoint. The node
+    // has already run, so it must not run again and the value must not advance.
+    let second = graph.invoke(State::new(), ExecutionConfig::new("thread-resume")).await.unwrap();
+    assert_eq!(
+        runs.load(Ordering::SeqCst),
+        1,
+        "resuming a completed run re-executed the node, double-applying its update"
+    );
+    assert_eq!(second.get("value"), Some(&json!(1)));
+}
+
+#[tokio::test]
+async fn a_streamed_run_saves_checkpoints() {
+    let checkpointer = Arc::new(MemoryCheckpointer::new());
+    let graph = StateGraph::with_channels(&["value"])
+        .add_node_fn("step", |ctx| async move {
+            let value = ctx.get("value").and_then(|v| v.as_i64()).unwrap_or(0);
+            Ok(NodeOutput::new().with_update("value", json!(value + 5)))
+        })
+        .add_edge(START, "step")
+        .add_edge("step", END)
+        .compile()
+        .unwrap()
+        .with_checkpointer_arc(checkpointer.clone() as Arc<dyn Checkpointer>);
+
+    let mut input = State::new();
+    input.insert("value".to_string(), json!(0));
+    let stream = graph.stream(input, ExecutionConfig::new("thread-stream"), StreamMode::Values);
+    let mut stream = std::pin::pin!(stream);
+    while let Some(event) = stream.next().await {
+        event.expect("the streamed run must not fail");
+    }
+
+    let cp = checkpointer
+        .load("thread-stream")
+        .await
+        .unwrap()
+        .expect("a streamed run must save a checkpoint so it can be resumed");
+    assert_eq!(cp.state.get("value"), Some(&json!(5)));
+}
+
+#[tokio::test]
+async fn messages_mode_executes_each_node_once() {
+    let runs = counter();
+    let runs_in_node = runs.clone();
+
+    let graph = StateGraph::with_channels(&["value"])
+        .add_node_fn("once", move |ctx| {
+            let runs = runs_in_node.clone();
+            async move {
+                runs.fetch_add(1, Ordering::SeqCst);
+                let value = ctx.get("value").and_then(|v| v.as_i64()).unwrap_or(0);
+                Ok(NodeOutput::new().with_update("value", json!(value + 1)))
+            }
+        })
+        .add_edge(START, "once")
+        .add_edge("once", END)
+        .compile()
+        .unwrap();
+
+    let mut input = State::new();
+    input.insert("value".to_string(), json!(0));
+    let stream = graph.stream(input, ExecutionConfig::new("thread-messages"), StreamMode::Messages);
+    let mut stream = std::pin::pin!(stream);
+    while let Some(event) = stream.next().await {
+        event.expect("the streamed run must not fail");
+    }
+
+    assert_eq!(
+        runs.load(Ordering::SeqCst),
+        1,
+        "Messages mode ran the node more than once; every agent behind an \
+         AgentNode would be billed twice"
+    );
+}
+
+#[tokio::test]
+async fn messages_mode_still_applies_state_updates() {
+    // Taking updates from the stream must not lose them.
+    let checkpointer = Arc::new(MemoryCheckpointer::new());
+    let graph = StateGraph::with_channels(&["value"])
+        .add_node_fn("double", |ctx| async move {
+            let value = ctx.get("value").and_then(|v| v.as_i64()).unwrap_or(0);
+            Ok(NodeOutput::new().with_update("value", json!(value * 2)))
+        })
+        .add_edge(START, "double")
+        .add_edge("double", END)
+        .compile()
+        .unwrap()
+        .with_checkpointer_arc(checkpointer.clone() as Arc<dyn Checkpointer>);
+
+    let mut input = State::new();
+    input.insert("value".to_string(), json!(21));
+    let stream = graph.stream(input, ExecutionConfig::new("thread-updates"), StreamMode::Messages);
+    let mut done_state = None;
+    let mut stream = std::pin::pin!(stream);
+    while let Some(event) = stream.next().await {
+        if let Ok(adk_graph::stream::StreamEvent::Done { state, .. }) =
+            event.as_ref().map(|e| e.clone())
+        {
+            done_state = Some(state);
+        }
+        event.expect("the streamed run must not fail");
+    }
+
+    let state = done_state.expect("the stream must report completion");
+    assert_eq!(state.get("value"), Some(&json!(42)));
+}

--- a/docs/official_docs/agents/graph-agents.md
+++ b/docs/official_docs/agents/graph-agents.md
@@ -1050,6 +1050,28 @@ let graph = StateGraph::with_channels(&["task", "result"])
     .with_checkpointer(checkpointer);
 ```
 
+### What a Checkpoint Records
+
+A checkpoint stores the accumulated state, the step number, and the **frontier** —
+the nodes that still have to run. It is written after the frontier advances, so
+resuming never re-executes a node that already completed and never double-applies
+its updates. A run that finishes checkpoints an empty frontier, so resuming a
+completed thread returns the final state rather than restarting the graph.
+
+Two cases deliberately checkpoint the frontier that was *executing* rather than
+the next one, because the interrupted node has not produced its updates yet and
+must run again on resume:
+
+| Situation | Frontier saved |
+|-----------|----------------|
+| Super-step completed | The next nodes to run |
+| Run finished | Empty |
+| Interrupt raised (blocking or streaming) | The nodes that were executing |
+
+Streamed runs checkpoint on the same schedule as blocking runs, including when an
+interrupt ends the stream, so a human-in-the-loop pause is resumable in either
+execution mode.
+
 ### Checkpoint History (Time Travel)
 
 Checkpoints also enable **durable resume** — if a graph execution crashes or the process restarts, execution resumes from the last persisted checkpoint rather than starting over. Use `SqliteCheckpointer` or `PostgresCheckpointer` for crash-safe persistence.
@@ -1206,6 +1228,21 @@ while let Some(event) = stream.next().await {
 | `Updates` | Stream only state changes |
 | `Messages` | Stream message-type updates |
 | `Debug` | Stream all internal events |
+
+`Messages` mode reads tokens from `Node::execute_stream` as they are produced.
+Each node runs **once** per super-step in this mode: the node reports its state
+updates on the stream as a `StreamEvent::Updates` event, and the executor applies
+those rather than executing the node a second time to collect them. This matters
+most for `AgentNode`, where a second execution would mean a second billed model
+call per node.
+
+> **Important:** a custom `Node` that overrides `execute_stream` must yield a
+> `StreamEvent::Updates` event carrying its state updates. Without it the node
+> streams events but contributes no state in `Messages` mode. The default
+> `execute_stream`, which wraps `execute`, does this for you.
+
+Timeout policies apply to the streamed execution itself. For a stream,
+`idle_timeout` means no event was produced within the limit.
 
 ## ADK Integration
 


### PR DESCRIPTION
## What

Three independent correctness defects in `PregelExecutor`, plus the docs for the guarantees they establish.

## Why

| # | Defect | Consequence |
|---|--------|-------------|
| 1 | `run` checkpointed **before** advancing the frontier | `pending_nodes` named the nodes that had just finished, so resuming re-executed them and re-applied their updates |
| 2 | `run_stream` saved **no** checkpoints, and its interrupt path returned without one | A streamed run could not be resumed; a streamed human-in-the-loop interrupt was unrecoverable |
| 3 | `StreamMode::Messages` drained `execute_stream` **and then** called `execute` | Every node ran twice per super-step — two billed model calls per `AgentNode` — and the streamed tokens came from a different execution than the state that was kept |

Defect 1 is only harmless for idempotent nodes. Counters, accumulators, appends, and anything with an external side effect were double-applied on every resume.

## How

- Checkpoints are written **after** the frontier advances. A finished run records an empty frontier, so resuming a completed thread returns the final state instead of restarting the graph.
- Interrupts deliberately keep saving the *executing* frontier, because an interrupted node has not produced its updates and must run again on resume. That distinction is now documented as a table.
- Streamed runs checkpoint on the same schedule as blocking runs, including on interrupt.
- Nodes report state updates on the stream as `StreamEvent::Updates`; the executor applies those from the single execution.

### Contract change worth reviewing

`Node::execute_stream` now carries the contract that an implementation yields a `StreamEvent::Updates` event with its state updates. The **default implementation does this**, so nodes built from closures and `add_node_fn` are unaffected. A hand-written override that does not yield it will stream events but contribute no state in `Messages` mode. This is documented in the rustdoc, the changelog, and `graph-agents.md`.

Only one override exists in the workspace: `AgentNode::execute_stream`. It never applied its output mapper — it produced `Message` and `agent_event` events and **no state at all**, which is precisely why the executor needed the second `execute` call. It now applies the mapper.

### Regression I introduced and then closed

Removing the second `execute` call also removed the only place a timeout policy was applied in `Messages` mode. Timeouts now apply to the streamed execution itself via a new `item_timeout_budget` helper, where `idle_timeout` means no event was produced within the limit — the streaming analogue of a node that never calls `report_progress()`. `OnTimeout::Skip` discards the node's updates; `Fail` and an exhausted `Retry` surface `GraphError::NodeTimedOut`.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo nextest run --workspace --profile ci` | **3770 passed**, 83 skipped |
| `cargo nextest run -p adk-graph` | 107 passed (was 102) |
| `RUSTDOCFLAGS=-D warnings cargo doc -p adk-graph` | exit 0 |
| `cargo semver-checks -p adk-graph --release-type minor` | only the `StateGraph.deferred_configs` breakage already recorded for 2.0.0 — no new breakage |

Five regression tests in `adk-graph/tests/checkpoint_correctness_tests.rs`; **four fail against the previous implementation** (the fifth asserts updates are still applied, which held before and must keep holding).

Not verified: no live provider call, so the `AgentNode` double-billing fix is demonstrated with a counting node rather than a real model.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed — n/a
- [x] Examples added or updated for new features — n/a (existing `examples/competitive_graph_resume` covers durable resume)