### PR TITLE
fix(model): request DeepSeek JSON output when a schema is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -318,6 +318,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **adk-model: DeepSeek requests now carry a response format when a schema is set.**
+  `DeepSeekClient::build_request` read temperature, top-p, token limits, tools,
+  thinking, and reasoning effort, but always sent `response_format: None` — even with
+  `GenerateContentConfig::response_schema` present — while the provider module
+  advertised structured JSON output. Native enforcement was never requested, so
+  structured turns relied entirely on the agent's textual instruction and could cost
+  extra retries.
+
+  A response schema now enables DeepSeek's JSON Output
+  (`response_format: {"type": "json_object"}`), which is the only mode the API
+  supports; there is no `json_schema` variant, so the schema itself remains enforced
+  by the agent's validation and the module documentation now says so rather than
+  implying provider-side schema enforcement. DeepSeek also requires the word "json"
+  to appear in the prompt when JSON Output is on, or the API can return empty
+  content, so the adapter adds that mention when the conversation does not already
+  contain it.
+
 - **adk-agent/adk-tool: workflow context wrappers no longer drop cancellation,
   secrets, and shared state.** Each wrapper re-implements `InvocationContext` and
   delegates to an inner context, but most capability methods have permissive trait

--- a/adk-model/src/deepseek/client.rs
+++ b/adk-model/src/deepseek/client.rs
@@ -4,7 +4,9 @@
 //! legacy models (`deepseek-chat`, `deepseek-reasoner`).
 
 use super::config::{DeepSeekConfig, ThinkingMode};
-use super::convert::{self, ChatCompletionRequest, ChatCompletionResponse, ThinkingConfig};
+use super::convert::{
+    self, ChatCompletionRequest, ChatCompletionResponse, ResponseFormat, ThinkingConfig,
+};
 use crate::retry::{RetryConfig, execute_with_retry, is_retryable_model_error};
 use adk_core::{
     AdkError, ErrorCategory, ErrorComponent, FinishReason, GenericSchemaAdapter, Llm, LlmRequest,
@@ -101,7 +103,29 @@ impl DeepSeekClient {
 
     /// Build a chat completion request from an LLM request.
     fn build_request(&self, request: &LlmRequest, stream: bool) -> ChatCompletionRequest {
-        let messages: Vec<_> = request.contents.iter().map(convert::content_to_message).collect();
+        let mut messages: Vec<_> =
+            request.contents.iter().map(convert::content_to_message).collect();
+
+        // DeepSeek's structured-output contract is JSON Output: `response_format`
+        // accepts only `{"type": "json_object"}` — there is no `json_schema` mode —
+        // and the API requires the word "json" to appear in the system or user
+        // prompt, otherwise it can return empty content.
+        // https://api-docs.deepseek.com/guides/json_mode
+        let response_format = match request.config.as_ref().and_then(|c| c.response_schema.as_ref())
+        {
+            Some(schema) => {
+                if !mentions_json(&messages) {
+                    messages.insert(
+                        0,
+                        convert::system_message(format!(
+                            "Respond with a single json object matching this schema: {schema}"
+                        )),
+                    );
+                }
+                Some(ResponseFormat { format_type: "json_object".to_string() })
+            }
+            None => None,
+        };
 
         let tools = if request.tools.is_empty() {
             None
@@ -143,12 +167,20 @@ impl DeepSeekClient {
             max_tokens,
             stream: Some(stream),
             tools,
-            response_format: None,
+            response_format,
             thinking,
             reasoning_effort,
             stop: None,
         }
     }
+}
+
+/// Whether the conversation already satisfies DeepSeek's requirement that the word
+/// "json" appear in the prompt when JSON Output is enabled.
+fn mentions_json(messages: &[convert::Message]) -> bool {
+    messages.iter().any(|message| {
+        message.content.as_deref().is_some_and(|text| text.to_lowercase().contains("json"))
+    })
 }
 
 #[async_trait]
@@ -434,5 +466,103 @@ impl Llm for DeepSeekClient {
         };
 
         Ok(crate::usage_tracking::with_usage_tracking(Box::pin(response_stream), usage_span))
+    }
+}
+
+#[cfg(test)]
+mod response_format_tests {
+    //! `build_request` read temperature, top-p, token limits, tools, thinking, and
+    //! reasoning effort but always sent `response_format: None`, even with a
+    //! `response_schema` present, while the module advertised structured JSON output.
+    //! The schema reached the model only as the agent's textual instruction, so native
+    //! enforcement was never requested and structured turns could cost retries.
+
+    use super::*;
+    use adk_core::{Content, GenerateContentConfig, LlmRequest};
+    use serde_json::json;
+
+    fn client() -> DeepSeekClient {
+        DeepSeekClient::chat("test-key").expect("client builds")
+    }
+
+    fn schema() -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": { "answer": { "type": "string" } },
+            "required": ["answer"]
+        })
+    }
+
+    fn request_with(config: Option<GenerateContentConfig>, prompt: &str) -> LlmRequest {
+        let mut request =
+            LlmRequest::new("deepseek-chat", vec![Content::new("user").with_text(prompt)]);
+        request.config = config;
+        request
+    }
+
+    #[test]
+    fn a_response_schema_requests_json_output() {
+        let request = request_with(
+            Some(GenerateContentConfig { response_schema: Some(schema()), ..Default::default() }),
+            "give me the answer as json",
+        );
+
+        let built = client().build_request(&request, false);
+        let wire = serde_json::to_value(&built).expect("request serializes");
+
+        // DeepSeek accepts only `json_object`; there is no `json_schema` mode.
+        assert_eq!(
+            wire["response_format"],
+            json!({ "type": "json_object" }),
+            "a response schema must request DeepSeek's JSON Output mode"
+        );
+    }
+
+    #[test]
+    fn no_schema_leaves_the_response_format_unset() {
+        let request = request_with(None, "hello");
+        let built = client().build_request(&request, false);
+        let wire = serde_json::to_value(&built).expect("request serializes");
+
+        assert!(
+            wire.get("response_format").is_none(),
+            "an ordinary turn must not request JSON Output"
+        );
+    }
+
+    #[test]
+    fn the_documented_json_keyword_requirement_is_satisfied() {
+        // DeepSeek requires the word "json" in the system or user prompt whenever
+        // JSON Output is enabled, or the API may return empty content.
+        let request = request_with(
+            Some(GenerateContentConfig { response_schema: Some(schema()), ..Default::default() }),
+            "summarise the document",
+        );
+
+        let built = client().build_request(&request, false);
+
+        assert!(
+            built.messages.iter().any(|m| m
+                .content
+                .as_deref()
+                .is_some_and(|text| text.to_lowercase().contains("json"))),
+            "enabling JSON Output without the keyword risks empty responses"
+        );
+    }
+
+    #[test]
+    fn an_existing_json_mention_is_not_duplicated() {
+        let request = request_with(
+            Some(GenerateContentConfig { response_schema: Some(schema()), ..Default::default() }),
+            "reply in json please",
+        );
+
+        let built = client().build_request(&request, false);
+
+        assert_eq!(
+            built.messages.len(),
+            1,
+            "the prompt already mentions json, so nothing needs to be added"
+        );
     }
 }

--- a/adk-model/src/deepseek/convert.rs
+++ b/adk-model/src/deepseek/convert.rs
@@ -195,6 +195,18 @@ pub struct Usage {
 }
 
 /// Convert ADK Content to DeepSeek Message.
+/// Builds a system message carrying `text`.
+pub fn system_message(text: impl Into<String>) -> Message {
+    Message {
+        role: "system".to_string(),
+        content: Some(text.into()),
+        name: None,
+        tool_calls: None,
+        tool_call_id: None,
+        reasoning_content: None,
+    }
+}
+
 pub fn content_to_message(content: &Content) -> Message {
     let role = match content.role.as_str() {
         "model" | "assistant" => "assistant",

--- a/adk-model/src/deepseek/mod.rs
+++ b/adk-model/src/deepseek/mod.rs
@@ -17,7 +17,10 @@
 //! - **Strict Tool Mode** (beta): Model strictly follows JSON schema for tool args
 //! - **Streaming**: Real-time streaming responses with reasoning chunks
 //! - **Prefix Caching**: Automatic disk-based KV cache (server-side, zero config)
-//! - **JSON Output**: Structured JSON responses via `response_format`
+//! - **JSON Output**: `GenerateContentConfig::response_schema` turns on DeepSeek's
+//!   JSON Output (`response_format: {"type": "json_object"}`), which guarantees
+//!   syntactically valid JSON. DeepSeek has no `json_schema` mode, so the schema
+//!   itself is enforced by the agent's validation rather than by the provider
 //! - **Anthropic API**: Compatible endpoint at `https://api.deepseek.com/anthropic`
 //!
 //! # V4 Quick Start

--- a/docs/official_docs/agents/llm-agent.md
+++ b/docs/official_docs/agents/llm-agent.md
@@ -437,6 +437,27 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+### How Providers Enforce the Schema
+
+`output_schema` reaches the provider as `GenerateContentConfig::response_schema`.
+What the provider does with it differs, and the agent validates the result either
+way:
+
+| Provider | Native enforcement |
+|----------|--------------------|
+| Gemini | Full schema, sent as the response schema |
+| OpenAI and OpenAI-compatible | Full schema, sent as a strict `json_schema` response format |
+| OpenRouter | Full schema |
+| DeepSeek | JSON **syntax** only — DeepSeek's JSON Output mode has no `json_schema` variant, so the schema is enforced by the agent's validation |
+
+Where a provider enforces syntax only, or nothing at all, the agent still injects the
+schema as an instruction and validates the reply, so a non-conforming answer costs a
+retry rather than returning bad data.
+
+> **Note:** DeepSeek requires the word "json" to appear in the prompt whenever JSON
+> Output is on, otherwise the API can return empty content. The adapter adds that
+> mention itself when your prompt does not already contain it.
+
 ### JSON Output Example
 
 Input: "John met Sarah in Paris on December 25th"


### PR DESCRIPTION
## What

A `response_schema` now turns on DeepSeek's JSON Output mode, and the module documentation states what that actually guarantees.

## Why

```rust
// build_request read temperature, top_p, max_tokens, tools, thinking,
// reasoning_effort … and then:
response_format: None,
```

Meanwhile the provider module advertised *"JSON Output: Structured JSON responses via `response_format`"*. The unified schema setting was dropped at the adapter, so native enforcement was never requested. `LlmAgent` still injects a textual schema instruction and validates the reply, so the visible symptom was extra retries rather than bad data — but the request never asked the provider for anything.

## How

`GenerateContentConfig::response_schema` now produces `response_format: {"type": "json_object"}`.

### Checked against DeepSeek's docs, not against the other adapters

The other adapters send a full schema (`json_schema` for OpenAI-compatible, response schema for Gemini). Copying that here would be wrong:

| Fact | Source |
|---|---|
| `response_format` accepts only `{"type": "json_object"}`; there is **no** `json_schema` mode | [DeepSeek JSON Output guide](https://api-docs.deepseek.com/guides/json_mode) |
| The word "json" must appear in the system or user prompt, or the API may return **empty content** | same guide, "Notice" §1–2, 4 |

So this mode guarantees valid JSON *syntax* and nothing more. The schema stays enforced by the agent's validation, and the module doc now says that instead of implying provider-side schema enforcement.

The prompt requirement matters: enabling JSON Output without satisfying it would trade retries for empty replies. The adapter adds a short system mention carrying the schema when the conversation does not already contain the word.

## Documentation

`llm-agent.md` gains a per-provider table for `output_schema`, because "structured output" previously read as uniform across providers:

| Provider | Native enforcement |
|---|---|
| Gemini, OpenAI/compatible, OpenRouter | Full schema |
| DeepSeek | JSON syntax only |

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo nextest run --workspace --profile ci` | **3765 passed**, 83 skipped |
| `cargo nextest run -p adk-model --features deepseek` | 113 passed |
| `RUSTDOCFLAGS=-D warnings cargo doc -p adk-model --features deepseek` | exit 0 |
| doc-examples guard | exit 0 |

Four request-serialization tests. Against the hardcoded `None`, **two fail**: `a_response_schema_requests_json_output` and `the_documented_json_keyword_requirement_is_satisfied`.

Not verified: no live DeepSeek call. The tests assert the serialized wire body, not the provider's behaviour.

## Not addressed

The finding also asks for model-compatibility validation and an explicit unsupported-capability error. DeepSeek's public docs do not currently state a per-model JSON Output matrix, so a hardcoded allowlist would be a guess that goes stale; the mode is sent for any model and the provider's own error surfaces if it is unsupported.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed — n/a
- [x] Examples added or updated for new features — n/a