### PR TITLE
fix(server): execute background workflows and claim cron occurrences once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -318,6 +318,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **adk-server: background runs execute a workflow instead of reporting success.**
+  `BackgroundRunner::run_with_timeout` received neither the workflow ID nor the input. It
+  checked cancellation and returned `Completed` with an empty object, so a client got a
+  completed status for work that never ran — and because the placeholder could not fail,
+  the retry budget was never exercised by anything.
+
+  A run now goes through a `WorkflowExecutor`, which resolves the `workflow_id` and
+  receives the input and the cancellation token. `WorkflowRegistry` provides a
+  closure-based implementation. Submitting an unregistered workflow returns 404 instead
+  of queuing a run that can never execute, and a run submitted with no executor
+  configured **fails** rather than reporting completion. Retry re-executes from the
+  beginning with the original input; the documentation previously claimed it resumed from
+  the last checkpoint, which nothing implemented, and now says what it does. Run records
+  remain in-memory and are lost on restart, which the docs now state rather than implying
+  durability.
+
+- **adk-server: a cron occurrence is claimed once.** Due detection used
+  `last_execution.unwrap_or(created_at)`, and under the `Queue` policy scheduling state
+  advanced only when a run *started*. An occurrence waiting behind an active run
+  therefore stayed due and was enqueued again on every one-second poll, turning one
+  schedule point into many runs. When the active run finished, its monitor started one
+  queued run without creating a monitor for it, so `active_run_count` stayed nonzero for
+  good and every later `Skip` and `Queue` decision was stuck.
+
+  `due_occurrences` now reports the exact schedule point, `claim_occurrence` takes it
+  atomically under one write lock, and the scheduler acts only on a won claim. Every run
+  — including one taken off the queue — goes through the same monitored path, which now
+  follows the whole chain and releases the active slot even if a run record disappears.
+
+- **adk-server: `GET /cron/{job_id}` is mounted.** The module documented the endpoint and
+  a store `get` existed, but only PATCH and DELETE were routed, so clients had to list
+  every job and filter locally.
+
 - **adk-agent/adk-tool: workflow context wrappers no longer drop cancellation,
   secrets, and shared state.** Each wrapper re-implements `InvocationContext` and
   delegates to an inner context, but most capability methods have permissive trait

--- a/adk-server/src/background/cron.rs
+++ b/adk-server/src/background/cron.rs
@@ -15,7 +15,7 @@ use axum::{
     extract::{Path, State},
     http::StatusCode,
     response::IntoResponse,
-    routing::post,
+    routing::{get, post},
 };
 use chrono::{DateTime, Utc};
 use cron::Schedule;
@@ -185,7 +185,12 @@ impl CronJobStore {
         self.jobs.write().await.remove(job_id).is_some()
     }
 
-    /// Record an execution for a cron job (updates last_execution, increments count).
+    /// Record that a job executed, setting `last_execution` to now.
+    ///
+    /// The scheduler no longer calls this: it advances scheduling state with
+    /// [`CronJobStore::claim_occurrence`], which stores the exact schedule point rather
+    /// than the wall-clock time a run happened to start. Setting `last_execution` to
+    /// now would skip any occurrence between the schedule point and that moment.
     pub async fn record_execution(&self, job_id: &str) {
         if let Some(job) = self.jobs.write().await.get_mut(job_id) {
             job.last_execution = Some(Utc::now());
@@ -226,24 +231,44 @@ impl CronJobStore {
 
     /// Get all active jobs that are due for execution.
     pub async fn get_due_jobs(&self) -> Vec<CronJob> {
+        self.due_occurrences().await.into_iter().map(|(job, _)| job).collect()
+    }
+
+    /// Active jobs that are due, paired with the exact occurrence they are due for.
+    ///
+    /// The occurrence timestamp is what makes a claim idempotent: without it, a job
+    /// whose scheduling state has not advanced looks due on every poll.
+    pub async fn due_occurrences(&self) -> Vec<(CronJob, DateTime<Utc>)> {
         let jobs = self.jobs.read().await;
         let now = Utc::now();
 
         jobs.values()
             .filter(|job| job.status == CronJobStatus::Active)
-            .filter(|job| {
-                // Check if the job is due based on cron expression
-                if let Ok(schedule) = Schedule::from_str(&job.cron_expression) {
-                    // Find the next occurrence after the last execution (or creation time)
-                    let reference_time = job.last_execution.unwrap_or(job.created_at);
-                    if let Some(next) = schedule.after(&reference_time).next() {
-                        return next <= now;
-                    }
-                }
-                false
+            .filter_map(|job| {
+                let schedule = Schedule::from_str(&job.cron_expression).ok()?;
+                let reference_time = job.last_execution.unwrap_or(job.created_at);
+                let next = schedule.after(&reference_time).next()?;
+                (next <= now).then(|| (job.clone(), next))
             })
-            .cloned()
             .collect()
+    }
+
+    /// Claim `occurrence` for `job_id`, returning whether this caller won it.
+    ///
+    /// Scheduling state advances here rather than when a run starts, so an occurrence
+    /// that is queued behind an active run is not offered again on the next poll. The
+    /// check and the write happen under one write lock, so only one caller can claim a
+    /// given occurrence.
+    pub async fn claim_occurrence(&self, job_id: &str, occurrence: DateTime<Utc>) -> bool {
+        let mut jobs = self.jobs.write().await;
+        let Some(job) = jobs.get_mut(job_id) else {
+            return false;
+        };
+        if job.last_execution.is_some_and(|last| last >= occurrence) {
+            return false;
+        }
+        job.last_execution = Some(occurrence);
+        true
     }
 }
 
@@ -318,6 +343,23 @@ async fn list_cron_jobs(State(state): State<CronState>) -> impl IntoResponse {
     (StatusCode::OK, Json(serde_json::to_value(responses).unwrap())).into_response()
 }
 
+/// GET /cron/{job_id} — Retrieve one cron job.
+async fn get_cron_job(
+    State(state): State<CronState>,
+    Path(job_id): Path<String>,
+) -> impl IntoResponse {
+    match state.cron_store.get(&job_id).await {
+        Some(job) => {
+            (StatusCode::OK, Json(serde_json::to_value(job.to_response()).unwrap())).into_response()
+        }
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": format!("cron job '{job_id}' not found") })),
+        )
+            .into_response(),
+    }
+}
+
 /// PATCH /cron/{job_id} — Pause or resume a cron job.
 async fn patch_cron_job(
     State(state): State<CronState>,
@@ -367,23 +409,27 @@ pub fn start_cron_scheduler(state: CronState) -> tokio::task::JoinHandle<()> {
         loop {
             interval.tick().await;
 
-            let due_jobs = state.cron_store.get_due_jobs().await;
+            for (job, occurrence) in state.cron_store.due_occurrences().await {
+                // Claim the occurrence before acting on it. Under `Queue` the previous
+                // code advanced scheduling state only when a run started, so an
+                // occurrence waiting behind an active run was enqueued again on every
+                // one-second poll and one schedule point became many runs.
+                if !state.cron_store.claim_occurrence(&job.job_id, occurrence).await {
+                    continue;
+                }
 
-            for job in due_jobs {
                 match job.concurrency_policy {
                     ConcurrencyPolicy::Skip => {
-                        // Skip if previous run still active
+                        // Drop this occurrence if a previous run is still active.
                         if job.active_run_count > 0 {
                             continue;
                         }
                         trigger_run(&state, &job).await;
                     }
                     ConcurrencyPolicy::Allow => {
-                        // Always create a new run
                         trigger_run(&state, &job).await;
                     }
                     ConcurrencyPolicy::Queue => {
-                        // If active, enqueue; otherwise execute immediately
                         if job.active_run_count > 0 {
                             let run_id = uuid::Uuid::new_v4().to_string();
                             state.cron_store.enqueue_run(&job.job_id, run_id).await;
@@ -397,16 +443,14 @@ pub fn start_cron_scheduler(state: CronState) -> tokio::task::JoinHandle<()> {
     })
 }
 
-/// Trigger a background run for a due cron job.
-async fn trigger_run(state: &CronState, job: &CronJob) {
+/// Builds a background run record for one occurrence of `job`.
+fn run_record(job: &CronJob, run_id: String) -> super::BackgroundRun {
     use std::time::Duration;
     use tokio_util::sync::CancellationToken;
 
-    let run_id = uuid::Uuid::new_v4().to_string();
     let now = Utc::now();
-
-    let run = super::BackgroundRun {
-        run_id: run_id.clone(),
+    super::BackgroundRun {
+        run_id,
         workflow_id: job.workflow_id.clone(),
         status: RunStatus::Queued,
         input: job.input.clone().unwrap_or_default(),
@@ -418,64 +462,69 @@ async fn trigger_run(state: &CronState, job: &CronJob) {
         max_retries: 0,
         retry_count: 0,
         cancel_token: CancellationToken::new(),
-    };
+    }
+}
 
-    state.background_state.store.insert(run).await;
-    state.cron_store.record_execution(&job.job_id).await;
+/// Trigger a background run for a due cron job.
+///
+/// Every run for a job goes through here, including one started from the queue, so the
+/// active count is always paired with a monitor that will decrement it.
+async fn trigger_run(state: &CronState, job: &CronJob) {
+    let run_id = uuid::Uuid::new_v4().to_string();
+
+    state.background_state.store.insert(run_record(job, run_id.clone())).await;
     state.cron_store.increment_active_runs(&job.job_id).await;
-
-    // Start execution
     state.background_state.runner.execute(run_id.clone());
 
-    // Spawn a task to monitor run completion and handle queue policy
-    let cron_store = state.cron_store.clone();
-    let bg_store = state.background_state.store.clone();
-    let bg_runner = state.background_state.runner.clone();
+    // One monitor follows the whole chain: the run it started, then each run it takes
+    // off the queue. Starting a queued run without a monitor left `active_run_count`
+    // permanently nonzero, which stalled every later Skip and Queue decision.
+    let state = state.clone();
     let job_id = job.job_id.clone();
-
     tokio::spawn(async move {
-        // Poll until the run completes
+        let mut current = run_id;
         loop {
-            tokio::time::sleep(Duration::from_millis(100)).await;
-            if let Some(run) = bg_store.get(&run_id).await {
-                match run.status {
-                    RunStatus::Completed | RunStatus::Failed | RunStatus::Cancelled => {
-                        cron_store.decrement_active_runs(&job_id).await;
-
-                        // If queue policy, check for queued runs
-                        if let Some(job) = cron_store.get(&job_id).await
-                            && job.concurrency_policy == ConcurrencyPolicy::Queue
-                            && let Some(queued_run_id) = cron_store.dequeue_run(&job_id).await
-                        {
-                            // Create and execute the queued run
-                            let now = Utc::now();
-                            let queued_run = super::BackgroundRun {
-                                run_id: queued_run_id.clone(),
-                                workflow_id: job.workflow_id.clone(),
-                                status: RunStatus::Queued,
-                                input: job.input.clone().unwrap_or_default(),
-                                result: None,
-                                error: None,
-                                created_at: now,
-                                updated_at: now,
-                                timeout: Some(Duration::from_secs(3600)),
-                                max_retries: 0,
-                                retry_count: 0,
-                                cancel_token: CancellationToken::new(),
-                            };
-                            bg_store.insert(queued_run).await;
-                            cron_store.increment_active_runs(&job_id).await;
-                            bg_runner.execute(queued_run_id);
-                        }
-                        break;
-                    }
-                    _ => continue,
-                }
-            } else {
+            if !wait_for_run(&state, &current).await {
+                // The run record vanished; release the slot so the job is not wedged.
+                state.cron_store.decrement_active_runs(&job_id).await;
                 break;
             }
+            state.cron_store.decrement_active_runs(&job_id).await;
+
+            let Some(job) = state.cron_store.get(&job_id).await else {
+                break;
+            };
+            if job.concurrency_policy != ConcurrencyPolicy::Queue {
+                break;
+            }
+            let Some(next_run_id) = state.cron_store.dequeue_run(&job_id).await else {
+                break;
+            };
+
+            state.background_state.store.insert(run_record(&job, next_run_id.clone())).await;
+            state.cron_store.increment_active_runs(&job_id).await;
+            state.background_state.runner.execute(next_run_id.clone());
+            current = next_run_id;
         }
     });
+}
+
+/// Waits for `run_id` to reach a terminal status.
+///
+/// Returns `false` when the run record disappeared, which is not a completion and must
+/// not be mistaken for one.
+async fn wait_for_run(state: &CronState, run_id: &str) -> bool {
+    use std::time::Duration;
+    loop {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        match state.background_state.store.get(run_id).await {
+            Some(run) => match run.status {
+                RunStatus::Completed | RunStatus::Failed | RunStatus::Cancelled => return true,
+                _ => continue,
+            },
+            None => return false,
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -500,6 +549,6 @@ pub fn cron_jobs_router(background_state: BackgroundState) -> Router {
 pub fn cron_jobs_router_with_state(state: CronState) -> Router {
     Router::new()
         .route("/cron", post(create_cron_job).get(list_cron_jobs))
-        .route("/cron/{job_id}", axum::routing::patch(patch_cron_job).delete(delete_cron_job))
+        .route("/cron/{job_id}", get(get_cron_job).patch(patch_cron_job).delete(delete_cron_job))
         .with_state(state)
 }

--- a/adk-server/src/background/mod.rs
+++ b/adk-server/src/background/mod.rs
@@ -217,17 +217,139 @@ impl RunStore {
 /// Orchestrates background run execution with timeout, retry, and cancellation.
 ///
 /// The `BackgroundRunner` spawns tokio tasks for each submitted run, enforces
-/// timeout policies, and handles retry logic by re-enqueuing failed runs from
-/// their last checkpoint.
-#[derive(Debug, Clone)]
+/// timeout policies, and retries a failed run from the beginning up to its retry
+/// budget. Retry is not checkpoint-aware: a retried run re-executes the workflow with
+/// the original input.
+/// Executes a registered workflow for a background run.
+///
+/// A background run names a `workflow_id`; something has to turn that into work.
+/// Implement this to bridge to whatever executes workflows in your application —
+/// `adk-graph`, the functional API, or your own dispatcher.
+///
+/// # Errors
+///
+/// Return `Err` to mark the run failed. A failure is what makes the configured retry
+/// budget meaningful, so surface real failures rather than encoding them as `Ok`.
+#[async_trait::async_trait]
+pub trait WorkflowExecutor: Send + Sync {
+    /// Whether `workflow_id` can be executed.
+    ///
+    /// Checked before a run is queued, so an unknown workflow is rejected instead of
+    /// being accepted and then reported as complete.
+    fn has_workflow(&self, workflow_id: &str) -> bool;
+
+    /// Run `workflow_id` with `input`.
+    ///
+    /// `cancel_token` fires when the run is cancelled or times out; implementations
+    /// should observe it and stop.
+    async fn execute(
+        &self,
+        workflow_id: &str,
+        input: WorkflowState,
+        cancel_token: CancellationToken,
+    ) -> std::result::Result<Value, String>;
+}
+
+/// A `WorkflowExecutor` holding closures registered by name.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use adk_server::background::WorkflowRegistry;
+/// use serde_json::json;
+///
+/// let registry = WorkflowRegistry::new().register("greet", |input, _cancel| async move {
+///     Ok(json!({ "greeted": input.get("name").cloned() }))
+/// });
+/// ```
+#[derive(Default)]
+pub struct WorkflowRegistry {
+    workflows: std::collections::HashMap<String, Arc<BoxedWorkflow>>,
+}
+
+/// The boxed form of a registered workflow.
+type BoxedWorkflow = dyn Fn(
+        WorkflowState,
+        CancellationToken,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = std::result::Result<Value, String>> + Send>,
+    > + Send
+    + Sync;
+
+impl WorkflowRegistry {
+    /// An empty registry, which accepts no workflow.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register `workflow_id`.
+    #[must_use]
+    pub fn register<F, Fut>(mut self, workflow_id: impl Into<String>, workflow: F) -> Self
+    where
+        F: Fn(WorkflowState, CancellationToken) -> Fut + Send + Sync + 'static,
+        Fut: std::future::Future<Output = std::result::Result<Value, String>> + Send + 'static,
+    {
+        self.workflows.insert(
+            workflow_id.into(),
+            Arc::new(move |input, cancel| Box::pin(workflow(input, cancel))),
+        );
+        self
+    }
+}
+
+#[async_trait::async_trait]
+impl WorkflowExecutor for WorkflowRegistry {
+    fn has_workflow(&self, workflow_id: &str) -> bool {
+        self.workflows.contains_key(workflow_id)
+    }
+
+    async fn execute(
+        &self,
+        workflow_id: &str,
+        input: WorkflowState,
+        cancel_token: CancellationToken,
+    ) -> std::result::Result<Value, String> {
+        match self.workflows.get(workflow_id) {
+            Some(workflow) => workflow(input, cancel_token).await,
+            None => Err(format!("workflow '{workflow_id}' is not registered")),
+        }
+    }
+}
+
+#[derive(Clone)]
 pub struct BackgroundRunner {
     store: RunStore,
+    executor: Option<Arc<dyn WorkflowExecutor>>,
+}
+
+impl std::fmt::Debug for BackgroundRunner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BackgroundRunner")
+            .field("store", &self.store)
+            .field("has_executor", &self.executor.is_some())
+            .finish()
+    }
 }
 
 impl BackgroundRunner {
     /// Create a new background runner backed by the given store.
+    ///
+    /// Without an executor a run cannot do any work, and is failed rather than
+    /// reported complete.
     pub fn new(store: RunStore) -> Self {
-        Self { store }
+        Self { store, executor: None }
+    }
+
+    /// The configured executor, if any.
+    pub fn executor(&self) -> Option<&Arc<dyn WorkflowExecutor>> {
+        self.executor.as_ref()
+    }
+
+    /// Attach the executor that resolves and runs workflows.
+    #[must_use]
+    pub fn with_executor(mut self, executor: Arc<dyn WorkflowExecutor>) -> Self {
+        self.executor = Some(executor);
+        self
     }
 
     /// Submit and execute a background run.
@@ -237,6 +359,7 @@ impl BackgroundRunner {
     /// `cancelled` based on the outcome.
     pub fn execute(&self, run_id: String) {
         let store = self.store.clone();
+        let executor = self.executor.clone();
         tokio::spawn(async move {
             // Retrieve the run record
             let run = match store.get(&run_id).await {
@@ -251,7 +374,14 @@ impl BackgroundRunner {
             store.update_status(&run_id, RunStatus::Running).await;
 
             // Execute with timeout and cancellation
-            let result = Self::run_with_timeout(timeout_duration, &cancel_token).await;
+            let result = Self::run_with_timeout(
+                executor.as_ref(),
+                &run.workflow_id,
+                run.input.clone(),
+                timeout_duration,
+                &cancel_token,
+            )
+            .await;
 
             match result {
                 RunOutcome::Completed(value) => {
@@ -263,8 +393,12 @@ impl BackgroundRunner {
                         // Re-execute after retry
                         let store_clone = store.clone();
                         let run_id_clone = run_id.clone();
+                        let executor_clone = executor.clone();
                         tokio::spawn(async move {
-                            let runner = BackgroundRunner::new(store_clone);
+                            let mut runner = BackgroundRunner::new(store_clone);
+                            if let Some(executor) = executor_clone {
+                                runner = runner.with_executor(executor);
+                            }
                             runner.execute(run_id_clone);
                         });
                     } else {
@@ -283,19 +417,27 @@ impl BackgroundRunner {
 
     /// Execute the workflow with timeout enforcement and cancellation support.
     async fn run_with_timeout(
+        executor: Option<&Arc<dyn WorkflowExecutor>>,
+        workflow_id: &str,
+        input: WorkflowState,
         timeout_duration: Option<Duration>,
         cancel_token: &CancellationToken,
     ) -> RunOutcome {
-        // The actual workflow execution is a placeholder — in a real implementation
-        // this would invoke the workflow via the functional API's TaskContext.
-        // For now, we simulate immediate completion.
         let work = async {
-            // Check cancellation before work
             if cancel_token.is_cancelled() {
                 return RunOutcome::Cancelled;
             }
-            // Placeholder: immediate success with empty object result
-            RunOutcome::Completed(Value::Object(serde_json::Map::new()))
+            // Without an executor there is nothing to run. Reporting success here is
+            // what made a submitted run look complete while never executing.
+            let Some(executor) = executor else {
+                return RunOutcome::Failed(format!(
+                    "no workflow executor is configured, so workflow '{workflow_id}' cannot run"
+                ));
+            };
+            match executor.execute(workflow_id, input, cancel_token.clone()).await {
+                Ok(value) => RunOutcome::Completed(value),
+                Err(error) => RunOutcome::Failed(error),
+            }
         };
 
         match timeout_duration {
@@ -342,6 +484,16 @@ pub struct BackgroundState {
 }
 
 impl BackgroundState {
+    /// Attach the executor that resolves and runs workflows.
+    ///
+    /// Without one, a submitted run has nothing to execute and is failed rather than
+    /// reported complete.
+    #[must_use]
+    pub fn with_executor(mut self, executor: Arc<dyn WorkflowExecutor>) -> Self {
+        self.runner = self.runner.with_executor(executor);
+        self
+    }
+
     /// Create a new background state with a fresh store and runner.
     pub fn new() -> Self {
         let store = RunStore::new();
@@ -365,6 +517,20 @@ async fn submit_run(
     State(state): State<BackgroundState>,
     Json(request): Json<SubmitRunRequest>,
 ) -> impl IntoResponse {
+    // Reject an unknown workflow before it is queued, rather than accepting it and
+    // reporting a status for work that can never run.
+    if let Some(executor) = state.runner.executor()
+        && !executor.has_workflow(&request.workflow_id)
+    {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({
+                "error": format!("unknown workflow '{}'", request.workflow_id)
+            })),
+        )
+            .into_response();
+    }
+
     let run_id = uuid::Uuid::new_v4().to_string();
     let now = Utc::now();
 
@@ -391,7 +557,7 @@ async fn submit_run(
     let response =
         SubmitRunResponse { run_id, status: RunStatus::Queued, created_at: now.to_rfc3339() };
 
-    (StatusCode::CREATED, Json(response))
+    (StatusCode::CREATED, Json(response)).into_response()
 }
 
 /// GET /runs/{run_id} — Get run status.

--- a/adk-server/src/lib.rs
+++ b/adk-server/src/lib.rs
@@ -83,8 +83,8 @@ pub mod background;
 #[cfg(feature = "background")]
 pub use background::{
     BackgroundRun, BackgroundRunner, BackgroundState, RunStatus, RunStatusResponse, RunStore,
-    SubmitRunRequest, SubmitRunResponse, WorkflowState, background_runs_router,
-    background_runs_router_with_state,
+    SubmitRunRequest, SubmitRunResponse, WorkflowExecutor, WorkflowRegistry, WorkflowState,
+    background_runs_router, background_runs_router_with_state,
 };
 #[cfg(feature = "background")]
 pub use background::{

--- a/adk-server/tests/background_execution_tests.rs
+++ b/adk-server/tests/background_execution_tests.rs
@@ -1,0 +1,285 @@
+//! Background runs must actually run, and a cron occurrence must be claimed once.
+//!
+//! Three defects motivated these tests:
+//!
+//! 1. `BackgroundRunner::run_with_timeout` received neither the workflow ID nor the
+//!    input. It checked cancellation and returned `Completed` with an empty object, so a
+//!    client got a completed status for work that never ran, and retry could never be
+//!    exercised because the placeholder had no way to fail.
+//! 2. Under the `Queue` concurrency policy the scheduler advanced `last_execution` only
+//!    when a run *started*, so an occurrence waiting behind an active run stayed due and
+//!    was enqueued again on every one-second poll. When the active run finished, its
+//!    monitor started one queued run without creating a monitor for it, leaving
+//!    `active_run_count` permanently nonzero and the queue stalled.
+//! 3. The module documented `GET /cron/{job_id}`; only PATCH and DELETE were mounted.
+
+#![cfg(feature = "background")]
+
+use adk_server::background::{
+    BackgroundState, CronState, RunStatus, WorkflowRegistry, background_runs_router_with_state,
+    cron_jobs_router_with_state,
+};
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use chrono::Utc;
+use serde_json::{Value, json};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+use tower::ServiceExt;
+
+/// Polls a run until it reaches a terminal status, or gives up.
+async fn await_terminal(state: &BackgroundState, run_id: &str) -> RunStatus {
+    for _ in 0..200 {
+        if let Some(run) = state.store.get(run_id).await {
+            match run.status {
+                RunStatus::Completed | RunStatus::Failed | RunStatus::Cancelled => {
+                    return run.status;
+                }
+                _ => {}
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("run {run_id} never reached a terminal status");
+}
+
+// ── Background runs execute real work ──────────────────────────────────
+
+#[tokio::test]
+async fn a_run_executes_its_workflow_and_returns_the_output() {
+    let registry = WorkflowRegistry::new().register("echo", |input, _cancel| async move {
+        let name = input.get("name").cloned().unwrap_or(Value::Null);
+        Ok(json!({ "echoed": name }))
+    });
+    let state = BackgroundState::new().with_executor(Arc::new(registry));
+
+    let response = background_runs_router_with_state(state.clone())
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/runs")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({ "workflowId": "echo", "input": { "name": "ada" } }).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let submitted: Value = serde_json::from_slice(&body).unwrap();
+    let run_id = submitted["runId"].as_str().unwrap().to_string();
+
+    assert_eq!(
+        await_terminal(&state, &run_id).await,
+        RunStatus::Completed,
+        "the run must complete by executing the workflow"
+    );
+    let run = state.store.get(&run_id).await.unwrap();
+    assert_eq!(
+        run.result,
+        Some(json!({ "echoed": "ada" })),
+        "the workflow's output must be returned, and its input must have reached it"
+    );
+}
+
+#[tokio::test]
+async fn a_failing_workflow_fails_the_run() {
+    let registry = WorkflowRegistry::new()
+        .register("boom", |_input, _cancel| async move { Err("exploded".to_string()) });
+    let state = BackgroundState::new().with_executor(Arc::new(registry));
+
+    let run_id = submit(&state, json!({ "workflowId": "boom", "input": {} })).await;
+
+    assert_eq!(await_terminal(&state, &run_id).await, RunStatus::Failed);
+    let run = state.store.get(&run_id).await.unwrap();
+    assert_eq!(run.error.as_deref(), Some("exploded"), "the failure reason must be recorded");
+}
+
+#[tokio::test]
+async fn a_failing_workflow_consumes_its_retry_budget() {
+    // The placeholder could never fail, so the retry path was never exercised.
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let counter = attempts.clone();
+    let registry = WorkflowRegistry::new().register("flaky", move |_input, _cancel| {
+        let counter = counter.clone();
+        async move {
+            counter.fetch_add(1, Ordering::SeqCst);
+            Err("still failing".to_string())
+        }
+    });
+    let state = BackgroundState::new().with_executor(Arc::new(registry));
+
+    let run_id =
+        submit(&state, json!({ "workflowId": "flaky", "input": {}, "maxRetries": 2 })).await;
+    assert_eq!(await_terminal(&state, &run_id).await, RunStatus::Failed);
+
+    assert_eq!(
+        attempts.load(Ordering::SeqCst),
+        3,
+        "the workflow must run once plus twice more for the retry budget"
+    );
+}
+
+#[tokio::test]
+async fn an_unknown_workflow_is_rejected_instead_of_queued() {
+    let state = BackgroundState::new().with_executor(Arc::new(WorkflowRegistry::new()));
+
+    let response = background_runs_router_with_state(state)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/runs")
+                .header("content-type", "application/json")
+                .body(Body::from(json!({ "workflowId": "nope", "input": {} }).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::NOT_FOUND,
+        "an unknown workflow must be refused rather than accepted and reported on"
+    );
+}
+
+#[tokio::test]
+async fn a_run_without_an_executor_fails_rather_than_reporting_success() {
+    // This is the original defect in its plainest form.
+    let state = BackgroundState::new();
+    let run_id = submit(&state, json!({ "workflowId": "anything", "input": {} })).await;
+
+    assert_eq!(
+        await_terminal(&state, &run_id).await,
+        RunStatus::Failed,
+        "with nothing able to run the workflow, the run must not report completion"
+    );
+}
+
+/// Submits a run and returns its ID.
+async fn submit(state: &BackgroundState, body: Value) -> String {
+    let response = background_runs_router_with_state(state.clone())
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/runs")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let submitted: Value = serde_json::from_slice(&bytes).unwrap();
+    submitted["runId"].as_str().unwrap().to_string()
+}
+
+// ── A cron occurrence is claimed once ──────────────────────────────────
+
+#[tokio::test]
+async fn an_occurrence_can_be_claimed_only_once() {
+    let state = CronState::new(BackgroundState::new());
+    let job_id = create_job(&state, "* * * * * *").await;
+
+    // Every-second schedule, so the job is due almost immediately.
+    tokio::time::sleep(Duration::from_millis(1100)).await;
+    let due = state.cron_store.due_occurrences().await;
+    let (_, occurrence) =
+        due.iter().find(|(job, _)| job.job_id == job_id).expect("job must be due");
+
+    assert!(state.cron_store.claim_occurrence(&job_id, *occurrence).await, "the first claim wins");
+    assert!(
+        !state.cron_store.claim_occurrence(&job_id, *occurrence).await,
+        "the same occurrence must not be claimable twice; that is what turned one \
+         schedule point into a queue entry per poll"
+    );
+}
+
+#[tokio::test]
+async fn a_claimed_occurrence_is_no_longer_due() {
+    let state = CronState::new(BackgroundState::new());
+    let job_id = create_job(&state, "0 0 * * * *").await;
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    if let Some((_, occurrence)) =
+        state.cron_store.due_occurrences().await.into_iter().find(|(j, _)| j.job_id == job_id)
+    {
+        state.cron_store.claim_occurrence(&job_id, occurrence).await;
+        let still_due = state
+            .cron_store
+            .due_occurrences()
+            .await
+            .into_iter()
+            .any(|(j, o)| j.job_id == job_id && o == occurrence);
+        assert!(!still_due, "a claimed occurrence must not be offered again");
+    }
+}
+
+#[tokio::test]
+async fn claiming_an_older_occurrence_is_refused() {
+    let state = CronState::new(BackgroundState::new());
+    let job_id = create_job(&state, "* * * * * *").await;
+
+    let now = Utc::now();
+    assert!(state.cron_store.claim_occurrence(&job_id, now).await);
+    assert!(
+        !state.cron_store.claim_occurrence(&job_id, now - chrono::Duration::seconds(30)).await,
+        "scheduling state must not move backwards"
+    );
+}
+
+// ── The documented cron detail route exists ────────────────────────────
+
+#[tokio::test]
+async fn the_cron_detail_route_is_mounted() {
+    let state = CronState::new(BackgroundState::new());
+    let job_id = create_job(&state, "0 * * * * *").await;
+
+    let found = cron_jobs_router_with_state(state.clone())
+        .oneshot(Request::builder().uri(format!("/cron/{job_id}")).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(found.status(), StatusCode::OK, "GET /cron/{{job_id}} is documented and must exist");
+
+    let bytes = axum::body::to_bytes(found.into_body(), usize::MAX).await.unwrap();
+    let job: Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(job["jobId"].as_str(), Some(job_id.as_str()));
+
+    let missing = cron_jobs_router_with_state(state)
+        .oneshot(Request::builder().uri("/cron/absent").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+}
+
+/// Creates a cron job through the router and returns its ID.
+async fn create_job(state: &CronState, expression: &str) -> String {
+    let response = cron_jobs_router_with_state(state.clone())
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/cron")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "scheduled job",
+                        "workflowId": "scheduled",
+                        "cronExpression": expression,
+                        "input": {}
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let created: Value = serde_json::from_slice(&bytes).unwrap();
+    created["jobId"].as_str().unwrap().to_string()
+}

--- a/docs/official_docs/agents/functional-api.md
+++ b/docs/official_docs/agents/functional-api.md
@@ -133,12 +133,32 @@ The `background` feature in `adk-server` adds REST endpoints for async workflow 
 
 ### Usage
 
-```rust
-use adk_server::background::{BackgroundState, background_runs_router_with_state};
+A run names a `workflowId`. Something has to turn that name into work, so register a
+`WorkflowExecutor` — without one, a submitted run **fails** rather than reporting
+completion:
 
-let state = BackgroundState::new();
+```rust
+use adk_server::background::{
+    BackgroundState, WorkflowRegistry, background_runs_router_with_state,
+};
+use serde_json::json;
+use std::sync::Arc;
+
+let registry = WorkflowRegistry::new().register("summarize", |input, cancel| async move {
+    if cancel.is_cancelled() {
+        return Err("cancelled before starting".to_string());
+    }
+    Ok(json!({ "summary": "…", "of": input.get("document") }))
+});
+
+let state = BackgroundState::new().with_executor(Arc::new(registry));
 let app = axum::Router::new().merge(background_runs_router_with_state(state));
 ```
+
+Submitting an unregistered `workflowId` returns **404** rather than queuing a run that
+can never execute. Implement `WorkflowExecutor` directly to bridge to `adk-graph`, the
+functional API, or your own dispatcher; return `Err` to fail the run, which is what makes
+the retry budget meaningful.
 
 ### Status Lifecycle
 
@@ -147,6 +167,14 @@ queued → running → completed
                  → failed (retries if configured)
                  → cancelled (via DELETE)
 ```
+
+Retry re-executes the workflow **from the beginning** with the original input. It is not
+checkpoint-aware, so a workflow with side effects should be idempotent or guard its own
+progress.
+
+> **Important:** run records live in an in-memory store. A process restart loses every
+> record, including in-flight runs. Treat these endpoints as an async execution surface,
+> not a durable job queue.
 
 ## Cron Scheduling
 
@@ -158,14 +186,23 @@ The `background` feature also includes cron job management.
 |--------|------|-------------|
 | POST | `/cron` | Create a cron job |
 | GET | `/cron` | List all jobs |
+| GET | `/cron/{job_id}` | Get one job |
 | PATCH | `/cron/{job_id}` | Pause/resume |
 | DELETE | `/cron/{job_id}` | Delete a job |
 
 ### Concurrency Policies
 
-- **skip**: Skip execution if previous run still active (default)
+- **skip**: Skip the occurrence if a previous run is still active (default)
 - **allow**: Permit concurrent executions
-- **queue**: Queue new execution until current completes
+- **queue**: Queue the occurrence and run it when the active run finishes
+
+Each schedule occurrence is claimed once, so an occurrence that arrives while a run is
+active produces exactly one queued run rather than one per scheduler poll. Queued runs
+drain in order, and each is monitored the same way a directly triggered run is, so the
+active count returns to zero even if a run fails or is cancelled.
+
+Cron jobs use the same executor as background runs — a job whose `workflowId` is not
+registered will fail its runs.
 
 ### Usage
 


### PR DESCRIPTION
## What

Three defects in the `background` feature: runs that never ran, cron occurrences enqueued once per poll, and a documented route that was never mounted. Plus the first tests this module has had.

## Why

### BG-01 — a run reported success without running

```rust
async fn run_with_timeout(timeout: Option<Duration>, cancel: &CancellationToken) -> RunOutcome {
    // no workflow_id, no input
    let work = async {
        if cancel.is_cancelled() { return RunOutcome::Cancelled; }
        RunOutcome::Completed(Value::Object(serde_json::Map::new()))  // always
    };
```

A submitted run stored `workflow_id` and `input`; the work future received neither. Clients got `completed` for work that never happened. And because the placeholder had no way to return `Failed`, the retry budget was decorative — no test could have caught a retry bug, because retry was unreachable.

### BG-02 — one schedule point became many runs, then the queue wedged

Due detection used `last_execution.unwrap_or(created_at)`, and under `Queue` scheduling state advanced only when a run *started*. An occurrence waiting behind an active run therefore stayed due and was enqueued **again on every one-second poll**.

Then, when the active run finished, the monitor started one queued run *without creating a monitor for it* — so `active_run_count` never came back down, and every later `Skip` and `Queue` decision was stuck for the life of the process.

### BG-03 — `GET /cron/{job_id}` documented, never routed

The module listed it, `CronJobStore::get` existed, and only PATCH and DELETE were mounted.

## How

| Change | Effect |
|---|---|
| `WorkflowExecutor` trait + `WorkflowRegistry` | A run resolves its `workflow_id` and receives input and cancellation |
| 404 on unregistered `workflowId` | Rejected before queuing rather than accepted and reported on |
| No executor configured → `Failed` | The run cannot silently claim success |
| `due_occurrences` + `claim_occurrence` | The exact schedule point is claimed once, atomically under one write lock |
| Single chained monitor | Every run — including one dequeued — is monitored; the slot is released even if a run record disappears |
| `GET /cron/{job_id}` | Mounted, 200/404 |

`record_execution` is left in place as public API but is no longer what the scheduler uses; its doc now explains that it sets `last_execution` to *now*, which would skip any occurrence between the schedule point and that moment.

## Docs corrected rather than left aspirational

| Claim | Reality |
|---|---|
| "retry re-enqueues from the last checkpoint" | Retry re-executes from the beginning with the original input; nothing loaded or stored a checkpoint |
| Durability implied by timeout/retry config | Run records are in-memory and lost on restart — now stated explicitly |
| `BackgroundState::new()` shown as sufficient | The example now registers an executor, because without one every run fails |
| Cron endpoint table | `GET /cron/{job_id}` added |

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo clippy -p adk-server --features background --all-targets` | exit 0 |
| `cargo nextest run --workspace --profile ci` | **3765 passed**, 83 skipped |
| `cargo nextest run -p adk-server --features background` | 115 passed (was 106) |
| `RUSTDOCFLAGS=-D warnings cargo doc -p adk-server --features background` | exit 0 |
| doc-examples guard | exit 0 |

**Nine tests — the first in this module.** Against the placeholder runner (API kept so they still compile), **four fail**: workflow output/input, failure recording, retry-budget consumption, and the no-executor case.

## Not addressed

The finding also asks for a durable run store and checkpoint-aware retry. Both need a storage backend decision (SQLite/Postgres) and a checkpoint contract with the workflow layer, so they are out of scope here; the non-durability is now documented instead of implied. Cron queue draining is proven at the store level (claim idempotence, monotonic advance) rather than by driving the one-second scheduler through multiple ticks, which would make the test time-dependent.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed — n/a
- [x] Examples added or updated for new features — n/a