### PR TITLE
fix(runner): key runs and persistence by full identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   | `adk-core` | New variant `Part::EmbeddedResource` (`Part` is not `#[non_exhaustive]`) | Exhaustive `match` must add an arm |
   | `adk-core` | `RunConfig` and `RunConfigBuilder` no longer `UnwindSafe`/`RefUnwindSafe` | Affects code holding them across `catch_unwind` |
   | `adk-graph` | New public field `StateGraph::deferred_configs` | Struct literals must add the field |
+  | `adk-runner` | `MutableSession::conversation_history_for_agent_impl` now takes two parameters (an `agent_name` and a `branch`) instead of one | Direct callers must pass the invocation branch; pass `""` for unscoped behaviour |
   | `adk-realtime` | `ClientEvent` and `ServerEvent` are now `#[non_exhaustive]` | Downstream `match` needs a wildcard arm; the enums can no longer be constructed exhaustively outside the crate |
   | `adk-realtime` | `ServerEvent::Unknown` discriminant changed 21 → 23 | Affects code depending on the numeric discriminant |
   | `adk-realtime` | New public field `RealtimeConfig::affective_dialog` | Struct literals must add the field |
@@ -317,6 +318,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   entries, so no plan update is emitted today.
 
 ### Fixed
+
+- **adk-runner: runs and persistence writes are keyed by full identity.** Two
+  defects with the same root cause — the identity triple was resolved and then
+  discarded.
+
+  Active runs were tracked in a `HashMap<String, CancellationToken>` keyed by the
+  raw session ID. Because a session ID is only unique within an app and user,
+  `(app-a, user-a, shared-id)` and `(app-b, user-b, shared-id)` collided inside one
+  `Runner`, and two concurrent runs for one identity overwrote each other's token.
+  The drop guard then removed the key unconditionally, so a finishing run could
+  deregister a different run that was still going. Runs are now keyed by a unique
+  run ID carrying the full identity, and cleanup removes only the entry it
+  inserted. `Runner::interrupt(session_id)` now cancels every run for that session
+  rather than whichever registered last; the new `Runner::interrupt_identity`
+  targets one exact identity, and `Runner::active_runs` reports identities.
+  Registration was also eager while cleanup was lazy inside the stream generator,
+  so a stream dropped before its first poll leaked its registration permanently;
+  the guard is now created eagerly.
+
+  Separately, the Runner resolved sessions with the full triple but persisted every
+  event through `append_event(session_id, event)`. All five write sites now use
+  `append_event_for_identity`, so a backend whose natural key is composite can bind
+  each event to its tenant.
 
 - **adk-agent/adk-tool: workflow context wrappers no longer drop cancellation,
   secrets, and shared state.** Each wrapper re-implements `InvocationContext` and

--- a/adk-runner/src/runner.rs
+++ b/adk-runner/src/runner.rs
@@ -14,6 +14,35 @@ use adk_skill::{SkillInjector, SkillInjectorConfig};
 use async_stream::stream;
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
+
+/// A run currently in flight, tracked so it can be interrupted.
+///
+/// Keyed by run ID rather than session ID: a session ID is only unique within an
+/// app and user, and one identity may have several runs in flight at once.
+#[derive(Debug, Clone)]
+struct ActiveRun {
+    identity: adk_core::AdkIdentity,
+    token: CancellationToken,
+}
+
+/// Registry of in-flight runs, keyed by run ID.
+type ActiveRuns = Arc<std::sync::Mutex<std::collections::HashMap<u64, ActiveRun>>>;
+
+/// Deregisters a run when its event stream is dropped.
+///
+/// Removal is by run ID, so a finishing run can never deregister a different run
+/// that happens to share the same session ID.
+struct ActiveRunCleanup {
+    active_runs: ActiveRuns,
+    run_id: u64,
+}
+
+impl Drop for ActiveRunCleanup {
+    fn drop(&mut self) {
+        let mut runs = self.active_runs.lock().unwrap_or_else(|e| e.into_inner());
+        runs.remove(&self.run_id);
+    }
+}
 use tracing::Instrument;
 
 /// Configuration for constructing a [`Runner`].
@@ -106,7 +135,8 @@ pub struct Runner {
     context_compaction: Option<Arc<crate::compaction::CompactionConfig>>,
     /// Per-session cancellation tokens for the interrupt API.
     /// Each `run()` call registers a token here; `interrupt()` cancels it.
-    active_sessions: Arc<std::sync::Mutex<std::collections::HashMap<String, CancellationToken>>>,
+    active_runs: ActiveRuns,
+    next_run_id: Arc<std::sync::atomic::AtomicU64>,
 }
 
 impl Runner {
@@ -179,7 +209,8 @@ impl Runner {
             intra_compactor,
             #[cfg(feature = "context-compaction")]
             context_compaction: config.context_compaction.map(Arc::new),
-            active_sessions: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            active_runs: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            next_run_id: Arc::new(std::sync::atomic::AtomicU64::new(1)),
         })
     }
 
@@ -252,17 +283,25 @@ impl Runner {
         #[cfg(feature = "context-compaction")]
         let context_compaction = self.context_compaction.clone();
 
-        // Register a per-session cancellation token for the interrupt API.
-        // If a global token is configured, create a child token so that
-        // either global cancellation OR per-session interrupt stops this run.
-        let session_token = CancellationToken::new();
-        let session_id_str = session_id.as_str().to_string();
-        {
-            let mut sessions = self.active_sessions.lock().unwrap_or_else(|e| e.into_inner());
-            sessions.insert(session_id_str.clone(), session_token.clone());
-        }
-        let active_sessions = self.active_sessions.clone();
+        // Built once and used for every persistence write, so a backend with a
+        // composite natural key can bind each event to its tenant.
+        let identity =
+            adk_core::AdkIdentity::new(typed_app_name.clone(), user_id.clone(), session_id.clone());
 
+        // Register this run for the interrupt API. The registration is keyed by a
+        // unique run ID rather than the raw session ID: two identities can share a
+        // session ID, and one identity can have two runs in flight, and both cases
+        // previously overwrote each other's token.
+        let session_token = CancellationToken::new();
+        let run_id = self.next_run_id.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        {
+            let mut runs = self.active_runs.lock().unwrap_or_else(|e| e.into_inner());
+            runs.insert(
+                run_id,
+                ActiveRun { identity: identity.clone(), token: session_token.clone() },
+            );
+        }
+        let active_runs = self.active_runs.clone();
         // Effective token: cancelled if either the global token or the session token fires
         let effective_token = if let Some(ref global) = cancellation_token {
             let combined = CancellationToken::new();
@@ -285,23 +324,14 @@ impl Runner {
             Some(session_token.clone())
         };
 
+        // Built here rather than inside the generator: registration happens as soon
+        // as `run` is called, so deregistration must also survive a stream that is
+        // dropped before it is ever polled. Moving the guard into the generator
+        // keeps it alive exactly as long as the stream.
+        let cleanup = ActiveRunCleanup { active_runs: active_runs.clone(), run_id };
+
         let s = stream! {
-            // Clean up session tracking when the stream ends.
-            // We use a simple struct with Drop to ensure cleanup even on early return.
-            struct SessionCleanup {
-                active_sessions: Arc<std::sync::Mutex<std::collections::HashMap<String, CancellationToken>>>,
-                session_id: String,
-            }
-            impl Drop for SessionCleanup {
-                fn drop(&mut self) {
-                    let mut sessions = self.active_sessions.lock().unwrap_or_else(|e| e.into_inner());
-                    sessions.remove(&self.session_id);
-                }
-            }
-            let _cleanup = SessionCleanup {
-                active_sessions: active_sessions.clone(),
-                session_id: session_id_str,
-            };
+            let _cleanup = cleanup;
 
             // Use the effective token (combines global + per-session)
             let cancellation_token = effective_token;
@@ -417,7 +447,12 @@ impl Runner {
                         early_event.llm_response.content = Some(content);
 
                         ctx.mutable_session().append_event(early_event.clone());
-                        if let Err(e) = session_service.append_event(ctx.session_id(), early_event.clone()).await {
+                        if let Err(e) = session_service
+                            .append_event_for_identity(adk_session::AppendEventRequest {
+                                identity: identity.clone(),
+                                event: early_event.clone(),
+                            })
+                            .await {
                             yield Err(e);
                             return;
                         }
@@ -502,7 +537,12 @@ impl Runner {
             // Note: adk_session::Event is a re-export of adk_core::Event, so we can use it directly
             ctx.mutable_session().append_event(user_event.clone());
 
-            if let Err(e) = session_service.append_event(ctx.session_id(), user_event).await {
+            if let Err(e) = session_service
+                .append_event_for_identity(adk_session::AppendEventRequest {
+                    identity: identity.clone(),
+                    event: user_event,
+                })
+                .await {
                 #[cfg(feature = "plugins")]
                 if let Some(manager) = plugin_manager.as_ref() {
                     manager.run_after_run(ctx.clone() as Arc<dyn adk_core::InvocationContext>).await;
@@ -793,7 +833,12 @@ impl Runner {
                         // constraint. The final chunk (partial=false) carries the
                         // complete accumulated content.
                         if !event.llm_response.partial
-                            && let Err(e) = session_service.append_event(ctx.session_id(), event.clone()).await {
+                            && let Err(e) = session_service
+                                .append_event_for_identity(adk_session::AppendEventRequest {
+                                    identity: identity.clone(),
+                                    event: event.clone(),
+                                })
+                                .await {
                                 #[cfg(feature = "plugins")]
                                 if let Some(manager) = plugin_manager.as_ref() {
                                     manager.run_after_run(ctx.clone() as Arc<dyn adk_core::InvocationContext>).await;
@@ -974,7 +1019,12 @@ impl Runner {
                             transfer_ctx.mutable_session().append_event(event.clone());
 
                             if !event.llm_response.partial
-                                && let Err(e) = session_service.append_event(ctx.session_id(), event.clone()).await {
+                                && let Err(e) = session_service
+                                    .append_event_for_identity(adk_session::AppendEventRequest {
+                                        identity: identity.clone(),
+                                        event: event.clone(),
+                                    })
+                                    .await {
                                     #[cfg(feature = "plugins")]
                                     if let Some(manager) = plugin_manager.as_ref() {
                                         manager.run_after_run(ctx.clone() as Arc<dyn adk_core::InvocationContext>).await;
@@ -1039,10 +1089,12 @@ impl Runner {
                             match compaction_cfg.summarizer.summarize_events(events_to_compact).await {
                                 Ok(Some(compaction_event)) => {
                                     // Persist the compaction event
-                                    if let Err(e) = session_service.append_event(
-                                        ctx.session_id(),
-                                        compaction_event.clone(),
-                                    ).await {
+                                    if let Err(e) = session_service
+                                        .append_event_for_identity(adk_session::AppendEventRequest {
+                                            identity: identity.clone(),
+                                            event: compaction_event.clone(),
+                                        })
+                                        .await {
                                         tracing::warn!(error = %e, "Failed to persist compaction event");
                                     } else {
                                         tracing::info!(
@@ -1118,21 +1170,78 @@ impl Runner {
     /// let mut stream = runner.run(user_id, session_id, new_content).await?;
     /// ```
     pub fn interrupt(&self, session_id: &str) -> bool {
-        let sessions = self.active_sessions.lock().unwrap_or_else(|e| e.into_inner());
-        if let Some(token) = sessions.get(session_id) {
-            tracing::info!(session.id = session_id, "interrupting running agent");
-            token.cancel();
-            true
-        } else {
+        let runs = self.active_runs.lock().unwrap_or_else(|e| e.into_inner());
+        let matching: Vec<&ActiveRun> =
+            runs.values().filter(|run| run.identity.session_id.as_ref() == session_id).collect();
+        if matching.is_empty() {
             tracing::debug!(session.id = session_id, "no active run to interrupt");
-            false
+            return false;
         }
+        tracing::info!(
+            session.id = session_id,
+            run.count = matching.len(),
+            "interrupting running agent"
+        );
+        for run in matching {
+            run.token.cancel();
+        }
+        true
+    }
+
+    /// Interrupts runs for one exact identity.
+    ///
+    /// A session ID is only unique within an app and user, so this is the precise
+    /// form of [`Runner::interrupt`] for a `Runner` shared across tenants.
+    /// Returns `true` when at least one run was cancelled.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let cancelled = runner.interrupt_identity("my-app", "user-1", "session-1");
+    /// ```
+    pub fn interrupt_identity(&self, app_name: &str, user_id: &str, session_id: &str) -> bool {
+        let runs = self.active_runs.lock().unwrap_or_else(|e| e.into_inner());
+        let mut cancelled = false;
+        for run in runs.values() {
+            if run.identity.app_name.as_ref() == app_name
+                && run.identity.user_id.as_ref() == user_id
+                && run.identity.session_id.as_ref() == session_id
+            {
+                run.token.cancel();
+                cancelled = true;
+            }
+        }
+        if !cancelled {
+            tracing::debug!(
+                app.name = app_name,
+                user.id = user_id,
+                session.id = session_id,
+                "no active run to interrupt"
+            );
+        }
+        cancelled
+    }
+
+    /// Returns the identity of every run currently in flight.
+    ///
+    /// One identity appears once per in-flight run, so a repeated entry means that
+    /// identity has concurrent runs.
+    pub fn active_runs(&self) -> Vec<adk_core::AdkIdentity> {
+        let runs = self.active_runs.lock().unwrap_or_else(|e| e.into_inner());
+        runs.values().map(|run| run.identity.clone()).collect()
     }
 
     /// Returns the session IDs of all currently running agent executions.
+    ///
+    /// Session IDs are deduplicated. Use [`Runner::active_runs`] when the app and
+    /// user dimensions matter.
     pub fn active_session_ids(&self) -> Vec<String> {
-        let sessions = self.active_sessions.lock().unwrap_or_else(|e| e.into_inner());
-        sessions.keys().cloned().collect()
+        let runs = self.active_runs.lock().unwrap_or_else(|e| e.into_inner());
+        let mut ids: Vec<String> =
+            runs.values().map(|run| run.identity.session_id.as_ref().to_string()).collect();
+        ids.sort();
+        ids.dedup();
+        ids
     }
 
     /// Returns a reference to the context compaction configuration, if set.

--- a/adk-runner/tests/identity_keying_tests.rs
+++ b/adk-runner/tests/identity_keying_tests.rs
@@ -1,0 +1,311 @@
+//! A `Runner` shared across tenants must not confuse their runs or their writes.
+//!
+//! Two defects motivated these tests:
+//!
+//! 1. Active runs were tracked in a `HashMap<String, CancellationToken>` keyed by
+//!    the raw session ID. A session ID is only unique within an app and user, so
+//!    `(app-a, user-a, shared-id)` and `(app-b, user-b, shared-id)` collided in one
+//!    map, and two concurrent runs for one identity overwrote each other. The drop
+//!    guard then removed the key unconditionally, so a finishing run could
+//!    deregister a different run that was still going.
+//! 2. The Runner resolved a session with the full `(app, user, session)` triple and
+//!    then persisted events through `append_event(session_id, event)`, discarding
+//!    the identity at the write boundary. A backend whose natural key is composite
+//!    could not bind an event to its tenant.
+
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use adk_core::{Agent, Content, EventStream, InvocationContext, Part, Result, SessionId, UserId};
+use adk_runner::Runner;
+use adk_session::{AppendEventRequest, Event, Events, GetRequest, Session, SessionService, State};
+use async_trait::async_trait;
+use futures::StreamExt;
+
+// ── Mocks ─────────────────────────────────────────────────────────────
+
+struct MockAgent;
+
+#[async_trait]
+impl Agent for MockAgent {
+    fn name(&self) -> &str {
+        "test-agent"
+    }
+    fn description(&self) -> &str {
+        "mock"
+    }
+    fn sub_agents(&self) -> &[Arc<dyn Agent>] {
+        &[]
+    }
+    async fn run(&self, _ctx: Arc<dyn InvocationContext>) -> Result<EventStream> {
+        Ok(Box::pin(futures::stream::empty()))
+    }
+}
+
+struct MockEvents;
+
+impl Events for MockEvents {
+    fn all(&self) -> Vec<Event> {
+        vec![]
+    }
+    fn len(&self) -> usize {
+        0
+    }
+    fn at(&self, _index: usize) -> Option<&Event> {
+        None
+    }
+}
+
+struct MockState;
+
+impl adk_session::ReadonlyState for MockState {
+    fn get(&self, _key: &str) -> Option<serde_json::Value> {
+        None
+    }
+    fn all(&self) -> std::collections::HashMap<String, serde_json::Value> {
+        std::collections::HashMap::new()
+    }
+}
+
+impl State for MockState {
+    fn get(&self, _key: &str) -> Option<serde_json::Value> {
+        None
+    }
+    fn set(&mut self, _key: String, _value: serde_json::Value) {}
+    fn all(&self) -> std::collections::HashMap<String, serde_json::Value> {
+        std::collections::HashMap::new()
+    }
+}
+
+struct MockSession {
+    id: String,
+    app_name: String,
+    user_id: String,
+}
+
+impl Session for MockSession {
+    fn id(&self) -> &str {
+        &self.id
+    }
+    fn app_name(&self) -> &str {
+        &self.app_name
+    }
+    fn user_id(&self) -> &str {
+        &self.user_id
+    }
+    fn state(&self) -> &dyn State {
+        &MockState
+    }
+    fn events(&self) -> &dyn Events {
+        &MockEvents
+    }
+    fn last_update_time(&self) -> chrono::DateTime<chrono::Utc> {
+        chrono::Utc::now()
+    }
+}
+
+/// A backend whose natural key is the full identity triple. It refuses a write
+/// that arrives with only a session ID, exactly as a composite-key store must.
+struct StrictCompositeService {
+    app_name: String,
+    user_id: String,
+    /// Identities recorded by identity-aware writes, in order.
+    identity_writes: Mutex<Vec<(String, String, String)>>,
+    /// Count of writes that arrived with a raw session ID only.
+    raw_writes: Mutex<usize>,
+}
+
+impl StrictCompositeService {
+    fn new(app_name: &str, user_id: &str) -> Self {
+        Self {
+            app_name: app_name.to_string(),
+            user_id: user_id.to_string(),
+            identity_writes: Mutex::new(Vec::new()),
+            raw_writes: Mutex::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl SessionService for StrictCompositeService {
+    async fn create(&self, _req: adk_session::CreateRequest) -> Result<Box<dyn Session>> {
+        unimplemented!("not exercised")
+    }
+
+    async fn get(&self, req: GetRequest) -> Result<Box<dyn Session>> {
+        Ok(Box::new(MockSession {
+            id: req.session_id,
+            app_name: self.app_name.clone(),
+            user_id: self.user_id.clone(),
+        }))
+    }
+
+    async fn list(&self, _req: adk_session::ListRequest) -> Result<Vec<Box<dyn Session>>> {
+        Ok(vec![])
+    }
+
+    async fn delete(&self, _req: adk_session::DeleteRequest) -> Result<()> {
+        Ok(())
+    }
+
+    async fn append_event(&self, _session_id: &str, _event: Event) -> Result<()> {
+        *self.raw_writes.lock().unwrap() += 1;
+        Err(adk_core::AdkError::session(
+            "this backend keys events by (app_name, user_id, session_id); \
+             a raw session ID cannot identify a session",
+        ))
+    }
+
+    async fn append_event_for_identity(&self, req: AppendEventRequest) -> Result<()> {
+        self.identity_writes.lock().unwrap().push((
+            req.identity.app_name.as_ref().to_string(),
+            req.identity.user_id.as_ref().to_string(),
+            req.identity.session_id.as_ref().to_string(),
+        ));
+        Ok(())
+    }
+}
+
+fn runner_for(service: Arc<StrictCompositeService>, app_name: &str) -> Runner {
+    Runner::builder()
+        .app_name(app_name)
+        .agent(Arc::new(MockAgent) as Arc<dyn Agent>)
+        .session_service(service as Arc<dyn SessionService>)
+        .build()
+        .unwrap()
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn every_persistence_write_carries_the_full_identity() {
+    let service = Arc::new(StrictCompositeService::new("app-a", "user-a"));
+    let runner = runner_for(service.clone(), "app-a");
+
+    let mut stream = runner
+        .run(
+            UserId::new("user-a").unwrap(),
+            SessionId::new("session-1").unwrap(),
+            Content { role: "user".to_string(), parts: vec![Part::Text { text: "hi".into() }] },
+        )
+        .await
+        .unwrap();
+    while let Some(event) = stream.next().await {
+        event.expect("the run must not fail: a composite-key backend rejects raw-ID writes");
+    }
+
+    assert_eq!(
+        *service.raw_writes.lock().unwrap(),
+        0,
+        "the Runner still wrote through the raw session-ID API, which a composite-key \
+         backend cannot bind to a tenant"
+    );
+    let writes = service.identity_writes.lock().unwrap().clone();
+    assert!(!writes.is_empty(), "the user event must be persisted");
+    for write in &writes {
+        assert_eq!(
+            write,
+            &("app-a".to_string(), "user-a".to_string(), "session-1".to_string()),
+            "an event was persisted under the wrong identity"
+        );
+    }
+}
+
+#[tokio::test]
+async fn runs_sharing_a_session_id_across_identities_do_not_collide() {
+    // One Runner per app, as a multi-tenant deployment would have, but the same
+    // raw session ID. Registration must not overwrite across identities.
+    let service_a = Arc::new(StrictCompositeService::new("app-a", "user-a"));
+    let runner_a = runner_for(service_a, "app-a");
+
+    let stream_a = runner_a
+        .run(
+            UserId::new("user-a").unwrap(),
+            SessionId::new("shared-id").unwrap(),
+            Content { role: "user".to_string(), parts: vec![Part::Text { text: "a".into() }] },
+        )
+        .await
+        .unwrap();
+
+    // While that run is registered, an interrupt for a different identity with the
+    // same session ID must not claim it.
+    assert!(
+        !runner_a.interrupt_identity("app-b", "user-b", "shared-id"),
+        "an interrupt for another tenant's identity matched this run"
+    );
+    assert!(
+        runner_a.interrupt_identity("app-a", "user-a", "shared-id"),
+        "the run's own identity must be interruptible"
+    );
+
+    drop(stream_a);
+}
+
+#[tokio::test]
+async fn two_runs_for_one_identity_are_tracked_separately() {
+    let service = Arc::new(StrictCompositeService::new("app-a", "user-a"));
+    let runner = runner_for(service, "app-a");
+
+    let content = |t: &str| Content {
+        role: "user".to_string(),
+        parts: vec![Part::Text { text: t.to_string() }],
+    };
+
+    let first = runner
+        .run(UserId::new("user-a").unwrap(), SessionId::new("session-1").unwrap(), content("first"))
+        .await
+        .unwrap();
+    let second = runner
+        .run(
+            UserId::new("user-a").unwrap(),
+            SessionId::new("session-1").unwrap(),
+            content("second"),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        runner.active_runs().len(),
+        2,
+        "two overlapping runs for one identity must both be registered; \
+         keying by session ID alone hid the first"
+    );
+
+    // Reverse completion order: dropping the second must not deregister the first.
+    drop(second);
+    assert_eq!(
+        runner.active_runs().len(),
+        1,
+        "cleanup removed a different run than the one that finished"
+    );
+    assert_eq!(runner.active_session_ids(), vec!["session-1".to_string()]);
+
+    drop(first);
+    assert!(runner.active_runs().is_empty(), "the last run must deregister itself");
+    assert!(runner.active_session_ids().is_empty());
+}
+
+#[tokio::test]
+async fn interrupting_a_session_cancels_all_of_its_runs() {
+    let service = Arc::new(StrictCompositeService::new("app-a", "user-a"));
+    let runner = runner_for(service, "app-a");
+
+    let content =
+        Content { role: "user".to_string(), parts: vec![Part::Text { text: "work".to_string() }] };
+    let first = runner
+        .run(UserId::new("user-a").unwrap(), SessionId::new("session-1").unwrap(), content.clone())
+        .await
+        .unwrap();
+    let second = runner
+        .run(UserId::new("user-a").unwrap(), SessionId::new("session-1").unwrap(), content)
+        .await
+        .unwrap();
+
+    // Session-wide semantics: the documented `interrupt(session_id)` cancels every
+    // run for that session rather than whichever one happened to register last.
+    assert!(runner.interrupt("session-1"));
+    assert!(!runner.interrupt("session-absent"));
+
+    drop(first);
+    drop(second);
+}

--- a/docs/official_docs/core/runner.md
+++ b/docs/official_docs/core/runner.md
@@ -159,6 +159,39 @@ let mut stream = runner.run_str(
 
 If the string fails validation (empty, contains null bytes, or exceeds the length limit), `run_str()` returns an error before starting the agent loop. The existing `run()` method with typed `UserId`/`SessionId` remains unchanged.
 
+## Interruption and Run Isolation
+
+A run is registered as soon as `run()` returns its stream, and deregistered when
+that stream is dropped — including when it is dropped without ever being polled.
+
+| Method | Scope |
+|--------|-------|
+| `interrupt(session_id)` | Cancels **every** in-flight run for that session ID, across apps and users |
+| `interrupt_identity(app_name, user_id, session_id)` | Cancels runs for one exact identity |
+| `active_runs()` | The identity of every in-flight run; a repeated identity means concurrent runs |
+| `active_session_ids()` | Deduplicated session IDs of in-flight runs |
+
+```rust
+// Cancel one tenant's run without touching another that shares the session ID
+let cancelled = runner.interrupt_identity("my-app", "user-1", "session-1");
+```
+
+A session ID is only unique within an app and user, so `interrupt(session_id)` is
+the broad form and `interrupt_identity` the precise one. Prefer
+`interrupt_identity` when a single `Runner` serves more than one app or user.
+
+Runs are tracked by a unique run ID rather than by session ID, so two runs for the
+same identity are tracked separately and each deregisters only itself.
+
+### Persistence Is Identity-Bound
+
+Every event the Runner persists — user turns, model responses, transfer events,
+plugin events, and compaction events — is written through
+`SessionService::append_event_for_identity` with the full
+`(app_name, user_id, session_id)` triple. A `SessionService` whose natural key is
+composite can therefore bind each event to its tenant, and can reject or ignore
+the raw-session-ID `append_event` path entirely.
+
 ## Execution Flow
 
 ```


### PR DESCRIPTION
## What

Two defects with one root cause: the Runner resolves the `(app_name, user_id, session_id)` triple and then throws it away.

## Why

### Run tracking collided across tenants and across concurrent runs

Active runs lived in a `HashMap<String, CancellationToken>` keyed by the **raw session ID**. A session ID is only unique within an app and user, so:

| Scenario | Old behaviour |
|---|---|
| `(app-a, user-a, shared-id)` and `(app-b, user-b, shared-id)` in one Runner | Second registration silently replaced the first |
| Two concurrent runs for the same identity | Second token hid the first; `interrupt` could only reach one |
| First run finishes while second still going | Drop guard removed the key unconditionally, deregistering the **other** run |

`interrupt("shared-id")` could therefore cancel the wrong execution, miss an older one, or report no active run while one was still going.

### Every persistence write discarded the identity

The Runner resolved the session with the full triple and then wrote through `append_event(session_id, event)` at all five sites. `append_event_for_identity` exists and is documented as the unambiguous API, but nothing called it, so a backend with a composite natural key could not bind an event to a tenant.

## How

- Runs are keyed by a unique run ID carrying the full `AdkIdentity`; cleanup removes only the entry it inserted.
- `interrupt(session_id)` now cancels **every** run for that session rather than whichever registered last — the semantics are now defined rather than incidental.
- New `interrupt_identity(app, user, session)` for exact targeting and `active_runs()` returning identities. `active_session_ids()` keeps its signature and now deduplicates.
- All five write sites use `append_event_for_identity`.

### A third defect found while testing

Registration was **eager** (in `run()`) while cleanup was **lazy** (a guard constructed inside the `stream!` generator). A stream dropped before its first poll therefore leaked its registration for the process lifetime, and `interrupt` would keep reporting it as active forever. The guard is now built eagerly and moved into the generator.

This surfaced because `two_runs_for_one_identity_are_tracked_separately` failed on the *fixed* code — the count stayed at 2 after dropping a stream. Worth noting the old code hid this: with session-ID keying, the second registration overwrote the first, so the leak was masked by a different bug.

## Undocumented breakage now recorded

`cargo semver-checks -p adk-runner --release-type minor` reports one break: `MutableSession::conversation_history_for_agent_impl` takes two parameters instead of one. That came from the branch-isolation change in #464 and was **missing** from the 2.0.0 semver inventory. This PR adds the row. No new breakage comes from this PR.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo nextest run --workspace --profile ci` | **3769 passed**, 83 skipped |
| `cargo nextest run -p adk-runner` | 117 passed (was 113) |
| `RUSTDOCFLAGS=-D warnings cargo doc -p adk-runner` | exit 0 |
| `cargo semver-checks -p adk-runner --release-type minor` | only the #464 break, now documented |
| doc-examples / doc-versions guards | exit 0 |

Four regression tests. `every_persistence_write_carries_the_full_identity` was run against the **unmodified** runner and fails there with the composite-key backend rejecting the raw-ID write:

```
the run must not fail: a composite-key backend rejects raw-ID writes:
AdkError { component: Session, code: "session.legacy",
message: "this backend keys events by (app_name, user_id, session_id); ..." }
```

The other three exercise APIs that did not exist before, so they cannot compile against the old code.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed — n/a
- [x] Examples added or updated for new features — n/a