### PR TITLE
feat(core): authorize and audit secret access per tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **adk-core/adk-auth: secret access from tools is authorizable and audited.**
+  `SecretService` and `SecretProvider` received only a secret *name*. Once a provider
+  was attached to an invocation, policy collapsed to whatever the backing cloud
+  credentials could read: nothing distinguished a weather tool requesting its own API
+  key from the same tool requesting a payment or database secret, and the ADK layer kept
+  no record of the access.
+
+  New `adk_core::SecretRequest` carries the requested name plus the identity the
+  framework observed — tool, app, user, session, invocation — and an optional purpose.
+  `SecretService::get_secret_for` and `InvocationContext::get_secret_for` take it, both
+  defaulting to the previous name-only behaviour so existing implementations keep
+  compiling. `ToolContext::get_secret_for_purpose` lets a tool state why it needs a
+  secret.
+
+  The identity is not something a tool asserts: `LlmAgent` stamps the dispatched tool's
+  name onto the request from its own dispatch record, so a tool cannot present another
+  tool's identity. Every workflow wrapper forwards the described access, as with the
+  other context capabilities.
+
+  `adk_auth::secrets::authorizing::AuthorizingSecretService` enforces declarative
+  per-tool grants (exact names or a namespace prefix), denying everything until granted.
+  A denied name never reaches the provider, so it does not even appear as an attempted
+  read in provider-side logs. Every decision goes to `SecretAuditSink` and to tracing
+  with the outcome, name, tool, user, invocation, and reason — never a value.
+
+  One boundary remains: an agent invoked as a tool crosses a `ToolContext`, which
+  carries no identity of its own, so accesses inside that agent present the outer
+  agent's identity rather than the inner tool's. That is documented rather than papered
+  over.
+
 - **adk-auth: the secret cache is now bounded, revocable, and cleared.**
   `CachedSecretProvider` stored values in an unbounded `HashMap` and checked the TTL
   only when the same name was read again. Expired entries were never removed, a

--- a/adk-agent/src/codeact/agent.rs
+++ b/adk-agent/src/codeact/agent.rs
@@ -2599,6 +2599,20 @@ impl ToolContext for CodeToolContext {
     async fn get_secret(&self, name: &str) -> adk_core::Result<Option<String>> {
         self.inner.get_secret(name).await
     }
+
+    async fn get_secret_for_purpose(
+        &self,
+        name: &str,
+        purpose: &str,
+    ) -> adk_core::Result<Option<String>> {
+        // Inline code runs under the CodeAct agent rather than a named tool, so the
+        // identity presented is the run's, with the stated purpose attached.
+        let request = adk_core::SecretRequest::new(name)
+            .with_identity(self.inner.app_name(), self.inner.user_id(), self.inner.session_id())
+            .with_invocation_id(self.inner.invocation_id())
+            .with_purpose(purpose);
+        self.inner.get_secret_for(&request).await
+    }
 }
 
 /// Wraps a [`CallbackContext`] to expose a [`ToolOutcome`] to after-tool

--- a/adk-agent/src/llm_agent.rs
+++ b/adk-agent/src/llm_agent.rs
@@ -949,6 +949,9 @@ impl LlmAgentBuilder {
 struct AgentToolContext {
     parent_ctx: Arc<dyn InvocationContext>,
     function_call_id: String,
+    /// The tool this context was built for, recorded by the dispatcher so secret
+    /// requests carry an identity the tool cannot choose.
+    tool_name: Option<String>,
     actions: Mutex<EventActions>,
     progress_tx: Option<tokio::sync::mpsc::UnboundedSender<Event>>,
 }
@@ -958,9 +961,16 @@ impl AgentToolContext {
         Self {
             parent_ctx,
             function_call_id,
+            tool_name: None,
             actions: Mutex::new(EventActions::default()),
             progress_tx: None,
         }
+    }
+
+    /// Record which tool this context serves.
+    fn with_tool_name(mut self, tool_name: impl Into<String>) -> Self {
+        self.tool_name = Some(tool_name.into());
+        self
     }
 
     /// Attach a progress sink so [`ToolContext::emit_progress`] forwards chunks
@@ -968,6 +978,27 @@ impl AgentToolContext {
     fn with_progress(mut self, tx: tokio::sync::mpsc::UnboundedSender<Event>) -> Self {
         self.progress_tx = Some(tx);
         self
+    }
+
+    /// Builds a described secret access from the identity the framework holds.
+    ///
+    /// The tool name comes from the dispatch record rather than from anything the tool
+    /// supplied, so one tool cannot request a secret under another tool's identity.
+    async fn request_secret(&self, name: &str, purpose: Option<&str>) -> Result<Option<String>> {
+        let mut request = adk_core::SecretRequest::new(name)
+            .with_identity(
+                self.parent_ctx.app_name(),
+                self.parent_ctx.user_id(),
+                self.parent_ctx.session_id(),
+            )
+            .with_invocation_id(self.parent_ctx.invocation_id());
+        if let Some(tool_name) = &self.tool_name {
+            request = request.with_tool_name(tool_name);
+        }
+        if let Some(purpose) = purpose {
+            request = request.with_purpose(purpose);
+        }
+        self.parent_ctx.get_secret_for(&request).await
     }
 
     fn actions_guard(&self) -> std::sync::MutexGuard<'_, EventActions> {
@@ -1049,7 +1080,11 @@ impl ToolContext for AgentToolContext {
     }
 
     async fn get_secret(&self, name: &str) -> Result<Option<String>> {
-        self.parent_ctx.get_secret(name).await
+        self.request_secret(name, None).await
+    }
+
+    async fn get_secret_for_purpose(&self, name: &str, purpose: &str) -> Result<Option<String>> {
+        self.request_secret(name, Some(purpose)).await
     }
 
     async fn emit_progress(&self, stream: &str, chunk: &str) {
@@ -2409,6 +2444,7 @@ impl Agent for LlmAgent {
                                 if let Some(tool) = tool_map.get(&name) {
                                     let tool_ctx: Arc<dyn ToolContext> = Arc::new(
                                         AgentToolContext::new(ctx.clone(), function_call_id.clone())
+                                            .with_tool_name(tool.name())
                                             .with_progress(progress_tx.clone()),
                                     );
                                     let span_name = format!("execute_tool {name}");

--- a/adk-agent/src/workflow/branch_context.rs
+++ b/adk-agent/src/workflow/branch_context.rs
@@ -138,6 +138,10 @@ impl InvocationContext for BranchContext {
     async fn get_secret(&self, name: &str) -> Result<Option<String>> {
         self.inner.get_secret(name).await
     }
+
+    async fn get_secret_for(&self, request: &adk_core::SecretRequest) -> Result<Option<String>> {
+        self.inner.get_secret_for(request).await
+    }
 }
 
 #[cfg(test)]

--- a/adk-agent/src/workflow/loop_agent.rs
+++ b/adk-agent/src/workflow/loop_agent.rs
@@ -364,6 +364,13 @@ impl InvocationContext for HistoryTrackingContext {
     async fn get_secret(&self, name: &str) -> adk_core::Result<Option<String>> {
         self.parent_ctx.get_secret(name).await
     }
+
+    async fn get_secret_for(
+        &self,
+        request: &adk_core::SecretRequest,
+    ) -> adk_core::Result<Option<String>> {
+        self.parent_ctx.get_secret_for(request).await
+    }
 }
 
 #[async_trait]

--- a/adk-agent/src/workflow/shared_state_context.rs
+++ b/adk-agent/src/workflow/shared_state_context.rs
@@ -118,4 +118,11 @@ impl InvocationContext for SharedStateContext {
     async fn get_secret(&self, name: &str) -> adk_core::Result<Option<String>> {
         self.inner.get_secret(name).await
     }
+
+    async fn get_secret_for(
+        &self,
+        request: &adk_core::SecretRequest,
+    ) -> adk_core::Result<Option<String>> {
+        self.inner.get_secret_for(request).await
+    }
 }

--- a/adk-agent/src/workflow/skill_context.rs
+++ b/adk-agent/src/workflow/skill_context.rs
@@ -138,6 +138,10 @@ impl InvocationContext for UserContentOverrideContext {
     async fn get_secret(&self, name: &str) -> Result<Option<String>> {
         self.parent.get_secret(name).await
     }
+
+    async fn get_secret_for(&self, request: &adk_core::SecretRequest) -> Result<Option<String>> {
+        self.parent.get_secret_for(request).await
+    }
 }
 
 #[allow(dead_code)]

--- a/adk-agent/tests/secret_identity_tests.rs
+++ b/adk-agent/tests/secret_identity_tests.rs
@@ -1,0 +1,267 @@
+//! A secret request must carry the identity of the tool the framework dispatched.
+//!
+//! `ToolContext::get_secret` forwarded a bare name to the invocation context, so the
+//! service saw no tool identity and could not tell which tool was asking. This drives
+//! a real tool through `LlmAgent` and inspects what the secret service received.
+
+use adk_agent::LlmAgentBuilder;
+use adk_core::{
+    Agent, Content, FinishReason, InvocationContext, Llm, LlmRequest, LlmResponse,
+    LlmResponseStream, Part, Result, RunConfig, SecretRequest, Session, State, Tool, ToolContext,
+};
+use async_trait::async_trait;
+use futures::StreamExt;
+use serde_json::{Value, json};
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, Mutex};
+
+// ── Mocks ─────────────────────────────────────────────────────────────
+
+struct SequencedModel {
+    responses: Arc<Mutex<VecDeque<LlmResponse>>>,
+}
+
+impl SequencedModel {
+    fn new(responses: Vec<LlmResponse>) -> Self {
+        Self { responses: Arc::new(Mutex::new(responses.into_iter().collect())) }
+    }
+
+    fn call(name: &str, id: &str) -> LlmResponse {
+        Self::wrap(Some(Content {
+            role: "model".to_string(),
+            parts: vec![Part::FunctionCall {
+                name: name.to_string(),
+                args: json!({}),
+                id: Some(id.to_string()),
+                thought_signature: None,
+            }],
+        }))
+    }
+
+    fn text(text: &str) -> LlmResponse {
+        Self::wrap(Some(Content {
+            role: "model".to_string(),
+            parts: vec![Part::Text { text: text.to_string() }],
+        }))
+    }
+
+    fn wrap(content: Option<Content>) -> LlmResponse {
+        LlmResponse {
+            content,
+            usage_metadata: None,
+            finish_reason: Some(FinishReason::Stop),
+            citation_metadata: None,
+            partial: false,
+            turn_complete: true,
+            interrupted: false,
+            error_code: None,
+            error_message: None,
+            provider_metadata: None,
+            interaction_id: None,
+        }
+    }
+}
+
+#[async_trait]
+impl Llm for SequencedModel {
+    fn name(&self) -> &str {
+        "sequenced-model"
+    }
+
+    async fn generate_content(&self, _req: LlmRequest, _stream: bool) -> Result<LlmResponseStream> {
+        let next = self
+            .responses
+            .lock()
+            .unwrap()
+            .pop_front()
+            .unwrap_or_else(|| SequencedModel::text("ok"));
+        let s = async_stream::stream! { yield Ok(next); };
+        Ok(Box::pin(s))
+    }
+}
+
+/// A tool that asks for a secret, optionally stating a purpose.
+struct SecretReadingTool {
+    purpose: Option<&'static str>,
+}
+
+#[async_trait]
+impl Tool for SecretReadingTool {
+    fn name(&self) -> &str {
+        "weather_lookup"
+    }
+    fn description(&self) -> &str {
+        "reads its API key"
+    }
+    fn parameters_schema(&self) -> Option<Value> {
+        Some(json!({ "type": "object", "properties": {} }))
+    }
+
+    async fn execute(&self, ctx: Arc<dyn ToolContext>, _args: Value) -> Result<Value> {
+        let secret = match self.purpose {
+            Some(purpose) => ctx.get_secret_for_purpose("weather-api-key", purpose).await?,
+            None => ctx.get_secret("weather-api-key").await?,
+        };
+        Ok(json!({ "got_secret": secret.is_some() }))
+    }
+}
+
+struct MockState;
+
+impl State for MockState {
+    fn get(&self, _key: &str) -> Option<Value> {
+        None
+    }
+    fn set(&mut self, _key: String, _value: Value) {}
+    fn all(&self) -> HashMap<String, Value> {
+        HashMap::new()
+    }
+}
+
+struct MockSession;
+
+impl Session for MockSession {
+    fn id(&self) -> &str {
+        "session-1"
+    }
+    fn app_name(&self) -> &str {
+        "test-app"
+    }
+    fn user_id(&self) -> &str {
+        "user-1"
+    }
+    fn state(&self) -> &dyn State {
+        &MockState
+    }
+    fn conversation_history(&self) -> Vec<Content> {
+        Vec::new()
+    }
+}
+
+/// Captures the secret requests the agent produced.
+struct RecordingContext {
+    session: MockSession,
+    user_content: Content,
+    requests: Arc<Mutex<Vec<SecretRequest>>>,
+}
+
+#[async_trait]
+impl adk_core::ReadonlyContext for RecordingContext {
+    fn invocation_id(&self) -> &str {
+        "inv-1"
+    }
+    fn agent_name(&self) -> &str {
+        "test-agent"
+    }
+    fn user_id(&self) -> &str {
+        "user-1"
+    }
+    fn app_name(&self) -> &str {
+        "test-app"
+    }
+    fn session_id(&self) -> &str {
+        "session-1"
+    }
+    fn branch(&self) -> &str {
+        "main"
+    }
+    fn user_content(&self) -> &Content {
+        &self.user_content
+    }
+}
+
+#[async_trait]
+impl adk_core::CallbackContext for RecordingContext {
+    fn artifacts(&self) -> Option<Arc<dyn adk_core::Artifacts>> {
+        None
+    }
+}
+
+#[async_trait]
+impl InvocationContext for RecordingContext {
+    fn agent(&self) -> Arc<dyn Agent> {
+        unimplemented!("not exercised")
+    }
+    fn memory(&self) -> Option<Arc<dyn adk_core::Memory>> {
+        None
+    }
+    fn session(&self) -> &dyn Session {
+        &self.session
+    }
+    fn run_config(&self) -> &RunConfig {
+        static RUN_CONFIG: std::sync::OnceLock<RunConfig> = std::sync::OnceLock::new();
+        RUN_CONFIG.get_or_init(RunConfig::default)
+    }
+    fn end_invocation(&self) {}
+    fn ended(&self) -> bool {
+        false
+    }
+
+    async fn get_secret_for(&self, request: &SecretRequest) -> Result<Option<String>> {
+        self.requests.lock().unwrap().push(request.clone());
+        Ok(Some("secret-value".to_string()))
+    }
+}
+
+/// Runs one tool-calling turn and returns the secret requests observed.
+async fn run_with(tool: SecretReadingTool) -> Vec<SecretRequest> {
+    let model = Arc::new(SequencedModel::new(vec![
+        SequencedModel::call("weather_lookup", "call-1"),
+        SequencedModel::text("done"),
+    ]));
+    let agent =
+        LlmAgentBuilder::new("test-agent").model(model).tool(Arc::new(tool)).build().unwrap();
+
+    let requests = Arc::new(Mutex::new(Vec::new()));
+    let ctx = Arc::new(RecordingContext {
+        session: MockSession,
+        user_content: Content {
+            role: "user".to_string(),
+            parts: vec![Part::Text { text: "go".to_string() }],
+        },
+        requests: requests.clone(),
+    });
+
+    let mut stream = agent.run(ctx).await.unwrap();
+    while let Some(result) = stream.next().await {
+        result.expect("the run must not fail");
+    }
+    requests.lock().unwrap().clone()
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn a_secret_request_from_a_tool_carries_that_tools_name() {
+    let requests = run_with(SecretReadingTool { purpose: None }).await;
+
+    let request = requests.first().expect("the tool's secret access must reach the service");
+    assert_eq!(
+        request.tool_name.as_deref(),
+        Some("weather_lookup"),
+        "the service saw no tool identity, so it cannot authorize per tool"
+    );
+    assert_eq!(request.name, "weather-api-key");
+}
+
+#[tokio::test]
+async fn a_secret_request_carries_the_run_identity() {
+    let requests = run_with(SecretReadingTool { purpose: None }).await;
+    let request = requests.first().expect("a request must be recorded");
+
+    assert_eq!(request.app_name.as_deref(), Some("test-app"));
+    assert_eq!(request.user_id.as_deref(), Some("user-1"));
+    assert_eq!(request.session_id.as_deref(), Some("session-1"));
+    assert_eq!(request.invocation_id.as_deref(), Some("inv-1"));
+}
+
+#[tokio::test]
+async fn a_stated_purpose_reaches_the_service() {
+    let requests =
+        run_with(SecretReadingTool { purpose: Some("call the forecast endpoint") }).await;
+    let request = requests.first().expect("a request must be recorded");
+
+    assert_eq!(request.purpose.as_deref(), Some("call the forecast endpoint"));
+    // The identity still comes from the framework, not from the tool.
+    assert_eq!(request.tool_name.as_deref(), Some("weather_lookup"));
+}

--- a/adk-auth/src/secrets/authorizing.rs
+++ b/adk-auth/src/secrets/authorizing.rs
@@ -1,0 +1,236 @@
+//! Per-tool authorization for secret access.
+//!
+//! A tool holding a context can name any secret, and a
+//! [`SecretProvider`](super::provider::SecretProvider) receives only
+//! that name. Policy therefore collapses to whatever the backing cloud credentials can
+//! read, and nothing distinguishes a weather tool asking for its own API key from the
+//! same tool asking for a payment credential.
+//!
+//! [`AuthorizingSecretService`] closes that at the ADK layer: a declarative grant per
+//! tool decides before the provider is called, and every decision is recorded without
+//! the secret value.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use adk_core::{AdkError, Result, SecretRequest, SecretService};
+use async_trait::async_trait;
+
+/// What a single tool may read.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SecretGrant {
+    /// Secret names allowed verbatim.
+    names: Vec<String>,
+    /// Name prefixes allowed, for namespaced secrets such as `billing/`.
+    prefixes: Vec<String>,
+}
+
+impl SecretGrant {
+    /// A grant that allows nothing.
+    pub fn none() -> Self {
+        Self::default()
+    }
+
+    /// Allow an exact secret name.
+    #[must_use]
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.names.push(name.into());
+        self
+    }
+
+    /// Allow every name beginning with `prefix`.
+    ///
+    /// Use this for a namespace the tool owns. A prefix is a blunt instrument: prefer
+    /// exact names where the set is known.
+    #[must_use]
+    pub fn prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.prefixes.push(prefix.into());
+        self
+    }
+
+    /// Whether this grant covers `name`.
+    fn allows(&self, name: &str) -> bool {
+        self.names.iter().any(|allowed| allowed == name)
+            || self.prefixes.iter().any(|prefix| name.starts_with(prefix.as_str()))
+    }
+}
+
+/// Records secret access decisions.
+///
+/// Implementations must not receive or log secret values — only the decision and the
+/// identity around it.
+pub trait SecretAuditSink: Send + Sync {
+    /// Called once per decision, before the provider is consulted on an allow.
+    fn record(&self, decision: SecretAccessDecision<'_>);
+}
+
+/// A single allow or deny, carrying no secret value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SecretAccessDecision<'a> {
+    /// Whether access was permitted.
+    pub allowed: bool,
+    /// The secret name requested.
+    pub name: &'a str,
+    /// The requesting tool, when the access came from one.
+    pub tool_name: Option<&'a str>,
+    /// The user the run belongs to.
+    pub user_id: Option<&'a str>,
+    /// The invocation the access happened in.
+    pub invocation_id: Option<&'a str>,
+    /// Why the decision went the way it did.
+    pub reason: &'static str,
+}
+
+/// Wraps a [`SecretService`] with declarative per-tool grants and an audit record.
+///
+/// A request whose tool has no grant, or whose grant does not cover the name, is
+/// refused **before** the inner service is called, so a denied name never reaches the
+/// provider.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use adk_auth::secrets::{AuthorizingSecretService, SecretGrant};
+/// use std::sync::Arc;
+///
+/// let service = AuthorizingSecretService::new(inner)
+///     .grant("weather_lookup", SecretGrant::none().name("weather-api-key"))
+///     .grant("charge_card", SecretGrant::none().prefix("billing/"));
+/// ```
+pub struct AuthorizingSecretService {
+    inner: Arc<dyn SecretService>,
+    grants: HashMap<String, SecretGrant>,
+    /// What an access with no tool identity may read.
+    untooled: SecretGrant,
+    audit: Option<Arc<dyn SecretAuditSink>>,
+}
+
+impl AuthorizingSecretService {
+    /// Wrap `inner`, denying everything until grants are added.
+    pub fn new(inner: Arc<dyn SecretService>) -> Self {
+        Self { inner, grants: HashMap::new(), untooled: SecretGrant::none(), audit: None }
+    }
+
+    /// Grant `tool_name` access to the secrets described by `grant`.
+    #[must_use]
+    pub fn grant(mut self, tool_name: impl Into<String>, grant: SecretGrant) -> Self {
+        self.grants.insert(tool_name.into(), grant);
+        self
+    }
+
+    /// Grant access for requests that carry no tool identity.
+    ///
+    /// These are accesses made by the agent itself rather than by a dispatched tool.
+    /// They are denied by default, because a request with no identity cannot be
+    /// attributed.
+    #[must_use]
+    pub fn grant_untooled(mut self, grant: SecretGrant) -> Self {
+        self.untooled = grant;
+        self
+    }
+
+    /// Record every decision to `sink`.
+    #[must_use]
+    pub fn with_audit_sink(mut self, sink: Arc<dyn SecretAuditSink>) -> Self {
+        self.audit = Some(sink);
+        self
+    }
+
+    /// Decide whether `request` is permitted, and why.
+    fn decide(&self, request: &SecretRequest) -> (bool, &'static str) {
+        match &request.tool_name {
+            Some(tool_name) => match self.grants.get(tool_name) {
+                Some(grant) if grant.allows(&request.name) => (true, "granted to tool"),
+                Some(_) => (false, "secret not in the tool's grant"),
+                None => (false, "no grant for tool"),
+            },
+            None => {
+                if self.untooled.allows(&request.name) {
+                    (true, "granted without tool identity")
+                } else {
+                    (false, "no grant for a request without tool identity")
+                }
+            }
+        }
+    }
+
+    fn record(&self, request: &SecretRequest, allowed: bool, reason: &'static str) {
+        let decision = SecretAccessDecision {
+            allowed,
+            name: &request.name,
+            tool_name: request.tool_name.as_deref(),
+            user_id: request.user_id.as_deref(),
+            invocation_id: request.invocation_id.as_deref(),
+            reason,
+        };
+        if allowed {
+            tracing::info!(
+                secret.name = %decision.name,
+                tool.name = decision.tool_name.unwrap_or("<none>"),
+                user.id = decision.user_id.unwrap_or("<unknown>"),
+                invocation.id = decision.invocation_id.unwrap_or("<unknown>"),
+                decision.reason = reason,
+                "secret access allowed"
+            );
+        } else {
+            tracing::warn!(
+                secret.name = %decision.name,
+                tool.name = decision.tool_name.unwrap_or("<none>"),
+                user.id = decision.user_id.unwrap_or("<unknown>"),
+                invocation.id = decision.invocation_id.unwrap_or("<unknown>"),
+                decision.reason = reason,
+                "secret access denied"
+            );
+        }
+        if let Some(sink) = &self.audit {
+            sink.record(decision);
+        }
+    }
+}
+
+impl std::fmt::Debug for AuthorizingSecretService {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AuthorizingSecretService")
+            .field("granted_tools", &self.grants.keys().collect::<Vec<_>>())
+            .field("audited", &self.audit.is_some())
+            .finish()
+    }
+}
+
+#[async_trait]
+impl SecretService for AuthorizingSecretService {
+    /// Denies unconditionally.
+    ///
+    /// # Errors
+    ///
+    /// A bare name carries no identity, so there is nothing to authorize against.
+    /// Callers reach this service through
+    /// [`SecretService::get_secret_for`], which the framework uses.
+    async fn get_secret(&self, name: &str) -> Result<String> {
+        let request = SecretRequest::new(name);
+        self.record(&request, false, "no identity supplied");
+        Err(AdkError::unauthorized(
+            adk_core::ErrorComponent::Tool,
+            "secret.no_identity",
+            format!("secret '{name}' was requested without identity, so it cannot be authorized"),
+        ))
+    }
+
+    async fn get_secret_for(&self, request: &SecretRequest) -> Result<String> {
+        let (allowed, reason) = self.decide(request);
+        self.record(request, allowed, reason);
+        if !allowed {
+            // The provider is never consulted, so a denied name is not even looked up.
+            return Err(AdkError::unauthorized(
+                adk_core::ErrorComponent::Tool,
+                "secret.access_denied",
+                format!(
+                    "tool {} is not permitted to read secret '{}': {reason}",
+                    request.tool_name.as_deref().unwrap_or("<none>"),
+                    request.name
+                ),
+            ));
+        }
+        self.inner.get_secret_for(request).await
+    }
+}

--- a/adk-auth/src/secrets/mod.rs
+++ b/adk-auth/src/secrets/mod.rs
@@ -17,6 +17,7 @@
 //! let secret = provider.get_secret("my-api-key").await?;
 //! ```
 
+pub mod authorizing;
 pub mod cached;
 pub mod provider;
 

--- a/adk-auth/tests/secret_authorization_tests.rs
+++ b/adk-auth/tests/secret_authorization_tests.rs
@@ -1,0 +1,201 @@
+//! Secret access from tools must be authorized and recorded.
+//!
+//! `SecretService` and `SecretProvider` received only a secret *name*. Once a provider
+//! was attached to an invocation, policy collapsed to whatever the backing cloud
+//! credentials could read: nothing distinguished a weather tool asking for its own API
+//! key from the same tool asking for a payment credential, and no record of the access
+//! existed at the ADK layer.
+
+use adk_auth::secrets::authorizing::{
+    AuthorizingSecretService, SecretAccessDecision, SecretAuditSink, SecretGrant,
+};
+use adk_core::{AdkError, SecretRequest, SecretService};
+use async_trait::async_trait;
+use std::sync::{Arc, Mutex};
+
+/// An inner service that records which names it was actually asked for.
+struct RecordingService {
+    asked: Arc<Mutex<Vec<String>>>,
+}
+
+impl RecordingService {
+    fn new() -> (Arc<Self>, Arc<Mutex<Vec<String>>>) {
+        let asked = Arc::new(Mutex::new(Vec::new()));
+        (Arc::new(Self { asked: asked.clone() }), asked)
+    }
+}
+
+#[async_trait]
+impl SecretService for RecordingService {
+    async fn get_secret(&self, name: &str) -> adk_core::Result<String> {
+        self.asked.lock().unwrap().push(name.to_string());
+        Ok(format!("value-of-{name}"))
+    }
+}
+
+/// One captured decision: allowed, secret name, tool, reason.
+type CapturedDecision = (bool, String, Option<String>, &'static str);
+
+/// Captures decisions so the audit record can be inspected.
+#[derive(Default)]
+struct CapturingSink {
+    records: Mutex<Vec<CapturedDecision>>,
+}
+
+impl SecretAuditSink for CapturingSink {
+    fn record(&self, decision: SecretAccessDecision<'_>) {
+        self.records.lock().unwrap().push((
+            decision.allowed,
+            decision.name.to_string(),
+            decision.tool_name.map(str::to_string),
+            decision.reason,
+        ));
+    }
+}
+
+fn request(tool: &str, name: &str) -> SecretRequest {
+    SecretRequest::new(name)
+        .with_tool_name(tool)
+        .with_identity("app", "user-1", "session-1")
+        .with_invocation_id("inv-1")
+}
+
+fn service(inner: Arc<RecordingService>) -> AuthorizingSecretService {
+    AuthorizingSecretService::new(inner)
+        .grant("weather_lookup", SecretGrant::none().name("weather-api-key"))
+        .grant("charge_card", SecretGrant::none().prefix("billing/"))
+}
+
+#[tokio::test]
+async fn a_tool_can_read_only_its_granted_secret() {
+    let (inner, asked) = RecordingService::new();
+    let service = service(inner);
+
+    let allowed = service.get_secret_for(&request("weather_lookup", "weather-api-key")).await;
+    assert_eq!(allowed.unwrap(), "value-of-weather-api-key");
+    assert_eq!(asked.lock().unwrap().as_slice(), ["weather-api-key"]);
+}
+
+#[tokio::test]
+async fn a_denied_name_never_reaches_the_provider() {
+    let (inner, asked) = RecordingService::new();
+    let service = service(inner);
+
+    let denied = service.get_secret_for(&request("weather_lookup", "billing/stripe-key")).await;
+
+    assert!(denied.is_err(), "a tool read a secret outside its grant");
+    assert!(
+        asked.lock().unwrap().is_empty(),
+        "the denied name was still looked up in the provider: {:?}",
+        asked.lock().unwrap()
+    );
+}
+
+#[tokio::test]
+async fn a_prefix_grant_covers_its_namespace_and_nothing_else() {
+    let (inner, _asked) = RecordingService::new();
+    let service = service(inner);
+
+    assert!(service.get_secret_for(&request("charge_card", "billing/stripe-key")).await.is_ok());
+    assert!(
+        service.get_secret_for(&request("charge_card", "weather-api-key")).await.is_err(),
+        "a prefix grant must not reach outside its namespace"
+    );
+}
+
+#[tokio::test]
+async fn an_ungranted_tool_is_denied() {
+    let (inner, asked) = RecordingService::new();
+    let service = service(inner);
+
+    let denied = service.get_secret_for(&request("unknown_tool", "weather-api-key")).await;
+    assert!(denied.is_err(), "a tool with no grant must be denied");
+    assert!(asked.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn a_request_without_identity_is_denied() {
+    // A bare name cannot be attributed, so there is nothing to authorize against.
+    let (inner, asked) = RecordingService::new();
+    let service = service(inner);
+
+    assert!(service.get_secret("weather-api-key").await.is_err());
+    assert!(
+        service.get_secret_for(&SecretRequest::new("weather-api-key")).await.is_err(),
+        "an access with no tool identity must be denied by default"
+    );
+    assert!(asked.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn an_untooled_grant_can_be_opened_deliberately() {
+    let (inner, _asked) = RecordingService::new();
+    let service =
+        AuthorizingSecretService::new(inner).grant_untooled(SecretGrant::none().name("agent-key"));
+
+    assert!(service.get_secret_for(&SecretRequest::new("agent-key")).await.is_ok());
+    assert!(service.get_secret_for(&SecretRequest::new("other-key")).await.is_err());
+}
+
+#[tokio::test]
+async fn a_tool_cannot_present_another_tools_grant() {
+    // The framework sets `tool_name` from the tool it dispatched. This asserts the
+    // policy side: a request naming a different tool only ever gets that tool's grant,
+    // so claiming an identity cannot widen access beyond what was granted to it.
+    let (inner, asked) = RecordingService::new();
+    let service = service(inner);
+
+    // `weather_lookup` claiming to be `charge_card` still cannot read a weather key,
+    // because charge_card was never granted one.
+    let spoofed = service.get_secret_for(&request("charge_card", "weather-api-key")).await;
+    assert!(spoofed.is_err());
+    assert!(asked.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn every_decision_is_audited_without_the_value() {
+    let (inner, _asked) = RecordingService::new();
+    let sink = Arc::new(CapturingSink::default());
+    let service = service(inner).with_audit_sink(sink.clone());
+
+    service.get_secret_for(&request("weather_lookup", "weather-api-key")).await.unwrap();
+    let _ = service.get_secret_for(&request("weather_lookup", "billing/stripe-key")).await;
+
+    let records = sink.records.lock().unwrap().clone();
+    assert_eq!(records.len(), 2, "both the allow and the deny must be recorded");
+
+    let (allowed, name, tool, _reason) = &records[0];
+    assert!(*allowed);
+    assert_eq!(name, "weather-api-key");
+    assert_eq!(tool.as_deref(), Some("weather_lookup"));
+
+    let (denied_allowed, denied_name, _, reason) = &records[1];
+    assert!(!*denied_allowed);
+    assert_eq!(denied_name, "billing/stripe-key");
+    assert!(!reason.is_empty(), "a deny must say why");
+
+    // The audit surface carries names and identities, never values.
+    let rendered = format!("{records:?}");
+    assert!(
+        !rendered.contains("value-of-"),
+        "the audit record contained a secret value: {rendered}"
+    );
+}
+
+#[tokio::test]
+async fn debug_output_lists_grants_without_values() {
+    let (inner, _asked) = RecordingService::new();
+    let rendered = format!("{:?}", service(inner));
+    assert!(rendered.contains("weather_lookup"));
+    assert!(!rendered.contains("value-of-"));
+}
+
+#[tokio::test]
+async fn the_denial_error_is_unauthorized() {
+    let (inner, _asked) = RecordingService::new();
+    let service = service(inner);
+
+    let error: AdkError =
+        service.get_secret_for(&request("unknown_tool", "weather-api-key")).await.unwrap_err();
+    assert!(error.is_unauthorized(), "a denial must be categorised as unauthorized: {error:?}");
+}

--- a/adk-core/src/context.rs
+++ b/adk-core/src/context.rs
@@ -558,6 +558,16 @@ pub trait InvocationContext: CallbackContext {
     async fn get_secret(&self, _name: &str) -> Result<Option<String>> {
         Ok(None)
     }
+
+    /// Resolves a secret for a described access.
+    ///
+    /// A wrapper context must forward this, and a tool context builds the request from
+    /// the identity the framework gave it. The default drops the description and calls
+    /// [`InvocationContext::get_secret`], which keeps a context that predates the
+    /// request object working.
+    async fn get_secret_for(&self, request: &SecretRequest) -> Result<Option<String>> {
+        self.get_secret(&request.name).await
+    }
 }
 
 // Placeholder service traits
@@ -650,6 +660,100 @@ pub trait SecretService: Send + Sync {
     ///
     /// Returns the secret string on success, or an [`AdkError`] on failure.
     async fn get_secret(&self, name: &str) -> Result<String>;
+
+    /// Retrieve a secret for a described access.
+    ///
+    /// This is the form an authorizing service implements: the request carries who is
+    /// asking and why, so a decision can be made before the value is fetched. The
+    /// default implementation ignores the context and calls
+    /// [`SecretService::get_secret`], which is correct for a service that has no
+    /// policy of its own.
+    ///
+    /// Every field on [`SecretRequest`] is set by the framework at the call site, not
+    /// supplied by the tool, so a tool cannot present another tool's identity.
+    async fn get_secret_for(&self, request: &SecretRequest) -> Result<String> {
+        self.get_secret(&request.name).await
+    }
+}
+
+/// A described secret access.
+///
+/// Carries the requested name plus the identity the framework observed at the call
+/// site, so a [`SecretService`] can authorize and audit rather than being handed a
+/// bare name with no context.
+///
+/// # Example
+///
+/// ```rust
+/// use adk_core::SecretRequest;
+///
+/// let request = SecretRequest::new("payments-api-key")
+///     .with_tool_name("charge_card")
+///     .with_purpose("authorize a customer payment");
+///
+/// assert_eq!(request.tool_name.as_deref(), Some("charge_card"));
+/// ```
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SecretRequest {
+    /// Name of the requested secret.
+    pub name: String,
+    /// The tool making the request, when the access came from a tool.
+    ///
+    /// Set by the framework from the tool it dispatched, never from a value the tool
+    /// provided.
+    pub tool_name: Option<String>,
+    /// Application the run belongs to.
+    pub app_name: Option<String>,
+    /// Authenticated user the run belongs to.
+    pub user_id: Option<String>,
+    /// Session the run belongs to.
+    pub session_id: Option<String>,
+    /// Invocation the access happened in, for correlating audit records.
+    pub invocation_id: Option<String>,
+    /// Why the secret is needed, when the caller states it.
+    pub purpose: Option<String>,
+}
+
+impl SecretRequest {
+    /// Creates a request for `name` with no identity attached.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self { name: name.into(), ..Default::default() }
+    }
+
+    /// Attaches the requesting tool's name.
+    #[must_use]
+    pub fn with_tool_name(mut self, tool_name: impl Into<String>) -> Self {
+        self.tool_name = Some(tool_name.into());
+        self
+    }
+
+    /// Attaches the run's identity.
+    #[must_use]
+    pub fn with_identity(
+        mut self,
+        app_name: impl Into<String>,
+        user_id: impl Into<String>,
+        session_id: impl Into<String>,
+    ) -> Self {
+        self.app_name = Some(app_name.into());
+        self.user_id = Some(user_id.into());
+        self.session_id = Some(session_id.into());
+        self
+    }
+
+    /// Attaches the invocation the access happened in.
+    #[must_use]
+    pub fn with_invocation_id(mut self, invocation_id: impl Into<String>) -> Self {
+        self.invocation_id = Some(invocation_id.into());
+        self
+    }
+
+    /// Attaches a stated purpose.
+    #[must_use]
+    pub fn with_purpose(mut self, purpose: impl Into<String>) -> Self {
+        self.purpose = Some(purpose.into());
+        self
+    }
 }
 
 /// A single entry returned from memory search.

--- a/adk-core/src/lib.rs
+++ b/adk-core/src/lib.rs
@@ -120,7 +120,7 @@ pub use callbacks::{
 pub use context::{
     Artifacts, BackpressurePolicy, CallbackContext, IncludeContents, InvocationContext,
     MAX_STATE_KEY_LEN, Memory, MemoryEntry, ReadonlyContext, ReadonlyState, RunConfig,
-    RunConfigBuilder, RuntimeToolset, SecretService, Session, State, StreamingMode,
+    RunConfigBuilder, RuntimeToolset, SecretRequest, SecretService, Session, State, StreamingMode,
     ToolCallbackContext, ToolConcurrencyConfig, ToolConfirmationDecision, ToolConfirmationHandler,
     ToolConfirmationPolicy, ToolConfirmationRequest, ToolOutcome, validate_state_key,
 };

--- a/adk-core/src/tool.rs
+++ b/adk-core/src/tool.rs
@@ -187,6 +187,16 @@ pub trait ToolContext: CallbackContext {
     async fn get_secret(&self, _name: &str) -> Result<Option<String>> {
         Ok(None)
     }
+
+    /// Resolves a secret, stating why it is needed.
+    ///
+    /// The tool identity is added by the framework, not taken from the tool, so a
+    /// purpose is the only part a tool contributes. An authorizing
+    /// [`SecretService`](crate::SecretService) sees both.
+    async fn get_secret_for_purpose(&self, name: &str, purpose: &str) -> Result<Option<String>> {
+        let _ = purpose;
+        self.get_secret(name).await
+    }
 }
 
 /// Configuration for automatic tool retry on failure.

--- a/adk-runner/src/context.rs
+++ b/adk-runner/src/context.rs
@@ -555,8 +555,18 @@ impl InvocationContextTrait for InvocationContext {
     }
 
     async fn get_secret(&self, name: &str) -> adk_core::Result<Option<String>> {
+        let request = adk_core::SecretRequest::new(name)
+            .with_identity(self.app_name(), self.user_id(), self.session_id())
+            .with_invocation_id(self.invocation_id());
+        self.get_secret_for(&request).await
+    }
+
+    async fn get_secret_for(
+        &self,
+        request: &adk_core::SecretRequest,
+    ) -> adk_core::Result<Option<String>> {
         match &self.secret_service {
-            Some(service) => service.get_secret(name).await.map(Some),
+            Some(service) => service.get_secret_for(request).await.map(Some),
             None => Ok(None),
         }
     }

--- a/adk-tool/src/agent_tool.rs
+++ b/adk-tool/src/agent_tool.rs
@@ -440,6 +440,19 @@ impl InvocationContext for AgentToolInvocationContext {
         self.parent_ctx.get_secret(name).await
     }
 
+    async fn get_secret_for(
+        &self,
+        request: &adk_core::SecretRequest,
+    ) -> adk_core::Result<Option<String>> {
+        // The parent here is a `ToolContext`, which carries no identity of its own, so
+        // only the stated purpose survives the hop. An agent invoked as a tool
+        // therefore presents that agent's identity rather than the inner tool's.
+        match &request.purpose {
+            Some(purpose) => self.parent_ctx.get_secret_for_purpose(&request.name, purpose).await,
+            None => self.parent_ctx.get_secret(&request.name).await,
+        }
+    }
+
     // `is_cancelled` and `request_metadata` are not forwarded: they are not part
     // of the `ToolContext` surface this wrapper is constructed from, so there is
     // nothing to delegate to. Cancellation therefore does not currently reach an

--- a/docs/official_docs/security/access-control.md
+++ b/docs/official_docs/security/access-control.md
@@ -378,6 +378,55 @@ let cached = Arc::new(CachedSecretProvider::new(provider, Duration::from_secs(30
 let service = Arc::new(SecretServiceAdapter::new(cached));
 ```
 
+### Per-Tool Authorization
+
+By default a tool holding a context can name any secret, and the provider sees only
+that name — nothing distinguishes a weather tool asking for its own API key from the
+same tool asking for a payment credential. `AuthorizingSecretService` decides per tool
+before the provider is consulted:
+
+```rust
+use adk_auth::secrets::authorizing::{AuthorizingSecretService, SecretGrant};
+use std::sync::Arc;
+
+let service = Arc::new(
+    AuthorizingSecretService::new(inner)
+        .grant("weather_lookup", SecretGrant::none().name("weather-api-key"))
+        .grant("charge_card", SecretGrant::none().prefix("billing/"))
+        .with_audit_sink(audit_sink),
+);
+```
+
+| Rule | Behaviour |
+|------|-----------|
+| Tool has a grant covering the name | Allowed |
+| Tool has a grant that does not cover the name | Denied; the provider is never called |
+| Tool has no grant | Denied |
+| Request carries no tool identity | Denied unless `grant_untooled` opens it |
+
+Everything is denied until granted, and a denial returns an `Unauthorized` error. A
+denied name is never looked up, so it does not appear in provider-side access logs as
+an attempted read.
+
+The identity is not something a tool asserts. `LlmAgent` stamps the dispatched tool's
+name onto the request, alongside the app, user, session, and invocation, so a tool
+cannot present another tool's identity. A tool can add only a *purpose*:
+
+```rust
+// inside a tool
+let key = ctx.get_secret_for_purpose("weather-api-key", "call the forecast endpoint").await?;
+```
+
+> **Note:** an agent invoked as a tool crosses a `ToolContext`, which carries no
+> identity of its own, so accesses made inside that agent present the outer agent's
+> identity rather than the inner tool's. Grant accordingly.
+
+### Auditing Access
+
+`SecretAuditSink` receives one `SecretAccessDecision` per decision, carrying the
+outcome, the secret name, the tool, the user, the invocation, and the reason — and
+never a secret value. Allows are also logged at `info` and denials at `warn`.
+
 ### Caching
 
 `CachedSecretProvider` serves a value for its TTL, then refetches. It is bounded and
@@ -402,12 +451,11 @@ may already have been reallocated, copied by the allocator, swapped to disk, or
 captured in a core dump. Debug output for the cache is redacted so a diagnostic print
 cannot leak a value.
 
-> **Important:** the provider interface takes only a secret *name*. There is no
-> per-tool grant, namespace, or access audit at the ADK layer, so any tool holding a
-> context can request any name the backing credentials can read. Scope the cloud
-> credentials themselves — one IAM identity per deployment with access to only the
-> secrets that deployment needs — and treat provider-side audit logs as the record of
-> access.
+> **Important:** a bare `SecretProvider` applies no policy of its own — any tool
+> holding a context can request any name the backing credentials can read. Wrap it in
+> [`AuthorizingSecretService`](#per-tool-authorization) to get a per-tool boundary, and
+> still scope the cloud credentials themselves: one IAM identity per deployment with
+> access to only the secrets that deployment needs.
 
 ## Error Handling
 


### PR DESCRIPTION
> **Stacked on #475.** Base is `fix/secret-cache-lifecycle`; GitHub retargets this to `main` when #475 merges. Both touch `adk-auth/src/secrets` and the same docs section, so sequencing them avoids a conflict. Review #475 first.

## What

Secret access carries the identity the framework observed, a policy layer decides per tool, and every decision is recorded without the value.

## Why

```rust
// the entire interface
async fn get_secret(&self, name: &str) -> Result<String>;
```

A tool holding a context could name any secret. `SecretService` and `SecretProvider` saw only that name — no tool identity, no principal, no namespace, no purpose, no audit sink. So once a provider was attached to an invocation, policy collapsed to whatever the backing cloud credentials could read, and nothing distinguished a weather tool asking for its own API key from the same tool asking for a payment credential.

## How

| Piece | Role |
|---|---|
| `adk_core::SecretRequest` | Name + tool, app, user, session, invocation, optional purpose |
| `SecretService::get_secret_for` | The form a policy-bearing service implements |
| `InvocationContext::get_secret_for` | Carries the request down the context chain |
| `ToolContext::get_secret_for_purpose` | Lets a tool state *why* |
| `AuthorizingSecretService` | Declarative per-tool grants + audit |

Both new trait methods default to the previous name-only behaviour, so existing `SecretService` and context implementations keep compiling. `cargo semver-checks -p adk-core` reports only the three breakages already recorded for 2.0.0 — nothing new from this PR.

### Identity is supplied, not claimed

This is the part that makes the boundary real. `LlmAgent` stamps the **dispatched** tool's name onto the request from its own dispatch record:

```rust
AgentToolContext::new(ctx.clone(), function_call_id.clone())
    .with_tool_name(tool.name())
```

A tool contributes only a purpose. Every workflow wrapper forwards `get_secret_for`, the same discipline the other context capabilities adopted in #465 — a wrapper that forgot to forward would silently lose the identity, which is exactly the failure mode that finding described.

### Policy

```rust
AuthorizingSecretService::new(inner)
    .grant("weather_lookup", SecretGrant::none().name("weather-api-key"))
    .grant("charge_card", SecretGrant::none().prefix("billing/"))
    .with_audit_sink(sink)
```

Deny-by-default. A denied name **never reaches the provider**, so it does not appear as an attempted read in provider-side access logs either. Denials return `Unauthorized`. A request with no tool identity is denied unless `grant_untooled` opens it deliberately.

## The gap this does not close

An agent invoked as a tool crosses a `ToolContext`, which carries no identity of its own, so accesses made inside that agent present the **outer** agent's identity rather than the inner tool's. Only the stated purpose survives that hop. Documented in the code, the changelog, and the docs — this is the same `ToolContext` limitation left open by #465, and closing it needs identity on `ToolContext` itself.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo clippy -p adk-agent --features codeact --all-targets` | exit 0 |
| `cargo nextest run --workspace --profile ci` | **3787 passed**, 83 skipped |
| `cargo test -p adk-core --doc` | 60 passed |
| `RUSTDOCFLAGS=-D warnings cargo doc` (core, auth, agent) | exit 0 |
| `cargo semver-checks -p adk-core --release-type minor` | only the 3 breakages already recorded for 2.0.0 |
| doc-examples / doc-versions guards | exit 0 |

**13 tests.** Ten policy tests in `adk-auth` cover granted reads, denials never reaching the provider, prefix scope, ungranted tools, missing identity, deliberate untooled grants, audit content, redacted `Debug`, and the error category.

Three end-to-end tests in `adk-agent` drive a real tool through `LlmAgent` and inspect what the service received. Deleting the dispatcher's `.with_tool_name(tool.name())` — leaving the API intact so it still compiles — fails **two of the three**, which is the plumbing everything else rests on.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch — targets #475's branch while stacked; retargets to `main` on merge

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed — n/a
- [x] Examples added or updated for new features — n/a