### PR TITLE
fix(memory): refuse project scoping instead of silently going global

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **adk-core/adk-memory: project-scoped memory no longer falls back to global
+  scope.** `add_session_to_project`, `add_entry_to_project`, and
+  `delete_entries_in_project` had default implementations that discarded `project_id`
+  and called their global equivalents, and `Memory::search_in_project` and
+  `Memory::add_to_project` did the same. A backend therefore compiled as
+  project-aware without implementing a single project method: the call succeeded
+  while operating in global scope, and neither the type system nor the return value
+  said so. Data intended for one project became visible to everything under the same
+  app and user, and a project-scoped delete removed entries outside the project.
+
+  Those defaults now return an error naming the method and the reason. Six built-in
+  backends (in-memory, SQLite, PostgreSQL, Redis, MongoDB, Neo4j) implement all four
+  project methods and now advertise `supports_project_scoping() == true`.
+  `GraphMemoryService` implements none of them and therefore refuses project calls it
+  previously answered in global scope — the behaviour change is the fix.
+  `MemoryServiceAdapter` reports the capability of the backend it wraps.
+
 - **Dependency advisories resolved.** Bumped `surrealdb` (optional `adk-rag`
   backend) to 3.2.1, fixing GHSA-cc8f-fcx3-gpjr (high: arbitrary file read via
   `DEFINE ANALYZER` mapper filter) plus four related medium advisories. Bumped
@@ -57,6 +74,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   | `adk-core` | New public fields: `RunConfig::{tool_confirmation_handler, runtime_toolsets}` | Struct literals must add the fields; prefer `RunConfig::builder()` |
   | `adk-core` | New variant `Part::EmbeddedResource` (`Part` is not `#[non_exhaustive]`) | Exhaustive `match` must add an arm |
   | `adk-core` | `RunConfig` and `RunConfigBuilder` no longer `UnwindSafe`/`RefUnwindSafe` | Affects code holding them across `catch_unwind` |
+  | `adk-core` | `Memory::search_in_project` and `Memory::add_to_project` now return an error by default instead of silently operating globally; new `Memory::supports_project_scoping` | A custom `Memory` that relied on the fallback must implement the project methods or accept the error |
+  | `adk-memory` | `MemoryService::{add_session_to_project, add_entry_to_project, delete_entries_in_project}` now return an error by default; new `MemoryService::supports_project_scoping` | A custom backend must implement them; `GraphMemoryService` now refuses project calls it previously answered globally |
   | `adk-graph` | New public field `StateGraph::deferred_configs` | Struct literals must add the field |
   | `adk-realtime` | `ClientEvent` and `ServerEvent` are now `#[non_exhaustive]` | Downstream `match` needs a wildcard arm; the enums can no longer be constructed exhaustively outside the crate |
   | `adk-realtime` | `ServerEvent::Unknown` discriminant changed 21 → 23 | Affects code depending on the numeric discriminant |

--- a/adk-core/src/context.rs
+++ b/adk-core/src/context.rs
@@ -604,19 +604,43 @@ pub trait Memory: Send + Sync {
         Err(AdkError::memory("delete not implemented"))
     }
 
-    /// Search for memories within a specific project.
-    /// Returns global entries + entries for the given project.
-    /// Default delegates to `search` (global-only results).
-    async fn search_in_project(&self, query: &str, project_id: &str) -> Result<Vec<MemoryEntry>> {
-        let _ = project_id;
-        self.search(query).await
+    /// Whether this memory keeps project-scoped entries isolated.
+    ///
+    /// Returns `false` by default, so a caller can tell real isolation apart from a
+    /// memory that has no project support instead of inferring it from data.
+    fn supports_project_scoping(&self) -> bool {
+        false
     }
 
-    /// Add a memory entry scoped to a specific project.
-    /// Default delegates to `add` (global entry).
+    /// Searches memories within a specific project.
+    ///
+    /// # Errors
+    ///
+    /// The default implementation returns an error. Delegating to the global search
+    /// would return entries the project boundary is meant to exclude, and nothing in
+    /// the result would say the boundary was ignored.
+    async fn search_in_project(&self, query: &str, project_id: &str) -> Result<Vec<MemoryEntry>> {
+        let _ = (query, project_id);
+        Err(AdkError::memory(
+            "this memory does not implement project scoping, so `search_in_project` cannot \
+             honour the project boundary; check `supports_project_scoping` first, or call \
+             `search` if global scope is intended",
+        ))
+    }
+
+    /// Adds a memory entry scoped to a specific project.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error by default. Writing the entry globally would make data
+    /// intended for one project visible everywhere under the same app and user.
     async fn add_to_project(&self, entry: MemoryEntry, project_id: &str) -> Result<()> {
-        let _ = project_id;
-        self.add(entry).await
+        let _ = (entry, project_id);
+        Err(AdkError::memory(
+            "this memory does not implement project scoping, so `add_to_project` cannot honour \
+             the project boundary; check `supports_project_scoping` first, or call `add` if \
+             global scope is intended",
+        ))
     }
 }
 

--- a/adk-memory/src/adapter.rs
+++ b/adk-memory/src/adapter.rs
@@ -104,6 +104,10 @@ impl adk_core::Memory for MemoryServiceAdapter {
         inner.health_check().await
     }
 
+    fn supports_project_scoping(&self) -> bool {
+        self.inner.supports_project_scoping()
+    }
+
     async fn search_in_project(
         &self,
         query: &str,

--- a/adk-memory/src/inmemory.rs
+++ b/adk-memory/src/inmemory.rs
@@ -73,6 +73,10 @@ impl MemoryService for InMemoryMemoryService {
         Ok(())
     }
 
+    fn supports_project_scoping(&self) -> bool {
+        true
+    }
+
     async fn add_session_to_project(
         &self,
         app_name: &str,

--- a/adk-memory/src/mongodb.rs
+++ b/adk-memory/src/mongodb.rs
@@ -367,6 +367,10 @@ impl MemoryService for MongoMemoryService {
         Ok(())
     }
 
+    fn supports_project_scoping(&self) -> bool {
+        true
+    }
+
     #[instrument(skip_all, fields(app_name = %app_name, user_id = %user_id, session_id = %session_id, project_id = %project_id, entry_count = entries.len()))]
     async fn add_session_to_project(
         &self,

--- a/adk-memory/src/neo4j.rs
+++ b/adk-memory/src/neo4j.rs
@@ -424,6 +424,10 @@ impl MemoryService for Neo4jMemoryService {
         Ok(())
     }
 
+    fn supports_project_scoping(&self) -> bool {
+        true
+    }
+
     #[instrument(skip_all, fields(app_name = %app_name, user_id = %user_id, session_id = %session_id, project_id = %project_id, entry_count = entries.len()))]
     async fn add_session_to_project(
         &self,

--- a/adk-memory/src/postgres.rs
+++ b/adk-memory/src/postgres.rs
@@ -737,6 +737,10 @@ impl MemoryService for PostgresMemoryService {
         Ok(result.rows_affected())
     }
 
+    fn supports_project_scoping(&self) -> bool {
+        true
+    }
+
     #[instrument(skip_all, fields(app_name = %app_name, user_id = %user_id, session_id = %session_id, project_id = %project_id))]
     async fn add_session_to_project(
         &self,

--- a/adk-memory/src/redis.rs
+++ b/adk-memory/src/redis.rs
@@ -334,6 +334,10 @@ impl MemoryService for RedisMemoryService {
         Ok(())
     }
 
+    fn supports_project_scoping(&self) -> bool {
+        true
+    }
+
     #[instrument(skip_all, fields(app_name = %app_name, user_id = %user_id, session_id = %session_id, project_id = %project_id, entry_count = entries.len()))]
     async fn add_session_to_project(
         &self,

--- a/adk-memory/src/service.rs
+++ b/adk-memory/src/service.rs
@@ -107,8 +107,23 @@ pub trait MemoryService: Send + Sync {
         Ok(())
     }
 
-    /// Add session entries scoped to a project.
-    /// Default delegates to `add_session` (global).
+    /// Whether this backend keeps project-scoped entries isolated.
+    ///
+    /// Returns `false` by default. A backend that implements the project methods
+    /// below overrides this to `true`, so a caller can tell isolation apart from a
+    /// backend that has no project support rather than discovering it from data.
+    fn supports_project_scoping(&self) -> bool {
+        false
+    }
+
+    /// Adds session entries scoped to a project.
+    ///
+    /// # Errors
+    ///
+    /// The default implementation returns an error. Discarding `project_id` and
+    /// writing globally would make entries intended for one project visible to
+    /// everything else under the same app and user, with nothing in the return value
+    /// to say so, so a backend without project support refuses the write instead.
     async fn add_session_to_project(
         &self,
         app_name: &str,
@@ -117,12 +132,16 @@ pub trait MemoryService: Send + Sync {
         project_id: &str,
         entries: Vec<MemoryEntry>,
     ) -> Result<()> {
-        let _ = project_id;
-        self.add_session(app_name, user_id, session_id, entries).await
+        let _ = (app_name, user_id, session_id, project_id, entries);
+        Err(project_scoping_unsupported("add_session_to_project"))
     }
 
-    /// Add a single entry scoped to a project.
-    /// Default delegates to `add_entry` (global).
+    /// Adds a single entry scoped to a project.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error by default, for the reason given on
+    /// [`MemoryService::add_session_to_project`].
     async fn add_entry_to_project(
         &self,
         app_name: &str,
@@ -130,12 +149,16 @@ pub trait MemoryService: Send + Sync {
         project_id: &str,
         entry: MemoryEntry,
     ) -> Result<()> {
-        let _ = project_id;
-        self.add_entry(app_name, user_id, entry).await
+        let _ = (app_name, user_id, project_id, entry);
+        Err(project_scoping_unsupported("add_entry_to_project"))
     }
 
-    /// Delete entries matching a query within a specific project.
-    /// Default delegates to `delete_entries` (global).
+    /// Deletes entries matching a query within a specific project.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error by default. Falling back to a global delete would remove
+    /// entries outside the named project, which is worse than refusing.
     async fn delete_entries_in_project(
         &self,
         app_name: &str,
@@ -143,8 +166,8 @@ pub trait MemoryService: Send + Sync {
         project_id: &str,
         query: &str,
     ) -> Result<u64> {
-        let _ = project_id;
-        self.delete_entries(app_name, user_id, query).await
+        let _ = (app_name, user_id, project_id, query);
+        Err(project_scoping_unsupported("delete_entries_in_project"))
     }
 
     /// Delete all entries for a specific project.
@@ -153,4 +176,13 @@ pub trait MemoryService: Send + Sync {
         let _ = (app_name, user_id, project_id);
         Err(adk_core::AdkError::memory("delete_project not implemented"))
     }
+}
+
+/// The error a backend without project support returns from a project method.
+fn project_scoping_unsupported(method: &str) -> adk_core::AdkError {
+    adk_core::AdkError::memory(format!(
+        "this memory backend does not implement project scoping, so `{method}` cannot honour \
+         the project boundary; use a backend whose `supports_project_scoping` returns true, or \
+         call the global method explicitly if global scope is intended"
+    ))
 }

--- a/adk-memory/src/sqlite.rs
+++ b/adk-memory/src/sqlite.rs
@@ -433,6 +433,10 @@ impl MemoryService for SqliteMemoryService {
         Ok(())
     }
 
+    fn supports_project_scoping(&self) -> bool {
+        true
+    }
+
     #[instrument(skip_all, fields(app_name = %app_name, user_id = %user_id, session_id = %session_id, project_id = %project_id, entry_count = entries.len()))]
     async fn add_session_to_project(
         &self,

--- a/adk-memory/tests/project_isolation_conformance_tests.rs
+++ b/adk-memory/tests/project_isolation_conformance_tests.rs
@@ -1,0 +1,191 @@
+//! Project scoping must be real or refused, never silently global.
+//!
+//! `add_session_to_project`, `add_entry_to_project`, and `delete_entries_in_project`
+//! had default implementations that discarded `project_id` and called their global
+//! equivalents. `Memory::search_in_project` and `Memory::add_to_project` did the
+//! same. A backend therefore compiled as project-aware without implementing a single
+//! project method: calls carrying a project identifier succeeded while operating in
+//! global scope, with nothing in the type system or the return value to say so. Data
+//! meant for one project became visible to everything under the same app and user,
+//! and a project-scoped delete could remove global entries.
+//!
+//! The defaults now fail, and `supports_project_scoping` lets a caller tell a
+//! project-aware backend from one without support.
+
+use adk_core::Content;
+use adk_memory::inmemory::InMemoryMemoryService;
+use adk_memory::{MemoryEntry, MemoryService, SearchRequest, SearchResponse};
+use async_trait::async_trait;
+
+const APP: &str = "conformance-app";
+const USER: &str = "conformance-user";
+
+fn entry(text: &str) -> MemoryEntry {
+    MemoryEntry {
+        content: Content::new("user").with_text(text),
+        author: "user".to_string(),
+        timestamp: chrono::Utc::now(),
+    }
+}
+
+/// The text of a stored entry, for readable assertions.
+fn text_of(entry: &MemoryEntry) -> String {
+    entry.content.parts.iter().filter_map(|part| part.text()).collect()
+}
+
+async fn search(service: &dyn MemoryService, query: &str, project: Option<&str>) -> Vec<String> {
+    let response = service
+        .search(SearchRequest {
+            query: query.to_string(),
+            app_name: APP.to_string(),
+            user_id: USER.to_string(),
+            limit: None,
+            min_score: None,
+            project_id: project.map(str::to_string),
+        })
+        .await
+        .expect("search must succeed");
+    response.memories.iter().map(text_of).collect()
+}
+
+// ── A project-aware backend keeps its boundaries ───────────────────────
+
+#[tokio::test]
+async fn a_project_aware_backend_isolates_projects() {
+    let service = InMemoryMemoryService::new();
+    assert!(
+        service.supports_project_scoping(),
+        "a backend that implements the project methods must advertise support"
+    );
+
+    service.add_entry(APP, USER, entry("shared knowledge")).await.unwrap();
+    service
+        .add_entry_to_project(APP, USER, "project-a", entry("knowledge for alpha"))
+        .await
+        .unwrap();
+    service
+        .add_entry_to_project(APP, USER, "project-b", entry("knowledge for beta"))
+        .await
+        .unwrap();
+
+    let in_a = search(&service, "knowledge", Some("project-a")).await;
+    assert!(
+        in_a.iter().any(|c| c.contains("alpha")),
+        "a project search must see its own entries: {in_a:?}"
+    );
+    assert!(
+        !in_a.iter().any(|c| c.contains("beta")),
+        "a project search must not see another project's entries: {in_a:?}"
+    );
+
+    let global = search(&service, "knowledge", None).await;
+    assert!(
+        !global.iter().any(|c| c.contains("alpha") || c.contains("beta")),
+        "a global search must not see project entries: {global:?}"
+    );
+}
+
+#[tokio::test]
+async fn a_project_scoped_delete_does_not_reach_other_scopes() {
+    let service = InMemoryMemoryService::new();
+
+    service.add_entry(APP, USER, entry("deletable global")).await.unwrap();
+    service.add_entry_to_project(APP, USER, "project-a", entry("deletable alpha")).await.unwrap();
+    service.add_entry_to_project(APP, USER, "project-b", entry("deletable beta")).await.unwrap();
+
+    service.delete_entries_in_project(APP, USER, "project-a", "deletable").await.unwrap();
+
+    assert!(
+        search(&service, "deletable", Some("project-b")).await.iter().any(|c| c.contains("beta")),
+        "another project's entries must survive a project-scoped delete"
+    );
+    assert!(
+        search(&service, "deletable", None).await.iter().any(|c| c.contains("global")),
+        "global entries must survive a project-scoped delete"
+    );
+}
+
+// ── A backend without project support refuses rather than widening scope ─
+
+/// A backend that implements only the global surface, as a third-party backend or
+/// `GraphMemoryService` does.
+///
+/// It implements `delete_entries`, so a project-scoped delete that fell back to the
+/// global one would be observable here rather than merely erroring for want of an
+/// implementation.
+#[derive(Default)]
+struct GlobalOnlyBackend {
+    global_deletes: std::sync::atomic::AtomicUsize,
+}
+
+#[async_trait]
+impl MemoryService for GlobalOnlyBackend {
+    async fn add_session(
+        &self,
+        _app_name: &str,
+        _user_id: &str,
+        _session_id: &str,
+        _entries: Vec<MemoryEntry>,
+    ) -> adk_core::Result<()> {
+        Ok(())
+    }
+
+    async fn search(&self, _req: SearchRequest) -> adk_core::Result<SearchResponse> {
+        Ok(SearchResponse { memories: Vec::new() })
+    }
+
+    async fn delete_entries(
+        &self,
+        _app_name: &str,
+        _user_id: &str,
+        _query: &str,
+    ) -> adk_core::Result<u64> {
+        self.global_deletes.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        Ok(7)
+    }
+}
+
+#[tokio::test]
+async fn a_backend_without_project_support_reports_it() {
+    assert!(
+        !GlobalOnlyBackend::default().supports_project_scoping(),
+        "a backend that implements no project method must not advertise support"
+    );
+}
+
+#[tokio::test]
+async fn project_writes_fail_rather_than_silently_going_global() {
+    let backend = GlobalOnlyBackend::default();
+
+    let session_write = backend
+        .add_session_to_project(APP, USER, "session-1", "project-a", vec![entry("secret")])
+        .await;
+    assert!(
+        session_write.is_err(),
+        "a project session write must fail instead of writing globally"
+    );
+    let message = session_write.unwrap_err().to_string();
+    assert!(
+        message.contains("project scoping"),
+        "the error must say why the write was refused: {message}"
+    );
+
+    assert!(
+        backend.add_entry_to_project(APP, USER, "project-a", entry("secret")).await.is_err(),
+        "a project entry write must fail instead of writing globally"
+    );
+}
+
+#[tokio::test]
+async fn a_project_scoped_delete_fails_rather_than_deleting_globally() {
+    // The most damaging fallback: a scoped delete widening to every entry.
+    let backend = GlobalOnlyBackend::default();
+    let result = backend.delete_entries_in_project(APP, USER, "project-a", "anything").await;
+
+    assert!(result.is_err(), "a project-scoped delete must fail instead of deleting globally");
+    assert_eq!(
+        backend.global_deletes.load(std::sync::atomic::Ordering::SeqCst),
+        0,
+        "the scoped delete reached the global delete, so it removed entries outside the project"
+    );
+}

--- a/docs/official_docs/memory/concepts.md
+++ b/docs/official_docs/memory/concepts.md
@@ -106,6 +106,36 @@ let adapter = MemoryServiceAdapter::new(service, "app", "user")
 Use projects to keep, say, a user's *work* and *personal* assistants from sharing
 memory while still sharing truly global facts.
 
+### Not every backend implements project scoping
+
+Project isolation is a backend capability, not something the trait can guarantee.
+Ask before relying on it:
+
+```rust
+if service.supports_project_scoping() {
+    service.add_entry_to_project("app", "user", "acme-project", entry).await?;
+} else {
+    // Decide explicitly: refuse, or store globally on purpose.
+}
+```
+
+| Backend | Project scoping |
+|---------|-----------------|
+| `InMemoryMemoryService` | Yes |
+| `SqliteMemoryService` | Yes |
+| `PostgresMemoryService` | Yes |
+| `RedisMemoryService` | Yes |
+| `MongoMemoryService` | Yes |
+| `Neo4jMemoryService` | Yes |
+| `GraphMemoryService` | **No** — project methods return an error |
+
+A backend without project support **fails** the call rather than silently writing or
+deleting globally. Widening the scope of a write would make data intended for one
+project visible to everything under the same app and user, and widening a delete
+would remove entries outside the named project — neither is something a caller could
+detect from the return value. `MemoryServiceAdapter::supports_project_scoping`
+reports what its backend supports.
+
 ## GDPR erasure
 
 `delete_user(app, user)` removes **all** of a user's memories (entries and


### PR DESCRIPTION
## What

Project-scoped memory methods fail when the backend does not implement them, instead of quietly operating in global scope. Adds `supports_project_scoping()` for capability discovery.

## Why

```rust
// before — the default for every project method
async fn add_entry_to_project(&self, app, user, project_id: &str, entry) -> Result<()> {
    let _ = project_id;                    // discarded
    self.add_entry(app, user, entry).await // global write
}
```

A backend compiled as project-aware without implementing a single project method. The call **succeeded** while operating globally, and neither the type system nor the return value said so:

| Fallback | Consequence |
|---|---|
| `add_session_to_project` / `add_entry_to_project` → global add | Data intended for one project becomes visible to everything under the same app and user |
| `delete_entries_in_project` → global delete | A scoped delete removes entries **outside** the named project |
| `Memory::search_in_project` → global search | Returns entries the boundary is meant to exclude |

## How

- The three `MemoryService` defaults and both `Memory` defaults return an error naming the method and the reason.
- New `supports_project_scoping()` on both traits, defaulting to `false`.
- The six backends that implement all four project methods advertise `true`. `MemoryServiceAdapter` delegates to its backend.

### One backend loses a capability it never really had

`GraphMemoryService` implements **none** of the project methods, so it now refuses project calls it previously answered in global scope. That behaviour change *is* the fix. The docs gain a per-backend table stating it, since "project-scoped isolation" was previously an unqualified claim.

| Backend | Project scoping |
|---|---|
| in-memory, SQLite, PostgreSQL, Redis, MongoDB, Neo4j | Yes |
| `GraphMemoryService` | No — project methods error |

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo nextest run --workspace --profile ci` | **3770 passed**, 83 skipped — nothing depended on the fallback |
| `cargo clippy -p adk-memory --features {sqlite-memory,redis-memory,graph-memory}` | exit 0 each |
| doc-examples guard | exit 0 |

Five conformance tests. Behavioural evidence against the old defaults, using a probe file that avoids the new API so it compiles both ways:

| Test | Old defaults |
|---|---|
| `project_writes_fail_rather_than_silently_going_global` | **FAIL** — the write succeeded globally |
| `a_project_scoped_delete_fails_rather_than_deleting_globally` | **FAIL** — the scoped delete reached the global delete |

The mock backend implements `delete_entries` and counts calls, so the widening is *observed* rather than inferred from an error that would have happened anyway. An earlier version of the mock omitted `delete_entries`, and that test passed against the old code for the wrong reason.

## Pre-existing issues found, not fixed here

`cargo clippy -p adk-memory` fails on three feature sets **on `main` as well**, with identical error counts, so they are not from this change:

| Feature | Errors on main |
|---|---|
| `mongodb-memory` | 1 (`collapsible_if`) |
| `neo4j-memory` | 1 |
| `database-memory` / `--all-features` | 16 (`pgvector::Vector` missing `sqlx::Encode`/`Type`) |

The nightly feature matrix does not appear to cover these combinations for `adk-memory`. Worth a separate issue.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed — n/a
- [x] Examples added or updated for new features — n/a