### PR TITLE
fix(server): authenticate UI routes and bind resource ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **adk-server: UI routes bypassed configured authentication.** The session,
+  artifact, and debug routers received the authentication layer; `ui_api_router` was
+  merged without it. With an extractor configured, an unauthenticated caller could
+  create and mutate MCP-UI bridge state under any chosen `(app_name, user_id,
+  session_id)` tuple, poll another user's notifications, and list, read, or overwrite
+  globally registered UI resources — including replacing the HTML text of an existing
+  resource URI.
+
+  All `/api/ui/*` routes now carry the same authentication layer as the other
+  routers. Bridge handlers substitute the authenticated user for the user named in
+  the request body, so one authenticated caller can no longer address another's
+  bridge state. A registered UI resource records the user that registered it; only
+  that user may read or replace it, and a read of another user's resource answers 404
+  rather than disclosing that the URI exists.
+
+  Servers with no extractor configured are unchanged: there is no authenticated
+  identity to bind, so routes stay open and resources stay globally visible.
+
 - **Dependency advisories resolved.** Bumped `surrealdb` (optional `adk-rag`
   backend) to 3.2.1, fixing GHSA-cc8f-fcx3-gpjr (high: arbitrary file read via
   `DEFINE ANALYZER` mapper filter) plus four related medium advisories. Bumped

--- a/adk-server/src/rest/controllers/ui.rs
+++ b/adk-server/src/rest/controllers/ui.rs
@@ -7,6 +7,7 @@ use crate::ui_types::{
     McpUiPermissions, McpUiResourceCsp, default_mcp_ui_host_capabilities, default_mcp_ui_host_info,
     validate_mcp_apps_render_options,
 };
+use axum::Extension;
 use axum::{Json, extract::Query, http::StatusCode};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -119,6 +120,11 @@ pub struct ReadUiResourceQuery {
 struct UiResourceEntry {
     resource: UiResource,
     content: UiResourceContent,
+    /// The authenticated user that registered this resource, when the server has
+    /// authentication configured. `None` means the resource was registered by an
+    /// unauthenticated server and is visible to everyone, which preserves the
+    /// behaviour of a server that has no auth to enforce.
+    owner: Option<String>,
 }
 
 static UI_RESOURCE_REGISTRY: OnceLock<RwLock<HashMap<String, UiResourceEntry>>> = OnceLock::new();
@@ -841,6 +847,83 @@ pub(crate) fn mark_mcp_ui_initialized(
     Ok(())
 }
 
+/// Whether `owner` may be accessed by `caller`.
+///
+/// A resource registered without an owner stays readable by anyone, so a server
+/// with no authentication behaves as before. Once a resource has an owner, only
+/// that user may read or replace it: the registry is process-global and keyed by
+/// URI alone, so without this check one authenticated caller could read or
+/// overwrite another's registered HTML.
+fn may_access_resource(owner: Option<&String>, caller: Option<&adk_core::RequestContext>) -> bool {
+    match (owner, caller) {
+        (None, _) => true,
+        (Some(_), None) => true,
+        (Some(owner), Some(caller)) => owner == &caller.user_id,
+    }
+}
+
+/// Bridge parameters that name the user whose bridge state is addressed.
+///
+/// Implemented for every bridge params type so one rule binds them all to the
+/// authenticated caller.
+trait BridgeUser {
+    fn user_id_mut(&mut self) -> &mut String;
+}
+
+/// Replaces the caller-supplied user with the authenticated one.
+///
+/// The bridge registry is keyed by `(app_name, user_id, session_id)` taken from the
+/// request body, so a body-supplied user would let one authenticated caller read and
+/// mutate another's bridge state. When authentication is configured, the body value
+/// is not trusted. When it is not configured, there is no authenticated identity to
+/// bind and the body value stands.
+fn bind_authenticated_user<P: BridgeUser>(
+    params: &mut P,
+    request_context: Option<&adk_core::RequestContext>,
+) {
+    if let Some(context) = request_context {
+        let supplied = params.user_id_mut();
+        if supplied != &context.user_id {
+            info!(
+                supplied.user_id = %supplied,
+                authenticated.user_id = %context.user_id,
+                "ui bridge request named a different user, using the authenticated user"
+            );
+            *supplied = context.user_id.clone();
+        }
+    }
+}
+
+impl BridgeUser for McpUiInitializeParams {
+    fn user_id_mut(&mut self) -> &mut String {
+        &mut self.user_id
+    }
+}
+
+impl BridgeUser for McpUiMessageParams {
+    fn user_id_mut(&mut self) -> &mut String {
+        &mut self.user_id
+    }
+}
+
+impl BridgeUser for McpUiUpdateModelContextParams {
+    fn user_id_mut(&mut self) -> &mut String {
+        &mut self.user_id
+    }
+}
+
+impl BridgeUser for McpUiPollNotificationsParams {
+    fn user_id_mut(&mut self) -> &mut String {
+        &mut self.user_id
+    }
+}
+
+impl BridgeUser for McpUiListChangedParams {
+    fn user_id_mut(&mut self) -> &mut String {
+        &mut self.user_id
+    }
+}
+
 /// GET /api/ui/capabilities
 pub async fn ui_capabilities() -> Json<UiCapabilities> {
     Json(UiCapabilities {
@@ -864,64 +947,85 @@ pub async fn ui_capabilities() -> Json<UiCapabilities> {
 
 /// POST /api/ui/initialize
 pub(crate) async fn ui_initialize(
+    Extension(request_context): Extension<Option<adk_core::RequestContext>>,
     Json(input): Json<McpUiBridgeInput<McpUiInitializeParams>>,
 ) -> Result<Json<Value>, (StatusCode, String)> {
-    let (params, response_mode) = parse_bridge_input(input, "ui/initialize")?;
+    let (mut params, response_mode) = parse_bridge_input(input, "ui/initialize")?;
+    bind_authenticated_user(&mut params, request_context.as_ref());
     let result = initialize_mcp_ui_bridge(params)?;
     bridge_result_json(response_mode, result)
 }
 
 /// POST /api/ui/message
 pub(crate) async fn ui_message(
+    Extension(request_context): Extension<Option<adk_core::RequestContext>>,
     Json(input): Json<McpUiBridgeInput<McpUiMessageParams>>,
 ) -> Result<Json<Value>, (StatusCode, String)> {
-    let (params, response_mode) = parse_bridge_input(input, "ui/message")?;
+    let (mut params, response_mode) = parse_bridge_input(input, "ui/message")?;
+    bind_authenticated_user(&mut params, request_context.as_ref());
     let result = message_mcp_ui_bridge(params)?;
     bridge_result_json(response_mode, result)
 }
 
 /// POST /api/ui/update-model-context
 pub(crate) async fn ui_update_model_context(
+    Extension(request_context): Extension<Option<adk_core::RequestContext>>,
     Json(input): Json<McpUiBridgeInput<McpUiUpdateModelContextParams>>,
 ) -> Result<Json<Value>, (StatusCode, String)> {
-    let (params, response_mode) = parse_bridge_input(input, "ui/update-model-context")?;
+    let (mut params, response_mode) = parse_bridge_input(input, "ui/update-model-context")?;
+    bind_authenticated_user(&mut params, request_context.as_ref());
     let result = update_mcp_ui_bridge_model_context(params)?;
     bridge_result_json(response_mode, result)
 }
 
 /// POST /api/ui/notifications/poll
 pub(crate) async fn ui_poll_notifications(
+    Extension(request_context): Extension<Option<adk_core::RequestContext>>,
     Json(input): Json<McpUiBridgeInput<McpUiPollNotificationsParams>>,
 ) -> Result<Json<Value>, (StatusCode, String)> {
-    let (params, response_mode) = parse_bridge_input(input, "ui/notifications/poll")?;
+    let (mut params, response_mode) = parse_bridge_input(input, "ui/notifications/poll")?;
+    bind_authenticated_user(&mut params, request_context.as_ref());
     let result = poll_mcp_ui_bridge_notifications(params)?;
     bridge_result_json(response_mode, result)
 }
 
 /// POST /api/ui/notifications/resources-list-changed
 pub(crate) async fn ui_notify_resources_list_changed(
+    Extension(request_context): Extension<Option<adk_core::RequestContext>>,
     Json(input): Json<McpUiBridgeInput<McpUiListChangedParams>>,
 ) -> Result<Json<Value>, (StatusCode, String)> {
-    let (params, response_mode) =
+    let (mut params, response_mode) =
         parse_bridge_input(input, "ui/notifications/resources/list_changed")?;
+    bind_authenticated_user(&mut params, request_context.as_ref());
     let result = notify_mcp_ui_resource_list_changed(params)?;
     bridge_result_json(response_mode, result)
 }
 
 /// POST /api/ui/notifications/tools-list-changed
 pub(crate) async fn ui_notify_tools_list_changed(
+    Extension(request_context): Extension<Option<adk_core::RequestContext>>,
     Json(input): Json<McpUiBridgeInput<McpUiListChangedParams>>,
 ) -> Result<Json<Value>, (StatusCode, String)> {
-    let (params, response_mode) = parse_bridge_input(input, "ui/notifications/tools/list_changed")?;
+    let (mut params, response_mode) =
+        parse_bridge_input(input, "ui/notifications/tools/list_changed")?;
+    bind_authenticated_user(&mut params, request_context.as_ref());
     let result = notify_mcp_ui_tool_list_changed(params)?;
     bridge_result_json(response_mode, result)
 }
 
 /// GET /api/ui/resources
-pub async fn list_ui_resources() -> Json<UiResourceListResponse> {
+pub async fn list_ui_resources(
+    Extension(request_context): Extension<Option<adk_core::RequestContext>>,
+) -> Json<UiResourceListResponse> {
     let resources: Vec<UiResource> = resource_registry()
         .read()
-        .map(|registry| registry.values().map(|entry| entry.resource.clone()).collect())
+        .map(|registry| {
+            registry
+                .values()
+                .filter(|entry| may_access_resource(entry.owner.as_ref(), request_context.as_ref()))
+                .map(|entry| entry.resource.clone())
+                .collect()
+        })
         .unwrap_or_default();
     info!(resource_count = resources.len(), "ui resource list requested");
     Json(UiResourceListResponse { resources })
@@ -929,6 +1033,7 @@ pub async fn list_ui_resources() -> Json<UiResourceListResponse> {
 
 /// GET /api/ui/resources/read?uri=ui://...
 pub async fn read_ui_resource(
+    Extension(request_context): Extension<Option<adk_core::RequestContext>>,
     Query(query): Query<ReadUiResourceQuery>,
 ) -> Result<Json<UiResourceReadResponse>, (StatusCode, String)> {
     validate_ui_resource_uri(&query.uri)?;
@@ -939,12 +1044,18 @@ pub async fn read_ui_resource(
         warn!(uri = %query.uri, "ui resource read failed: not found");
         return Err((StatusCode::NOT_FOUND, format!("resource not found: {}", query.uri)));
     };
+    if !may_access_resource(entry.owner.as_ref(), request_context.as_ref()) {
+        // Reported as not found so the URI's existence is not disclosed.
+        warn!(uri = %query.uri, "ui resource read denied: owned by another user");
+        return Err((StatusCode::NOT_FOUND, format!("resource not found: {}", query.uri)));
+    }
     info!(uri = %query.uri, "ui resource read");
     Ok(Json(UiResourceReadResponse { contents: vec![entry.content.clone()] }))
 }
 
 /// POST /api/ui/resources/register
 pub async fn register_ui_resource(
+    Extension(request_context): Extension<Option<adk_core::RequestContext>>,
     Json(req): Json<RegisterUiResourceRequest>,
 ) -> Result<StatusCode, (StatusCode, String)> {
     validate_ui_resource_uri(&req.uri)?;
@@ -972,12 +1083,22 @@ pub async fn register_ui_resource(
             blob: None,
             meta,
         },
+        owner: request_context.as_ref().map(|context| context.user_id.clone()),
     };
 
-    resource_registry()
-        .write()
-        .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "resource registry poisoned".to_string()))?
-        .insert(uri.clone(), entry);
+    let mut registry = resource_registry().write().map_err(|_| {
+        (StatusCode::INTERNAL_SERVER_ERROR, "resource registry poisoned".to_string())
+    })?;
+    // Registration replaces an existing URI, so an unauthorized overwrite would let
+    // one caller substitute another's resource content.
+    if let Some(existing) = registry.get(&uri)
+        && !may_access_resource(existing.owner.as_ref(), request_context.as_ref())
+    {
+        warn!(uri = %uri, "ui resource registration denied: owned by another user");
+        return Err((StatusCode::FORBIDDEN, format!("resource is owned by another user: {uri}")));
+    }
+    registry.insert(uri.clone(), entry);
+    drop(registry);
     info!(
         uri = %uri,
         name = %name,

--- a/adk-server/src/rest/mod.rs
+++ b/adk-server/src/rest/mod.rs
@@ -361,7 +361,10 @@ pub fn create_app_with_a2a(config: ServerConfig, a2a_base_url: Option<&str>) -> 
         )
         .route("/ui/resources", get(controllers::ui::list_ui_resources))
         .route("/ui/resources/read", get(controllers::ui::read_ui_resource))
-        .route("/ui/resources/register", post(controllers::ui::register_ui_resource));
+        .route("/ui/resources/register", post(controllers::ui::register_ui_resource))
+        // These routes mutate and read shared bridge and resource state, so they
+        // carry the same authentication as the session, artifact, and debug routers.
+        .layer(auth_layer.clone());
 
     let session_router = Router::new()
         .route("/sessions", post(controllers::session::create_session))
@@ -673,7 +676,10 @@ impl ServerBuilder {
             )
             .route("/ui/resources", get(controllers::ui::list_ui_resources))
             .route("/ui/resources/read", get(controllers::ui::read_ui_resource))
-            .route("/ui/resources/register", post(controllers::ui::register_ui_resource));
+            .route("/ui/resources/register", post(controllers::ui::register_ui_resource))
+            // These routes mutate and read shared bridge and resource state, so they
+            // carry the same authentication as the session, artifact, and debug routers.
+            .layer(auth_layer.clone());
 
         let session_router = Router::new()
             .route("/sessions", post(controllers::session::create_session))

--- a/adk-server/tests/server_tests.rs
+++ b/adk-server/tests/server_tests.rs
@@ -1984,3 +1984,171 @@ async fn test_ui_resources_reject_invalid_csp_domains() {
 
     assert_eq!(register_response.status(), StatusCode::BAD_REQUEST);
 }
+
+// ── UI routes under configured authentication ──────────────────────────
+//
+// `ui_api_router` was merged without `auth_layer` while the session, artifact, and
+// debug routers received it. With authentication configured, an unauthenticated
+// caller could create and mutate bridge state under any chosen identity tuple, poll
+// notifications, and list, read, or overwrite globally registered resources.
+
+fn authed_app() -> axum::Router {
+    let config =
+        adk_server::ServerConfig::new(Arc::new(MockAgentLoader), Arc::new(MockSessionService))
+            .with_request_context(Arc::new(HeaderExtractor));
+    create_app(config)
+}
+
+async fn status_without_auth(method: &str, uri: &str, body: Option<Value>) -> StatusCode {
+    let builder = Request::builder().method(method).uri(uri);
+    let request = match body {
+        Some(json) => builder
+            .header("content-type", "application/json")
+            .body(Body::from(json.to_string()))
+            .unwrap(),
+        None => builder.body(Body::empty()).unwrap(),
+    };
+    authed_app().oneshot(request).await.unwrap().status()
+}
+
+#[tokio::test]
+async fn ui_bridge_routes_require_auth_when_configured() {
+    let bridge_body = json!({
+        "appName": "victim-app",
+        "userId": "victim",
+        "sessionId": "victim-session",
+        "params": {}
+    });
+
+    for (method, uri) in [
+        ("POST", "/api/ui/initialize"),
+        ("POST", "/api/ui/message"),
+        ("POST", "/api/ui/update-model-context"),
+        ("POST", "/api/ui/notifications/poll"),
+        ("POST", "/api/ui/notifications/resources-list-changed"),
+        ("POST", "/api/ui/notifications/tools-list-changed"),
+    ] {
+        let status = status_without_auth(method, uri, Some(bridge_body.clone())).await;
+        assert_eq!(
+            status,
+            StatusCode::UNAUTHORIZED,
+            "{method} {uri} accepted an unauthenticated request"
+        );
+    }
+}
+
+#[tokio::test]
+async fn ui_resource_routes_require_auth_when_configured() {
+    assert_eq!(
+        status_without_auth("GET", "/api/ui/resources", None).await,
+        StatusCode::UNAUTHORIZED,
+        "resource listing accepted an unauthenticated request"
+    );
+    assert_eq!(
+        status_without_auth("GET", "/api/ui/resources/read?uri=ui://app/panel", None).await,
+        StatusCode::UNAUTHORIZED,
+        "resource read accepted an unauthenticated request"
+    );
+
+    let register = json!({
+        "uri": "ui://app/panel",
+        "name": "panel",
+        "mimeType": "text/html;profile=mcp-app",
+        "text": "<p>injected</p>"
+    });
+    assert_eq!(
+        status_without_auth("POST", "/api/ui/resources/register", Some(register)).await,
+        StatusCode::UNAUTHORIZED,
+        "resource registration accepted an unauthenticated request"
+    );
+}
+
+#[tokio::test]
+async fn a_ui_resource_cannot_be_overwritten_by_another_user() {
+    let uri = "ui://ownership-test/panel";
+    let register = |text: &str| {
+        json!({
+            "uri": uri,
+            "name": "panel",
+            "mimeType": "text/html;profile=mcp-app",
+            "text": text
+        })
+    };
+
+    let owner_response = authed_app()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/ui/resources/register")
+                .header("authorization", "Bearer owner")
+                .header("content-type", "application/json")
+                .body(Body::from(register("<p>mine</p>").to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(owner_response.status(), StatusCode::CREATED);
+
+    // A different authenticated user must not be able to replace the content.
+    let attacker_response = authed_app()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/ui/resources/register")
+                .header("authorization", "Bearer attacker")
+                .header("content-type", "application/json")
+                .body(Body::from(register("<p>substituted</p>").to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        attacker_response.status(),
+        StatusCode::FORBIDDEN,
+        "another user replaced the registered resource content"
+    );
+
+    // Nor read it.
+    let read_response = authed_app()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/ui/resources/read?uri={uri}"))
+                .header("authorization", "Bearer attacker")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        read_response.status(),
+        StatusCode::NOT_FOUND,
+        "another user read the resource content"
+    );
+
+    // The owner still can.
+    let owner_read = authed_app()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/ui/resources/read?uri={uri}"))
+                .header("authorization", "Bearer owner")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(owner_read.status(), StatusCode::OK, "the owner must still read its own resource");
+}
+
+#[tokio::test]
+async fn ui_routes_stay_open_when_no_extractor_is_configured() {
+    // Authentication is opt-in; a server without an extractor keeps working.
+    let config =
+        adk_server::ServerConfig::new(Arc::new(MockAgentLoader), Arc::new(MockSessionService));
+    let app = create_app(config);
+
+    let response = app
+        .oneshot(Request::builder().uri("/api/ui/resources").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}

--- a/docs/official_docs/security/access-control.md
+++ b/docs/official_docs/security/access-control.md
@@ -354,6 +354,27 @@ let extractor = JwtRequestContextExtractor::builder()
 
 The extractor validates the Bearer token, maps `user_id` with `ClaimsMapper`, and forwards JWT `scope` / `scp` claims into `RequestContext.scopes`.
 
+### What the extractor protects
+
+Configuring an extractor turns authentication on for every non-public route:
+
+| Routes | Behaviour with an extractor configured |
+|--------|----------------------------------------|
+| `/api/sessions/*`, `/api/apps/*`, artifacts, debug | 401 without a valid token |
+| `/api/ui/*` — bridge, notifications, resources | 401 without a valid token; the authenticated user replaces any user named in the request body |
+| `/api/run*` | 401 without a valid token; the authenticated user overrides the supplied user |
+| `/health` | Public |
+
+UI bridge state is keyed by `(app_name, user_id, session_id)` taken from the request
+body, so the authenticated user is substituted for the body value rather than
+trusted. A registered UI resource records the user that registered it; only that
+user can read or replace it, and a read of someone else's resource answers 404 so
+the URI's existence is not disclosed.
+
+With **no** extractor configured there is no authenticated identity to bind, so
+routes stay open and resources stay globally visible. Authentication is opt-in —
+configure an extractor for any deployment that is not a single trusted user.
+
 ## Error Handling
 
 ```rust


### PR DESCRIPTION
## What

`/api/ui/*` now carries the same authentication as every other non-public router, bridge state is bound to the authenticated user, and registered UI resources have an owner.

## Why

`ui_api_router` was merged into the app **without** `auth_layer`, while the session, artifact, and debug routers each received it:

```rust
.merge(health_router)
.merge(ui_api_router)   // no .layer(auth_layer)
.merge(session_router)  // .layer(auth_layer.clone())
```

With an extractor configured, an unauthenticated caller could:

- create and mutate MCP-UI bridge state under **any** chosen `(app_name, user_id, session_id)` tuple, since handlers key a process-global registry straight from the request body;
- poll another user's notifications;
- list, read, or **overwrite** globally registered UI resources, including replacing the HTML text behind an existing URI.

Runtime run routes also lack the shared layer but call `extract_request_context` in the handler and override the supplied user, so they were never part of this bypass.

## How

| Change | Why it is needed on its own |
|---|---|
| `auth_layer` applied to `/api/ui/*` in both router builders | Closes the unauthenticated bypass |
| Bridge handlers substitute the authenticated user for the body-supplied one | The registry key comes from the body, so auth alone still let one authenticated caller address another's state |
| Resources record an owner; only the owner may read or replace | The registry is keyed by URI alone and registration overwrites, so auth alone still allowed cross-user substitution |

A read of another user's resource answers **404** rather than 403, so the URI's existence is not disclosed. An overwrite attempt answers 403.

### Deployments without auth are unchanged

With no extractor configured there is no authenticated identity to bind, so routes stay open and resources stay globally visible. `ui_routes_stay_open_when_no_extractor_is_configured` asserts this, so the fix cannot silently lock down an unauthenticated deployment.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo nextest run --workspace --profile ci` | **3769 passed**, 83 skipped |
| `cargo nextest run -p adk-server` | 106 passed |
| doc-examples guard | exit 0 |

Four route tests. Run individually against the **unpatched** server:

| Test | Unpatched |
|---|---|
| `ui_bridge_routes_require_auth_when_configured` | **FAIL** |
| `ui_resource_routes_require_auth_when_configured` | **FAIL** |
| `a_ui_resource_cannot_be_overwritten_by_another_user` | **FAIL** |
| `ui_routes_stay_open_when_no_extractor_is_configured` | PASS (guards against over-locking) |

## Not addressed

From the finding: per-tenant registry namespacing beyond owner checks, and CSP/safe-HTML handling for resource text. Whether a given UI renders that HTML as executable content is still not assessed here.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed — n/a
- [x] Examples added or updated for new features — n/a