### PR TITLE
fix(graph): carry the caller's runtime into graph nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   | `adk-memory` | `MemoryService::{add_session_to_project, add_entry_to_project, delete_entries_in_project}` now return an error by default; new `MemoryService::supports_project_scoping` | A custom backend must implement them; `GraphMemoryService` now refuses project calls it previously answered globally |
   | `adk-core` | `RunConfig::tool_confirmation_decisions` is now keyed by **function call ID** instead of tool name | Approvals keyed by tool name are no longer found, so the call stays unconfirmed; key by `ToolConfirmationRequest::function_call_id` |
   | `adk-core` | New public field `RunConfig::tool_confirmation_fingerprints` | Struct literals must add the field; prefer `RunConfig::builder()` |
+  | `adk-graph` | `TimeTravelHandle::replay` renamed to `state_history` | Rename the call; behaviour is unchanged, and it never re-executed anything despite the old name |
+  | `adk-graph` | New public field `ExecutionConfig::parent_context` | Struct literals must add the field; prefer `ExecutionConfig::new` plus `with_parent_context` |
   | `adk-graph` | New public field `StateGraph::deferred_configs` | Struct literals must add the field |
   | `adk-runner` | `MutableSession::conversation_history_for_agent_impl` now takes two parameters (an `agent_name` and a `branch`) instead of one | Direct callers must pass the invocation branch; pass `""` for unscoped behaviour |
   | `adk-realtime` | `ClientEvent` and `ServerEvent` are now `#[non_exhaustive]` | Downstream `match` needs a wildcard arm; the enums can no longer be constructed exhaustively outside the crate |
@@ -425,6 +427,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   entries, so no plan update is emitted today.
 
 ### Fixed
+
+- **adk-graph: an agent inside a graph keeps the caller's runtime.** `AgentNode` built a
+  `GraphInvocationContext` from scratch for every run: it hardcoded
+  `user_id = "graph_user"`, `app_name = "graph_app"`, and branch `main`, used a default
+  `RunConfig`, returned `None` for artifacts and memory, and let every optional
+  capability fall back to its default — so secrets, shared state, cancellation, scopes,
+  and request metadata all disappeared. An identity-dependent tool saw a synthetic
+  principal inside a graph and the real one outside it, and `Runner::interrupt` could
+  not reach an agent running as a node.
+
+  `ExecutionConfig::with_parent_context` carries the invocation into the graph, and
+  `GraphAgent` sets it automatically, so identity, scopes, request metadata, secrets,
+  memory, artifacts, shared state, cancellation, and `RunConfig` all reach the agent.
+  The branch is deliberately *derived* as `{caller_branch}.{agent_name}` so a node's
+  events stay attributable. A graph invoked directly, with no parent, keeps the
+  synthetic identity — that is now an explicit standalone mode rather than the only
+  behaviour. Node conversation history remains scoped to the node's own graph session.
+
+- **adk-graph: `TimeTravelHandle::replay` is renamed to `state_history`.** Its rustdoc
+  said it "re-executes the graph", and the module described replaying. The
+  implementation listed checkpoints, sorted and filtered them, and returned stored
+  `(step, state)` pairs — it never invoked a node. Callers could have treated stored
+  snapshots as a fresh replay. The method now says what it does: it reads checkpoints
+  and executes nothing, and `fork_at` plus a normal invoke is the way to actually re-run
+  from a point in history. `adk graph replay` keeps its name but no longer claims to
+  replay; its output states that nothing was re-executed.
+
 
 - **adk-server: background runs execute a workflow instead of reporting success.**
   `BackgroundRunner::run_with_timeout` received neither the workflow ID nor the input. It

--- a/adk-cli/src/cli.rs
+++ b/adk-cli/src/cli.rs
@@ -158,7 +158,7 @@ pub enum GraphCommands {
         db: Option<String>,
     },
 
-    /// Replay execution between two steps, printing state transitions
+    /// Print the recorded state at each checkpointed step in a range (reads only)
     Replay {
         /// Thread identifier to replay
         thread_id: String,

--- a/adk-cli/src/graph.rs
+++ b/adk-cli/src/graph.rs
@@ -54,7 +54,9 @@ async fn run_steps(thread_id: &str, db: Option<&str>) -> Result<()> {
     Ok(())
 }
 
-/// Replay execution between two steps, printing state transitions.
+/// Print the recorded state at each checkpointed step in a range.
+///
+/// Reads checkpoints; nothing is executed.
 async fn run_replay(
     thread_id: &str,
     from: usize,
@@ -64,7 +66,8 @@ async fn run_replay(
     let checkpointer = load_checkpointer(db)?;
     let handle = standalone_handle(thread_id, checkpointer.clone());
 
-    let transitions = handle.replay(from, to).await.context("failed to replay")?;
+    let transitions =
+        handle.state_history(from, to).await.context("failed to read state history")?;
 
     if transitions.is_empty() {
         println!("No state transitions found in the specified range.");
@@ -75,7 +78,7 @@ async fn run_replay(
         Some(end) => format!("{from}..={end}"),
         None => format!("{from}..end"),
     };
-    println!("Replaying thread '{thread_id}' (steps {range_desc}):\n");
+    println!("Recorded state for thread '{thread_id}' (steps {range_desc}):\n");
 
     for (step, state) in &transitions {
         println!("── Step {step} ──");
@@ -83,7 +86,7 @@ async fn run_replay(
         println!("{json}\n");
     }
 
-    println!("Replay complete: {} state(s) shown.", transitions.len());
+    println!("{} recorded state(s) shown; nothing was re-executed.", transitions.len());
     Ok(())
 }
 
@@ -205,8 +208,8 @@ impl StandaloneTimeTravelHandle {
         Ok(steps)
     }
 
-    /// Replay between two steps, returning intermediate states.
-    async fn replay(
+    /// Return the recorded state at each checkpointed step in a range.
+    async fn state_history(
         &self,
         from_step: usize,
         to_step: Option<usize>,

--- a/adk-graph/src/agent.rs
+++ b/adk-graph/src/agent.rs
@@ -131,8 +131,10 @@ impl Agent for GraphAgent {
         // Map context to input state
         let input = (self.input_mapper)(ctx.as_ref());
 
-        // Create execution config from context
-        let config = ExecutionConfig::new(ctx.session_id());
+        // Create execution config from context, carrying the invocation so an
+        // `AgentNode` inside the graph presents this run's identity, services, and
+        // cancellation rather than a synthetic standalone context.
+        let config = ExecutionConfig::new(ctx.session_id()).with_parent_context(ctx.clone());
 
         // Execute graph
         let graph = self.graph.clone();

--- a/adk-graph/src/node.rs
+++ b/adk-graph/src/node.rs
@@ -25,6 +25,15 @@ pub struct ExecutionConfig {
     pub recursion_limit: usize,
     /// Additional configuration
     pub metadata: HashMap<String, Value>,
+    /// The invocation this graph run belongs to, when it has one.
+    ///
+    /// An [`AgentNode`] runs a real agent, and that agent expects the identity,
+    /// services, and cancellation of the run it belongs to. Without a parent the node
+    /// has to fabricate them, which makes an agent behave differently inside a graph
+    /// than outside it. Set this with
+    /// [`ExecutionConfig::with_parent_context`] to carry them through; leaving it
+    /// unset is standalone mode and is what a graph invoked outside a `Runner` gets.
+    pub parent_context: Option<Arc<dyn adk_core::InvocationContext>>,
 }
 
 impl ExecutionConfig {
@@ -35,7 +44,19 @@ impl ExecutionConfig {
             resume_from: None,
             recursion_limit: 50,
             metadata: HashMap::new(),
+            parent_context: None,
         }
+    }
+
+    /// Carry the invocation this graph run belongs to into its nodes.
+    ///
+    /// An [`AgentNode`] then presents the caller's identity, services, request
+    /// context, and cancellation to the agent it runs, instead of a synthetic
+    /// standalone context.
+    #[must_use]
+    pub fn with_parent_context(mut self, parent: Arc<dyn adk_core::InvocationContext>) -> Self {
+        self.parent_context = Some(parent);
+        self
     }
 
     /// Set the recursion limit
@@ -387,10 +408,11 @@ impl Node for AgentNode {
         let content = (self.input_mapper)(&ctx.state);
 
         // Create a graph invocation context with the agent
-        let invocation_ctx = Arc::new(GraphInvocationContext::new(
+        let invocation_ctx = Arc::new(GraphInvocationContext::with_parent(
             ctx.config.thread_id.clone(),
             content,
             self.agent.clone(),
+            ctx.config.parent_context.clone(),
         ));
 
         // Run the agent and collect events
@@ -426,15 +448,17 @@ impl Node for AgentNode {
         let agent = self.agent.clone();
         let input_mapper = &self.input_mapper;
         let output_mapper = &self.output_mapper;
+        let parent_context = ctx.config.parent_context.clone();
         let thread_id = ctx.config.thread_id.clone();
         let content = (input_mapper)(&ctx.state);
 
         Box::pin(async_stream::stream! {
             tracing::debug!("AgentNode::execute_stream called for {}", name);
-            let invocation_ctx = Arc::new(GraphInvocationContext::new(
+            let invocation_ctx = Arc::new(GraphInvocationContext::with_parent(
                 thread_id,
                 content,
                 agent.clone(),
+                parent_context,
             ));
 
             let stream = match agent.run(invocation_ctx).await {
@@ -503,25 +527,66 @@ struct GraphInvocationContext {
     session: Arc<GraphSession>,
     run_config: adk_core::RunConfig,
     ended: std::sync::atomic::AtomicBool,
+    /// The invocation this graph run belongs to, when it has one.
+    ///
+    /// Present: identity, services, request context, and cancellation come from the
+    /// caller, so an agent behaves the same inside a graph as outside it.
+    /// Absent: standalone mode, with the synthetic identity below.
+    parent: Option<Arc<dyn adk_core::InvocationContext>>,
+    /// Identity strings, owned because the trait returns them by reference.
+    user_id: String,
+    app_name: String,
+    branch: String,
 }
 
+/// Identity used when a graph runs with no parent invocation.
+const STANDALONE_USER_ID: &str = "graph_user";
+/// Application name used when a graph runs with no parent invocation.
+const STANDALONE_APP_NAME: &str = "graph_app";
+
 impl GraphInvocationContext {
-    fn new(
+    fn with_parent(
         session_id: String,
         user_content: adk_core::Content,
         agent: Arc<dyn adk_core::Agent>,
+        parent: Option<Arc<dyn adk_core::InvocationContext>>,
     ) -> Self {
         let invocation_id = uuid::Uuid::new_v4().to_string();
         let session = Arc::new(GraphSession::new(session_id));
         // Add user content to history
         session.append_content(user_content.clone());
+
+        // A node runs on its own branch below the caller's, so events it produces are
+        // attributable and do not read as the parent agent's own turn.
+        let (user_id, app_name, branch, run_config) = match parent.as_ref() {
+            Some(parent) => (
+                parent.user_id().to_string(),
+                parent.app_name().to_string(),
+                match parent.branch() {
+                    "" => agent.name().to_string(),
+                    existing => format!("{existing}.{}", agent.name()),
+                },
+                parent.run_config().clone(),
+            ),
+            None => (
+                STANDALONE_USER_ID.to_string(),
+                STANDALONE_APP_NAME.to_string(),
+                "main".to_string(),
+                adk_core::RunConfig::default(),
+            ),
+        };
+
         Self {
             invocation_id,
             user_content,
             agent,
             session,
-            run_config: adk_core::RunConfig::default(),
+            run_config,
             ended: std::sync::atomic::AtomicBool::new(false),
+            parent,
+            user_id,
+            app_name,
+            branch,
         }
     }
 }
@@ -537,11 +602,11 @@ impl adk_core::ReadonlyContext for GraphInvocationContext {
     }
 
     fn user_id(&self) -> &str {
-        "graph_user"
+        &self.user_id
     }
 
     fn app_name(&self) -> &str {
-        "graph_app"
+        &self.app_name
     }
 
     fn session_id(&self) -> &str {
@@ -549,7 +614,7 @@ impl adk_core::ReadonlyContext for GraphInvocationContext {
     }
 
     fn branch(&self) -> &str {
-        "main"
+        &self.branch
     }
 
     fn user_content(&self) -> &adk_core::Content {
@@ -561,7 +626,11 @@ impl adk_core::ReadonlyContext for GraphInvocationContext {
 #[async_trait]
 impl adk_core::CallbackContext for GraphInvocationContext {
     fn artifacts(&self) -> Option<Arc<dyn adk_core::Artifacts>> {
-        None
+        self.parent.as_ref().and_then(|parent| parent.artifacts())
+    }
+
+    fn shared_state(&self) -> Option<Arc<adk_core::SharedState>> {
+        self.parent.as_ref().and_then(|parent| parent.shared_state())
     }
 }
 
@@ -573,7 +642,7 @@ impl adk_core::InvocationContext for GraphInvocationContext {
     }
 
     fn memory(&self) -> Option<Arc<dyn adk_core::Memory>> {
-        None
+        self.parent.as_ref().and_then(|parent| parent.memory())
     }
 
     fn session(&self) -> &dyn adk_core::Session {
@@ -586,10 +655,43 @@ impl adk_core::InvocationContext for GraphInvocationContext {
 
     fn end_invocation(&self) {
         self.ended.store(true, std::sync::atomic::Ordering::SeqCst);
+        if let Some(parent) = &self.parent {
+            parent.end_invocation();
+        }
     }
 
     fn ended(&self) -> bool {
         self.ended.load(std::sync::atomic::Ordering::SeqCst)
+            || self.parent.as_ref().is_some_and(|parent| parent.ended())
+    }
+
+    fn is_cancelled(&self) -> bool {
+        self.parent.as_ref().is_some_and(|parent| parent.is_cancelled())
+    }
+
+    fn user_scopes(&self) -> Vec<String> {
+        self.parent.as_ref().map(|parent| parent.user_scopes()).unwrap_or_default()
+    }
+
+    fn request_metadata(&self) -> std::collections::HashMap<String, Value> {
+        self.parent.as_ref().map(|parent| parent.request_metadata()).unwrap_or_default()
+    }
+
+    async fn get_secret(&self, name: &str) -> adk_core::Result<Option<String>> {
+        match &self.parent {
+            Some(parent) => parent.get_secret(name).await,
+            None => Ok(None),
+        }
+    }
+
+    async fn get_secret_for(
+        &self,
+        request: &adk_core::SecretRequest,
+    ) -> adk_core::Result<Option<String>> {
+        match &self.parent {
+            Some(parent) => parent.get_secret_for(request).await,
+            None => Ok(None),
+        }
     }
 }
 

--- a/adk-graph/src/time_travel.rs
+++ b/adk-graph/src/time_travel.rs
@@ -1,6 +1,6 @@
 //! Time-travel debugging for graph execution history.
 //!
-//! This module provides [`TimeTravelHandle`] for navigating, replaying, and forking
+//! This module provides [`TimeTravelHandle`] for navigating, inspecting, and forking
 //! graph execution history. It works with any [`Checkpointer`] implementation to
 //! inspect past execution steps, resume from arbitrary points, and create divergent
 //! execution branches.
@@ -39,7 +39,7 @@
 //! handle.fork_at(2, "thread_1_fork").await?;
 //!
 //! // Replay steps 0 through 3
-//! let states = handle.replay(0, Some(3)).await?;
+//! let states = handle.state_history(0, Some(3)).await?;
 //! ```
 
 use std::sync::Arc;
@@ -288,38 +288,40 @@ impl<'g> TimeTravelHandle<'g> {
         Ok(())
     }
 
-    /// Replay execution between two steps, returning intermediate states.
+    /// Returns the stored state at each checkpointed step in a range.
     ///
-    /// Re-executes the graph from `from_step` to `to_step` (inclusive),
-    /// collecting the state at each step. If `to_step` is `None`, replays
-    /// to the last available step.
+    /// This **reads** checkpoints; it does not execute anything. No node runs, no
+    /// event is regenerated, and no side effect is repeated — the states returned are
+    /// the snapshots that were saved when the graph originally ran. Use it to inspect
+    /// how state evolved, not to reproduce a decision.
+    ///
+    /// To re-run from a point in history, fork that checkpoint with `fork_at`
+    /// and invoke the graph on the forked thread.
     ///
     /// # Arguments
     ///
-    /// * `from_step` - The step number to start replaying from
-    /// * `to_step` - The step number to stop at (inclusive), or `None` for the last step
+    /// * `from_step` - First step to include
+    /// * `to_step` - Last step to include, or `None` for the last checkpointed step
     ///
     /// # Errors
     ///
-    /// Returns [`GraphError`] if:
-    /// - No checkpoint exists at `from_step`
-    /// - The replay execution fails
+    /// Returns [`GraphError`] when no checkpoint exists at `from_step`.
     ///
     /// # Example
     ///
     /// ```rust,ignore
     /// let handle = graph.time_travel("thread_1");
     ///
-    /// // Replay steps 1 through 4
-    /// let transitions = handle.replay(1, Some(4)).await?;
+    /// // The stored state at steps 1 through 4
+    /// let transitions = handle.state_history(1, Some(4)).await?;
     /// for (step, state) in &transitions {
     ///     println!("Step {}: {:?}", step, state.keys().collect::<Vec<_>>());
     /// }
     ///
-    /// // Replay from step 2 to the end
-    /// let all_remaining = handle.replay(2, None).await?;
+    /// // From step 2 to the last checkpoint
+    /// let all_remaining = handle.state_history(2, None).await?;
     /// ```
-    pub async fn replay(
+    pub async fn state_history(
         &self,
         from_step: usize,
         to_step: Option<usize>,
@@ -461,14 +463,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_replay_returns_states_in_range() {
+    async fn test_state_history_returns_states_in_range() {
         let (graph, checkpointer) = build_test_graph();
         seed_checkpoints(&checkpointer, "thread_1", 5).await;
 
         let handle = graph.time_travel("thread_1");
 
         // Replay steps 1 through 3
-        let results = handle.replay(1, Some(3)).await.unwrap();
+        let results = handle.state_history(1, Some(3)).await.unwrap();
         assert_eq!(results.len(), 3);
         assert_eq!(
             results[0],
@@ -483,14 +485,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_replay_to_end() {
+    async fn test_state_history_to_end() {
         let (graph, checkpointer) = build_test_graph();
         seed_checkpoints(&checkpointer, "thread_1", 5).await;
 
         let handle = graph.time_travel("thread_1");
 
         // Replay from step 2 to end (None)
-        let results = handle.replay(2, None).await.unwrap();
+        let results = handle.state_history(2, None).await.unwrap();
         assert_eq!(results.len(), 3); // steps 2, 3, 4
         assert_eq!(results[0].0, 2);
         assert_eq!(results[1].0, 3);
@@ -504,7 +506,7 @@ mod tests {
 
         let handle = graph.time_travel("thread_1");
 
-        let result = handle.replay(99, None).await;
+        let result = handle.state_history(99, None).await;
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
         assert!(err_msg.contains("no checkpoint found at step 99"));

--- a/adk-graph/tests/agent_node_context_tests.rs
+++ b/adk-graph/tests/agent_node_context_tests.rs
@@ -1,0 +1,281 @@
+//! An agent must not lose its runtime when it runs inside a graph.
+//!
+//! `AgentNode` built a `GraphInvocationContext` from scratch for every run: it
+//! hardcoded `user_id = "graph_user"`, `app_name = "graph_app"`, and branch `main`,
+//! used a default `RunConfig`, and returned `None` for artifacts and memory. Every
+//! optional capability fell back to its default, so secrets, shared state,
+//! cancellation, scopes, and request metadata all disappeared. An identity-dependent
+//! tool therefore saw a synthetic principal inside a graph and the real one outside
+//! it, and `Runner::interrupt` could not reach the agent at all.
+
+use adk_core::{
+    Agent, Content, EventStream, InvocationContext, Part, Result, RunConfig, SecretRequest,
+    Session, State,
+};
+use adk_graph::edge::{END, START};
+use adk_graph::graph::StateGraph;
+use adk_graph::node::{AgentNode, ExecutionConfig};
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+/// What the agent observed about the context it was handed.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct Observed {
+    user_id: String,
+    app_name: String,
+    branch: String,
+    scopes: Vec<String>,
+    metadata_keys: Vec<String>,
+    secret: Option<String>,
+    cancelled: bool,
+    has_memory: bool,
+}
+
+/// An agent that records the capabilities of the context it runs under.
+struct ObservingAgent {
+    observed: Arc<Mutex<Option<Observed>>>,
+}
+
+#[async_trait]
+impl Agent for ObservingAgent {
+    fn name(&self) -> &str {
+        "observer"
+    }
+    fn description(&self) -> &str {
+        "records what its context exposes"
+    }
+    fn sub_agents(&self) -> &[Arc<dyn Agent>] {
+        &[]
+    }
+
+    async fn run(&self, ctx: Arc<dyn InvocationContext>) -> Result<EventStream> {
+        let mut metadata_keys: Vec<String> = ctx.request_metadata().into_keys().collect();
+        metadata_keys.sort();
+        let observed = Observed {
+            user_id: ctx.user_id().to_string(),
+            app_name: ctx.app_name().to_string(),
+            branch: ctx.branch().to_string(),
+            scopes: ctx.user_scopes(),
+            metadata_keys,
+            secret: ctx.get_secret("api-key").await?,
+            cancelled: ctx.is_cancelled(),
+            has_memory: ctx.memory().is_some(),
+        };
+        *self.observed.lock().unwrap() = Some(observed);
+        Ok(Box::pin(futures::stream::empty()))
+    }
+}
+
+// ── A capability-rich sentinel context ────────────────────────────────
+
+struct SentinelState;
+
+impl State for SentinelState {
+    fn get(&self, _key: &str) -> Option<Value> {
+        None
+    }
+    fn set(&mut self, _key: String, _value: Value) {}
+    fn all(&self) -> HashMap<String, Value> {
+        HashMap::new()
+    }
+}
+
+struct SentinelSession;
+
+impl Session for SentinelSession {
+    fn id(&self) -> &str {
+        "caller-session"
+    }
+    fn app_name(&self) -> &str {
+        "caller-app"
+    }
+    fn user_id(&self) -> &str {
+        "caller-user"
+    }
+    fn state(&self) -> &dyn State {
+        &SentinelState
+    }
+    fn conversation_history(&self) -> Vec<Content> {
+        Vec::new()
+    }
+}
+
+struct SentinelMemory;
+
+#[async_trait]
+impl adk_core::Memory for SentinelMemory {
+    async fn search(&self, _query: &str) -> Result<Vec<adk_core::MemoryEntry>> {
+        Ok(Vec::new())
+    }
+}
+
+/// A context with a non-default value for every capability under test.
+struct SentinelContext {
+    user_content: Content,
+    session: SentinelSession,
+    cancelled: bool,
+}
+
+impl SentinelContext {
+    fn new(cancelled: bool) -> Self {
+        Self {
+            user_content: Content {
+                role: "user".to_string(),
+                parts: vec![Part::Text { text: "go".to_string() }],
+            },
+            session: SentinelSession,
+            cancelled,
+        }
+    }
+}
+
+#[async_trait]
+impl adk_core::ReadonlyContext for SentinelContext {
+    fn invocation_id(&self) -> &str {
+        "caller-invocation"
+    }
+    fn agent_name(&self) -> &str {
+        "caller-agent"
+    }
+    fn user_id(&self) -> &str {
+        "caller-user"
+    }
+    fn app_name(&self) -> &str {
+        "caller-app"
+    }
+    fn session_id(&self) -> &str {
+        "caller-session"
+    }
+    fn branch(&self) -> &str {
+        "caller-branch"
+    }
+    fn user_content(&self) -> &Content {
+        &self.user_content
+    }
+}
+
+#[async_trait]
+impl adk_core::CallbackContext for SentinelContext {
+    fn artifacts(&self) -> Option<Arc<dyn adk_core::Artifacts>> {
+        None
+    }
+}
+
+#[async_trait]
+impl InvocationContext for SentinelContext {
+    fn agent(&self) -> Arc<dyn Agent> {
+        unimplemented!("not exercised")
+    }
+    fn memory(&self) -> Option<Arc<dyn adk_core::Memory>> {
+        Some(Arc::new(SentinelMemory))
+    }
+    fn session(&self) -> &dyn Session {
+        &self.session
+    }
+    fn run_config(&self) -> &RunConfig {
+        static RUN_CONFIG: std::sync::OnceLock<RunConfig> = std::sync::OnceLock::new();
+        RUN_CONFIG.get_or_init(RunConfig::default)
+    }
+    fn end_invocation(&self) {}
+    fn ended(&self) -> bool {
+        false
+    }
+    fn is_cancelled(&self) -> bool {
+        self.cancelled
+    }
+    fn user_scopes(&self) -> Vec<String> {
+        vec!["tools:read".to_string(), "secrets:api".to_string()]
+    }
+    fn request_metadata(&self) -> HashMap<String, Value> {
+        HashMap::from([("tenant".to_string(), json!("acme"))])
+    }
+    async fn get_secret(&self, _name: &str) -> Result<Option<String>> {
+        Ok(Some("sentinel-secret".to_string()))
+    }
+    async fn get_secret_for(&self, _request: &SecretRequest) -> Result<Option<String>> {
+        Ok(Some("sentinel-secret".to_string()))
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+/// Runs the observing agent through an `AgentNode`, with or without a parent.
+async fn run_in_graph(parent: Option<Arc<dyn InvocationContext>>) -> Observed {
+    let observed = Arc::new(Mutex::new(None));
+    let agent = Arc::new(ObservingAgent { observed: observed.clone() });
+
+    let node = AgentNode::new(agent)
+        .with_input_mapper(|_state| Content::new("user").with_text("go"))
+        .with_output_mapper(|_events| HashMap::new());
+
+    let graph = StateGraph::with_channels(&["value"])
+        .add_node(node)
+        .add_edge(START, "observer")
+        .add_edge("observer", END)
+        .compile()
+        .unwrap();
+
+    let mut config = ExecutionConfig::new("thread-1");
+    if let Some(parent) = parent {
+        config = config.with_parent_context(parent);
+    }
+    graph.invoke(adk_graph::state::State::new(), config).await.unwrap();
+
+    observed.lock().unwrap().clone().expect("the agent must have run")
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn a_graph_run_preserves_the_callers_identity_and_services() {
+    let observed = run_in_graph(Some(Arc::new(SentinelContext::new(false)))).await;
+
+    assert_eq!(observed.user_id, "caller-user", "the synthetic user replaced the real one");
+    assert_eq!(observed.app_name, "caller-app", "the synthetic app replaced the real one");
+    assert_eq!(
+        observed.scopes,
+        vec!["tools:read".to_string(), "secrets:api".to_string()],
+        "scope checks inside a graph could not see the caller's grants"
+    );
+    assert_eq!(observed.metadata_keys, vec!["tenant".to_string()]);
+    assert_eq!(
+        observed.secret.as_deref(),
+        Some("sentinel-secret"),
+        "secret access disappeared inside the graph"
+    );
+    assert!(observed.has_memory, "memory access disappeared inside the graph");
+}
+
+#[tokio::test]
+async fn cancellation_reaches_an_agent_inside_a_graph() {
+    let observed = run_in_graph(Some(Arc::new(SentinelContext::new(true)))).await;
+    assert!(
+        observed.cancelled,
+        "Runner::interrupt could not reach an agent running as a graph node"
+    );
+}
+
+#[tokio::test]
+async fn a_node_runs_on_its_own_branch_below_the_caller() {
+    // Derived rather than inherited, so events a node produces are attributable and do
+    // not read as the calling agent's own turn.
+    let observed = run_in_graph(Some(Arc::new(SentinelContext::new(false)))).await;
+    assert_eq!(observed.branch, "caller-branch.observer");
+}
+
+#[tokio::test]
+async fn standalone_execution_still_works_without_a_parent() {
+    // A graph invoked outside a Runner has no invocation to inherit. That is a
+    // deliberate mode, not an accident, so the synthetic identity stays.
+    let observed = run_in_graph(None).await;
+
+    assert_eq!(observed.user_id, "graph_user");
+    assert_eq!(observed.app_name, "graph_app");
+    assert_eq!(observed.branch, "main");
+    assert!(observed.scopes.is_empty());
+    assert_eq!(observed.secret, None);
+    assert!(!observed.has_memory);
+    assert!(!observed.cancelled);
+}

--- a/docs/official_docs/agents/graph-agents.md
+++ b/docs/official_docs/agents/graph-agents.md
@@ -732,6 +732,41 @@ Final Answer: "The weather in Paris is 72°F and sunny with 45% humidity.
 
 Wraps any ADK `Agent` (typically `LlmAgent`) as a graph node:
 
+#### What the agent sees
+
+An agent inside a graph runs under a context derived from the invocation that
+started the graph, so it behaves the same as it does outside one. When a `Runner`
+invokes a `GraphAgent`, the caller's identity and services are carried through
+automatically:
+
+| Carried through | Note |
+|-----------------|------|
+| `app_name`, `user_id`, `session_id` | The caller's, not a synthetic one |
+| Scopes and request metadata | So scope checks see the caller's grants |
+| Secret service, memory, artifacts, shared state | Available exactly as outside the graph |
+| Cancellation | `Runner::interrupt` reaches an agent running as a node |
+| `RunConfig` | Inherited from the caller |
+| `branch` | **Derived**, as `{caller_branch}.{agent_name}`, so a node's events are attributable |
+
+A graph invoked directly — `graph.invoke(state, ExecutionConfig::new("thread"))` —
+has no invocation to inherit. That is **standalone mode**: the node gets
+`user_id = "graph_user"`, `app_name = "graph_app"`, branch `main`, no secrets, and no
+memory. It is a deliberate mode for running a graph outside a `Runner`, not a
+fallback to reach for in production.
+
+To bridge manually — for instance when driving a graph from your own executor — pass
+the invocation explicitly:
+
+```rust
+let config = ExecutionConfig::new(ctx.session_id()).with_parent_context(ctx.clone());
+```
+
+> **Note:** the node still runs on its own in-memory graph session, so agent
+> conversation history inside a node is scoped to the node rather than appended to the
+> caller's session.
+
+
+
 ```rust
 let node = AgentNode::new(llm_agent)
     .with_input_mapper(|state| {
@@ -1073,6 +1108,14 @@ interrupt ends the stream, so a human-in-the-loop pause is resumable in either
 execution mode.
 
 ### Checkpoint History (Time Travel)
+
+> **Reads only.** `TimeTravelHandle::state_history(from, to)` returns the state that
+> was *stored* at each checkpointed step. It executes nothing — no node runs, no event
+> is regenerated, and no side effect repeats. To re-run from a point in history, use
+> `fork_at` to branch that checkpoint and invoke the graph on the forked thread. The
+> method was previously named `replay` and documented as re-executing the graph, which
+> it never did.
+
 
 Checkpoints also enable **durable resume** — if a graph execution crashes or the process restarts, execution resumes from the last persisted checkpoint rather than starting over. Use `SqliteCheckpointer` or `PostgresCheckpointer` for crash-safe persistence.
 


### PR DESCRIPTION
## What

Two findings in `adk-graph`: an agent inside a graph lost the caller's entire runtime, and a method named `replay` never replayed anything.

## GR-04 — `AgentNode` fabricated a context

```rust
fn user_id(&self)   -> &str { "graph_user" }
fn app_name(&self)  -> &str { "graph_app" }
fn branch(&self)    -> &str { "main" }
fn artifacts(&self) -> Option<..> { None }
fn memory(&self)    -> Option<..> { None }
```

Every optional capability fell through to its default, so secrets, shared state, cancellation, scopes, and request metadata all disappeared, and `RunConfig` was a default. Consequences:

| Symptom | Why |
|---|---|
| Identity-dependent tools saw a synthetic principal | `graph_user` / `graph_app` |
| Scope checks couldn't use the caller's grants | `user_scopes()` → empty |
| Secret and memory access vanished | `None` / default |
| `Runner::interrupt` couldn't stop the agent | `is_cancelled()` → `false` |

An agent behaved differently inside a graph than outside it, which is the kind of difference nothing warns you about.

### How

`ExecutionConfig::with_parent_context` carries the invocation into the graph, and **`GraphAgent` sets it from its own context** — so the bridge exists by default rather than only when a caller knows to build one. Every capability is delegated to the parent.

Two deliberate choices, both pinned by tests so they are decisions rather than accidents:

- **Branch is derived, not inherited:** `{caller_branch}.{agent_name}`. A node's events stay attributable instead of reading as the calling agent's own turn.
- **No parent means standalone mode.** A graph invoked directly (`graph.invoke(state, ExecutionConfig::new(..))`) has no invocation to inherit and keeps the synthetic identity. That is now an explicit mode, documented as not for production, rather than the only behaviour.

### What this does *not* fix

The node still runs on its own in-memory `GraphSession`, so agent conversation history inside a node is scoped to the node rather than appended to the caller's session. Sharing the caller's session changes what `include_contents` feeds the model and deserves its own change; the docs state the boundary rather than implying it is gone.

## GR-05 — `replay` didn't replay

The rustdoc said *"Re-executes the graph from `from_step` to `to_step`"*. The implementation listed checkpoints, sorted, filtered, and returned stored `(step, state)` pairs. No node ran. A caller could reasonably have treated stored snapshots as a fresh replay when validating deterministic behaviour.

Real replay needs deterministic inputs and a side-effect policy for re-running nodes, so the honest fix is the name: **`state_history`**, documented as reading checkpoints and executing nothing, with `fork_at` plus a normal invoke as the way to actually re-run from history.

The `adk graph replay` CLI subcommand keeps its name — renaming a CLI surface breaks users for little gain — but its help text and output no longer claim to replay. It now prints `N recorded state(s) shown; nothing was re-executed.`

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo nextest run --workspace --profile ci` | **3823 passed**, 83 skipped, 2 failed — see below |
| `cargo nextest run -p adk-graph` | 107 passed + 4 new |
| `RUSTDOCFLAGS=-D warnings cargo doc -p adk-graph -p adk-cli` | exit 0 |
| doc-examples guard | exit 0 |

Four tests in `adk-graph/tests/agent_node_context_tests.rs` push a sentinel context (non-default identity, scopes, metadata, secret, memory, cancellation) through an `AgentNode`. Dropping the parent — keeping the API so it still compiles — fails **three of the four**; the fourth is the standalone-mode guard that must pass both ways.

### The two failures are not from this PR

`adk-code::rust_sandbox_property_tests::{test_timeout_during_execution_phase, test_timeout_produces_timeout_failure_short}` fail identically on clean `main`. Diagnosed: `RustSandboxExecutor` links `serde_json` by finding an rlib in `target/debug/deps`, and the newest ones on my machine were built by **rustc 1.95.0** (from the #479 toolchain work) while `main` uses 1.94.0, so rustc rejects the metadata instantly — `CompileFailed` in 0.08 s where the test expects `Timeout`. Local artifact contamination in a shared target dir, not a repo defect; CI builds clean. Worth noting separately that `find_rlib_in_dir` picks an rlib without checking which compiler produced it.

## Breaking changes recorded

| Crate | Change |
|---|---|
| `adk-graph` | `TimeTravelHandle::replay` → `state_history` |
| `adk-graph` | New public field `ExecutionConfig::parent_context` |

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass (except the two pre-existing failures above)
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed — n/a
- [x] Examples added or updated for new features — n/a