### PR TITLE
fix(agent): restore the brace lost merging two adjacent insertions

### DIFF
--- a/adk-agent/src/llm_agent.rs
+++ b/adk-agent/src/llm_agent.rs
@@ -1068,6 +1068,8 @@ impl AgentToolContext {
             request = request.with_purpose(purpose);
         }
         self.parent_ctx.get_secret_for(&request).await
+    }
+
     /// Forwards one progress chunk under this call's budget.
     ///
     /// The policy is bounded and lossy by design: memory is capped, and output that


### PR DESCRIPTION
## Urgent: `main` does not compile

```
adk-agent/src/llm_agent.rs:3089:3: error: this file contains an unclosed delimiter
error: could not compile `adk-agent` (lib)
```

## What happened

#470 (bounded tool progress) and #476 (secret identity) both inserted a new method into `impl AgentToolContext` **immediately before `actions_guard`**. Each was green on its own and each was reported MERGEABLE. Combining them dropped the closing brace of `request_secret`, so `forward_progress` ended up nested inside it:

```rust
    async fn request_secret(&self, name: &str, purpose: Option<&str>) -> Result<Option<String>> {
        ...
        self.parent_ctx.get_secret_for(&request).await
                                    // ← the closing brace was here
    /// Forwards one progress chunk under this call's budget.
    async fn forward_progress(
```

Git's three-way merge had no conflict to report: neither side changed the other's lines, they just anchored at the same point. Textual mergeability is not syntactic validity.

## Fix

One brace. I verified nothing else was lost in the collision:

| Expected on `main` | Present |
|---|---|
| `AgentToolContext::get_secret` | line 1222 |
| `AgentToolContext::get_secret_for_purpose` | line 1226 |
| dispatcher's `.with_tool_name(tool.name())` | line 2653 |

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo clippy -p adk-agent --features codeact --all-targets` | exit 0 |
| `cargo nextest run --workspace --profile ci` | **3821 passed**, 83 skipped |
| `cargo nextest run -p adk-agent --test secret_identity_tests` | 3 passed — the identity plumbing still works |

## Worth acting on separately

No per-PR gate could have caught this, because each side compiles in isolation. What would have caught it is a build on `main` after merge. `ci-merge.yml` runs on `push: main` but is explicitly **not** branch-protection-required, and its cross-platform test job is the only compile there — so a broken `main` is discovered by the next contributor rather than by CI.

Given eleven PRs merged into `main` in quick succession here, I'd suggest either a required post-merge compile check or serialising merges that touch the same file. I can open an issue for that if you want.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests — n/a, this restores a brace; existing tests cover the behaviour
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes — n/a, `main` never shipped in this state
- [x] README updated if crate capabilities changed — n/a
- [x] Examples added or updated for new features — n/a