### PR TITLE
fix(core): scope tool approvals to one exact call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   | `adk-core` | New public fields: `RunConfig::{tool_confirmation_handler, runtime_toolsets}` | Struct literals must add the fields; prefer `RunConfig::builder()` |
   | `adk-core` | New variant `Part::EmbeddedResource` (`Part` is not `#[non_exhaustive]`) | Exhaustive `match` must add an arm |
   | `adk-core` | `RunConfig` and `RunConfigBuilder` no longer `UnwindSafe`/`RefUnwindSafe` | Affects code holding them across `catch_unwind` |
+  | `adk-core` | `RunConfig::tool_confirmation_decisions` is now keyed by **function call ID** instead of tool name | Approvals keyed by tool name are no longer found, so the call stays unconfirmed; key by `ToolConfirmationRequest::function_call_id` |
+  | `adk-core` | New public field `RunConfig::tool_confirmation_fingerprints` | Struct literals must add the field; prefer `RunConfig::builder()` |
   | `adk-graph` | New public field `StateGraph::deferred_configs` | Struct literals must add the field |
   | `adk-realtime` | `ClientEvent` and `ServerEvent` are now `#[non_exhaustive]` | Downstream `match` needs a wildcard arm; the enums can no longer be constructed exhaustively outside the crate |
   | `adk-realtime` | `ServerEvent::Unknown` discriminant changed 21 → 23 | Affects code depending on the numeric discriminant |
@@ -317,6 +319,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   entries, so no plan update is emitted today.
 
 ### Fixed
+
+- **adk-core/adk-agent: tool approvals are scoped to one exact call.** Live
+  decisions from a `ToolConfirmationHandler` were tracked by function-call ID, but
+  static decisions in `RunConfig::tool_confirmation_decisions` were looked up by
+  **tool name**. One `delete_file` approval therefore authorized every
+  `delete_file` call evaluated against that map, whatever its arguments, and two
+  calls to the same tool in one turn could not receive different decisions. A
+  decision intended for one action could be replayed onto a materially different
+  one, which weakens the authorization boundary precisely in the resumed and
+  web-driven flows that rely on the static map.
+
+  Static decisions are now keyed by function-call ID, matching the live path and
+  the ID already reported on `ToolConfirmationRequest`. An unrecognized key means
+  "no decision", so the call stays pending rather than executing.
+
+  The new `RunConfig::tool_confirmation_fingerprints` optionally binds a decision
+  to the arguments it was granted for, using the new
+  `adk_core::tool_call_fingerprint`. This defends the case where a call ID is
+  replayed with different arguments after a round trip through something
+  untrusted, such as a browser. A mismatch is treated as unconfirmed. The
+  fingerprint is canonical over object key order, so re-serialized arguments still
+  match.
+
+  Consumers updated to the call-keyed contract: `adk-acp`'s permission bridge
+  (whose own module documentation already claimed call-level correlation while the
+  code keyed by name), and both confirmation gates in `adk-agent`'s CodeAct agent.
 
 - **adk-agent/adk-tool: workflow context wrappers no longer drop cancellation,
   secrets, and shared state.** Each wrapper re-implements `InvocationContext` and

--- a/adk-acp/src/server/handler.rs
+++ b/adk-acp/src/server/handler.rs
@@ -570,10 +570,10 @@ impl AcpSessionHandler {
         let session_id = AdkSessionId::new(request.session_id.to_string())
             .map_err(|e| AcpServerError::Execution(e.to_string()))?;
 
-        // Accumulated tool-confirmation decisions, keyed by tool name (the key
-        // ADK's `RunConfig::tool_confirmation_decisions` resume API uses). The
-        // map grows one decision per resume as the runner pauses at each
-        // still-undecided confirmation.
+        // Accumulated tool-confirmation decisions, keyed by function-call ID (the
+        // key `RunConfig::tool_confirmation_decisions` uses, so a decision
+        // authorizes only the call it was granted for). The map grows one decision
+        // per resume as the runner pauses at each still-undecided confirmation.
         let mut decisions: HashMap<String, ToolConfirmationDecision> = HashMap::new();
         // The first run carries the client's prompt content; every resume run
         // carries an empty user turn so the runner replays persisted history and
@@ -583,9 +583,9 @@ impl AcpSessionHandler {
 
         // The runner pauses at the first still-undecided confirmation and
         // resumes one decision at a time, so the number of iterations is bounded
-        // by the number of distinct tools requiring confirmation. The guard is a
+        // by the number of distinct calls requiring confirmation. The guard is a
         // defensive backstop against a misbehaving agent that re-interrupts for a
-        // tool that already has a decision.
+        // call that already has a decision.
         const MAX_CONFIRMATION_ROUNDS: usize = 64;
 
         for _round in 0..MAX_CONFIRMATION_ROUNDS {
@@ -656,7 +656,7 @@ impl AcpSessionHandler {
 
             // Drive the permission bridge for each pending confirmation: send a
             // `session/request_permission` to the client, await the outcome, and
-            // record the decision (cancellation → deny) keyed by tool name for
+            // record the decision (cancellation → deny) against the exact call for
             // the next resume run.
             for confirmation in &pending {
                 if cancellation_token.is_cancelled() {
@@ -665,7 +665,16 @@ impl AcpSessionHandler {
                 let decision =
                     PermissionBridge::request(&connection, &request.session_id, confirmation)
                         .await?;
-                decisions.insert(confirmation.tool_name.clone(), decision);
+                // A confirmation without a call ID cannot be bound to one call, so
+                // there is nothing safe to authorize.
+                let Some(call_id) = confirmation.function_call_id.clone() else {
+                    return Err(AcpServerError::Execution(
+                        "tool confirmation request carried no function call ID, so a \
+                         decision cannot be bound to the call"
+                            .into(),
+                    ));
+                };
+                decisions.insert(call_id, decision);
             }
             is_resume = true;
         }

--- a/adk-acp/src/server/permission.rs
+++ b/adk-acp/src/server/permission.rs
@@ -13,12 +13,11 @@
 //! tool-call id, so the client sees the exact call it is approving and the
 //! outcome is correlated to that call (Requirement 7.5, Property P8).
 //!
-//! ADK's resume API ([`RunConfig::tool_confirmation_decisions`]) is keyed by
-//! *tool name*, so the decision the bridge derives is applied to the runner
-//! under the tool name from the same request. Because the runner pauses at the
-//! first still-undecided confirmation and resumes one decision at a time, this
-//! preserves the function-call correlation for the call that was actually
-//! awaiting approval.
+//! The resume API ([`RunConfig::tool_confirmation_decisions`]) is keyed by
+//! *function-call ID*, so the decision the bridge derives is recorded against the
+//! exact call the client approved and cannot be replayed onto another call of the
+//! same tool. A confirmation request that carries no call ID is rejected rather
+//! than approved under a weaker key.
 //!
 //! # SDK safety
 //!

--- a/adk-acp/src/server/transport/stdio.rs
+++ b/adk-acp/src/server/transport/stdio.rs
@@ -889,7 +889,7 @@ mod tests {
         }
 
         async fn run(&self, ctx: Arc<dyn InvocationContext>) -> AdkResult<EventStream> {
-            let decision = ctx.run_config().tool_confirmation_decisions.get("delete_file").copied();
+            let decision = ctx.run_config().tool_confirmation_decisions.get("call-1").copied();
             let applied_decision = self.applied_decision.clone();
             let executed = self.executed.clone();
             let s = async_stream::stream! {

--- a/adk-agent/src/codeact/agent.rs
+++ b/adk-agent/src/codeact/agent.rs
@@ -307,10 +307,12 @@ fn run_codeact(input: LoopInputs) -> impl Stream<Item = adk_core::Result<Event>>
                     Disposition::Resolved(rec) => Some(rec.clone()),
                     Disposition::AwaitingConfirmation => {
                         let call_id = cp.call.call_id.to_string();
+                        // Static decisions are keyed by call ID, so a resumed
+                        // checkpoint is authorized only for its own call.
                         let mut decision = live_confirmation_decisions
                             .get(&call_id)
                             .copied()
-                            .or_else(|| decisions.get(&cp.call.tool).copied());
+                            .or_else(|| decisions.get(&call_id).copied());
                         if decision.is_none()
                             && let Some(handler) = confirmation_handler.as_ref()
                         {
@@ -494,7 +496,7 @@ fn run_codeact(input: LoopInputs) -> impl Stream<Item = adk_core::Result<Event>>
                             let mut decision = live_confirmation_decisions
                                 .get(&call_id_key)
                                 .copied()
-                                .or_else(|| decisions.get(&name).copied());
+                                .or_else(|| decisions.get(&call_id_key).copied());
                             if decision.is_none()
                                 && let Some(handler) = confirmation_handler.as_ref()
                             {

--- a/adk-agent/src/llm_agent.rs
+++ b/adk-agent/src/llm_agent.rs
@@ -136,6 +136,35 @@ impl std::fmt::Debug for LlmAgent {
     }
 }
 
+/// Resolves a static confirmation decision for one exact tool call.
+///
+/// Decisions are keyed by function call ID rather than tool name, so an approval
+/// cannot be replayed onto a different call that happens to use the same tool. When
+/// the run also supplies a fingerprint for that ID, the call's own fingerprint must
+/// match it; a mismatch is treated as no decision, which leaves the call
+/// unconfirmed rather than silently authorising different arguments.
+fn static_confirmation_decision(
+    decisions: &std::collections::HashMap<String, ToolConfirmationDecision>,
+    fingerprints: &std::collections::HashMap<String, String>,
+    function_call_id: &str,
+    tool_name: &str,
+    args: &serde_json::Value,
+) -> Option<ToolConfirmationDecision> {
+    let decision = decisions.get(function_call_id).copied()?;
+    if let Some(expected) = fingerprints.get(function_call_id) {
+        let actual = adk_core::tool_call_fingerprint(tool_name, args);
+        if &actual != expected {
+            tracing::warn!(
+                tool.name = %tool_name,
+                function_call.id = %function_call_id,
+                "confirmation decision does not match this call's arguments, treating as unconfirmed"
+            );
+            return None;
+        }
+    }
+    Some(decision)
+}
+
 impl LlmAgent {
     /// Returns the sandbox configuration attached to this agent, if any.
     ///
@@ -1234,6 +1263,8 @@ impl Agent for LlmAgent {
         let s = stream! {
             let confirmation_decisions =
                 ctx.run_config().tool_confirmation_decisions.clone();
+            let confirmation_fingerprints =
+                ctx.run_config().tool_confirmation_fingerprints.clone();
             let mut live_confirmation_decisions =
                 std::collections::HashMap::<String, ToolConfirmationDecision>::new();
             let confirmation_handler = ctx.run_config().tool_confirmation_handler.clone();
@@ -2140,7 +2171,14 @@ impl Agent for LlmAgent {
                     let mut confirmation_interrupted = false;
                     for (_, fc_name, fc_args, _, fc_call_id) in &fc_parts {
                         if tool_confirmation_policy.requires_confirmation(fc_name)
-                            && confirmation_decisions.get(fc_name).copied().is_none()
+                            && static_confirmation_decision(
+                                &confirmation_decisions,
+                                &confirmation_fingerprints,
+                                fc_call_id,
+                                fc_name,
+                                fc_args,
+                            )
+                            .is_none()
                             && live_confirmation_decisions
                                 .get(fc_call_id)
                                 .copied()
@@ -2226,6 +2264,7 @@ impl Agent for LlmAgent {
                         #[cfg(feature = "enhanced-plugins")]
                         let enhanced_plugin_manager = &enhanced_plugin_manager;
                         let confirmation_decisions = &confirmation_decisions;
+                        let confirmation_fingerprints = &confirmation_fingerprints;
                         let live_confirmation_decisions = &live_confirmation_decisions;
                         async move {
                             let mut tool_actions = EventActions::default();
@@ -2261,7 +2300,15 @@ impl Agent for LlmAgent {
                                 match live_confirmation_decisions
                                     .get(&function_call_id)
                                     .copied()
-                                    .or_else(|| confirmation_decisions.get(&name).copied())
+                                    .or_else(|| {
+                                        static_confirmation_decision(
+                                            confirmation_decisions,
+                                            confirmation_fingerprints,
+                                            &function_call_id,
+                                            &name,
+                                            &args,
+                                        )
+                                    })
                                 {
                                     Some(ToolConfirmationDecision::Approve) => {
                                         tool_actions.tool_confirmation_decision =

--- a/adk-agent/tests/tool_confirmation_tests.rs
+++ b/adk-agent/tests/tool_confirmation_tests.rs
@@ -294,7 +294,7 @@ async fn test_tool_confirmation_deny_skips_tool_execution() {
     let mut run_config = RunConfig::default();
     run_config
         .tool_confirmation_decisions
-        .insert("test_tool".to_string(), ToolConfirmationDecision::Deny);
+        .insert("call-2".to_string(), ToolConfirmationDecision::Deny);
 
     let mut stream = agent.run(Arc::new(MockContext::new(run_config))).await.unwrap();
     let mut saw_denied_response = false;
@@ -339,7 +339,7 @@ async fn test_tool_confirmation_approve_executes_tool() {
     let mut run_config = RunConfig::default();
     run_config
         .tool_confirmation_decisions
-        .insert("test_tool".to_string(), ToolConfirmationDecision::Approve);
+        .insert("call-3".to_string(), ToolConfirmationDecision::Approve);
 
     let mut stream = agent.run(Arc::new(MockContext::new(run_config))).await.unwrap();
     let mut saw_tool_result = false;
@@ -386,4 +386,148 @@ async fn live_allow_once_is_requested_for_each_tool_call() {
 
     assert_eq!(confirmation.decisions.load(Ordering::SeqCst), 2);
     assert_eq!(tool_calls.load(Ordering::SeqCst), 2);
+}
+
+// ── Approvals are scoped to one exact call ─────────────────────────────
+
+/// A model emitting two calls to the same tool with different arguments in one turn.
+fn two_calls_to_same_tool() -> LlmResponse {
+    LlmResponse {
+        content: Some(Content {
+            role: "model".to_string(),
+            parts: vec![
+                Part::FunctionCall {
+                    name: "test_tool".to_string(),
+                    args: json!({ "path": "/tmp/scratch" }),
+                    id: Some("call-scratch".to_string()),
+                    thought_signature: None,
+                },
+                Part::FunctionCall {
+                    name: "test_tool".to_string(),
+                    args: json!({ "path": "/etc/passwd" }),
+                    id: Some("call-sensitive".to_string()),
+                    thought_signature: None,
+                },
+            ],
+        }),
+        usage_metadata: None,
+        finish_reason: Some(FinishReason::Stop),
+        citation_metadata: None,
+        partial: false,
+        turn_complete: true,
+        interrupted: false,
+        error_code: None,
+        error_message: None,
+        provider_metadata: None,
+        interaction_id: None,
+    }
+}
+
+#[tokio::test]
+async fn approving_one_call_does_not_approve_a_sibling_with_the_same_tool_name() {
+    let model = Arc::new(SequencedModel::new(vec![two_calls_to_same_tool()]));
+    let agent = LlmAgentBuilder::new("test-agent")
+        .model(model)
+        .tool(Arc::new(CountingTool::new()))
+        .require_tool_confirmation("test_tool")
+        .build()
+        .unwrap();
+
+    // Approve only the scratch-path call.
+    let mut run_config = RunConfig::default();
+    run_config
+        .tool_confirmation_decisions
+        .insert("call-scratch".to_string(), ToolConfirmationDecision::Approve);
+
+    let mut stream = agent.run(Arc::new(MockContext::new(run_config))).await.unwrap();
+    let mut confirmation_requests = Vec::new();
+    while let Some(result) = stream.next().await {
+        let event = result.unwrap();
+        if let Some(request) = event.actions.tool_confirmation.as_ref() {
+            confirmation_requests.push(request.clone());
+        }
+    }
+
+    // The sensitive call must still be held for confirmation. Under name keying the
+    // approval for the scratch path authorised it too.
+    assert!(
+        confirmation_requests
+            .iter()
+            .any(|r| r.function_call_id.as_deref() == Some("call-sensitive")),
+        "the un-approved sibling call must still require confirmation; \
+         requests seen: {confirmation_requests:?}"
+    );
+}
+
+#[tokio::test]
+async fn an_approval_bound_to_arguments_is_ignored_when_they_change() {
+    let model = Arc::new(SequencedModel::new(vec![SequencedModel::function_call_response(
+        "test_tool",
+        json!({ "path": "/etc/passwd" }),
+        "call-replayed",
+    )]));
+    let agent = LlmAgentBuilder::new("test-agent")
+        .model(model)
+        .tool(Arc::new(CountingTool::new()))
+        .require_tool_confirmation("test_tool")
+        .build()
+        .unwrap();
+
+    // The decision was granted for a different path, and is bound to it.
+    let mut run_config = RunConfig::default();
+    run_config
+        .tool_confirmation_decisions
+        .insert("call-replayed".to_string(), ToolConfirmationDecision::Approve);
+    run_config.tool_confirmation_fingerprints.insert(
+        "call-replayed".to_string(),
+        adk_core::tool_call_fingerprint("test_tool", &json!({ "path": "/tmp/scratch" })),
+    );
+
+    let mut stream = agent.run(Arc::new(MockContext::new(run_config))).await.unwrap();
+    let mut confirmation_requests = Vec::new();
+    while let Some(result) = stream.next().await {
+        let event = result.unwrap();
+        if let Some(request) = event.actions.tool_confirmation.as_ref() {
+            confirmation_requests.push(request.clone());
+        }
+    }
+
+    assert!(
+        !confirmation_requests.is_empty(),
+        "a decision replayed onto different arguments must not authorise the call"
+    );
+}
+
+#[tokio::test]
+async fn a_matching_fingerprint_still_authorises_the_call() {
+    let args = json!({ "path": "/tmp/scratch" });
+    let model = Arc::new(SequencedModel::new(vec![
+        SequencedModel::function_call_response("test_tool", args.clone(), "call-bound"),
+        SequencedModel::text_response("done"),
+    ]));
+    let agent = LlmAgentBuilder::new("test-agent")
+        .model(model)
+        .tool(Arc::new(CountingTool::new()))
+        .require_tool_confirmation("test_tool")
+        .build()
+        .unwrap();
+
+    let mut run_config = RunConfig::default();
+    run_config
+        .tool_confirmation_decisions
+        .insert("call-bound".to_string(), ToolConfirmationDecision::Approve);
+    run_config
+        .tool_confirmation_fingerprints
+        .insert("call-bound".to_string(), adk_core::tool_call_fingerprint("test_tool", &args));
+
+    let mut stream = agent.run(Arc::new(MockContext::new(run_config))).await.unwrap();
+    let mut approved = false;
+    while let Some(result) = stream.next().await {
+        let event = result.unwrap();
+        if event.actions.tool_confirmation_decision == Some(ToolConfirmationDecision::Approve) {
+            approved = true;
+        }
+    }
+
+    assert!(approved, "a fingerprint matching the actual call must authorise it");
 }

--- a/adk-core/src/context.rs
+++ b/adk-core/src/context.rs
@@ -697,6 +697,71 @@ pub enum ToolConfirmationDecision {
     Deny,
 }
 
+/// Produces a canonical fingerprint of a tool call.
+///
+/// The fingerprint is the tool name followed by its arguments in canonical JSON
+/// form, with object keys sorted at every level so that two structurally equal
+/// argument sets always produce the same string. It is deliberately readable
+/// rather than hashed, so a mismatch can be diagnosed by inspection.
+///
+/// Use it with
+/// [`RunConfig::tool_confirmation_fingerprints`](RunConfig::tool_confirmation_fingerprints)
+/// to bind an approval to the exact arguments it was granted for.
+///
+/// # Example
+///
+/// ```rust
+/// use adk_core::tool_call_fingerprint;
+/// use serde_json::json;
+///
+/// // Key order does not change the fingerprint.
+/// let a = tool_call_fingerprint("delete_file", &json!({ "path": "/tmp/a", "force": true }));
+/// let b = tool_call_fingerprint("delete_file", &json!({ "force": true, "path": "/tmp/a" }));
+/// assert_eq!(a, b);
+///
+/// // A different path does not.
+/// let c = tool_call_fingerprint("delete_file", &json!({ "path": "/etc/passwd", "force": true }));
+/// assert_ne!(a, c);
+/// ```
+pub fn tool_call_fingerprint(tool_name: &str, args: &Value) -> String {
+    let mut out = String::with_capacity(tool_name.len() + 32);
+    out.push_str(tool_name);
+    out.push('\u{1f}');
+    write_canonical(args, &mut out);
+    out
+}
+
+/// Writes `value` as canonical JSON, with object keys sorted at every level.
+fn write_canonical(value: &Value, out: &mut String) {
+    match value {
+        Value::Object(map) => {
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort();
+            out.push('{');
+            for (i, key) in keys.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                out.push_str(&Value::String((*key).clone()).to_string());
+                out.push(':');
+                write_canonical(&map[*key], out);
+            }
+            out.push('}');
+        }
+        Value::Array(items) => {
+            out.push('[');
+            for (i, item) in items.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                write_canonical(item, out);
+            }
+            out.push(']');
+        }
+        other => out.push_str(&other.to_string()),
+    }
+}
+
 /// Policy defining which tools require human confirmation before execution.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
@@ -799,9 +864,32 @@ impl std::fmt::Debug for RuntimeToolset {
 pub struct RunConfig {
     /// The streaming mode for agent responses.
     pub streaming_mode: StreamingMode,
-    /// Optional per-tool confirmation decisions for the current run.
-    /// Keys are tool names.
+    /// Static confirmation decisions for the current run, keyed by **function
+    /// call ID**.
+    ///
+    /// The ID is the one reported on
+    /// [`ToolConfirmationRequest::function_call_id`], so a decision authorizes the
+    /// exact call it was requested for. A decision under a tool *name* is not
+    /// consulted, because one name can cover materially different calls — a
+    /// `delete_file` approval for a scratch path must not authorize a call that
+    /// targets a different path.
+    ///
+    /// Use [`tool_confirmation_fingerprints`](Self::tool_confirmation_fingerprints)
+    /// to additionally bind a decision to the arguments it was granted for. For
+    /// name-wide or policy-driven decisions, supply a
+    /// [`tool_confirmation_handler`](Self::tool_confirmation_handler) instead.
     pub tool_confirmation_decisions: HashMap<String, ToolConfirmationDecision>,
+    /// Optional argument binding for entries in
+    /// [`tool_confirmation_decisions`](Self::tool_confirmation_decisions), keyed by
+    /// the same function call ID.
+    ///
+    /// The value is the fingerprint produced by [`tool_call_fingerprint`] for the
+    /// call the decision was granted for. When an entry is present and the actual
+    /// call does not match it, the decision is ignored and the call is treated as
+    /// unconfirmed — the safe direction. Use this when a decision travels through
+    /// an untrusted round trip, such as a browser, where the arguments could be
+    /// changed while the call ID is replayed.
+    pub tool_confirmation_fingerprints: HashMap<String, String>,
     /// Optional live decision source for confirmations that have no static
     /// entry in [`tool_confirmation_decisions`](Self::tool_confirmation_decisions).
     pub tool_confirmation_handler: Option<Arc<dyn ToolConfirmationHandler>>,
@@ -858,6 +946,7 @@ impl Default for RunConfig {
         Self {
             streaming_mode: StreamingMode::SSE,
             tool_confirmation_decisions: HashMap::new(),
+            tool_confirmation_fingerprints: HashMap::new(),
             tool_confirmation_handler: None,
             runtime_toolsets: Vec::new(),
             cached_content: None,
@@ -923,12 +1012,25 @@ impl RunConfigBuilder {
         self
     }
 
-    /// Sets per-tool confirmation decisions for the current run.
+    /// Sets static confirmation decisions for the current run, keyed by function
+    /// call ID.
+    ///
+    /// The ID is the one carried on `ToolConfirmationRequest::function_call_id`.
     pub fn tool_confirmation_decisions(
         mut self,
         decisions: HashMap<String, ToolConfirmationDecision>,
     ) -> Self {
         self.config.tool_confirmation_decisions = decisions;
+        self
+    }
+
+    /// Binds confirmation decisions to the arguments they were granted for.
+    ///
+    /// Keys are function call IDs and values are fingerprints from
+    /// [`tool_call_fingerprint`]. A decision whose fingerprint does not match the
+    /// actual call is ignored and the call is treated as unconfirmed.
+    pub fn tool_confirmation_fingerprints(mut self, fingerprints: HashMap<String, String>) -> Self {
+        self.config.tool_confirmation_fingerprints = fingerprints;
         self
     }
 

--- a/adk-core/src/lib.rs
+++ b/adk-core/src/lib.rs
@@ -122,7 +122,8 @@ pub use context::{
     MAX_STATE_KEY_LEN, Memory, MemoryEntry, ReadonlyContext, ReadonlyState, RunConfig,
     RunConfigBuilder, RuntimeToolset, SecretService, Session, State, StreamingMode,
     ToolCallbackContext, ToolConcurrencyConfig, ToolConfirmationDecision, ToolConfirmationHandler,
-    ToolConfirmationPolicy, ToolConfirmationRequest, ToolOutcome, validate_state_key,
+    ToolConfirmationPolicy, ToolConfirmationRequest, ToolOutcome, tool_call_fingerprint,
+    validate_state_key,
 };
 pub use error::{AdkError, ErrorCategory, ErrorComponent, ErrorDetails, Result, RetryHint};
 pub use event::{

--- a/docs/official_docs/migration/1.0-to-2.0.md
+++ b/docs/official_docs/migration/1.0-to-2.0.md
@@ -18,6 +18,7 @@ adk-rust = { version = "2.0.0", features = ["standard"] }
 |---|---|
 | matches on `PermissionDecision::Allow` | choose `AllowOnce`, `AllowAlways`, or `Select(id)` |
 | builds `RunConfig` with a struct literal | switch to `RunConfig::builder()` |
+| keys `tool_confirmation_decisions` by tool name | key by the request's `function_call_id` |
 | matches exhaustively on `Part` | add an arm for `Part::EmbeddedResource` |
 | matches exhaustively on `ClientEvent`/`ServerEvent` | add a `_ => {}` arm |
 | builds `StateGraph`/`RealtimeConfig`/`PermissionRequest` with struct literals | add the new fields or spread `..Default::default()` |
@@ -100,6 +101,50 @@ literals that name every field break.
 
 `RunConfig` and `RunConfigBuilder` no longer implement `UnwindSafe`/`RefUnwindSafe`
 because the confirmation handler is a boxed async callback.
+
+### Tool confirmation decisions are keyed by call ID
+
+`RunConfig::tool_confirmation_decisions` was looked up by **tool name**, so one
+approval authorized every call of that tool regardless of its arguments. It is now
+keyed by the **function-call ID** already reported on `ToolConfirmationRequest`.
+
+An entry under a tool name is simply not found, so the call remains unconfirmed
+rather than executing. This fails safe, but silently: an approval that used to work
+now results in the run pausing for confirmation again.
+
+```rust
+// 1.0 — one approval covers every call of this tool
+let mut decisions = HashMap::new();
+decisions.insert("delete_file".to_string(), ToolConfirmationDecision::Approve);
+
+// 2.0 — the approval covers exactly the call it was requested for
+let mut decisions = HashMap::new();
+decisions.insert(
+    confirmation.function_call_id.clone().expect("the agent always sets this"),
+    ToolConfirmationDecision::Approve,
+);
+```
+
+When a decision travels through an untrusted round trip, bind it to the arguments
+it was granted for so a replayed call ID cannot smuggle different arguments:
+
+```rust
+use adk_core::tool_call_fingerprint;
+
+let mut fingerprints = HashMap::new();
+fingerprints.insert(
+    call_id.clone(),
+    tool_call_fingerprint(&confirmation.tool_name, &confirmation.args),
+);
+
+let config = RunConfig::builder()
+    .tool_confirmation_decisions(decisions)
+    .tool_confirmation_fingerprints(fingerprints)
+    .build();
+```
+
+For decisions that should apply by policy rather than per call, implement a
+`ToolConfirmationHandler` instead.
 
 ### `Part::EmbeddedResource`
 

--- a/docs/official_docs/security/tool-authorization.md
+++ b/docs/official_docs/security/tool-authorization.md
@@ -53,7 +53,8 @@ let agent = LlmAgentBuilder::new("assistant")
    ```
 3. The agent stream ends — execution is paused
 4. Your UI shows the user: "The agent wants to delete `/data/report.csv`. Allow?"
-5. On the next `Runner::run()`, pass the decision:
+5. On the next `Runner::run()`, pass the decision **keyed by the function call ID**
+   from the request:
 
 ```rust
 use adk_core::{RunConfig, ToolConfirmationDecision};
@@ -61,7 +62,7 @@ use std::collections::HashMap;
 
 let mut decisions = HashMap::new();
 decisions.insert(
-    "delete_file".to_string(),
+    "call_abc123".to_string(), // functionCallId from the request, not the tool name
     ToolConfirmationDecision::Approve, // or Deny
 );
 
@@ -69,6 +70,52 @@ decisions.insert(
 ```
 
 If denied, the tool is skipped and the LLM receives a message like "Tool execution was denied by the user" so it can adjust its approach.
+
+### Decisions Authorize One Exact Call
+
+A decision applies to the single call it was requested for. Keying by tool name
+would make one approval authorize every call of that tool, so an approval for
+`delete_file` on a scratch path would also authorize a call targeting something
+else. Two calls to the same tool in one turn therefore need two decisions.
+
+An unknown call ID means "no decision", which leaves the call awaiting
+confirmation. The failure direction is always toward asking again rather than
+executing.
+
+### Binding a Decision to Its Arguments
+
+When a decision travels through something you do not control — a browser, a queue,
+an external approval service — the call ID could be replayed with different
+arguments. Bind the decision to the arguments it was granted for:
+
+```rust
+use adk_core::{RunConfig, ToolConfirmationDecision, tool_call_fingerprint};
+use serde_json::json;
+use std::collections::HashMap;
+
+let approved_args = json!({ "path": "/data/report.csv" });
+
+let mut decisions = HashMap::new();
+decisions.insert("call_abc123".to_string(), ToolConfirmationDecision::Approve);
+
+let mut fingerprints = HashMap::new();
+fingerprints.insert(
+    "call_abc123".to_string(),
+    tool_call_fingerprint("delete_file", &approved_args),
+);
+
+let config = RunConfig::builder()
+    .tool_confirmation_decisions(decisions)
+    .tool_confirmation_fingerprints(fingerprints)
+    .build();
+```
+
+If the call that arrives does not match the fingerprint, the decision is ignored
+and the call is treated as unconfirmed. `tool_call_fingerprint` is canonical over
+key order, so a re-serialized argument object still matches.
+
+For decisions that should apply by policy rather than per call, implement a
+`ToolConfirmationHandler` instead of widening the static map.
 
 ### CLI Example
 
@@ -174,7 +221,10 @@ async fn main() -> anyhow::Result<()> {
 
                 // Re-run with the decision
                 let mut decisions = HashMap::new();
-                decisions.insert(confirmation.tool_name.clone(), decision);
+                // Keyed by the call ID, so the decision authorizes only this call.
+                if let Some(call_id) = confirmation.function_call_id.clone() {
+                    decisions.insert(call_id, decision);
+                }
 
                 let content = Content::new("user").with_text("");
                 let mut resume_stream = runner.run(


### PR DESCRIPTION
## What

Static tool-confirmation decisions are keyed by **function-call ID** instead of tool name, with optional argument binding. Three docs that taught the unsafe pattern are corrected.

## Why

Live decisions from a `ToolConfirmationHandler` were already tracked by call ID. Static decisions in `RunConfig::tool_confirmation_decisions` were looked up by **tool name**:

```rust
// before — in both the pre-check and the execution gate
confirmation_decisions.get(fc_name)
```

So one `delete_file` approval authorized **every** `delete_file` call evaluated against that map, whatever its arguments, and two calls to the same tool in one turn could not receive different decisions. A decision intended for one action could be replayed onto a materially different one — in exactly the resumed and web-driven flows that depend on the static map rather than the live handler.

## How

| Change | Effect |
|---|---|
| Decisions keyed by `function_call_id` | An approval authorizes only the call it was requested for |
| Unknown key = no decision | The call stays pending; the failure direction is toward asking again |
| New `RunConfig::tool_confirmation_fingerprints` | Optionally binds a decision to the arguments it was granted for |
| New `adk_core::tool_call_fingerprint` | Canonical, readable fingerprint of tool name + args |

Both the pre-check and the execution gate now go through one resolver, so they cannot disagree about whether a call was approved.

The fingerprint is canonical over object key order (re-serialized arguments still match) and deliberately readable rather than hashed, so a mismatch can be diagnosed by inspection — and no hashing dependency is added to `adk-core`.

## Consumers that were keying by name

Found by auditing every reader of the map, not just the site in the finding:

- **`adk-acp`'s permission bridge** — its own module documentation claimed *"the outcome is correlated to that call"* while the code keyed by tool name. A confirmation request without a call ID is now rejected rather than approved under a weaker key.
- **`adk-agent`'s CodeAct agent** — both confirmation gates, including the resumed-checkpoint path.

## Documentation taught the vulnerable pattern

Three places, all corrected:

| Location | Was |
|---|---|
| `security/tool-authorization.md` walkthrough | `decisions.insert("delete_file", Approve)` |
| Same file, web-server example | `decisions.insert(confirmation.tool_name.clone(), decision)` |
| `adk-acp/src/server/permission.rs` module docs | Described name keying as preserving call correlation |

The migration guide documents the **silent but safe** failure mode: an approval keyed by name is no longer found, so the run pauses for confirmation again rather than executing.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo nextest run --workspace --profile ci` | **3768 passed**, 83 skipped |
| `cargo nextest run -p adk-agent --features codeact` | 171 passed |
| `cargo test -p adk-core --doc` | 60 passed, including the new `tool_call_fingerprint` example |
| `RUSTDOCFLAGS=-D warnings cargo doc` (core, agent, acp) | exit 0 |
| doc-examples / doc-versions guards | exit 0 |

Three new security regression tests. `approving_one_call_does_not_approve_a_sibling_with_the_same_tool_name` was run against the name-keyed lookup and **fails** there — that failure is the vulnerability. Two pre-existing tests in `tool_confirmation_tests.rs` were keyed by name and are migrated to call IDs, which is the same edit downstream users make.

## Breaking change

Recorded in the 2.0.0 semver inventory:

| Crate | Change |
|---|---|
| `adk-core` | `RunConfig::tool_confirmation_decisions` keyed by function call ID instead of tool name |
| `adk-core` | New public field `RunConfig::tool_confirmation_fingerprints` |

## Not addressed

The finding also asks for one-shot consumption of an approval and rejection of duplicate provider IDs. Neither is implemented here; the map remains re-readable within a run, which is what resumed flows depend on today.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed — n/a
- [x] Examples added or updated for new features — n/a