### PR TITLE
fix(graph): reject unavailable action backends when the graph is built

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -426,6 +426,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **adk-graph: an action node whose backend does not exist is rejected when the graph is
+  built.** Database actions validated a connection and then returned an error explaining
+  that no driver is integrated; email monitor and send did the same; JavaScript and
+  TypeScript code execution is a placeholder; and a node needing an unenabled feature
+  failed the same way. A workflow could deserialize, validate, and compile, then fail
+  only when that node executed — after earlier nodes had already had their side effects.
+
+  `Node::validate` is a new defaulted trait method, and `StateGraph::compile` calls it
+  for every node, so an unavailable configuration is refused up front with the node name
+  and the reason. `ActionNodeExecutor` reports database nodes, email nodes, JS/TS code
+  nodes, and feature-gated nodes whose feature is off. Rust code nodes and every
+  implemented action are unaffected. A custom node can take part by overriding
+  `validate`. The node-type table in the docs now marks what is not implemented instead
+  of listing it as available.
+
 - **adk-server: background runs execute a workflow instead of reporting success.**
   `BackgroundRunner::run_with_timeout` received neither the workflow ID nor the input. It
   checked cancellation and returned `Completed` with an empty object, so a client got a

--- a/adk-graph/src/action/mod.rs
+++ b/adk-graph/src/action/mod.rs
@@ -62,6 +62,45 @@ impl ActionNodeExecutor {
         &self.config
     }
 
+    /// Why this node cannot execute, if it cannot.
+    ///
+    /// Some action variants accept and validate a configuration while their backend is
+    /// still a placeholder, and some require a feature that is not compiled in. Both
+    /// used to surface only when the node ran, which is operationally different from a
+    /// configuration rejected before the workflow starts.
+    pub fn unavailable_reason(&self) -> Option<String> {
+        match &self.config {
+            ActionNodeConfig::Database(config) => Some(format!(
+                "database node '{}' cannot execute: the driver is a validated placeholder \
+                 with no backend integrated",
+                config.standard.id
+            )),
+            ActionNodeConfig::Email(config) => Some(format!(
+                "email node '{}' cannot execute: IMAP monitoring and SMTP sending are \
+                 not implemented",
+                config.standard.id
+            )),
+            ActionNodeConfig::Code(config)
+                if matches!(
+                    config.language,
+                    adk_action::CodeLanguage::Javascript | adk_action::CodeLanguage::Typescript
+                ) =>
+            {
+                Some(format!(
+                    "code node '{}' cannot execute: JavaScript and TypeScript have no \
+                     sandboxed runtime yet; use language 'rust'",
+                    config.standard.id
+                ))
+            }
+            #[cfg(not(feature = "action-http"))]
+            ActionNodeConfig::Http(config) => Some(format!(
+                "http node '{}' cannot execute: the 'action-http' feature is not enabled",
+                config.standard.id
+            )),
+            _ => None,
+        }
+    }
+
     /// Build a state map from the `NodeContext` for interpolation.
     fn state_map(ctx: &NodeContext) -> HashMap<String, Value> {
         ctx.state.clone()
@@ -204,6 +243,13 @@ impl ActionNodeExecutor {
 
 #[async_trait]
 impl Node for ActionNodeExecutor {
+    fn validate(&self) -> Result<()> {
+        match self.unavailable_reason() {
+            Some(message) => Err(GraphError::InvalidGraph(message)),
+            None => Ok(()),
+        }
+    }
+
     #[allow(clippy::misnamed_getters)]
     fn name(&self) -> &str {
         // Node::name() is used as a unique identifier, which is the `id` field

--- a/adk-graph/src/graph.rs
+++ b/adk-graph/src/graph.rs
@@ -193,6 +193,13 @@ impl StateGraph {
             return Err(GraphError::NoEntryPoint);
         }
 
+        // Reject a node that cannot execute. A configuration whose backend is
+        // unavailable should fail here, not part-way through a run when earlier nodes
+        // may already have had side effects.
+        for node in self.nodes.values() {
+            node.validate()?;
+        }
+
         // Check all node references exist
         for edge in &self.edges {
             match edge {

--- a/adk-graph/src/node.rs
+++ b/adk-graph/src/node.rs
@@ -190,6 +190,19 @@ pub trait Node: Send + Sync {
     /// Execute the node and return state updates
     async fn execute(&self, ctx: &NodeContext) -> Result<NodeOutput>;
 
+    /// Rejects a node that cannot execute, before the graph runs.
+    ///
+    /// Called for every node by [`StateGraph::compile`], so a configuration whose
+    /// backend is unavailable fails while the graph is being built rather than
+    /// part-way through a run, when earlier nodes may already have had side effects.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error describing what is unavailable. The default accepts the node.
+    fn validate(&self) -> Result<()> {
+        Ok(())
+    }
+
     /// Streams execution events for this node.
     ///
     /// An implementation must report the node's state updates by yielding a

--- a/adk-graph/src/node.rs
+++ b/adk-graph/src/node.rs
@@ -192,7 +192,7 @@ pub trait Node: Send + Sync {
 
     /// Rejects a node that cannot execute, before the graph runs.
     ///
-    /// Called for every node by [`StateGraph::compile`], so a configuration whose
+    /// Called for every node by [`StateGraph::compile`](crate::graph::StateGraph::compile), so a configuration whose
     /// backend is unavailable fails while the graph is being built rather than
     /// part-way through a run, when earlier nodes may already have had side effects.
     ///

--- a/adk-graph/tests/action_capability_tests.rs
+++ b/adk-graph/tests/action_capability_tests.rs
@@ -1,0 +1,112 @@
+//! A node whose backend does not exist must be rejected before the graph runs.
+//!
+//! Several action variants accept and validate a configuration while their backend is
+//! still a placeholder: database drivers are not integrated, IMAP monitoring and SMTP
+//! sending are not implemented, and JavaScript/TypeScript code has no sandboxed
+//! runtime. A workflow could deserialize, validate, and compile, then fail only when
+//! that node executed — after earlier nodes had already had their side effects. That is
+//! operationally different from a configuration refused up front.
+
+#![cfg(feature = "action")]
+
+use adk_action::{
+    ActionNodeConfig, Callbacks, CodeLanguage, CodeNodeConfig, DatabaseConnection,
+    DatabaseNodeConfig, DatabaseType, ErrorHandling, ErrorMode, ExecutionControl,
+    InputOutputMapping, LogLevel, StandardProperties, Tracing,
+};
+use adk_graph::action::ActionNodeExecutor;
+use adk_graph::edge::{END, START};
+use adk_graph::graph::StateGraph;
+use adk_graph::node::NodeOutput;
+use serde_json::json;
+
+fn standard(id: &str) -> StandardProperties {
+    StandardProperties {
+        id: id.to_string(),
+        name: id.to_string(),
+        description: None,
+        position: None,
+        error_handling: ErrorHandling {
+            mode: ErrorMode::Stop,
+            retry_count: None,
+            retry_delay: None,
+            fallback_value: None,
+        },
+        tracing: Tracing { enabled: false, log_level: LogLevel::None },
+        callbacks: Callbacks { on_start: None, on_complete: None, on_error: None },
+        execution: ExecutionControl { timeout: 30000, condition: None },
+        mapping: InputOutputMapping { input_mapping: None, output_key: "value".to_string() },
+    }
+}
+
+/// Compiles a one-node graph around `config` and returns the outcome.
+fn compile_with(config: ActionNodeConfig) -> Result<(), String> {
+    let node_id = config.standard().id.clone();
+    let graph = StateGraph::with_channels(&["value"])
+        .add_node(ActionNodeExecutor::new(config))
+        .add_edge(START, &node_id)
+        .add_edge(&node_id, END)
+        .compile();
+    graph.map(|_| ()).map_err(|e| e.to_string())
+}
+
+#[test]
+fn a_database_node_is_rejected_at_build_time() {
+    let config = ActionNodeConfig::Database(DatabaseNodeConfig {
+        standard: standard("db"),
+        connection: DatabaseConnection {
+            database_type: DatabaseType::Postgresql,
+            connection_string: Some("postgres://localhost/db".to_string()),
+            credential_ref: None,
+        },
+        sql: None,
+        mongo: None,
+        redis: None,
+    });
+
+    let error = compile_with(config).expect_err("a placeholder backend must not compile");
+    assert!(
+        error.contains("placeholder") || error.contains("cannot execute"),
+        "the rejection must say why: {error}"
+    );
+}
+
+#[test]
+fn a_javascript_code_node_is_rejected_at_build_time() {
+    let config = ActionNodeConfig::Code(CodeNodeConfig {
+        standard: standard("js"),
+        language: CodeLanguage::Javascript,
+        code: "return 1;".to_string(),
+        sandbox: None,
+    });
+
+    let error = compile_with(config).expect_err("JS has no runtime, so it must not compile");
+    assert!(error.contains("cannot execute"), "the rejection must say why: {error}");
+}
+
+#[test]
+fn a_rust_code_node_still_compiles() {
+    // Guards against the gate rejecting a variant that does work.
+    let config = ActionNodeConfig::Code(CodeNodeConfig {
+        standard: standard("rs"),
+        language: CodeLanguage::Rust,
+        code: json!({ "value": 1 }).to_string(),
+        sandbox: None,
+    });
+
+    compile_with(config).expect("a rust code node is executable and must compile");
+}
+
+#[test]
+fn an_ordinary_graph_still_compiles() {
+    // The new per-node validation pass must not reject plain nodes.
+    StateGraph::with_channels(&["value"])
+        .add_node_fn("double", |ctx| async move {
+            let value = ctx.get("value").and_then(|v| v.as_i64()).unwrap_or(0);
+            Ok(NodeOutput::new().with_update("value", json!(value * 2)))
+        })
+        .add_edge(START, "double")
+        .add_edge("double", END)
+        .compile()
+        .expect("a plain graph must still compile");
+}

--- a/docs/official_docs/tools/action-nodes.md
+++ b/docs/official_docs/tools/action-nodes.md
@@ -33,12 +33,29 @@ adk-rust = { version = "2.0.0", features = ["action"] }
 | `Loop` | Iterate over collections or until a condition | Control |
 | `Merge` | Join multiple branches back together | Control |
 | `Wait` | Pause execution for a duration or until event | Control |
-| `Code` | Execute arbitrary code (JavaScript/Python/Rust) | Compute |
-| `Database` | Query databases (SQL, key-value, document) | I/O |
-| `Email` | Send emails via SMTP or provider APIs | I/O |
+| `Code` | Execute arbitrary code (Rust; **JS/TS not implemented**) | Compute |
+| `Database` | Query databases — **not implemented** | I/O |
+| `Email` | Send emails via SMTP — **not implemented** | I/O |
 | `Notification` | Send notifications (Slack, webhook, push) | I/O |
 | `RSS` | Read and parse RSS/Atom feeds | I/O |
 | `File` | Read, write, and transform files | I/O |
+
+## Availability Is Checked When the Graph Is Built
+
+Some node types accept and validate a configuration while their backend does not exist.
+Those are refused by `StateGraph::compile()`, not part-way through a run:
+
+| Configuration | Status |
+|---------------|--------|
+| `Database` (any type) | Rejected — no driver is integrated |
+| `Email` (monitor or send) | Rejected — IMAP and SMTP are not implemented |
+| `Code` with `language: javascript` or `typescript` | Rejected — no sandboxed runtime; use `rust` |
+| `Http` without the `action-http` feature | Rejected — enable the feature |
+
+A rejection names the node and the reason, so a workflow that cannot run fails while it
+is being assembled rather than after earlier nodes have already had side effects.
+
+Implement `Node::validate` on a custom node to take part in the same check.
 
 ## StandardProperties
 


### PR DESCRIPTION
## What

An action node whose backend does not exist is now refused by `StateGraph::compile()` instead of failing part-way through a run.

## Why

Several action variants accept and validate a configuration while the backend behind them is a placeholder:

| Node | What it did |
|---|---|
| `Database` (all types) | Validated the connection, then returned "no driver integrated" |
| `Email` (monitor / send) | Validated config, then returned "not yet available" |
| `Code` with `javascript` / `typescript` | Placeholder — no sandboxed runtime |
| Feature-gated nodes with the feature off | Same shape of runtime error |

So a workflow could deserialize, validate, and compile, then fail when that node executed — **after earlier nodes had already had their side effects**. A half-run workflow with external writes already committed is operationally very different from a configuration refused before anything started.

## How

`Node::validate` is a new **defaulted** trait method, and `StateGraph::compile` calls it for every node. Two reasons for putting it on the trait rather than special-casing actions:

- The check becomes a property of the graph, so it applies to any node.
- A custom node can opt in by overriding `validate`.

`ActionNodeExecutor::unavailable_reason` reports the four cases above, naming the node and the reason. Rust code nodes and every implemented action are unaffected.

## Documentation was wrong, not just incomplete

The node-type table listed these as available capabilities:

```
| `Code`     | Execute arbitrary code (JavaScript/Python/Rust) | Compute |
| `Database` | Query databases (SQL, key-value, document)      | I/O     |
| `Email`    | Send emails via SMTP or provider APIs           | I/O     |
```

None of those three worked. The table now marks what is not implemented, and a new section states that availability is checked when the graph is built.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo clippy -p adk-graph` with each of `action`, `action-full`, `action-http`, `action-db`, `action-code`, `action-email`, `action-rss`, `action-trigger` | exit 0 each |
| `cargo nextest run -p adk-graph --features action` | 154 passed |
| `cargo nextest run --workspace --profile ci` | **3819 passed**, 83 skipped, 2 failed — pre-existing, see below |
| doc-examples guard | exit 0 |

Four tests. Removing the compile-time gate fails **two** (`a_database_node_is_rejected_at_build_time`, `a_javascript_code_node_is_rejected_at_build_time`); the other two exist to prove the gate does not over-reject — a Rust code node and a plain closure graph must still compile.

### The two failures are not from this PR

`adk-code::rust_sandbox_property_tests::{test_timeout_during_execution_phase, test_timeout_produces_timeout_failure_short}` fail identically on clean `main`. `RustSandboxExecutor` links `serde_json` by finding an rlib in `target/debug/deps`, and the newest ones on this machine were built by rustc **1.95.0** (from the #479 toolchain work) while `main` uses 1.94.0, so rustc rejects the metadata instantly — `CompileFailed` in 0.08 s where the test expects `Timeout`. Local artifact contamination in a shared target dir; CI builds clean.

## Not addressed

The finding's other branch — implementing the database, email, and JS backends with security and resource controls — is out of scope here. This PR makes their absence honest at build time and in the docs.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass (except the two pre-existing failures above)
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed — n/a
- [x] Examples added or updated for new features — n/a