### PR TITLE
chore: pin the toolchain to 1.95 and make rust-toolchain.toml authoritative

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,7 +27,7 @@ What actually happened. Include error messages, stack traces, or logs.
 ## Environment
 
 - OS: [e.g., macOS 15, Ubuntu 24.04]
-- Rust version: [e.g., 1.94.0]
+- Rust version: [e.g., 1.95.0]
 - ADK-Rust version/commit: [e.g., v0.3.0 or commit hash]
 - Affected crate(s): [e.g., adk-gemini, adk-realtime]
 

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -7,9 +7,11 @@ description: >-
 
 inputs:
   toolchain:
-    description: 'Rust toolchain version to install.'
+    description: >-
+      Rust toolchain version to install. Defaults to the workspace toolchain, so
+      a job only sets this when it genuinely needs a different one.
     required: false
-    default: '1.94.0'
+    default: '1.95.0'
   components:
     description: 'Comma-separated list of toolchain components (e.g. clippy,rustfmt).'
     required: false

--- a/.github/workflows/ci-merge.yml
+++ b/.github/workflows/ci-merge.yml
@@ -99,8 +99,8 @@ jobs:
   #     its pinned git dependency during quiet periods. It no longer carries a
   #     push-to-main trigger, so a Monty-touching merge is not built twice.
   #
-  # adk-codeact-monty is outside the root workspace: it needs rustc 1.95 (the
-  # workspace is pinned to 1.94) plus rustfmt + clippy. neutralize-wild is true
+  # adk-codeact-monty is outside the root workspace and needs rustfmt + clippy on
+  # the workspace toolchain. neutralize-wild is true
   # because this is a plain Linux runner that does not provide the `wild` linker
   # pinned in .cargo/config.toml. The cache is keyed on the Monty crate's own
   # lockfile so a dependency change there is not masked by a stale workspace cache.
@@ -112,7 +112,6 @@ jobs:
     - name: Setup Rust
       uses: ./.github/actions/setup-rust
       with:
-        toolchain: '1.95.0'
         components: rustfmt,clippy
         cache-key: monty-${{ hashFiles('adk-codeact-monty/Cargo.lock') }}
         neutralize-wild: 'true'

--- a/.github/workflows/codeact-monty.yml
+++ b/.github/workflows/codeact-monty.yml
@@ -2,7 +2,7 @@ name: CodeAct Monty
 
 # `adk-codeact-monty` is intentionally OUTSIDE the main workspace: it depends on
 # the Monty interpreter via a git dependency (not yet on crates.io) and requires
-# rustc 1.95+, while the workspace is pinned to 1.94. The main CI workflow does
+# rustc 1.95+, which is the workspace toolchain. The main CI workflow does
 # not build it, so this workflow exercises it (and the CodeAct feature in
 # adk-agent) separately.
 #
@@ -71,7 +71,7 @@ jobs:
     - name: Test (codeact feature)
       run: cargo nextest run -p adk-agent --features codeact
 
-  # ── adk-codeact-monty (out-of-workspace: rustc 1.95 + Monty git dep) ──
+  # ── adk-codeact-monty (out-of-workspace: Monty git dep) ──
   # Weekly-cron tier: the heavy build stays off the per-PR path. The per-merge
   # build lives in ci-merge.yml (`out-of-workspace-monty`); this cron rebuilds
   # Monty against its pinned git dependency during quiet periods between merges.
@@ -80,13 +80,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
-    # Monty needs rustc 1.95 + rustfmt + clippy. The cache is keyed on the Monty
+    # Monty needs rustfmt + clippy. The cache is keyed on the Monty
     # crate's own lockfile so a dependency change there cannot be masked by a
     # stale workspace cache.
     - name: Setup Rust
       uses: ./.github/actions/setup-rust
       with:
-        toolchain: '1.95.0'
         components: rustfmt,clippy
         cache-key: monty-${{ hashFiles('adk-codeact-monty/Cargo.lock') }}
     - name: Format check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Rust Agent Development Kit — a modular workspace of publishable crates for bui
 
 ## Dev environment
 
-- Rust 1.94.0+, edition 2024. Use `make setup` or `devenv shell` to bootstrap.
+- Rust 1.95+, edition 2024. Use `make setup` or `devenv shell` to bootstrap.
 - `sccache` is the compilation cache. Set `RUSTC_WRAPPER=sccache` in your shell profile.
 - On Linux, `wild` is the linker (configured in `.cargo/config.toml`). macOS uses the default linker.
 - Copy `.env.example` to `.env` for API keys. Never commit `.env` files or secrets.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **ADK agent tool confirmation can be resolved live.** `RunConfig` accepts an
   asynchronous `ToolConfirmationHandler`, and allow-once decisions are keyed by
   exact function-call ID rather than tool name.
+- **Breaking:** the minimum supported Rust version is now **1.95**, up from 1.94.0.
+  1.95 is the lowest version that satisfies every constraint the workspace already
+  had: `adk-codeact-monty` requires 1.95, and a fresh resolution of the `aws-secrets`
+  dependencies requires 1.94.1. `rust-toolchain.toml` is now the single source of
+  truth — `devenv` reads the same file through `languages.rust.toolchainFile`, so a
+  Nix shell and a plain `cargo` invocation can no longer disagree — and the workspace
+  moves to `resolver = "3"` so the declared MSRV is enforced during dependency
+  resolution rather than only documented.
+
 - **Breaking:** major version bump. The complete list of public API breakage since
   1.0.0, as reported by `cargo semver-checks check-release --release-type minor`
   against the published 1.0.0 baseline, is below. A migration guide with

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ cargo nextest run --workspace
 
 ### Prerequisites
 
-- Rust 1.94.0+ (edition 2024)
+- Rust 1.95+ (edition 2024)
 - For browser examples: Chrome/Chromium
 - For `openai-webrtc` feature: cmake (audiopus builds Opus from source)
 - For mistral.rs: see [adk-mistralrs section](#adk-mistralrs)
@@ -504,7 +504,7 @@ If your change is purely internal refactoring with no behavior change, existing 
 
 ### Rust Conventions
 
-- Edition 2024, MSRV 1.94.0
+- Edition 2024, MSRV 1.95
 - `thiserror` for library error types
 - `async-trait` for async trait methods
 - `Arc<T>` for shared ownership across async boundaries

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 members = [
     # Core packages (publishable to crates.io)
     "adk-core",
@@ -120,7 +120,7 @@ opt-level = 2
 [workspace.package]
 version = "2.0.0"
 edition = "2024"
-rust-version = "1.94.0"
+rust-version = "1.95"
 license = "Apache-2.0"
 authors = ["James Karanja Maina <james.karanja@zavora.ai>"]
 homepage = "https://www.zavora.ai"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![docs.rs](https://docs.rs/adk-rust/badge.svg)](https://docs.rs/adk-rust)
 [![Wiki](https://img.shields.io/badge/docs-Wiki-blue)](https://github.com/zavora-ai/adk-rust/wiki)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-![Rust](https://img.shields.io/badge/rust-1.94%2B-orange.svg)
+![Rust](https://img.shields.io/badge/rust-1.95%2B-orange.svg)
 [![GitHub Discussions](https://img.shields.io/github/discussions/zavora-ai/adk-rust?style=flat&logo=github&color=5865F2)](https://github.com/zavora-ai/adk-rust/discussions)
 
 > **🚀 v2.0.0 Released!** 41 published crates. Official `rmcp 2.2` MCP SDK (protocol `2025-11-25`) with effective HTTP configuration, official `agent-client-protocol` 1.2 for ACP with exact capability publication, the new `adk-computer-use` governed desktop-automation layer, `adk-devtools` coding-agent tools, live async tool confirmation keyed by function-call ID, and resolved dependency advisories. See the [migration guide](docs/official_docs/migration/1.0-to-2.0.md) for the complete breaking-change list and [CHANGELOG](CHANGELOG.md) for full details.
@@ -273,7 +273,7 @@ Use `cargo adk build` to verify compilation without deploying.
 
 ### Manual installation
 
-Requires Rust 1.94 or later (Rust 2024 edition). Add to your `Cargo.toml`:
+Requires Rust 1.95 or later (Rust 2024 edition). Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]

--- a/adk-agent/src/llm_agent.rs
+++ b/adk-agent/src/llm_agent.rs
@@ -1068,6 +1068,8 @@ impl AgentToolContext {
             request = request.with_purpose(purpose);
         }
         self.parent_ctx.get_secret_for(&request).await
+    }
+
     /// Forwards one progress chunk under this call's budget.
     ///
     /// The policy is bounded and lossy by design: memory is capped, and output that

--- a/adk-codeact-monty/rust-toolchain.toml
+++ b/adk-codeact-monty/rust-toolchain.toml
@@ -1,5 +1,5 @@
 # Monty (v0.0.18) requires rustc 1.95+, while the parent adk-rust workspace is
-# pinned to 1.94.0. This crate is its own workspace, so it overrides the
+# pinned to 1.95. This crate is its own workspace, so it overrides the
 # toolchain locally. Build from inside this directory (or with `cargo +1.95.0`).
 [toolchain]
 channel = "1.95.0"

--- a/adk-computer-use/src/eval.rs
+++ b/adk-computer-use/src/eval.rs
@@ -96,7 +96,7 @@ fn canonical_json(value: &serde_json::Value) -> String {
         }
         serde_json::Value::Object(values) => {
             let mut entries = values.iter().collect::<Vec<_>>();
-            entries.sort_by(|(left, _), (right, _)| left.cmp(right));
+            entries.sort_by_key(|(key, _)| *key);
             format!(
                 "{{{}}}",
                 entries

--- a/adk-enterprise/tests/integration_tests.rs
+++ b/adk-enterprise/tests/integration_tests.rs
@@ -200,15 +200,14 @@ async fn test_custom_tool_round_trip() {
 
                     tool_use_id = Some(custom_tool_use_id);
                 }
-                SessionEvent::Message { content, .. } => {
-                    // 7. After tool result is sent, agent should produce a final message
-                    if tool_use_id.is_some() {
-                        let has_text =
-                            content.iter().any(|block| matches!(block, ContentBlock::Text { .. }));
-                        if has_text {
-                            final_message_received = true;
-                        }
-                    }
+                // 7. After tool result is sent, agent should produce a final message
+                SessionEvent::Message { content, .. }
+                    if tool_use_id.is_some()
+                        && content
+                            .iter()
+                            .any(|block| matches!(block, ContentBlock::Text { .. })) =>
+                {
+                    final_message_received = true;
                 }
                 SessionEvent::StatusIdle { .. } => {
                     break;

--- a/adk-gemini/examples/image_editing.rs
+++ b/adk-gemini/examples/image_editing.rs
@@ -141,10 +141,8 @@ fn save_generated_images(
         if let Some(parts) = &candidate.content.parts {
             for part in parts.iter() {
                 match part {
-                    adk_gemini::Part::Text { text, .. } => {
-                        if !text.trim().is_empty() {
-                            info!(text = text.trim(), prefix = prefix, "model text response");
-                        }
+                    adk_gemini::Part::Text { text, .. } if !text.trim().is_empty() => {
+                        info!(text = text.trim(), prefix = prefix, "model text response");
                     }
                     adk_gemini::Part::InlineData { inline_data } => {
                         image_count += 1;

--- a/adk-gemini/examples/multi_speaker_tts.rs
+++ b/adk-gemini/examples/multi_speaker_tts.rs
@@ -77,46 +77,43 @@ Alice: I couldn't agree more. It's remarkable how far AI-generated speech has co
                     for (j, part) in parts.iter().enumerate() {
                         match part {
                             // Look for inline data with audio MIME type
-                            Part::InlineData { inline_data } => {
-                                if inline_data.mime_type.starts_with("audio/") {
-                                    info!("📄 Found audio data: {}", inline_data.mime_type);
+                            Part::InlineData { inline_data }
+                                if inline_data.mime_type.starts_with("audio/") =>
+                            {
+                                info!("📄 Found audio data: {}", inline_data.mime_type);
 
-                                    // Decode base64 audio data
-                                    match general_purpose::STANDARD.decode(&inline_data.data) {
-                                        Ok(audio_bytes) => {
-                                            let filename =
-                                                format!("multi_speaker_dialogue_{}_{}.pcm", i, j);
+                                // Decode base64 audio data
+                                match general_purpose::STANDARD.decode(&inline_data.data) {
+                                    Ok(audio_bytes) => {
+                                        let filename =
+                                            format!("multi_speaker_dialogue_{}_{}.pcm", i, j);
 
-                                            // Save audio to file
-                                            match File::create(&filename) {
-                                                Ok(mut file) => {
-                                                    if let Err(e) = file.write_all(&audio_bytes) {
-                                                        error!(
-                                                            "❌ Error writing audio file: {}",
-                                                            e
-                                                        );
-                                                    } else {
-                                                        info!(
-                                                            "💾 Multi-speaker audio saved as: {}",
-                                                            filename
-                                                        );
-                                                        info!(
-                                                            "🎧 Play with: aplay {} (Linux) or afplay {} (macOS)",
-                                                            filename, filename
-                                                        );
-                                                        info!(
-                                                            "👥 Features Alice (Puck voice) and Bob (Charon voice)"
-                                                        );
-                                                    }
-                                                }
-                                                Err(e) => {
-                                                    error!("❌ Error creating audio file: {}", e)
+                                        // Save audio to file
+                                        match File::create(&filename) {
+                                            Ok(mut file) => {
+                                                if let Err(e) = file.write_all(&audio_bytes) {
+                                                    error!("❌ Error writing audio file: {}", e);
+                                                } else {
+                                                    info!(
+                                                        "💾 Multi-speaker audio saved as: {}",
+                                                        filename
+                                                    );
+                                                    info!(
+                                                        "🎧 Play with: aplay {} (Linux) or afplay {} (macOS)",
+                                                        filename, filename
+                                                    );
+                                                    info!(
+                                                        "👥 Features Alice (Puck voice) and Bob (Charon voice)"
+                                                    );
                                                 }
                                             }
+                                            Err(e) => {
+                                                error!("❌ Error creating audio file: {}", e)
+                                            }
                                         }
-                                        Err(e) => {
-                                            error!("❌ Error decoding base64 audio: {}", e)
-                                        }
+                                    }
+                                    Err(e) => {
+                                        error!("❌ Error decoding base64 audio: {}", e)
                                     }
                                 }
                             }

--- a/adk-gemini/examples/simple_speech_generation.rs
+++ b/adk-gemini/examples/simple_speech_generation.rs
@@ -65,8 +65,8 @@ async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
                     for (j, part) in parts.iter().enumerate() {
                         match part {
                             // Look for inline data with audio MIME type
-                            Part::InlineData { inline_data } => {
-                                if inline_data.mime_type.starts_with("audio/") {
+                            Part::InlineData { inline_data }
+                                if inline_data.mime_type.starts_with("audio/") => {
                                     info!(mime_type = inline_data.mime_type, "found audio data");
 
                                     // Decode base64 audio data using the new API
@@ -89,8 +89,7 @@ async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
                                         },
                                         Err(e) => error!(error = %e, "error decoding base64 audio"),
                                     }
-                                }
-                            },
+                                },
                             // Display any text content
                             Part::Text { text, thought, thought_signature: _ } => {
                                 if thought.unwrap_or(false) {

--- a/adk-graph/src/graph.rs
+++ b/adk-graph/src/graph.rs
@@ -309,11 +309,9 @@ impl CompiledGraph {
         for edge in &self.edges {
             match edge {
                 Edge::Direct { source, target: EdgeTarget::Node(n) }
-                    if executed.contains(source) =>
+                    if executed.contains(source) && !next.contains(n) =>
                 {
-                    if !next.contains(n) {
-                        next.push(n.clone());
-                    }
+                    next.push(n.clone());
                 }
                 Edge::Conditional { source, router, targets } if executed.contains(source) => {
                     let route = router(state);
@@ -335,10 +333,8 @@ impl CompiledGraph {
     pub fn leads_to_end(&self, executed: &[String], state: &State) -> bool {
         for edge in &self.edges {
             match edge {
-                Edge::Direct { source, target } if executed.contains(source) => {
-                    if target.is_end() {
-                        return true;
-                    }
+                Edge::Direct { source, target } if executed.contains(source) && target.is_end() => {
+                    return true;
                 }
                 Edge::Conditional { source, router, targets } if executed.contains(source) => {
                     let route = router(state);

--- a/adk-memory/src/inmemory.rs
+++ b/adk-memory/src/inmemory.rs
@@ -182,7 +182,7 @@ impl MemoryService for InMemoryMemoryService {
                 sessions.values().flatten().map(|stored| stored.entry.clone()).collect()
             })
             .unwrap_or_default();
-        entries.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        entries.sort_by_key(|entry| std::cmp::Reverse(entry.timestamp));
         entries.truncate(limit);
         Ok(entries)
     }

--- a/adk-model/src/openrouter/adapter.rs
+++ b/adk-model/src/openrouter/adapter.rs
@@ -1028,8 +1028,8 @@ impl ChatStreamState {
 
     fn drain_chat_tool_calls(&mut self) -> Vec<Part> {
         self.pending_tool_calls
-            .iter()
-            .filter_map(|(_, pending)| {
+            .values()
+            .filter_map(|pending| {
                 let name = pending.name.clone()?;
                 let args = serde_json::from_str(&pending.arguments).ok()?;
                 Some(Part::FunctionCall {

--- a/adk-realtime/benches/README.md
+++ b/adk-realtime/benches/README.md
@@ -49,8 +49,8 @@ Environment:
 
 - Linux `michael-MacPro5-1`, kernel `7.1.3-x64v2-xanmod1`
 - x86_64, dual Intel Xeon E5520 at 2.27 GHz, 16 logical CPUs
-- rustc 1.94.0 with LLVM 21.1.8
-- cargo 1.94.0
+- rustc 1.95.0 with LLVM 21.1.8
+- cargo 1.95.0
 - default optimized benchmark profile
 
 ### Synchronous ownership cost

--- a/adk-realtime/src/runner.rs
+++ b/adk-realtime/src/runner.rs
@@ -796,10 +796,10 @@ impl RealtimeRunner {
                 self.respond_after_tools().await?;
                 self.check_resumption_queue().await?;
             }
-            ServerEvent::FunctionCallDone { call_id, name, arguments, .. } => {
-                if self.runner_config.auto_execute_tools {
-                    self.execute_tool_call(&call_id, &name, &arguments).await?;
-                }
+            ServerEvent::FunctionCallDone { call_id, name, arguments, .. }
+                if self.runner_config.auto_execute_tools =>
+            {
+                self.execute_tool_call(&call_id, &name, &arguments).await?;
             }
             ServerEvent::SessionUpdated { session, .. } => {
                 // Check if the generic session update contains a resumption token

--- a/devenv.nix
+++ b/devenv.nix
@@ -30,7 +30,9 @@
   # --------------------------------------------------------------------------
   languages.rust = {
     enable = true;
-    channel = "stable";
+    # Read the same file rustup reads, so a devenv shell and a plain `cargo`
+    # invocation always agree. `channel`/`version` cannot be combined with this.
+    toolchainFile = ./rust-toolchain.toml;
   };
 
   languages.javascript = {

--- a/docs/official_docs/a2a/getting-started.md
+++ b/docs/official_docs/a2a/getting-started.md
@@ -4,7 +4,7 @@ Create and run an A2A (Agent-to-Agent) protocol agent in under 5 minutes.
 
 ## Prerequisites
 
-- Rust 1.94.0 or later (`rustup update stable`)
+- Rust 1.95 or later (`rustup update stable`)
 - `cargo-adk` installed (`cargo install cargo-adk`)
 - A Google API key ([get one here](https://aistudio.google.com/app/apikey))
 

--- a/docs/official_docs/development/development-guidelines.md
+++ b/docs/official_docs/development/development-guidelines.md
@@ -18,7 +18,7 @@ This document provides comprehensive guidelines for developers contributing to A
 
 ### Prerequisites
 
-- **Rust**: 1.94.0 or higher (edition 2024, check with `rustc --version`)
+- **Rust**: 1.95 or higher (edition 2024, check with `rustc --version`)
 - **Cargo**: Latest stable
 - **Git**: For version control
 - **sccache** (recommended): Compilation cache that cuts rebuild times by ~70%

--- a/docs/official_docs/introduction.md
+++ b/docs/official_docs/introduction.md
@@ -2,7 +2,7 @@
 
 Agent Development Kit (ADK) is a flexible and modular framework for developing and deploying AI agents. While optimized for Gemini and the Google ecosystem, ADK is model-agnostic, deployment-agnostic, and built for compatibility with other frameworks. ADK was designed to make agent development feel more like software development, making it easier for developers to create, deploy, and orchestrate agentic architectures that range from simple tasks to complex workflows.
 
-> **Note:** ADK-Rust requires Rust 1.94.0 or higher.
+> **Note:** ADK-Rust requires Rust 1.95 or higher.
 
 ## Installation
 

--- a/docs/official_docs/quickstart.md
+++ b/docs/official_docs/quickstart.md
@@ -4,7 +4,7 @@ Create your first AI agent in under 5 minutes.
 
 ## Prerequisites
 
-- Rust 1.94.0 or later (`rustup update stable`)
+- Rust 1.95 or later (`rustup update stable`)
 - A Google API key ([get one here](https://aistudio.google.com/app/apikey))
 
 ## Step 1: Scaffold Your Project

--- a/examples/a2a_interceptors/README.md
+++ b/examples/a2a_interceptors/README.md
@@ -15,7 +15,7 @@ Demonstrates ADK-Rust's A2A (Agent-to-Agent) interceptor chain for request proce
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - **`GOOGLE_API_KEY`** environment variable set with a valid Gemini API key
 
 Set up your environment:

--- a/examples/agent_registry/README.md
+++ b/examples/agent_registry/README.md
@@ -14,7 +14,7 @@ Demonstrates the Agent Registry REST API from ADK-Rust v1.0 for registering, dis
 
 ## Prerequisites
 
-- Rust 1.94+
+- Rust 1.95+
 - No LLM provider or API keys required
 
 ## Environment Variables

--- a/examples/ambient_cron_agent/README.md
+++ b/examples/ambient_cron_agent/README.md
@@ -10,7 +10,7 @@ Runs an ambient agent on a `CronTrigger`, wrapping a Gemini-powered quote genera
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - **`GOOGLE_API_KEY`** environment variable set
 
 ## Run

--- a/examples/background_runs/README.md
+++ b/examples/background_runs/README.md
@@ -10,7 +10,7 @@ Exercises the Background Runs REST API from `adk-server`: submit a run, poll its
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - Built with the adk-server `background` feature (already enabled in this example's manifest)
 
 ## Run

--- a/examples/bedrock_test/README.md
+++ b/examples/bedrock_test/README.md
@@ -10,7 +10,7 @@ Drives the Amazon Bedrock provider through the ADK stack, including prompt cachi
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - **`AWS_REGION (or AWS_DEFAULT_REGION)`** environment variable set
 
 Authentication uses the standard AWS credential chain — run `aws configure` first.

--- a/examples/bigquery_toolset/README.md
+++ b/examples/bigquery_toolset/README.md
@@ -14,7 +14,7 @@ lists datasets, inspects table schemas, and executes SQL queries via the BigQuer
 
 ## Prerequisites
 
-- Rust 1.94+
+- Rust 1.95+
 - `GOOGLE_API_KEY` for the Gemini LLM provider
 - (Optional) A Google Cloud project with BigQuery enabled for live mode
 - (Optional) Application Default Credentials configured via `gcloud auth application-default login`

--- a/examples/codeact_monty_agent/rust-toolchain.toml
+++ b/examples/codeact_monty_agent/rust-toolchain.toml
@@ -1,5 +1,5 @@
 # This example pulls in `monty` (via adk-codeact-monty), which requires rustc
-# 1.95+, while the parent adk-rust workspace is pinned to 1.94.0. As a standalone
+# 1.95+, while the parent adk-rust workspace is pinned to 1.95. As a standalone
 # workspace, it overrides the toolchain locally.
 [toolchain]
 channel = "1.95.0"

--- a/examples/competitive_ergonomics/README.md
+++ b/examples/competitive_ergonomics/README.md
@@ -10,7 +10,7 @@ Validation example for the convenience APIs and encrypted session storage.
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - **`One of ANTHROPIC_API_KEY, OPENAI_API_KEY, or GOOGLE_API_KEY`** environment variable set
 
 ## Run

--- a/examples/competitive_graph_resume/README.md
+++ b/examples/competitive_graph_resume/README.md
@@ -10,7 +10,7 @@ Validation example for resume-from-checkpoint in `adk-graph`.
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - No API key required
 
 ## Run

--- a/examples/competitive_tool_search/README.md
+++ b/examples/competitive_tool_search/README.md
@@ -9,7 +9,7 @@ Validation example for `ToolSearchConfig` filtering and realtime interruption mo
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - No API key required
 
 ## Run

--- a/examples/context_compaction/README.md
+++ b/examples/context_compaction/README.md
@@ -12,7 +12,7 @@ Demonstrates ADK-Rust's automatic context window management, showing how to hand
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - **`GOOGLE_API_KEY`** environment variable set with a valid Gemini API key
 
 Set up your environment:

--- a/examples/cron_scheduling/README.md
+++ b/examples/cron_scheduling/README.md
@@ -10,7 +10,7 @@ Exercises the cron scheduling API from `adk-server`: create jobs, list them, and
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - Built with the adk-server `background` feature (already enabled in this example's manifest)
 
 ## Run

--- a/examples/customer_service/README.md
+++ b/examples/customer_service/README.md
@@ -51,7 +51,7 @@ Camera frames are sent via the realtime crate's `send_video_frame`:
 
 ## Prerequisites
 
-- Rust 1.94+
+- Rust 1.95+
 - `OPENAI_API_KEY` (OpenAI) and/or `GEMINI_API_KEY` / `GOOGLE_API_KEY` (Gemini)
 - A browser with WebSocket + Web Audio + mic/camera access
 

--- a/examples/delta_checkpoints/README.md
+++ b/examples/delta_checkpoints/README.md
@@ -13,7 +13,7 @@ Demonstrates ADK-Rust's delta checkpointing system that stores incremental state
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - **`GOOGLE_API_KEY`** environment variable set with a valid Gemini API key
 
 Set up your environment:

--- a/examples/desktop_agent/README.md
+++ b/examples/desktop_agent/README.md
@@ -11,7 +11,7 @@ Controls a macOS desktop with a Gemini-powered agent driving the
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - **`GOOGLE_API_KEY`** (or `GEMINI_API_KEY`) environment variable set
 - **`computer-use-mcp`** installed: `npm install -g @zavora-ai/computer-use-mcp`
 - **macOS**, with the accessibility and screen-recording permissions the MCP server requests

--- a/examples/desktop_audio/README.md
+++ b/examples/desktop_audio/README.md
@@ -4,7 +4,7 @@ Practical examples exercising the full `adk-audio` desktop audio pipeline: devic
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - **Audio hardware** — microphone and speakers (all examples except `config-validation`)
 - **GEMINI_API_KEY** — required for the `voice-agent` example ([get a key](https://aistudio.google.com/apikey))
 

--- a/examples/functional_workflow/README.md
+++ b/examples/functional_workflow/README.md
@@ -11,7 +11,7 @@ Demonstrates the Functional API from `adk-graph`: write a workflow as async func
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - Built with the adk-graph `functional` feature (already enabled in this example's manifest)
 
 ## Run

--- a/examples/gemini_managed_agents/README.md
+++ b/examples/gemini_managed_agents/README.md
@@ -14,7 +14,7 @@ Four focused agents that do real work, built on the official [Managed Agents Qui
 
 ## Prerequisites
 
-- Rust 1.94.0+
+- Rust 1.95+
 - A `GOOGLE_API_KEY` with [Interactions API (Beta)](https://ai.google.dev/gemini-api/docs/interactions) access
 
 ## Setup

--- a/examples/gemini_search_bug/README.md
+++ b/examples/gemini_search_bug/README.md
@@ -9,7 +9,7 @@ Reproduction for GitHub issue #224: a built-in Google Search tool and a function
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - **`GOOGLE_API_KEY`** environment variable set
 
 ## Run

--- a/examples/intra_compaction/README.md
+++ b/examples/intra_compaction/README.md
@@ -31,7 +31,7 @@ The low threshold in this example ensures compaction triggers quickly for demons
 
 ## Prerequisites
 
-- Rust 1.94+
+- Rust 1.95+
 - `GOOGLE_API_KEY` environment variable set
 
 ## Environment Variables

--- a/examples/live_translation/README.md
+++ b/examples/live_translation/README.md
@@ -63,7 +63,7 @@ lives entirely server-side.
 
 ## Prerequisites
 
-- Rust 1.94+
+- Rust 1.95+
 - `OPENAI_API_KEY` (for OpenAI) and/or `GEMINI_API_KEY` / `GOOGLE_API_KEY` (for Gemini)
 - A modern browser with WebSocket + Web Audio + microphone access
 

--- a/examples/managed_agents_custom_tools/README.md
+++ b/examples/managed_agents_custom_tools/README.md
@@ -4,7 +4,7 @@ Demonstrates defining a custom tool on a managed agent, handling `AgentCustomToo
 
 ## Prerequisites
 
-- Rust 1.94.0+
+- Rust 1.95+
 - An `ANTHROPIC_API_KEY` with Managed Agents beta access
 
 ## Setup

--- a/examples/managed_agents_files/README.md
+++ b/examples/managed_agents_files/README.md
@@ -4,7 +4,7 @@ Demonstrates uploading a file via the Anthropic Files API, mounting it in a mana
 
 ## Prerequisites
 
-- Rust 1.94.0+
+- Rust 1.95+
 - An `ANTHROPIC_API_KEY` with Managed Agents and Files API beta access
 
 ## Setup

--- a/examples/managed_agents_hello/README.md
+++ b/examples/managed_agents_hello/README.md
@@ -4,7 +4,7 @@ The simplest possible Anthropic Managed Agents session. Creates an agent, enviro
 
 ## Prerequisites
 
-- Rust 1.94.0+
+- Rust 1.95+
 - An `ANTHROPIC_API_KEY` with Managed Agents beta access
 
 ## Setup

--- a/examples/managed_agents_memory/README.md
+++ b/examples/managed_agents_memory/README.md
@@ -4,7 +4,7 @@ Demonstrates creating a memory store, seeding it with content, running a session
 
 ## Prerequisites
 
-- Rust 1.94.0+
+- Rust 1.95+
 - An `ANTHROPIC_API_KEY` with Managed Agents beta access
 
 ## Setup

--- a/examples/managed_agents_multiagent/README.md
+++ b/examples/managed_agents_multiagent/README.md
@@ -4,7 +4,7 @@ Demonstrates creating multiple specialized agents, configuring a coordinator age
 
 ## Prerequisites
 
-- Rust 1.94.0+
+- Rust 1.95+
 - An `ANTHROPIC_API_KEY` with Managed Agents beta access
 
 ## Setup

--- a/examples/managed_runtime_hello/README.md
+++ b/examples/managed_runtime_hello/README.md
@@ -10,7 +10,7 @@ End-to-end smoke test of the managed agent runtime against a scripted LLM, so it
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - Built with the adk-rust `managed-runtime` feature (already enabled in this example's manifest)
 
 ## Run

--- a/examples/mcp_sampling/README.md
+++ b/examples/mcp_sampling/README.md
@@ -52,7 +52,7 @@ let toolset = McpToolset::with_sampling_handler(transport, elicitation, sampling
 
 ## Prerequisites
 
-- Rust 1.94+
+- Rust 1.95+
 - `GOOGLE_API_KEY` environment variable set
 
 ## Environment Variables

--- a/examples/multi_perspective_analysis/README.md
+++ b/examples/multi_perspective_analysis/README.md
@@ -20,7 +20,7 @@ merges their event streams.
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - **`GOOGLE_API_KEY`** environment variable set with a valid Gemini API key
 
 ```bash

--- a/examples/node_caching/README.md
+++ b/examples/node_caching/README.md
@@ -12,7 +12,7 @@ Demonstrates ADK-Rust's blake3-keyed LRU caching of graph node results, showing 
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - **`GOOGLE_API_KEY`** environment variable set with a valid Gemini API key
 
 Set up your environment:

--- a/examples/node_timeouts/README.md
+++ b/examples/node_timeouts/README.md
@@ -15,7 +15,7 @@ The example builds a four-node graph where each node demonstrates a different ti
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - **`GOOGLE_API_KEY`** environment variable set with a valid Gemini API key
 
 Set the API key in your shell or create a `.env` file:

--- a/examples/openai_background/README.md
+++ b/examples/openai_background/README.md
@@ -6,7 +6,7 @@ This is useful for long-running requests where you don't want to hold open a str
 
 ## Prerequisites
 
-- Rust 1.94.0+
+- Rust 1.95+
 - `OPENAI_API_KEY` environment variable set with a valid OpenAI API key
 
 ## Running

--- a/examples/openai_builtin_tools/README.md
+++ b/examples/openai_builtin_tools/README.md
@@ -8,7 +8,7 @@ This example covers two built-in tools:
 
 ## Prerequisites
 
-- Rust 1.94.0+
+- Rust 1.95+
 - `OPENAI_API_KEY` environment variable set with a valid OpenAI API key
 
 ## Running

--- a/examples/openai_conversations/README.md
+++ b/examples/openai_conversations/README.md
@@ -4,7 +4,7 @@ Demonstrates the OpenAI Responses API **Conversations** lifecycle. The Conversat
 
 ## Prerequisites
 
-- Rust 1.94.0+
+- Rust 1.95+
 - `OPENAI_API_KEY` environment variable set with a valid OpenAI API key
 
 ## Running

--- a/examples/openai_deep_research/README.md
+++ b/examples/openai_deep_research/README.md
@@ -6,7 +6,7 @@ Deep research models are designed for complex research tasks that require synthe
 
 ## Prerequisites
 
-- Rust 1.94.0+
+- Rust 1.95+
 - `OPENAI_API_KEY` environment variable set with a valid OpenAI API key
 - Access to deep research models (may require specific API tier)
 

--- a/examples/openai_open_responses/README.md
+++ b/examples/openai_open_responses/README.md
@@ -4,7 +4,7 @@ Demonstrates the **Open Responses mode** for provider-agnostic usage of the Resp
 
 ## Prerequisites
 
-- Rust 1.94.0+
+- Rust 1.95+
 - One of the following:
   - `OPENAI_API_KEY` environment variable set (for OpenAI)
   - A running Open Responses-compatible local server (LM Studio, Ollama, vLLM)

--- a/examples/openai_responses/README.md
+++ b/examples/openai_responses/README.md
@@ -10,7 +10,7 @@ Drives `OpenAIResponsesClient` through the full ADK stack (Runner â†’ LlmAgent â
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - **`OPENAI_API_KEY`** environment variable set
 
 ## Run

--- a/examples/openai_ws_minimal/README.md
+++ b/examples/openai_ws_minimal/README.md
@@ -4,7 +4,7 @@ Demonstrates the lowest-level WebSocket transport for the OpenAI Responses API. 
 
 ## Prerequisites
 
-- Rust 1.94.0+
+- Rust 1.95+
 - `OPENAI_API_KEY` environment variable set
 - The `openai-ws` feature flag on `adk-model`
 

--- a/examples/openrouter/README.md
+++ b/examples/openrouter/README.md
@@ -10,7 +10,7 @@ Live integration example for the native OpenRouter provider and its discovery AP
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - **`OPENROUTER_API_KEY`** environment variable set
 - Built with the adk-model `openrouter` feature (already enabled in this example's manifest)
 

--- a/examples/output_schema_agent/README.md
+++ b/examples/output_schema_agent/README.md
@@ -10,7 +10,7 @@ Demonstrates structured-output enforcement on an `LlmAgent`.
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - **`GOOGLE_API_KEY`** environment variable set
 
 ## Run

--- a/examples/plugin_system/README.md
+++ b/examples/plugin_system/README.md
@@ -43,7 +43,7 @@ Demonstrates the ADK-Rust Enhanced Plugin System (Sprint 1) with three custom pl
 
 ## Prerequisites
 
-- Rust 1.94+
+- Rust 1.95+
 - `GOOGLE_API_KEY` environment variable set
 
 ## Setup

--- a/examples/realtime_voice/README.md
+++ b/examples/realtime_voice/README.md
@@ -92,7 +92,7 @@ configures its capture/playback contexts accordingly.
 
 ## Prerequisites
 
-- Rust 1.94.0+
+- Rust 1.95+
 - `OPENAI_API_KEY` (for OpenAI) and/or `GEMINI_API_KEY` / `GOOGLE_API_KEY` (for Gemini)
 - A modern browser with WebSocket + Web Audio API support and microphone access
 

--- a/examples/retry_reflect/README.md
+++ b/examples/retry_reflect/README.md
@@ -62,7 +62,7 @@ This gives the agent context to self-correct on the next turn.
 
 ## Prerequisites
 
-- Rust 1.94+
+- Rust 1.95+
 - `GOOGLE_API_KEY` environment variable set
 
 ## Setup

--- a/examples/secret_provider/README.md
+++ b/examples/secret_provider/README.md
@@ -11,7 +11,7 @@ Demonstrates ADK-Rust's secret management — retrieving secrets from a provider
 
 ## Prerequisites
 
-- Rust 1.94+
+- Rust 1.95+
 - `GOOGLE_API_KEY` environment variable set
 
 ## Environment Variables

--- a/examples/server_builder/README.md
+++ b/examples/server_builder/README.md
@@ -85,7 +85,7 @@ Routes added via `add_api_routes()` additionally receive the auth middleware lay
 
 ## Prerequisites
 
-- Rust 1.94+
+- Rust 1.95+
 - No LLM provider or API keys required
 
 ## Environment Variables

--- a/examples/skill_memory_improvements/README.md
+++ b/examples/skill_memory_improvements/README.md
@@ -10,7 +10,7 @@ Validation example covering the skill-discovery and memory APIs added by the ski
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - No API key required
 
 ## Run

--- a/examples/skills_multilingual/README.md
+++ b/examples/skills_multilingual/README.md
@@ -6,7 +6,7 @@ Previously, non-ASCII characters in queries and skill metadata were silently dro
 
 ## Prerequisites
 
-- Rust 1.94+
+- Rust 1.95+
 - `GOOGLE_API_KEY` environment variable set (for Scenario 6 live demo)
 
 ## Running

--- a/examples/slack_toolset/README.md
+++ b/examples/slack_toolset/README.md
@@ -14,7 +14,7 @@ reads channels, sends messages, adds reactions, and lists threads via the Slack 
 
 ## Prerequisites
 
-- Rust 1.94+
+- Rust 1.95+
 - `GOOGLE_API_KEY` for the Gemini LLM provider
 - (Optional) A Slack Bot Token for live mode
 

--- a/examples/spanner_toolset/README.md
+++ b/examples/spanner_toolset/README.md
@@ -14,7 +14,7 @@ lists tables, inspects table schemas, and executes SQL queries via the Cloud Spa
 
 ## Prerequisites
 
-- Rust 1.94+
+- Rust 1.95+
 - `GOOGLE_API_KEY` for the Gemini LLM provider
 - (Optional) A Google Cloud project with Cloud Spanner enabled for live mode
 - (Optional) Application Default Credentials configured via `gcloud auth application-default login`

--- a/examples/telemetry_sqlite_export/README.md
+++ b/examples/telemetry_sqlite_export/README.md
@@ -10,7 +10,7 @@ Traces an agent run end-to-end into a local SQLite file — no OTLP collector or
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - **`GOOGLE_API_KEY`** environment variable set
 - Built with the adk-telemetry `sqlite` feature (already enabled in this example's manifest)
 

--- a/examples/time_travel/README.md
+++ b/examples/time_travel/README.md
@@ -13,7 +13,7 @@ Demonstrates ADK-Rust's time-travel debugging capabilities for graph workflows, 
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - **`GOOGLE_API_KEY`** environment variable set with a valid Gemini API key
 
 Set up your environment:

--- a/examples/tool_concurrency/README.md
+++ b/examples/tool_concurrency/README.md
@@ -12,7 +12,7 @@ Demonstrates ADK-Rust's per-tool concurrency limits with backpressure policies, 
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - **`GOOGLE_API_KEY`** environment variable set with a valid Gemini API key
 
 Set up your environment:

--- a/examples/video_avatar/README.md
+++ b/examples/video_avatar/README.md
@@ -46,7 +46,7 @@ let builder = RealtimeAgentBuilder::new("my_agent")
 
 ## Prerequisites
 
-- Rust 1.94.0+
+- Rust 1.95+
 - No API keys or LLM provider required
 
 ## Environment Variables

--- a/examples/yaml_agent/README.md
+++ b/examples/yaml_agent/README.md
@@ -11,7 +11,7 @@ Demonstrates the YAML agent definition loading feature from ADK-Rust v1.0.
 
 ## Prerequisites
 
-- Rust 1.94+
+- Rust 1.95+
 - A Google API key for Gemini
 
 ## Environment Variables

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,11 @@
 [toolchain]
-channel = "1.94.0"
+# Single source of truth for the toolchain: rustup reads this locally, and
+# devenv reads the same file through `languages.rust.toolchainFile`, so CI and
+# local builds cannot drift.
+#
+# 1.95 rather than the newest stable: it is the lowest version that satisfies
+# every constraint — adk-codeact-monty needs 1.95, and a fresh resolution of the
+# aws-secrets dependencies needs 1.95.1 — while still leaving consumers on 1.95
+# able to build the published crates.
+channel = "1.95.0"
+components = ["rustc", "cargo", "clippy", "rustfmt", "rust-analyzer"]


### PR DESCRIPTION
> **Draft: one command is needed before CI can pass.** `devenv.lock` pins rust-overlay at **2026-03-25**; rustc 1.95.0 was released **2026-04-14**, so the pinned overlay has no 1.95 manifest. Someone with nix must run `devenv update rust-overlay` and commit the lock. I could not: nix, nix-shell, and devenv are all absent from this environment (`command -v nix nix-shell devenv` → nothing).

## Correcting something I said earlier

I previously told you CI was already floating near 1.96. That was wrong. `channel = "stable"` resolves against the *pinned* rust-overlay, and that pin (2026-03-25) predates 1.95.0 (2026-04-14), so **the PR-tier CI jobs are on 1.94.0** — matching `rust-toolchain.toml` by coincidence, not by configuration. CI does not float today; it is frozen at whatever stable existed when the lock was last updated.

## Why the version was declared four times

| Place | Was | Who reads it |
|---|---|---|
| `rust-toolchain.toml` | 1.94.0 | rustup only — the devenv jobs ignore it entirely |
| `Cargo.toml` `rust-version` | 1.94.0 | MSRV promise to consumers |
| `devenv.nix` | `channel = "stable"` | **the PR-tier CI jobs** |
| `.github/actions/setup-rust` | `default: '1.94.0'` | merge/nightly/semver/monty jobs |

Plus two workflows overriding to `1.95.0` for `adk-codeact-monty`, with comments explaining the workspace was behind.

## Why 1.95 and not 1.96

1.95 is the lowest version satisfying every constraint that already existed:

- `adk-codeact-monty` needs 1.95 — the two overrides are now redundant and removed.
- A fresh resolution of `aws-secrets` needs 1.94.1. Our lockfile pins `aws-config 1.8.18` (MSRV 1.91.1), so builds here were fine — but **consumers do not use our lockfile**. `cargo add adk-auth --features aws-secrets` resolves aws-config 1.10.x, which needs 1.94.1 against a declared MSRV of 1.94.0. That is the promise we could not keep.
- Staying below current stable keeps consumers on 1.95 able to build the published crates. 1.96 would exclude them and buy nothing.

`rust-version` is now `"1.95"` rather than `"1.95.0"`: an MSRV is conventionally major.minor, and a patch-level MSRV is what made the `1.94.1` comparison surprising.

## `rust-toolchain.toml` becomes the single source of truth

`devenv.nix` reads it via `languages.rust.toolchainFile`, so a Nix shell and a plain `cargo` invocation cannot disagree. That option cannot be combined with `channel`/`version`, so components moved into the toolchain file to preserve clippy, rustfmt, and rust-analyzer.

## `resolver = "2"` → `"3"`

The declared MSRV was documentation only; resolver 2 does not consider `rust-version` when picking versions. Resolver 3 does, so a future `cargo update` cannot silently pull a dependency past our MSRV. **The lockfile does not change** — resolver 3 only affects resolution, not an existing lock.

## Migration cost: 1.95 clippy

`-D warnings` turns new lints into errors. Eight sites, applied with `cargo clippy --fix` rather than by hand:

| Crate | Lint |
|---|---|
| `adk-graph` (×2), `adk-realtime`, `adk-enterprise` (test), `adk-gemini` (example) | `collapsible_match` |
| `adk-memory`, `adk-computer-use` | `sort_by_key` |
| `adk-model` (`openrouter`) | iterating on a map's values |

## Verification — all on 1.95.0

| Gate | Result |
|---|---|
| active toolchain | `rustc 1.95.0 (59807616e 2026-04-14)` via the new toolchain file |
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo nextest run --workspace --profile ci` | **3821 passed**, 83 skipped |
| `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps` | exit 0 |
| feature-coverage matrix (`adk-agent codeact`, `adk-model openrouter`, `adk-sandbox wasm`, `adk-audio fx`, `adk-rag lancedb`) | exit 0 each |
| `adk-auth --features aws-secrets` | exit 0 |
| `Cargo.lock` | unchanged |
| doc-versions / doc-examples guards | exit 0 |

**Not verified:** anything that runs through devenv, because nix is unavailable here. That includes whether `toolchainFile` behaves as documented in this repo's devenv version. If it does not, the fallback is `channel = "stable"; version = "1.95.0";` — which works per the devenv options reference but reintroduces the duplicated version.

## Documentation

71 files updated: README badge and install text, CONTRIBUTING, `docs/official_docs/` (quickstart, introduction, development guidelines, a2a getting-started), the issue template, and 54 example READMEs. Historical CHANGELOG statements and the podcast slide deck are left alone — they were true when written. A `### Breaking` changelog entry records the MSRV bump.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

> Run as `cargo` directly on 1.95.0; the `devenv shell` wrappers could not be used here.

### Code Quality

- [x] New code has tests — n/a, no behaviour change; the lint fixes are covered by the existing suite
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed
- [x] Examples added or updated for new features — 54 example READMEs updated