### PR TITLE
fix(runner): key context caches by their material

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -426,6 +426,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **adk-runner: context caches are keyed by their material, not Runner-global.** A Runner
+  held one `active_cache_name` and one invocation counter, reused across sessions and
+  across whichever sub-agent `find_agent_to_run` selected, and created the cache from
+  `agent_to_run.description()` with an empty tool map — while the real instruction was
+  resolved later inside `LlmAgent`. A cache built for one agent could therefore be
+  attached to a request for another, refresh was driven by a Runner-wide counter rather
+  than by content changing, and the cached text was never the text being sent.
+
+  `CacheManager` now holds a bounded map (16 entries, oldest evicted) keyed by model,
+  agent, and a canonical digest of the cached material, so a cache is reused only for
+  byte-equivalent material on the same model and agent, and a superseded or evicted entry
+  is deleted provider-side instead of leaked. The new `Agent::cacheable_instruction`
+  (defaulted to `None`) supplies the material: `LlmAgent` returns its static instruction
+  and returns `None` when an instruction provider is configured, and the runner skips
+  caching rather than substituting the description. `CacheCapable::cache_scope`
+  (defaulted, implemented by `GeminiModel`) keeps caches for different models apart.
+  Tools are still resolved inside the agent, so a cache covers instruction material only;
+  the documentation states that.
+
 - **adk-server: background runs execute a workflow instead of reporting success.**
   `BackgroundRunner::run_with_timeout` received neither the workflow ID nor the input. It
   checked cancellation and returned `Completed` with an empty object, so a client got a

--- a/adk-agent/src/llm_agent.rs
+++ b/adk-agent/src/llm_agent.rs
@@ -1338,6 +1338,17 @@ impl Agent for LlmAgent {
         &self.name
     }
 
+    /// The static instruction, when this agent has one.
+    ///
+    /// Returns `None` when an instruction provider is configured, because the text then
+    /// depends on the request and caching it would attach the wrong instruction.
+    fn cacheable_instruction(&self) -> Option<&str> {
+        match self.instruction_provider {
+            Some(_) => None,
+            None => self.instruction.as_deref(),
+        }
+    }
+
     fn description(&self) -> &str {
         &self.description
     }

--- a/adk-core/src/agent.rs
+++ b/adk-core/src/agent.rs
@@ -22,6 +22,20 @@ pub trait Agent: Send + Sync {
     /// Returns the child agents managed by this agent.
     fn sub_agents(&self) -> &[Arc<dyn Agent>];
 
+    /// The system instruction this agent will send, when it is fixed for every turn.
+    ///
+    /// A runner uses this as the material for provider-side context caching. It must be
+    /// the instruction the agent actually sends, not a stand-in: a cache built from
+    /// different text than the request it is attached to is either ignored by the
+    /// provider or applies the wrong instruction.
+    ///
+    /// Returns `None` — the default — when the agent has no fixed instruction, for
+    /// example because it is computed per request. A runner must then skip caching
+    /// rather than caching something else.
+    fn cacheable_instruction(&self) -> Option<&str> {
+        None
+    }
+
     /// Whether this agent participates in LLM-driven agent transfer and may be
     /// resumed directly across conversation turns.
     ///

--- a/adk-core/src/model.rs
+++ b/adk-core/src/model.rs
@@ -160,6 +160,16 @@ pub struct LlmResponse {
 /// ```
 #[async_trait]
 pub trait CacheCapable: Send + Sync {
+    /// Identifies the provider and model a cache belongs to.
+    ///
+    /// A provider cache is only valid for the model it was created against, so a runner
+    /// includes this in the identity of a cache it holds. The default is empty, which
+    /// leaves the model out of that identity; implement it to keep caches for different
+    /// models apart.
+    fn cache_scope(&self) -> &str {
+        ""
+    }
+
     /// Create a cached content resource from the given system instruction,
     /// tool definitions, and TTL.
     ///

--- a/adk-model/src/gemini/client.rs
+++ b/adk-model/src/gemini/client.rs
@@ -1687,6 +1687,10 @@ mod native_tool_tests {
 
 #[async_trait]
 impl CacheCapable for GeminiModel {
+    fn cache_scope(&self) -> &str {
+        self.name()
+    }
+
     async fn create_cache(
         &self,
         system_instruction: &str,

--- a/adk-runner/src/cache.rs
+++ b/adk-runner/src/cache.rs
@@ -1,20 +1,71 @@
 use adk_core::{ContextCacheConfig, Event};
 use serde::{Deserialize, Serialize};
 
-/// Internal cache lifecycle manager.
+/// Identifies one cacheable context.
 ///
-/// Tracks the active cache name, invocation count, and determines
-/// when caching should be attempted or refreshed based on
-/// [`ContextCacheConfig`] settings.
-pub(crate) struct CacheManager {
-    config: ContextCacheConfig,
-    active_cache_name: Option<String>,
+/// A provider cache is only valid for the material it was created from. Keying by the
+/// model, the agent, and a digest of that material means a cache is never attached to a
+/// request built from something else — previously a single Runner-wide name was reused
+/// across sessions and across whichever sub-agent was selected.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct CacheKey {
+    /// Model the cache was created against; a cache is provider- and model-specific.
+    model: String,
+    /// Agent whose instruction the cache holds.
+    agent: String,
+    /// Canonical digest of the instruction and tool material.
+    material: String,
+}
+
+impl CacheKey {
+    /// Build a key from the exact material a cache will be created from.
+    pub(crate) fn new(model: &str, agent: &str, instruction: &str, tool_names: &[String]) -> Self {
+        // Readable and canonical rather than hashed: tool order cannot change the key,
+        // and a mismatch can be diagnosed by looking at it.
+        let mut tools = tool_names.to_vec();
+        tools.sort();
+        Self {
+            model: model.to_string(),
+            agent: agent.to_string(),
+            material: format!("{instruction}\u{1f}{}", tools.join(",")),
+        }
+    }
+}
+
+/// One cached context and how many invocations have used it.
+#[derive(Debug, Clone)]
+struct CacheEntry {
+    name: String,
     invocation_count: u32,
 }
 
+/// Internal cache lifecycle manager.
+///
+/// Tracks a bounded map of caches keyed by [`CacheKey`], so a cache is reused only for
+/// byte-equivalent material on the same model and agent, and determines when caching
+/// should be attempted or refreshed based on [`ContextCacheConfig`] settings.
+pub(crate) struct CacheManager {
+    config: ContextCacheConfig,
+    /// Live caches, keyed by the material they hold.
+    entries: std::collections::HashMap<CacheKey, CacheEntry>,
+    /// Insertion order, used to evict the oldest entry when at capacity.
+    order: std::collections::VecDeque<CacheKey>,
+}
+
+/// Number of distinct cached contexts held at once.
+///
+/// A bound matters because the key includes the agent and its instruction: a deployment
+/// with many agents, or instructions that vary, would otherwise accumulate provider-side
+/// caches for the lifetime of the process.
+const MAX_CACHE_ENTRIES: usize = 16;
+
 impl CacheManager {
     pub(crate) fn new(config: ContextCacheConfig) -> Self {
-        Self { config, active_cache_name: None, invocation_count: 0 }
+        Self {
+            config,
+            entries: std::collections::HashMap::new(),
+            order: std::collections::VecDeque::new(),
+        }
     }
 
     /// Check if caching should be attempted based on config.
@@ -29,39 +80,61 @@ impl CacheManager {
         self.config.min_tokens > 0 && self.config.ttl_seconds > 0
     }
 
-    /// Return the active cache name, if any.
-    pub(crate) fn active_cache_name(&self) -> Option<&str> {
-        self.active_cache_name.as_deref()
+    /// The cache for exactly this material, if one is live.
+    #[cfg(test)]
+    pub(crate) fn cache_name_for(&self, key: &CacheKey) -> Option<&str> {
+        self.entries.get(key).map(|entry| entry.name.as_str())
     }
 
-    /// Check if the cache needs refresh based on invocation count.
+    /// Whether the cache for this material needs recreating.
     ///
-    /// Returns `true` when the number of recorded invocations has
-    /// reached or exceeded `cache_intervals`.
-    pub(crate) fn needs_refresh(&self) -> bool {
-        self.invocation_count >= self.config.cache_intervals
+    /// True when nothing is cached for it, or when the entry has served
+    /// `cache_intervals` invocations.
+    pub(crate) fn needs_refresh(&self, key: &CacheKey) -> bool {
+        match self.entries.get(key) {
+            None => true,
+            Some(entry) => entry.invocation_count >= self.config.cache_intervals,
+        }
     }
 
-    /// Record an invocation and return the current cache name (if any).
-    pub(crate) fn record_invocation(&mut self) -> Option<&str> {
-        self.invocation_count += 1;
-        self.active_cache_name.as_deref()
+    /// Record an invocation against this material and return its cache name.
+    pub(crate) fn record_invocation(&mut self, key: &CacheKey) -> Option<&str> {
+        let entry = self.entries.get_mut(key)?;
+        entry.invocation_count += 1;
+        Some(entry.name.as_str())
     }
 
-    /// Set the active cache name after creation, resetting the
-    /// invocation counter.
-    pub(crate) fn set_active_cache(&mut self, name: String) {
-        self.active_cache_name = Some(name);
-        self.invocation_count = 0;
-    }
-
-    /// Clear the active cache (after deletion or on error),
-    /// resetting the invocation counter.
+    /// Store a freshly created cache, returning any name it replaces.
     ///
-    /// Returns the previously active cache name, if any.
-    pub(crate) fn clear_active_cache(&mut self) -> Option<String> {
-        self.invocation_count = 0;
-        self.active_cache_name.take()
+    /// The replaced name is returned so the caller can delete it provider-side rather
+    /// than leaking it. Storing at capacity evicts the oldest entry, whose name is
+    /// returned for the same reason.
+    pub(crate) fn store(&mut self, key: CacheKey, name: String) -> Vec<String> {
+        let mut replaced = Vec::new();
+
+        if let Some(previous) =
+            self.entries.insert(key.clone(), CacheEntry { name, invocation_count: 0 })
+        {
+            replaced.push(previous.name);
+        } else {
+            self.order.push_back(key);
+        }
+
+        while self.order.len() > MAX_CACHE_ENTRIES {
+            if let Some(oldest) = self.order.pop_front()
+                && let Some(evicted) = self.entries.remove(&oldest)
+            {
+                replaced.push(evicted.name);
+            }
+        }
+
+        replaced
+    }
+
+    /// Number of caches currently held.
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.entries.len()
     }
 }
 
@@ -166,11 +239,15 @@ mod tests {
         ContextCacheConfig { min_tokens: 4096, ttl_seconds: 600, cache_intervals: 3 }
     }
 
+    fn key(agent: &str, instruction: &str) -> CacheKey {
+        CacheKey::new("gemini-2.5-flash", agent, instruction, &[])
+    }
+
     #[test]
-    fn test_new_manager_has_no_active_cache() {
+    fn a_new_manager_holds_nothing() {
         let cm = CacheManager::new(default_config());
-        assert!(cm.active_cache_name.is_none());
-        assert_eq!(cm.invocation_count, 0);
+        assert_eq!(cm.len(), 0);
+        assert!(cm.cache_name_for(&key("a", "be helpful")).is_none());
     }
 
     #[test]
@@ -182,122 +259,125 @@ mod tests {
     #[test]
     fn test_is_enabled_false_when_min_tokens_zero() {
         let config = ContextCacheConfig { min_tokens: 0, ttl_seconds: 600, cache_intervals: 3 };
-        let cm = CacheManager::new(config);
-        assert!(!cm.is_enabled());
+        assert!(!CacheManager::new(config).is_enabled());
     }
 
     #[test]
     fn test_is_enabled_false_when_ttl_zero() {
         let config = ContextCacheConfig { min_tokens: 4096, ttl_seconds: 0, cache_intervals: 3 };
-        let cm = CacheManager::new(config);
-        assert!(!cm.is_enabled());
+        assert!(!CacheManager::new(config).is_enabled());
     }
 
     #[test]
-    fn test_is_enabled_false_when_both_zero() {
-        let config = ContextCacheConfig { min_tokens: 0, ttl_seconds: 0, cache_intervals: 3 };
-        let cm = CacheManager::new(config);
-        assert!(!cm.is_enabled());
-    }
-
-    #[test]
-    fn test_needs_refresh_false_initially() {
+    fn unknown_material_needs_a_cache() {
         let cm = CacheManager::new(default_config());
-        assert!(!cm.needs_refresh());
+        assert!(cm.needs_refresh(&key("a", "be helpful")));
     }
 
     #[test]
-    fn test_needs_refresh_true_after_n_invocations() {
+    fn a_stored_cache_is_reused_until_its_interval_elapses() {
         let mut cm = CacheManager::new(default_config());
-        // cache_intervals = 3, so after 3 invocations needs_refresh should be true
-        cm.record_invocation();
-        assert!(!cm.needs_refresh());
-        cm.record_invocation();
-        assert!(!cm.needs_refresh());
-        cm.record_invocation();
-        assert!(cm.needs_refresh());
+        let k = key("a", "be helpful");
+        cm.store(k.clone(), "cachedContents/1".to_string());
+
+        assert!(!cm.needs_refresh(&k));
+        assert_eq!(cm.record_invocation(&k), Some("cachedContents/1"));
+        assert_eq!(cm.record_invocation(&k), Some("cachedContents/1"));
+        assert!(!cm.needs_refresh(&k));
+        assert_eq!(cm.record_invocation(&k), Some("cachedContents/1"));
+        assert!(cm.needs_refresh(&k), "three invocations reaches cache_intervals");
     }
 
     #[test]
-    fn test_record_invocation_returns_none_without_active_cache() {
+    fn different_agents_do_not_share_a_cache() {
+        // A cache made while one sub-agent was selected must not be attached to a
+        // request for another.
         let mut cm = CacheManager::new(default_config());
-        assert!(cm.record_invocation().is_none());
+        cm.store(key("planner", "plan carefully"), "cachedContents/planner".to_string());
+
+        assert!(cm.cache_name_for(&key("writer", "plan carefully")).is_none());
+        assert!(cm.needs_refresh(&key("writer", "plan carefully")));
     }
 
     #[test]
-    fn test_record_invocation_returns_cache_name() {
+    fn changed_instruction_material_invalidates_reuse() {
         let mut cm = CacheManager::new(default_config());
-        cm.set_active_cache("cachedContents/abc123".to_string());
-        let name = cm.record_invocation();
-        assert_eq!(name, Some("cachedContents/abc123"));
+        cm.store(key("a", "be helpful"), "cachedContents/1".to_string());
+
+        assert!(
+            cm.needs_refresh(&key("a", "be terse")),
+            "a cache must not be reused for different instruction material"
+        );
     }
 
     #[test]
-    fn test_set_active_cache_resets_invocation_count() {
+    fn different_models_do_not_share_a_cache() {
         let mut cm = CacheManager::new(default_config());
-        cm.record_invocation();
-        cm.record_invocation();
-        assert_eq!(cm.invocation_count, 2);
-
-        cm.set_active_cache("cachedContents/new".to_string());
-        assert_eq!(cm.invocation_count, 0);
-        assert_eq!(cm.active_cache_name.as_deref(), Some("cachedContents/new"));
+        cm.store(
+            CacheKey::new("gemini-2.5-flash", "a", "be helpful", &[]),
+            "cachedContents/flash".to_string(),
+        );
+        let other = CacheKey::new("gemini-3-pro", "a", "be helpful", &[]);
+        assert!(cm.cache_name_for(&other).is_none());
     }
 
     #[test]
-    fn test_clear_active_cache_returns_old_name() {
+    fn tool_order_does_not_change_identity() {
+        let one = CacheKey::new("m", "a", "i", &["b".to_string(), "a".to_string()]);
+        let two = CacheKey::new("m", "a", "i", &["a".to_string(), "b".to_string()]);
+        assert_eq!(one, two);
+    }
+
+    #[test]
+    fn storing_the_same_material_twice_reports_the_replaced_name() {
         let mut cm = CacheManager::new(default_config());
-        cm.set_active_cache("cachedContents/old".to_string());
-        cm.record_invocation();
+        let k = key("a", "be helpful");
+        assert!(cm.store(k.clone(), "cachedContents/1".to_string()).is_empty());
 
-        let old = cm.clear_active_cache();
-        assert_eq!(old.as_deref(), Some("cachedContents/old"));
-        assert!(cm.active_cache_name.is_none());
-        assert_eq!(cm.invocation_count, 0);
+        let replaced = cm.store(k, "cachedContents/2".to_string());
+        assert_eq!(
+            replaced,
+            vec!["cachedContents/1".to_string()],
+            "the superseded cache must be reported so it can be deleted provider-side"
+        );
+        assert_eq!(cm.len(), 1);
     }
 
     #[test]
-    fn test_clear_active_cache_returns_none_when_empty() {
+    fn the_map_is_bounded_and_reports_evictions() {
         let mut cm = CacheManager::new(default_config());
-        let old = cm.clear_active_cache();
-        assert!(old.is_none());
+        let mut evicted = Vec::new();
+        for index in 0..(MAX_CACHE_ENTRIES + 4) {
+            evicted.extend(cm.store(key(&format!("agent-{index}"), "i"), format!("cache/{index}")));
+        }
+
+        assert_eq!(cm.len(), MAX_CACHE_ENTRIES, "the cache map must stay bounded");
+        assert_eq!(evicted.len(), 4, "each eviction must be reported for deletion");
+        assert_eq!(evicted[0], "cache/0", "the oldest entry is evicted first");
     }
 
     #[test]
-    fn test_full_lifecycle() {
+    fn a_full_lifecycle_stays_keyed() {
         let mut cm = CacheManager::new(ContextCacheConfig {
             min_tokens: 1024,
             ttl_seconds: 300,
             cache_intervals: 2,
         });
+        let k = key("a", "be helpful");
 
         assert!(cm.is_enabled());
-        assert!(!cm.needs_refresh());
+        assert!(cm.needs_refresh(&k), "nothing is cached yet");
 
-        // No cache yet
-        assert!(cm.record_invocation().is_none());
+        cm.store(k.clone(), "cachedContents/first".to_string());
+        assert_eq!(cm.record_invocation(&k), Some("cachedContents/first"));
+        assert!(!cm.needs_refresh(&k));
+        assert_eq!(cm.record_invocation(&k), Some("cachedContents/first"));
+        assert!(cm.needs_refresh(&k), "two invocations reaches cache_intervals");
 
-        // Set a cache
-        cm.set_active_cache("cachedContents/v1".to_string());
-        assert_eq!(cm.invocation_count, 0);
-
-        // First invocation returns cache name
-        assert_eq!(cm.record_invocation(), Some("cachedContents/v1"));
-        assert!(!cm.needs_refresh());
-
-        // Second invocation triggers refresh
-        assert_eq!(cm.record_invocation(), Some("cachedContents/v1"));
-        assert!(cm.needs_refresh());
-
-        // Refresh: clear old, set new
-        let old = cm.clear_active_cache();
-        assert_eq!(old.as_deref(), Some("cachedContents/v1"));
-        cm.set_active_cache("cachedContents/v2".to_string());
-        assert!(!cm.needs_refresh());
-        assert_eq!(cm.record_invocation(), Some("cachedContents/v2"));
+        let replaced = cm.store(k.clone(), "cachedContents/second".to_string());
+        assert_eq!(replaced, vec!["cachedContents/first".to_string()]);
+        assert!(!cm.needs_refresh(&k), "a fresh cache resets the interval");
     }
-
-    // --- CachePerformanceAnalyzer tests ---
 
     use adk_core::{LlmResponse, UsageMetadata};
 
@@ -331,20 +411,8 @@ mod tests {
         let metrics = CachePerformanceAnalyzer::analyze(&[]);
         assert_eq!(metrics.total_requests, 0);
         assert_eq!(metrics.requests_with_cache_hits, 0);
-        assert_eq!(metrics.total_prompt_tokens, 0);
-        assert_eq!(metrics.total_cache_read_tokens, 0);
-        assert_eq!(metrics.total_cache_creation_tokens, 0);
         assert_eq!(metrics.cache_hit_ratio, 0.0);
         assert_eq!(metrics.cache_utilization_ratio, 0.0);
-        assert_eq!(metrics.avg_cached_tokens_per_request, 0.0);
-    }
-
-    #[test]
-    fn test_analyze_events_without_usage_metadata() {
-        let events = vec![event_without_usage(), event_without_usage()];
-        let metrics = CachePerformanceAnalyzer::analyze(&events);
-        assert_eq!(metrics.total_requests, 0);
-        assert_eq!(metrics.cache_hit_ratio, 0.0);
     }
 
     #[test]

--- a/adk-runner/src/runner.rs
+++ b/adk-runner/src/runner.rs
@@ -556,53 +556,72 @@ impl Runner {
             // create or refresh the cached content before agent execution.
             // Cache failures are non-fatal — log a warning and proceed without cache.
             if let (Some(cm_mutex), Some(cache_model)) = (&cache_manager_ref, &cache_capable) {
-                let should_refresh_cache = {
-                    let cm = cm_mutex.lock().await;
-                    cm.is_enabled() && (cm.active_cache_name().is_none() || cm.needs_refresh())
-                };
+                // Cache only material the agent will actually send. An agent whose
+                // instruction is computed per request returns `None`, and caching is
+                // skipped rather than caching a stand-in such as the description — a
+                // cache built from different text than the request it is attached to is
+                // either ignored by the provider or applies the wrong instruction.
+                let cache_key = agent_to_run.cacheable_instruction().map(|instruction| {
+                    // Tools are resolved inside the agent, so the key records that this
+                    // cache covers instruction material only.
+                    crate::cache::CacheKey::new(
+                        cache_model.cache_scope(),
+                        agent_to_run.name(),
+                        instruction,
+                        &[],
+                    )
+                });
 
-                if should_refresh_cache {
-                    // Gather system instruction from the agent's description
-                    // (the full instruction is resolved inside the agent, but the
-                    // description provides a reasonable proxy for cache keying).
-                    let system_instruction = agent_to_run.description().to_string();
-                    let tools = std::collections::HashMap::new();
-                    let ttl = context_cache_config.as_ref().map_or(600, |c| c.ttl_seconds);
+                let cache_name = match cache_key {
+                    None => None,
+                    Some(key) => {
+                        let should_refresh = {
+                            let cm = cm_mutex.lock().await;
+                            cm.is_enabled() && cm.needs_refresh(&key)
+                        };
 
-                    match cache_model.create_cache(&system_instruction, &tools, ttl).await {
-                        Ok(name) => {
-                            let old_cache = {
-                                let mut cm = cm_mutex.lock().await;
-                                let old = cm.clear_active_cache();
-                                cm.set_active_cache(name);
-                                old
-                            };
+                        if should_refresh {
+                            let instruction = agent_to_run
+                                .cacheable_instruction()
+                                .unwrap_or_default()
+                                .to_string();
+                            let tools = std::collections::HashMap::new();
+                            let ttl =
+                                context_cache_config.as_ref().map_or(600, |c| c.ttl_seconds);
 
-                            if let Some(old) = old_cache
-                                && let Err(e) = cache_model.delete_cache(&old).await {
+                            match cache_model.create_cache(&instruction, &tools, ttl).await {
+                                Ok(name) => {
+                                    let superseded = {
+                                        let mut cm = cm_mutex.lock().await;
+                                        cm.store(key.clone(), name)
+                                    };
+                                    // Delete what this replaced or evicted, so provider
+                                    // caches are not leaked.
+                                    for old in superseded {
+                                        if let Err(e) = cache_model.delete_cache(&old).await {
+                                            tracing::warn!(
+                                                old_cache = %old,
+                                                error = %e,
+                                                "failed to delete superseded cache"
+                                            );
+                                        }
+                                    }
+                                }
+                                Err(e) => {
                                     tracing::warn!(
-                                        old_cache = %old,
                                         error = %e,
-                                        "failed to delete old cache, proceeding with new cache"
+                                        "cache creation failed, proceeding without cache"
                                     );
                                 }
+                            }
                         }
-                        Err(e) => {
-                            tracing::warn!(
-                                error = %e,
-                                "cache creation failed, proceeding without cache"
-                            );
-                        }
-                    }
-                }
 
-                // Attach cache name to run config so agents can use it.
-                let cache_name = {
-                    let mut cm = cm_mutex.lock().await;
-                    if cm.is_enabled() {
-                        cm.record_invocation().map(str::to_string)
-                    } else {
-                        None
+                        let mut cm = cm_mutex.lock().await;
+                        if cm.is_enabled() {
+                            cm.record_invocation(&key).map(str::to_string)
+                        } else {
+                            None
+                        }
                     }
                 };
 

--- a/docs/official_docs/core/runner.md
+++ b/docs/official_docs/core/runner.md
@@ -159,6 +159,34 @@ let mut stream = runner.run_str(
 
 If the string fails validation (empty, contains null bytes, or exceeds the length limit), `run_str()` returns an error before starting the agent loop. The existing `run()` method with typed `UserId`/`SessionId` remains unchanged.
 
+## Context Caching
+
+Setting `context_cache_config` and `cache_capable` lets the runner create provider-side
+cached content and attach it to requests.
+
+A cache is only valid for the material it was built from, so the runner identifies each
+one by **model, agent, and a digest of the cached material** and holds a bounded map (16
+entries, oldest evicted) rather than a single name. Consequences worth knowing:
+
+| Situation | Behaviour |
+|-----------|-----------|
+| Two agents with different instructions | Separate caches; one is never attached to the other's request |
+| The same agent on a different model | Separate caches |
+| The instruction text changes | The old cache is not reused; a new one is created and the old one deleted |
+| A cache is superseded or evicted | Deleted provider-side, so caches are not leaked |
+
+Caching applies only to an agent's **fixed** instruction, read through
+`Agent::cacheable_instruction`. `LlmAgent` returns its static instruction, and returns
+`None` when an instruction *provider* is configured, because that text depends on the
+request. When it returns `None`, caching is skipped — the runner will not cache a
+stand-in such as the agent description, since a cache built from different text than the
+request it is attached to is either ignored by the provider or applies the wrong
+instruction.
+
+> **Note:** tools are resolved inside the agent, so a cache currently covers instruction
+> material only. Refresh is still counted in invocations via `cache_intervals`, per
+> cache entry rather than per runner.
+
 ## Interruption and Run Isolation
 
 A run is registered as soon as `run()` returns its stream, and deregistered when


### PR DESCRIPTION
## What

Provider context caches are identified by the material they hold — model, agent, and a digest of the cached text — in a bounded map, instead of one Runner-global name built from the agent's *description*.

## Why

```rust
struct CacheManager {
    active_cache_name: Option<String>,   // one, for the whole Runner
    invocation_count: u32,               // one counter
}
```

and at the creation site:

```rust
// "the description provides a reasonable proxy for cache keying"
let system_instruction = agent_to_run.description().to_string();
let tools = std::collections::HashMap::new();
```

Three separate problems:

| Problem | Consequence |
|---|---|
| One name per Runner, reused across sessions and across whichever sub-agent was selected | A cache built for one agent could be attached to a request for another |
| Refresh driven by a Runner-wide invocation counter | Refresh had nothing to do with the content changing |
| Cache built from `description()` with an empty tool map | The cached text was **never** the text being sent |

A cache that does not represent its request is either ignored by the provider or applies the wrong instruction. The third point is the root: keying could not be fixed while the material was a stand-in.

## How

| Change | Effect |
|---|---|
| `CacheKey { model, agent, material digest }` | Reuse only for byte-equivalent material on the same model and agent |
| Bounded map (16, oldest evicted) | The key includes the instruction, so an unbounded map would accumulate provider caches for the process lifetime |
| `store` returns superseded and evicted names | The runner deletes them provider-side instead of leaking them |
| `Agent::cacheable_instruction` (defaulted `None`) | The material is what the agent will actually send |
| `CacheCapable::cache_scope` (defaulted, `GeminiModel` implements) | Caches for different models stay apart |

`LlmAgent` returns its static instruction, and returns `None` when an instruction **provider** is configured, because that text depends on the request. On `None` the runner **skips caching** rather than substituting something else.

## Scope, stated plainly

Tools are resolved inside `LlmAgent`, so a cache currently covers instruction material only. The key records that fact and the docs say it, rather than implying tools are covered. Fully keying on provider-normalized system *and* tool material would mean resolving tools before dispatch or moving the cache lifecycle into the agent — a larger change than this.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo nextest run -p adk-runner` | 116 passed |
| `cargo nextest run --workspace --profile ci` | **3819 passed**, 83 skipped, 2 failed — pre-existing, see below |
| `RUSTDOCFLAGS=-D warnings cargo doc -p adk-runner -p adk-core` | exit 0 |
| `cargo semver-checks -p adk-core --release-type minor` | only the 3 breakages already recorded for 2.0.0 — the new trait methods are defaulted |
| doc-examples guard | exit 0 |

The `CacheManager` unit tests are rewritten around the keyed manager: distinct agents, changed instruction text, and distinct models each get their own entry; tool order does not affect identity; superseded and evicted names are reported for deletion; and the map stays bounded at 16 with the oldest evicted first.

The old tests asserted counters on a single global name — exactly the shape the finding identified as insufficient — so they are replaced rather than extended.

### The two failures are not from this PR

`adk-code::rust_sandbox_property_tests::{test_timeout_during_execution_phase, test_timeout_produces_timeout_failure_short}` fail identically on clean `main`: the executor links `serde_json` from an rlib in `target/debug/deps`, and the newest ones here were built by rustc 1.95.0 (from #479) while `main` uses 1.94.0, so rustc rejects the metadata in 0.08 s — `CompileFailed` where the test expects `Timeout`. Local artifact contamination; CI builds clean.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass (except the two pre-existing failures above)
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed — n/a
- [x] Examples added or updated for new features — n/a