### PR TITLE
fix(devtools): contain workspace paths against symlink escapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **adk-devtools: workspace containment was bypassable through symlinks.**
+  `Workspace::resolve` normalized a requested path lexically and checked
+  `starts_with(root)`. A symlink sitting lexically under the root satisfies that
+  check while pointing anywhere on the host, and ordinary file I/O follows it, so
+  `read_file`, `write_file`, and `edit_file` could reach host files outside the
+  advertised workspace. A symlinked parent directory redirected creation and writes
+  the same way. The existing containment test covered `..` traversal only.
+
+  Containment is now enforced against the resolved path: the deepest existing
+  ancestor of the target is canonicalized, resolving every link along the way, and
+  the result must still be inside the root. That covers both a symlinked final
+  component and a symlinked parent directory, including creation of a file that does
+  not exist yet under a redirected directory. A symlink whose target stays inside the
+  workspace keeps working, because repositories legitimately contain internal links
+  and refusing them would break ordinary work without improving containment.
+
+  This is a check, not a lock. A symlink planted between the check and the
+  subsequent open would still be followed; closing that window needs
+  descriptor-relative traversal with platform no-follow semantics, which the
+  documentation now states plainly.
+
 - **Dependency advisories resolved.** Bumped `surrealdb` (optional `adk-rag`
   backend) to 3.2.1, fixing GHSA-cc8f-fcx3-gpjr (high: arbitrary file read via
   `DEFINE ANALYZER` mapper filter) plus four related medium advisories. Bumped

--- a/adk-devtools/src/workspace.rs
+++ b/adk-devtools/src/workspace.rs
@@ -117,7 +117,46 @@ impl Workspace {
         if !normalized.starts_with(&self.root) {
             return Err(DevToolError::PathEscape(path.to_string()));
         }
+        // A lexical check alone is not containment: a symlink sitting lexically
+        // under the root can point anywhere, and ordinary file I/O follows it.
+        self.reject_symlink_escape(&normalized, path)?;
         Ok(normalized)
+    }
+
+    /// Rejects a path that reaches outside the root by following a symlink.
+    ///
+    /// The deepest existing ancestor of the target is canonicalized, which resolves
+    /// every symlink along the way, and the result must still be inside the root.
+    /// That covers a symlinked final component and a symlinked parent directory, so
+    /// creation through a redirected directory is refused as well. A symlink whose
+    /// target stays inside the workspace is allowed, since repositories legitimately
+    /// contain internal links.
+    ///
+    /// This is a check, not a lock. A symlink swapped between this check and the
+    /// subsequent open would still be followed; closing that window needs
+    /// descriptor-relative traversal with platform no-follow semantics.
+    fn reject_symlink_escape(
+        &self,
+        normalized: &Path,
+        requested: &str,
+    ) -> Result<(), DevToolError> {
+        let mut existing = normalized;
+        loop {
+            match std::fs::canonicalize(existing) {
+                Ok(canonical) => {
+                    if !canonical.starts_with(&self.root) {
+                        return Err(DevToolError::PathEscape(requested.to_string()));
+                    }
+                    return Ok(());
+                }
+                // The path does not exist yet, so step up to what does. A component
+                // that does not exist cannot redirect anything.
+                Err(_) => match existing.parent() {
+                    Some(parent) if parent.starts_with(&self.root) => existing = parent,
+                    _ => return Ok(()),
+                },
+            }
+        }
     }
 
     /// Render a path relative to the root for display (falls back to the full path).

--- a/adk-devtools/tests/symlink_containment_tests.rs
+++ b/adk-devtools/tests/symlink_containment_tests.rs
@@ -1,0 +1,119 @@
+//! A workspace must contain file tools, including when symlinks are involved.
+//!
+//! `Workspace::resolve` normalized a path lexically and checked `starts_with(root)`.
+//! A symlink sitting lexically under the root satisfies that check while pointing
+//! anywhere on the host, and ordinary file I/O follows it. A symlinked parent
+//! directory redirected creation and writes the same way. The existing containment
+//! test covered `..` traversal only.
+
+#![cfg(unix)]
+
+use adk_devtools::Workspace;
+use std::fs;
+use std::os::unix::fs::symlink;
+
+/// A workspace root plus an outside directory, both inside one temp dir.
+struct Fixture {
+    _temp: tempfile::TempDir,
+    root: std::path::PathBuf,
+    outside: std::path::PathBuf,
+}
+
+fn fixture() -> Fixture {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().join("workspace");
+    let outside = temp.path().join("outside");
+    fs::create_dir_all(&root).unwrap();
+    fs::create_dir_all(&outside).unwrap();
+    fs::write(outside.join("secret.txt"), "host secret").unwrap();
+    Fixture { _temp: temp, root, outside }
+}
+
+#[test]
+fn a_symlinked_file_pointing_outside_is_refused() {
+    let f = fixture();
+    symlink(f.outside.join("secret.txt"), f.root.join("link.txt")).unwrap();
+
+    let workspace = Workspace::new(&f.root);
+    let result = workspace.resolve("link.txt");
+
+    assert!(
+        result.is_err(),
+        "a symlink to a host file was accepted, resolving to {:?}",
+        result.ok()
+    );
+}
+
+#[test]
+fn a_symlinked_directory_pointing_outside_is_refused() {
+    let f = fixture();
+    symlink(&f.outside, f.root.join("escape")).unwrap();
+
+    let workspace = Workspace::new(&f.root);
+
+    assert!(
+        workspace.resolve("escape/secret.txt").is_err(),
+        "a read through a symlinked directory was accepted"
+    );
+    // Creation through a symlinked parent must be refused too, even though the
+    // final component does not exist yet.
+    assert!(
+        workspace.resolve("escape/planted.txt").is_err(),
+        "a write through a symlinked directory was accepted"
+    );
+}
+
+#[test]
+fn a_nested_symlinked_parent_is_refused() {
+    let f = fixture();
+    fs::create_dir_all(f.root.join("a/b")).unwrap();
+    symlink(&f.outside, f.root.join("a/b/out")).unwrap();
+
+    let workspace = Workspace::new(&f.root);
+    assert!(
+        workspace.resolve("a/b/out/secret.txt").is_err(),
+        "a symlink deeper in the tree was accepted"
+    );
+}
+
+#[test]
+fn parent_traversal_is_still_refused() {
+    // The original containment property must keep holding.
+    let f = fixture();
+    let workspace = Workspace::new(&f.root);
+    assert!(workspace.resolve("../outside/secret.txt").is_err());
+    assert!(workspace.resolve("/etc/passwd").is_err());
+}
+
+#[test]
+fn ordinary_paths_inside_the_workspace_still_resolve() {
+    // Guards against the containment check rejecting legitimate work.
+    let f = fixture();
+    fs::create_dir_all(f.root.join("src")).unwrap();
+    fs::write(f.root.join("src/main.rs"), "fn main() {}").unwrap();
+
+    let workspace = Workspace::new(&f.root);
+
+    let existing = workspace.resolve("src/main.rs").expect("an existing file must resolve");
+    assert!(existing.ends_with("src/main.rs"));
+
+    let new_file = workspace.resolve("src/new_module.rs").expect("a new file must resolve");
+    assert!(new_file.ends_with("src/new_module.rs"));
+
+    let new_dir = workspace.resolve("docs/guide/index.md").expect("a new nested path must resolve");
+    assert!(new_dir.ends_with("docs/guide/index.md"));
+}
+
+#[test]
+fn a_symlink_that_stays_inside_the_workspace_is_allowed() {
+    // Containment is about where a link *points*, not that a link exists.
+    // Repositories legitimately contain internal symlinks, and refusing them would
+    // break ordinary work without improving containment.
+    let f = fixture();
+    fs::write(f.root.join("real.txt"), "inside").unwrap();
+    symlink(f.root.join("real.txt"), f.root.join("alias.txt")).unwrap();
+
+    let workspace = Workspace::new(&f.root);
+    assert!(workspace.resolve("alias.txt").is_ok(), "an inside-pointing link must resolve");
+    assert!(workspace.resolve("real.txt").is_ok());
+}

--- a/docs/official_docs/coding-agent/devtools.md
+++ b/docs/official_docs/coding-agent/devtools.md
@@ -51,7 +51,18 @@ let ws = Workspace::new("./my-repo")
 ```
 
 - **Path containment** — any path that resolves outside the root is rejected, so
-  the agent can't read or write `../../etc/...`.
+  the agent can't read or write `../../etc/...`. Containment is enforced against the
+  **resolved** path, not just the literal one: a symlink pointing outside the root is
+  rejected even though it sits lexically inside. That covers a symlinked final
+  component and a symlinked parent directory, so creation through a redirected
+  directory is refused too. A symlink whose target stays inside the workspace keeps
+  working, since repositories legitimately contain internal links.
+
+  The check is not a lock. A symlink planted between the check and the subsequent
+  open would still be followed; closing that window needs descriptor-relative
+  traversal with platform no-follow semantics. Treat the file tools as containment
+  against an agent that wanders, not as isolation against an adversary that can
+  write into the workspace concurrently.
 - **Read-only mode** — `Workspace::read_only(..)` hides the mutating tools
   entirely (the model only ever sees `read_file`/`glob`/`grep`).
 - **`bash` timeout + output caps** — long or chatty commands are bounded.


### PR DESCRIPTION
## What

`Workspace::resolve` now enforces containment against the **resolved** path, not just the literal one.

## Why

```rust
// before
let normalized = normalize(&joined);          // purely lexical
if !normalized.starts_with(&self.root) { ... } // then a prefix check
```

A symlink sitting lexically under the root satisfies `starts_with(root)` while pointing anywhere on the host, and ordinary file I/O follows it. So `read_file`, `write_file`, and `edit_file` could reach host files outside the advertised workspace, and a symlinked parent directory redirected creation and writes the same way. The existing containment test covered `..` traversal only.

## How

The deepest existing ancestor of the target is canonicalized — which resolves every link along the path — and the result must still be inside the root. Walking up to the deepest *existing* ancestor is what makes this work for a file that does not exist yet: creating `escape/planted.txt` under a symlinked `escape` is refused because `escape` itself resolves outside.

### A design choice worth reviewing

My first implementation refused **every** symlink below the root, on the reasoning that a link pointing inside now could point elsewhere later. I changed it: that is stricter but breaks repositories that legitimately contain internal symlinks, and it does not actually improve containment — what matters is where a link points, not that one exists. TOCTOU is unaffected either way.

`a_symlink_that_stays_inside_the_workspace_is_allowed` pins the chosen behaviour so it is a decision rather than an accident.

### Honest limit

This is a check, not a lock. A symlink swapped between the check and the subsequent open would still be followed. Closing that window needs descriptor-relative traversal with platform no-follow semantics. The docs previously implied the file tools were a containment boundary; they now state this limit and say to treat them as containment against an agent that wanders, not isolation against an adversary writing into the workspace concurrently.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo nextest run --workspace --profile ci` | **3771 passed**, 83 skipped |
| `cargo nextest run -p adk-devtools` | 14 passed (was 8) |
| `RUSTDOCFLAGS=-D warnings cargo doc -p adk-devtools` | exit 0 |

Six tests, each run individually against the previous resolver:

| Test | Old resolver |
|---|---|
| `a_symlinked_file_pointing_outside_is_refused` | **FAIL** |
| `a_symlinked_directory_pointing_outside_is_refused` | **FAIL** |
| `a_nested_symlinked_parent_is_refused` | **FAIL** |
| `parent_traversal_is_still_refused` | PASS (original property preserved) |
| `ordinary_paths_inside_the_workspace_still_resolve` | PASS (guards against over-rejection) |
| `a_symlink_that_stays_inside_the_workspace_is_allowed` | PASS (pins the design choice) |

Tests are `#![cfg(unix)]` because they create symlinks; Windows symlink creation needs elevation.

## Not addressed

From the finding: descriptor-relative traversal, per-component `O_NOFOLLOW`, and the symlink-swap race test. `glob`/`grep` traversal is not separately hardened here — they go through the same `resolve`, but a directory walk that encounters a link is not covered by these tests.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed — n/a
- [x] Examples added or updated for new features — n/a