### PR TITLE
fix(agent): bound tool progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -318,6 +318,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **adk-agent: tool progress is bounded.** Each tool batch created a
+  `tokio::sync::mpsc::unbounded_channel`, and `emit_progress` sent into it with no
+  backpressure and no aggregate limit. A tool producing output faster than the
+  client consumed it — a compiler log, a shell command, a runaway loop — grew the
+  queue until it was drained or the process ran out of memory, and a slow SSE
+  consumer made it worse.
+
+  The queue is now bounded at 256 events, a chunk is capped at 8 KiB (truncated on
+  a character boundary, so multi-byte text is never split), and a call may forward
+  1 MiB of progress in total. A tool that outruns its consumer waits up to 100 ms
+  for space and then drops the chunk, so a stalled consumer slows the tool briefly
+  but can never stall it indefinitely. Whenever output is dropped, exactly one
+  progress event carrying `[adk: tool progress truncated]` is emitted for that
+  call, so a gap is visible rather than silent. Final tool results are unaffected.
+
 - **adk-agent/adk-tool: workflow context wrappers no longer drop cancellation,
   secrets, and shared state.** Each wrapper re-implements `InvocationContext` and
   delegates to an inner context, but most capability methods have permissive trait

--- a/adk-agent/src/llm_agent.rs
+++ b/adk-agent/src/llm_agent.rs
@@ -946,11 +946,49 @@ impl LlmAgentBuilder {
 
 // AgentToolContext wraps the parent InvocationContext and preserves all context
 // instead of throwing it away like SimpleToolContext did
+/// Progress events held in flight for one tool batch.
+///
+/// The queue exists to decouple a tool that writes progress from a client that
+/// reads it. It is bounded so a verbose tool cannot grow the queue without limit
+/// while the consumer is slow.
+const TOOL_PROGRESS_CAPACITY: usize = 256;
+
+/// How long a tool waits for queue space before its chunk is dropped.
+///
+/// A short wait applies real backpressure to a tool that outruns its consumer,
+/// without letting a stalled consumer block the tool indefinitely.
+const TOOL_PROGRESS_SEND_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(100);
+
+/// Largest single progress chunk forwarded, in bytes.
+const TOOL_PROGRESS_MAX_CHUNK_BYTES: usize = 8 * 1024;
+
+/// Total progress bytes forwarded for one tool call.
+const TOOL_PROGRESS_MAX_TOTAL_BYTES: usize = 1024 * 1024;
+
+/// Text appended in place of progress output that was not forwarded.
+const TOOL_PROGRESS_TRUNCATION_MARKER: &str = "[adk: tool progress truncated]";
+
+/// Truncates `text` to at most `max_bytes`, never splitting a character.
+fn truncate_on_char_boundary(text: &str, max_bytes: usize) -> &str {
+    if text.len() <= max_bytes {
+        return text;
+    }
+    let mut end = max_bytes;
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    &text[..end]
+}
+
 struct AgentToolContext {
     parent_ctx: Arc<dyn InvocationContext>,
     function_call_id: String,
     actions: Mutex<EventActions>,
-    progress_tx: Option<tokio::sync::mpsc::UnboundedSender<Event>>,
+    progress_tx: Option<tokio::sync::mpsc::Sender<Event>>,
+    /// Progress bytes forwarded so far for this call.
+    progress_bytes: std::sync::atomic::AtomicUsize,
+    /// Set once the truncation marker has been emitted, so it is emitted once.
+    progress_truncated: std::sync::atomic::AtomicBool,
 }
 
 impl AgentToolContext {
@@ -960,14 +998,87 @@ impl AgentToolContext {
             function_call_id,
             actions: Mutex::new(EventActions::default()),
             progress_tx: None,
+            progress_bytes: std::sync::atomic::AtomicUsize::new(0),
+            progress_truncated: std::sync::atomic::AtomicBool::new(false),
         }
     }
 
     /// Attach a progress sink so [`ToolContext::emit_progress`] forwards chunks
     /// as partial [`Event`]s onto the agent's `EventStream`.
-    fn with_progress(mut self, tx: tokio::sync::mpsc::UnboundedSender<Event>) -> Self {
+    fn with_progress(mut self, tx: tokio::sync::mpsc::Sender<Event>) -> Self {
         self.progress_tx = Some(tx);
         self
+    }
+
+    /// Forwards one progress chunk under this call's budget.
+    ///
+    /// The policy is bounded and lossy by design: memory is capped, and output that
+    /// does not fit is replaced by a single truncation marker rather than stalling
+    /// the tool or growing without limit. A tool that outruns its consumer waits
+    /// briefly, which slows the tool rather than the whole run.
+    async fn forward_progress(
+        &self,
+        tx: &tokio::sync::mpsc::Sender<Event>,
+        stream: &str,
+        chunk: &str,
+    ) {
+        use std::sync::atomic::Ordering;
+
+        if self.progress_truncated.load(Ordering::Relaxed) {
+            return;
+        }
+
+        // Cap one chunk, then cap the call. Truncation respects char boundaries so
+        // multi-byte text is never split mid-character.
+        let payload = truncate_on_char_boundary(chunk, TOOL_PROGRESS_MAX_CHUNK_BYTES);
+        let forwarded = self.progress_bytes.fetch_add(payload.len(), Ordering::Relaxed);
+        if forwarded.saturating_add(payload.len()) > TOOL_PROGRESS_MAX_TOTAL_BYTES {
+            self.mark_progress_truncated(tx, stream).await;
+            return;
+        }
+
+        let event = Event::tool_progress(
+            self.parent_ctx.invocation_id(),
+            self.parent_ctx.agent_name(),
+            &self.function_call_id,
+            stream,
+            payload,
+        );
+
+        match tx.try_send(event) {
+            Ok(()) => {}
+            Err(tokio::sync::mpsc::error::TrySendError::Full(event)) => {
+                // Wait briefly for the consumer to catch up, then give up on this
+                // chunk so a stalled consumer cannot block the tool.
+                match tokio::time::timeout(TOOL_PROGRESS_SEND_TIMEOUT, tx.send(event)).await {
+                    Ok(Ok(())) => {}
+                    Ok(Err(_)) => {}
+                    Err(_) => self.mark_progress_truncated(tx, stream).await,
+                }
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {}
+        }
+    }
+
+    /// Emits the truncation marker once for this call.
+    async fn mark_progress_truncated(&self, tx: &tokio::sync::mpsc::Sender<Event>, stream: &str) {
+        use std::sync::atomic::Ordering;
+        if self.progress_truncated.swap(true, Ordering::Relaxed) {
+            return;
+        }
+        tracing::warn!(
+            function_call.id = %self.function_call_id,
+            progress.stream = %stream,
+            "tool progress exceeded its budget, remaining output is not forwarded"
+        );
+        let marker = Event::tool_progress(
+            self.parent_ctx.invocation_id(),
+            self.parent_ctx.agent_name(),
+            &self.function_call_id,
+            stream,
+            TOOL_PROGRESS_TRUNCATION_MARKER,
+        );
+        let _ = tx.try_send(marker);
     }
 
     fn actions_guard(&self) -> std::sync::MutexGuard<'_, EventActions> {
@@ -1056,15 +1167,10 @@ impl ToolContext for AgentToolContext {
         // Primary path: forward as a partial Event on the agent's EventStream so
         // UIs consume tool progress through the same channel as everything else.
         if let Some(tx) = &self.progress_tx {
-            let event = Event::tool_progress(
-                self.parent_ctx.invocation_id(),
-                self.parent_ctx.agent_name(),
-                &self.function_call_id,
-                stream,
-                chunk,
-            );
-            // Best-effort: a closed receiver just means nobody is listening.
-            let _ = tx.send(event);
+            // A closed receiver means nobody is listening, so stop building events.
+            if !tx.is_closed() {
+                self.forward_progress(tx, stream, chunk).await;
+            }
         }
         // Secondary path: structured trace for log-based observability.
         tracing::debug!(
@@ -2202,7 +2308,7 @@ impl Agent for LlmAgent {
                     // AgentToolContext gets a clone; the dispatch loop below drains
                     // it concurrently and yields progress events to the client.
                     let (progress_tx, mut progress_rx) =
-                        tokio::sync::mpsc::unbounded_channel::<Event>();
+                        tokio::sync::mpsc::channel::<Event>(TOOL_PROGRESS_CAPACITY);
 
                     // Per-tool execution async block. Returns (index, Content, EventActions, escalate_or_skip).
                     // Each tool retains its own retry budget, circuit breaker, tracing span,

--- a/adk-agent/tests/tool_progress_bounds_tests.rs
+++ b/adk-agent/tests/tool_progress_bounds_tests.rs
@@ -1,0 +1,313 @@
+//! Tool progress must be bounded.
+//!
+//! Each tool batch previously created a `tokio::sync::mpsc::unbounded_channel`,
+//! and `emit_progress` sent into it without backpressure or any aggregate limit. A
+//! tool producing output faster than the client consumed it — a compiler log, a
+//! shell command, a faulty loop — grew the queue until it was drained or the
+//! process ran out of memory.
+//!
+//! The queue is now bounded, each call has a byte budget, and output beyond the
+//! budget is replaced by a single deterministic marker.
+
+use adk_agent::LlmAgentBuilder;
+use adk_core::{
+    Agent, Content, FinishReason, InvocationContext, Llm, LlmRequest, LlmResponse,
+    LlmResponseStream, Part, Result, RunConfig, Session, State, Tool, ToolContext,
+};
+use async_trait::async_trait;
+use futures::StreamExt;
+use serde_json::{Value, json};
+use std::collections::{HashMap, VecDeque};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+/// The marker the agent emits in place of progress it did not forward.
+const TRUNCATION_MARKER: &str = "[adk: tool progress truncated]";
+
+/// The per-call byte budget the agent enforces.
+const MAX_TOTAL_BYTES: usize = 1024 * 1024;
+
+// ── Mocks ─────────────────────────────────────────────────────────────
+
+struct SequencedModel {
+    responses: Arc<Mutex<VecDeque<LlmResponse>>>,
+}
+
+impl SequencedModel {
+    fn new(responses: Vec<LlmResponse>) -> Self {
+        Self { responses: Arc::new(Mutex::new(responses.into_iter().collect())) }
+    }
+
+    fn call(name: &str, id: &str) -> LlmResponse {
+        Self::response(Some(Content {
+            role: "model".to_string(),
+            parts: vec![Part::FunctionCall {
+                name: name.to_string(),
+                args: json!({}),
+                id: Some(id.to_string()),
+                thought_signature: None,
+            }],
+        }))
+    }
+
+    fn text(text: &str) -> LlmResponse {
+        Self::response(Some(Content {
+            role: "model".to_string(),
+            parts: vec![Part::Text { text: text.to_string() }],
+        }))
+    }
+
+    fn response(content: Option<Content>) -> LlmResponse {
+        LlmResponse {
+            content,
+            usage_metadata: None,
+            finish_reason: Some(FinishReason::Stop),
+            citation_metadata: None,
+            partial: false,
+            turn_complete: true,
+            interrupted: false,
+            error_code: None,
+            error_message: None,
+            provider_metadata: None,
+            interaction_id: None,
+        }
+    }
+}
+
+#[async_trait]
+impl Llm for SequencedModel {
+    fn name(&self) -> &str {
+        "sequenced-model"
+    }
+
+    async fn generate_content(&self, _req: LlmRequest, _stream: bool) -> Result<LlmResponseStream> {
+        let next = self
+            .responses
+            .lock()
+            .unwrap()
+            .pop_front()
+            .unwrap_or_else(|| SequencedModel::text("done"));
+        let s = async_stream::stream! { yield Ok(next); };
+        Ok(Box::pin(s))
+    }
+}
+
+/// A tool that emits far more progress than the per-call budget allows.
+struct FloodingTool {
+    /// Chunks the tool attempted to emit.
+    attempted: Arc<AtomicUsize>,
+    chunk_bytes: usize,
+    chunks: usize,
+}
+
+#[async_trait]
+impl Tool for FloodingTool {
+    fn name(&self) -> &str {
+        "flooding_tool"
+    }
+
+    fn description(&self) -> &str {
+        "emits a great deal of progress"
+    }
+
+    fn parameters_schema(&self) -> Option<Value> {
+        Some(json!({ "type": "object", "properties": {} }))
+    }
+
+    async fn execute(&self, ctx: Arc<dyn ToolContext>, _args: Value) -> Result<Value> {
+        let chunk = "x".repeat(self.chunk_bytes);
+        for _ in 0..self.chunks {
+            self.attempted.fetch_add(1, Ordering::Relaxed);
+            ctx.emit_progress("stdout", &chunk).await;
+        }
+        Ok(json!({ "ok": true }))
+    }
+}
+
+struct MockState;
+
+impl State for MockState {
+    fn get(&self, _key: &str) -> Option<Value> {
+        None
+    }
+    fn set(&mut self, _key: String, _value: Value) {}
+    fn all(&self) -> HashMap<String, Value> {
+        HashMap::new()
+    }
+}
+
+struct MockSession;
+
+impl Session for MockSession {
+    fn id(&self) -> &str {
+        "session-1"
+    }
+    fn app_name(&self) -> &str {
+        "test-app"
+    }
+    fn user_id(&self) -> &str {
+        "user-1"
+    }
+    fn state(&self) -> &dyn State {
+        &MockState
+    }
+    fn conversation_history(&self) -> Vec<Content> {
+        Vec::new()
+    }
+}
+
+struct MockContext {
+    session: MockSession,
+    user_content: Content,
+}
+
+#[async_trait]
+impl adk_core::ReadonlyContext for MockContext {
+    fn invocation_id(&self) -> &str {
+        "inv-1"
+    }
+    fn agent_name(&self) -> &str {
+        "test-agent"
+    }
+    fn user_id(&self) -> &str {
+        "user-1"
+    }
+    fn app_name(&self) -> &str {
+        "test-app"
+    }
+    fn session_id(&self) -> &str {
+        "session-1"
+    }
+    fn branch(&self) -> &str {
+        "main"
+    }
+    fn user_content(&self) -> &Content {
+        &self.user_content
+    }
+}
+
+#[async_trait]
+impl adk_core::CallbackContext for MockContext {
+    fn artifacts(&self) -> Option<Arc<dyn adk_core::Artifacts>> {
+        None
+    }
+}
+
+#[async_trait]
+impl InvocationContext for MockContext {
+    fn agent(&self) -> Arc<dyn Agent> {
+        unimplemented!("not exercised")
+    }
+    fn memory(&self) -> Option<Arc<dyn adk_core::Memory>> {
+        None
+    }
+    fn session(&self) -> &dyn Session {
+        &self.session
+    }
+    fn run_config(&self) -> &RunConfig {
+        static RUN_CONFIG: std::sync::OnceLock<RunConfig> = std::sync::OnceLock::new();
+        RUN_CONFIG.get_or_init(RunConfig::default)
+    }
+    fn end_invocation(&self) {}
+    fn ended(&self) -> bool {
+        false
+    }
+}
+
+fn context() -> Arc<MockContext> {
+    Arc::new(MockContext {
+        session: MockSession,
+        user_content: Content {
+            role: "user".to_string(),
+            parts: vec![Part::Text { text: "go".to_string() }],
+        },
+    })
+}
+
+/// Total bytes of progress text the stream delivered, and whether the marker appeared.
+async fn run_and_measure(tool: Arc<FloodingTool>) -> (usize, bool, usize) {
+    let model = Arc::new(SequencedModel::new(vec![
+        SequencedModel::call("flooding_tool", "call-1"),
+        SequencedModel::text("finished"),
+    ]));
+    let agent = LlmAgentBuilder::new("test-agent").model(model).tool(tool).build().unwrap();
+
+    let mut stream = agent.run(context()).await.unwrap();
+    let mut progress_bytes = 0;
+    let mut progress_events = 0;
+    let mut saw_marker = false;
+    while let Some(result) = stream.next().await {
+        let event = result.expect("the run must not fail");
+        if event.tool_progress_stream().is_none() {
+            continue;
+        }
+        progress_events += 1;
+        if let Some(content) = &event.llm_response.content {
+            for part in &content.parts {
+                if let Part::Text { text } = part {
+                    if text == TRUNCATION_MARKER {
+                        saw_marker = true;
+                    } else {
+                        progress_bytes += text.len();
+                    }
+                }
+            }
+        }
+    }
+    (progress_bytes, saw_marker, progress_events)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn progress_beyond_the_call_budget_is_replaced_by_one_marker() {
+    // 4 MiB attempted against a 1 MiB budget.
+    let tool = Arc::new(FloodingTool {
+        attempted: Arc::new(AtomicUsize::new(0)),
+        chunk_bytes: 8 * 1024,
+        chunks: 512,
+    });
+    let (progress_bytes, saw_marker, _events) = run_and_measure(tool.clone()).await;
+
+    assert!(
+        tool.attempted.load(Ordering::Relaxed) > 0,
+        "the tool must actually have emitted progress"
+    );
+    assert!(
+        progress_bytes <= MAX_TOTAL_BYTES,
+        "forwarded {progress_bytes} bytes of progress, above the {MAX_TOTAL_BYTES} byte budget"
+    );
+    assert!(saw_marker, "output dropped for budget reasons must be reported by a marker");
+}
+
+#[tokio::test]
+async fn a_single_oversized_chunk_is_capped() {
+    // One 64 KiB chunk against the 8 KiB per-chunk cap.
+    let tool = Arc::new(FloodingTool {
+        attempted: Arc::new(AtomicUsize::new(0)),
+        chunk_bytes: 64 * 1024,
+        chunks: 1,
+    });
+    let (progress_bytes, _marker, events) = run_and_measure(tool).await;
+
+    assert_eq!(events, 1, "one emitted chunk must produce one progress event");
+    assert!(
+        progress_bytes <= 8 * 1024,
+        "a single chunk forwarded {progress_bytes} bytes, above the 8 KiB per-chunk cap"
+    );
+}
+
+#[tokio::test]
+async fn modest_progress_is_forwarded_intact() {
+    // Guards against the budget swallowing ordinary output.
+    let tool = Arc::new(FloodingTool {
+        attempted: Arc::new(AtomicUsize::new(0)),
+        chunk_bytes: 16,
+        chunks: 8,
+    });
+    let (progress_bytes, saw_marker, events) = run_and_measure(tool).await;
+
+    assert_eq!(events, 8, "every modest chunk must be forwarded");
+    assert_eq!(progress_bytes, 128);
+    assert!(!saw_marker, "ordinary output must not be reported as truncated");
+}

--- a/docs/official_docs/tools/function-tools.md
+++ b/docs/official_docs/tools/function-tools.md
@@ -513,6 +513,24 @@ model text, and the final tool result all arrive on one ordered stream.
 tools and runners that don't stream are unaffected. Only tools that opt in emit
 progress, and only consumers that check `tool_progress_stream()` observe it.
 
+**Progress is bounded and lossy.** A tool can produce output faster than a client
+consumes it — a compiler log, a shell command, a runaway loop — so the framework
+caps what it will hold and forward rather than growing without limit:
+
+| Limit | Value | On exceeding it |
+|-------|-------|-----------------|
+| Queue depth per tool batch | 256 events | The tool waits up to 100 ms for space, then the chunk is dropped |
+| Bytes per chunk | 8 KiB | The chunk is truncated on a character boundary |
+| Bytes per tool call | 1 MiB | Remaining progress is not forwarded |
+
+When output is dropped for any of these reasons, exactly one progress event
+carrying the text `[adk: tool progress truncated]` is emitted for that call, so a
+gap is always visible rather than silent. A slow consumer therefore slows the tool
+briefly but can never stall it indefinitely or exhaust memory.
+
+These limits apply only to *progress*. A tool's final result is not affected, so
+truncate large results inside the tool if that matters to you.
+
 > See the `streaming_bash` example for a complete web UI that renders live
 > `bash` output and one-shot tool results (`read_file`, `grep`, `glob`) from a
 > single event feed. The streaming `bash` tool itself lives in `adk-devtools`.


### PR DESCRIPTION
## What

Tool progress moves from an unbounded queue to a bounded one with per-chunk and per-call byte budgets and a visible truncation marker.

## Why

```rust
// before — one per tool batch, no bound, no backpressure
tokio::sync::mpsc::unbounded_channel::<Event>()
```

`emit_progress` sent into it best-effort. A tool producing output faster than the client consumed it grew the queue until it was drained or the process ran out of memory. Queued events retain their strings and metadata, so large compiler logs, shell output, or a faulty loop translate directly into resident memory. A slow SSE consumer widens the window.

## How

| Limit | Value | On exceeding it |
|---|---|---|
| Queue depth per tool batch | 256 events | Tool waits up to 100 ms for space, then the chunk is dropped |
| Bytes per chunk | 8 KiB | Truncated on a character boundary |
| Bytes per tool call | 1 MiB | Remaining progress is not forwarded |

Whenever output is dropped for any reason, **exactly one** event carrying `[adk: tool progress truncated]` is emitted for that call, so a gap is never silent.

### Why lossy rather than blocking

The drain is a biased `tokio::select!` polled concurrently with the dispatch future, so `tx.send().await` would be safe against the runtime. It would not be safe against the *client*: a consumer that stops polling the agent stream stops the drain, and the tool would then block for as long as the client stays away. Bounding the wait keeps backpressure real (a fast tool does slow down) without handing a remote consumer the ability to stall tool execution indefinitely.

Character-boundary-safe truncation matters here — the repo has prior UTF-8 boundary fixes for CJK text, and naive byte slicing would panic.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo nextest run --workspace --profile ci` | **3768 passed**, 83 skipped |
| doc-examples guard | exit 0 |

Three regression tests. Against the unbounded implementation, **two fail**: `a_single_oversized_chunk_is_capped` and `progress_beyond_the_call_budget_is_replaced_by_one_marker`. The third (`modest_progress_is_forwarded_intact`) passes both ways by design — it guards against the budget swallowing ordinary output.

Not verified: actual resident memory. The tests assert forwarded bytes and marker behaviour, which is what the code controls; they do not measure RSS.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed — n/a
- [x] Examples added or updated for new features — n/a