### PR TITLE
fix(devtools): clear the bash environment and kill process groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **adk-devtools: `bash` no longer inherits the agent's environment, and a timeout takes
+  descendants with it.** `BashTool` ran `sh -c` with only `current_dir` set. It never
+  called `env_clear`, so a model-directed command could read the parent environment — an
+  agent process routinely holds provider API keys — with nothing more than `env`. A
+  timeout called `start_kill` on the direct child, so anything `sh` had started (a
+  background build, a spawned server) kept running after the tool returned.
+
+  The command now receives only `PATH`, `HOME`, `LANG`, `LC_ALL`, `TMPDIR`, `TERM`,
+  `USER`, and `SHELL`; `Workspace::inherit_env(true)` restores the previous behaviour and
+  `env_allowlist` replaces the set. The child leads its own process group and a timeout
+  signals the group, so descendants are killed too. Goal-mode `--until` checks in the CLI
+  run under the same policy, so a check cannot see credentials the agent cannot.
+
+  The surface is no longer described as sandboxed. A working directory is not an OS
+  boundary: `bash` can still use absolute paths and reach the network, and nothing limits
+  memory or CPU. The CLI help, README, and coding-agent docs now say what is enforced —
+  path containment for file tools, environment isolation, bounded output and time — and
+  what is not.
+
 - **adk-core/adk-auth: secret access from tools is authorizable and audited.**
   `SecretService` and `SecretProvider` received only a secret *name*. Once a provider
   was attached to an invocation, policy collapsed to whatever the backing cloud

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,6 +427,7 @@ dependencies = [
  "adk-core",
  "async-trait",
  "glob",
+ "libc",
  "regex",
  "serde",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -551,7 +551,7 @@ Examples live in the dedicated [adk-playground](https://github.com/zavora-ai/adk
 
 ### Coding Agent
 
-A native coding agent: read/edit/run code in a **sandboxed workspace**, plan with
+A native coding agent: read/edit/run code in a **confined workspace**, plan with
 todos, iterate toward a goal autonomously, and orchestrate parallel reviewers —
 on any provider. Build one in a single call:
 
@@ -574,7 +574,7 @@ adk-rust goal "all tests green" --until "cargo test" --resume    # autonomous, d
 adk-rust ultracode "add input validation"                        # parallel ultra-review
 ```
 
-- **`code`** — one-shot tasks in a sandboxed dir (`adk-devtools`: read/write/edit/glob/grep/bash).
+- **`code`** — one-shot tasks confined to a workspace dir (`adk-devtools`: read/write/edit/glob/grep/bash). File tools are path-contained; `bash` runs host-local with a cleared environment, not in an OS sandbox.
 - **`goal`** — Codex/Hermes-style autonomous loop (plan → act → verify against a
   `--until` command), **durable & resumable** via an on-disk checkpoint.
 - **`ultracode`** — Claude Code-style fan-out to parallel correctness/edge-case/style

--- a/adk-cli/src/cli.rs
+++ b/adk-cli/src/cli.rs
@@ -64,13 +64,14 @@ pub enum Commands {
 
     /// Run the coding agent on a task in a workspace directory.
     ///
-    /// The agent can read/edit files and run commands, sandboxed to the
+    /// The agent can read/edit files and run commands, confined to the
     /// directory. Example: `adk-rust code "make the failing test pass"`
     Code {
         /// The task / instruction for the agent.
         task: String,
 
-        /// Workspace directory the agent operates in (sandboxed).
+        /// Workspace directory the agent operates in. File tools are confined to it;
+        /// `bash` runs on the host with the environment cleared, not in an OS sandbox.
         #[arg(short, long, default_value = ".")]
         dir: String,
 
@@ -92,7 +93,8 @@ pub enum Commands {
         #[arg(long)]
         until: String,
 
-        /// Workspace directory the agent operates in (sandboxed).
+        /// Workspace directory the agent operates in. File tools are confined to it;
+        /// `bash` runs on the host with the environment cleared, not in an OS sandbox.
         #[arg(short, long, default_value = ".")]
         dir: String,
 
@@ -118,7 +120,8 @@ pub enum Commands {
         /// The task to implement and review.
         task: String,
 
-        /// Workspace directory the agent operates in (sandboxed).
+        /// Workspace directory the agent operates in. File tools are confined to it;
+        /// `bash` runs on the host with the environment cleared, not in an OS sandbox.
         #[arg(short, long, default_value = ".")]
         dir: String,
 

--- a/adk-cli/src/main.rs
+++ b/adk-cli/src/main.rs
@@ -166,8 +166,23 @@ async fn stream_turn(runner: &Runner, session_id: &str, prompt: &str) -> Result<
 }
 
 /// Run a shell command in `dir`; returns (exit_code, combined stdout+stderr).
+/// Run the goal-mode success check.
+///
+/// Uses the same environment policy as the agent's `bash` tool, so a check cannot see
+/// credentials the agent itself is not allowed to see.
 fn run_check(dir: &str, command: &str) -> (Option<i32>, String) {
-    match std::process::Command::new("sh").arg("-c").arg(command).current_dir(dir).output() {
+    let mut cmd = std::process::Command::new("sh");
+    cmd.arg("-c").arg(command).current_dir(dir);
+
+    let workspace = adk_devtools::Workspace::new(dir);
+    if !workspace.inherits_env() {
+        cmd.env_clear();
+        for (key, value) in workspace.bash_env() {
+            cmd.env(key, value);
+        }
+    }
+
+    match cmd.output() {
         Ok(o) => {
             let mut out = String::from_utf8_lossy(&o.stdout).to_string();
             out.push_str(&String::from_utf8_lossy(&o.stderr));

--- a/adk-devtools/Cargo.toml
+++ b/adk-devtools/Cargo.toml
@@ -20,14 +20,18 @@ serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 tokio = { workspace = true, features = ["fs", "process", "time", "io-util", "rt", "macros"] }
-
-[target.'cfg(unix)'.dependencies]
-libc = "0.2"
 regex.workspace = true
 walkdir = "2.5"
 glob = "0.3"
 
-[dev-dependencies]
+# Only used for the process-group kill that stops a timed-out command's descendants.
+[target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+# The bash boundary tests are `#![cfg(unix)]` and probe liveness with `libc::kill`.
+[target.'cfg(unix)'.dev-dependencies]
+libc = "0.2"
+
+[dev-dependencies]
 tempfile = "3"
 tokio = { workspace = true, features = ["full"] }

--- a/adk-devtools/Cargo.toml
+++ b/adk-devtools/Cargo.toml
@@ -20,10 +20,14 @@ serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 tokio = { workspace = true, features = ["fs", "process", "time", "io-util", "rt", "macros"] }
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
 regex.workspace = true
 walkdir = "2.5"
 glob = "0.3"
 
 [dev-dependencies]
+libc = "0.2"
 tempfile = "3"
 tokio = { workspace = true, features = ["full"] }

--- a/adk-devtools/src/lib.rs
+++ b/adk-devtools/src/lib.rs
@@ -41,4 +41,4 @@ pub mod tools;
 pub use error::DevToolError;
 pub use tools::{BashTool, EditFileTool, GlobTool, GrepTool, ReadFileTool, WriteFileTool};
 pub use toolset::DevToolset;
-pub use workspace::Workspace;
+pub use workspace::{DEFAULT_ENV_ALLOWLIST, Workspace};

--- a/adk-devtools/src/tools/bash.rs
+++ b/adk-devtools/src/tools/bash.rs
@@ -71,14 +71,30 @@ impl Tool for BashTool {
             .map(Duration::from_secs)
             .unwrap_or_else(|| self.workspace.bash_timeout_value());
 
-        let mut child = tokio::process::Command::new("sh")
-            .arg("-c")
+        let mut cmd = tokio::process::Command::new("sh");
+        cmd.arg("-c")
             .arg(&command)
             .current_dir(self.workspace.root())
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .map_err(DevToolError::from)?;
+            .stderr(Stdio::piped());
+
+        // The parent environment of an agent process routinely holds provider API keys,
+        // and `env` would print them. Pass through only what tools need, unless the
+        // workspace opts into inheriting.
+        if !self.workspace.inherits_env() {
+            cmd.env_clear();
+            for (key, value) in self.workspace.bash_env() {
+                cmd.env(key, value);
+            }
+        }
+
+        // Run in its own process group so a timeout can terminate descendants. Killing
+        // only the direct child left `sh`'s children running after the tool returned.
+        #[cfg(unix)]
+        cmd.process_group(0);
+
+        let mut child = cmd.spawn().map_err(DevToolError::from)?;
+        let child_pid = child.id();
 
         let stdout_pipe = child.stdout.take();
         let stderr_pipe = child.stderr.take();
@@ -136,13 +152,34 @@ impl Tool for BashTool {
             }
             Ok(Err(e)) => Err(DevToolError::from(e).into()),
             Err(_) => {
-                let _ = child.start_kill();
+                terminate_process_group(&mut child, child_pid);
                 ctx.emit_progress("stderr", &format!("\n[timeout after {}s]\n", timeout.as_secs()))
                     .await;
                 Err(DevToolError::Timeout(timeout).into())
             }
         }
     }
+}
+
+/// Terminate a timed-out command and everything it started.
+///
+/// The child leads its own process group, so signalling the negated pid reaches
+/// grandchildren too. Killing only the direct child left descendants — a spawned server,
+/// a background build — running after the tool returned.
+fn terminate_process_group(child: &mut tokio::process::Child, pid: Option<u32>) {
+    #[cfg(unix)]
+    if let Some(pid) = pid {
+        // SAFETY: `killpg` takes a process-group id and a signal, and cannot violate
+        // memory safety. A failure means the group already exited.
+        unsafe {
+            libc::killpg(pid as libc::pid_t, libc::SIGKILL);
+        }
+    }
+    #[cfg(not(unix))]
+    let _ = pid;
+
+    // Also signal the child directly, which is all that is available off Unix.
+    let _ = child.start_kill();
 }
 
 fn truncate(mut s: String, cap: usize) -> (String, bool) {

--- a/adk-devtools/src/workspace.rs
+++ b/adk-devtools/src/workspace.rs
@@ -27,7 +27,19 @@ pub struct Workspace {
     bash_timeout: Duration,
     max_output_bytes: usize,
     read_tracker: Arc<Mutex<HashSet<PathBuf>>>,
+    /// Whether `bash` inherits the parent process environment.
+    inherit_env: bool,
+    /// Variables passed through when the environment is not inherited.
+    env_allowlist: Vec<String>,
 }
+
+/// Environment variables `bash` receives by default.
+///
+/// The parent environment of an agent process routinely holds provider API keys, and a
+/// model-directed command could read them with `env`. Only variables tools genuinely
+/// need to function are passed through, and none of them is a credential.
+pub const DEFAULT_ENV_ALLOWLIST: &[&str] =
+    &["PATH", "HOME", "LANG", "LC_ALL", "TMPDIR", "TERM", "USER", "SHELL"];
 
 impl Workspace {
     /// Create a read-write workspace rooted at `root` (bash enabled).
@@ -43,6 +55,8 @@ impl Workspace {
             bash_timeout: Duration::from_secs(120),
             max_output_bytes: 1_048_576,
             read_tracker: Arc::new(Mutex::new(HashSet::new())),
+            inherit_env: false,
+            env_allowlist: DEFAULT_ENV_ALLOWLIST.iter().map(|k| (*k).to_string()).collect(),
         }
     }
 
@@ -77,6 +91,51 @@ impl Workspace {
     pub fn max_output_bytes(mut self, bytes: usize) -> Self {
         self.max_output_bytes = bytes;
         self
+    }
+
+    /// Pass the whole parent environment to `bash`.
+    ///
+    /// Off by default, because the parent environment of an agent process routinely
+    /// holds provider API keys and a model-directed command can read them with `env`.
+    /// Enable it only when the commands you run genuinely need the caller's environment
+    /// and you accept that exposure.
+    #[must_use]
+    pub fn inherit_env(mut self, yes: bool) -> Self {
+        self.inherit_env = yes;
+        self
+    }
+
+    /// Replace the variables `bash` receives when the environment is not inherited.
+    ///
+    /// Defaults to [`DEFAULT_ENV_ALLOWLIST`]. Adding a variable that holds a credential
+    /// re-exposes it.
+    #[must_use]
+    pub fn env_allowlist<I, S>(mut self, keys: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.env_allowlist = keys.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Whether `bash` inherits the parent environment.
+    pub fn inherits_env(&self) -> bool {
+        self.inherit_env
+    }
+
+    /// The variables `bash` receives, resolved from the current process.
+    ///
+    /// Empty when the environment is inherited, in which case the caller must not clear
+    /// it.
+    pub fn bash_env(&self) -> Vec<(String, String)> {
+        if self.inherit_env {
+            return Vec::new();
+        }
+        self.env_allowlist
+            .iter()
+            .filter_map(|key| std::env::var(key).ok().map(|value| (key.clone(), value)))
+            .collect()
     }
 
     /// The workspace root.

--- a/adk-devtools/tests/bash_boundary_tests.rs
+++ b/adk-devtools/tests/bash_boundary_tests.rs
@@ -1,0 +1,143 @@
+//! What a model-directed shell command can reach.
+//!
+//! `BashTool` ran `sh -c` with only `current_dir` set. It did not call `env_clear`, so
+//! the command inherited the parent environment — including provider API keys an agent
+//! process routinely holds — and a timeout called `start_kill` on the direct child only,
+//! so anything `sh` had started kept running after the tool returned.
+//!
+//! These tests state what the boundary does and does not do. A working directory is not
+//! an OS sandbox: the command can still reach absolute paths and the network. What is
+//! asserted here is the part that is enforced.
+
+#![cfg(unix)]
+
+use adk_core::{ReadonlyContext, Tool, ToolContext};
+use adk_devtools::{DevToolset, Workspace};
+use serde_json::{Value, json};
+use std::sync::Arc;
+use std::time::Duration;
+
+mod common;
+use common::TestCtx;
+
+/// Runs `command` through the toolset's bash tool.
+async fn run_bash(
+    workspace: Workspace,
+    command: &str,
+    timeout_secs: Option<u64>,
+) -> adk_core::Result<Value> {
+    let toolset = DevToolset::new(workspace);
+    let readonly_ctx: Arc<dyn ReadonlyContext> = Arc::new(TestCtx);
+    let tools = adk_core::Toolset::tools(&toolset, readonly_ctx).await.unwrap();
+    let bash: &Arc<dyn Tool> =
+        tools.iter().find(|tool| tool.name() == "bash").expect("the toolset must expose bash");
+
+    let mut args = json!({ "command": command });
+    if let Some(secs) = timeout_secs {
+        args["timeout_secs"] = json!(secs);
+    }
+    let ctx: Arc<dyn ToolContext> = Arc::new(TestCtx);
+    bash.execute(ctx, args).await
+}
+
+fn temp_workspace() -> (tempfile::TempDir, Workspace) {
+    let dir = tempfile::tempdir().unwrap();
+    let workspace = Workspace::new(dir.path());
+    (dir, workspace)
+}
+
+// ── The environment is not inherited ──────────────────────────────────
+
+#[tokio::test]
+async fn a_command_cannot_read_an_inherited_secret() {
+    // SAFETY: single-threaded setup before any command runs; mirrors how an agent
+    // process would already hold a provider key in its environment.
+    unsafe {
+        std::env::set_var("ADK_TEST_PROVIDER_KEY", "super-secret-value");
+    }
+
+    let (_dir, workspace) = temp_workspace();
+    let result = run_bash(workspace, "env", None).await.expect("env must run");
+    let stdout = result["stdout"].as_str().unwrap_or_default();
+
+    assert!(
+        !stdout.contains("super-secret-value"),
+        "a model-directed command read an inherited credential: {stdout}"
+    );
+    assert!(
+        !stdout.contains("ADK_TEST_PROVIDER_KEY"),
+        "the variable name leaked even without its value: {stdout}"
+    );
+
+    unsafe {
+        std::env::remove_var("ADK_TEST_PROVIDER_KEY");
+    }
+}
+
+#[tokio::test]
+async fn allowlisted_variables_still_reach_the_command() {
+    // Clearing everything would break the tools an agent is meant to run.
+    let (_dir, workspace) = temp_workspace();
+    let result = run_bash(workspace, "echo \"path=$PATH\"", None).await.expect("must run");
+    let stdout = result["stdout"].as_str().unwrap_or_default();
+
+    assert!(stdout.contains("path=/"), "PATH must be available or nothing can run: {stdout}");
+}
+
+#[tokio::test]
+async fn inheriting_the_environment_is_available_but_opt_in() {
+    unsafe {
+        std::env::set_var("ADK_TEST_OPT_IN", "visible");
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let workspace = Workspace::new(dir.path()).inherit_env(true);
+    let result = run_bash(workspace, "echo \"v=$ADK_TEST_OPT_IN\"", None).await.expect("must run");
+
+    assert!(
+        result["stdout"].as_str().unwrap_or_default().contains("v=visible"),
+        "opting in must actually pass the environment through"
+    );
+
+    unsafe {
+        std::env::remove_var("ADK_TEST_OPT_IN");
+    }
+}
+
+// ── A timeout takes descendants with it ───────────────────────────────
+
+#[tokio::test]
+async fn a_timeout_kills_processes_the_command_started() {
+    let dir = tempfile::tempdir().unwrap();
+    let marker = dir.path().join("grandchild.pid");
+    let workspace = Workspace::new(dir.path());
+
+    // `sh` starts a background sleep that records its own pid, then blocks. Killing only
+    // the direct child would leave that sleep running.
+    let command = format!("(sleep 30 & echo $! > {}) ; sleep 30", marker.to_string_lossy());
+    let result = run_bash(workspace, &command, Some(1)).await;
+    assert!(result.is_err(), "the command must time out");
+
+    // Give the signal a moment to land.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let pid: i32 = std::fs::read_to_string(&marker)
+        .expect("the background process must have recorded its pid")
+        .trim()
+        .parse()
+        .expect("a numeric pid");
+
+    // SAFETY: signal 0 only probes for existence and cannot violate memory safety.
+    let alive = unsafe { libc::kill(pid, 0) } == 0;
+    assert!(!alive, "a descendant (pid {pid}) survived the timeout");
+}
+
+#[tokio::test]
+async fn a_command_that_finishes_is_unaffected() {
+    // Guards against the process-group handling breaking ordinary execution.
+    let (_dir, workspace) = temp_workspace();
+    let result = run_bash(workspace, "echo hello", None).await.expect("must run");
+
+    assert_eq!(result["exit_code"], json!(0));
+    assert!(result["stdout"].as_str().unwrap_or_default().contains("hello"));
+}

--- a/docs/official_docs/coding-agent/cli.md
+++ b/docs/official_docs/coding-agent/cli.md
@@ -1,7 +1,7 @@
 # Coding Agent CLI
 
 The `adk-rust` CLI ships three native coding commands. All run a real agent in a
-**sandboxed workspace**, default to a Gemini 3 model, and resolve the API key
+**confined workspace**, default to a Gemini 3 model, and resolve the API key
 non-interactively from `--api-key` or the environment
 (`GEMINI_API_KEY`/`GOOGLE_API_KEY`, `OPENAI_API_KEY`, …) — so they never block on
 a setup prompt.

--- a/docs/official_docs/coding-agent/devtools.md
+++ b/docs/official_docs/coding-agent/devtools.md
@@ -1,7 +1,7 @@
 # Dev Tools (`adk-devtools`)
 
 `adk-devtools` is the inner-loop toolset a coding agent needs — read, edit,
-search, and run — with every operation **scoped to a sandboxed workspace**. It's
+search, and run — with every operation **scoped to a workspace directory**. It's
 a standalone, publishable crate depending only on `adk-core`, so it composes with
 any `LlmAgent` (the [`CodingAgent`](harness.md) harness wires it for you).
 
@@ -65,7 +65,13 @@ let ws = Workspace::new("./my-repo")
   write into the workspace concurrently.
 - **Read-only mode** — `Workspace::read_only(..)` hides the mutating tools
   entirely (the model only ever sees `read_file`/`glob`/`grep`).
-- **`bash` timeout + output caps** — long or chatty commands are bounded.
+- **`bash` environment is cleared** — the command receives only `PATH`, `HOME`, `LANG`,
+  `LC_ALL`, `TMPDIR`, `TERM`, `USER`, and `SHELL`, so provider API keys held by the agent
+  process are not readable with `env`. `Workspace::inherit_env(true)` restores the old
+  pass-everything behaviour, and `env_allowlist` replaces the set.
+- **`bash` timeout + output caps** — long or chatty commands are bounded. A timed-out
+  command is killed as a **process group**, so anything it started is killed too;
+  previously only the direct child was signalled and descendants survived.
 
 ## Using it directly
 
@@ -87,9 +93,16 @@ workspace yields a read-only agent automatically.
 
 ## Sandboxing model
 
-Phase 1 runs `bash` **host-local** (`sh -c`, working directory pinned to the
-root) with a timeout — it is path-contained and bounded, but not strongly
-OS-isolated. The policy vocabulary aligns with `adk-code`'s `SandboxPolicy`; for
+Phase 1 runs `bash` **host-local** (`sh -c`, working directory pinned to the root) with a
+timeout and a cleared environment. What that does and does not give you:
+
+| Enforced | Not enforced |
+|----------|--------------|
+| File tools cannot resolve outside the root, including through symlinks | `bash` can still use absolute paths — the working directory is not an OS boundary |
+| The command cannot read the agent's environment variables | The command can reach the network |
+| A timeout kills the command and its descendants | Nothing limits memory or CPU |
+
+So it is path-contained, environment-isolated, and bounded, but **not** OS-isolated. The policy vocabulary aligns with `adk-code`'s `SandboxPolicy`; for
 strong isolation, run `bash` behind a containerized executor (see the
 [design doc](https://github.com/zavora-ai/adk-rust/blob/main/docs/design/coding-agent.md#9-security--sandboxing)).
 Combine with [`adk-guardrail`](../security/guardrails.md) (command allowlists,

--- a/docs/official_docs/coding-agent/harness.md
+++ b/docs/official_docs/coding-agent/harness.md
@@ -26,7 +26,7 @@ Builder options:
 | Method | Effect |
 |--------|--------|
 | `.model(Arc<dyn Llm>)` | The model (required). |
-| `.workspace(Workspace)` | The sandboxed workspace (required). |
+| `.workspace(Workspace)` | The workspace the tools are confined to (required). |
 | `.name("…")` | Agent name (default `"coding-agent"`). |
 | `.instruction("…")` | Extra guidance appended to the base coding prompt. |
 | `.tool(Arc<dyn Tool>)` | Register an extra tool (MCP, function tool, …). |

--- a/docs/official_docs/coding-agent/index.md
+++ b/docs/official_docs/coding-agent/index.md
@@ -8,7 +8,7 @@ This is assembled from a few focused pieces rather than a monolithic framework:
 
 | Piece | What it gives you | Page |
 |-------|-------------------|------|
-| **`adk-devtools`** | The inner-loop tools — `read_file`, `write_file`, `edit_file`, `glob`, `grep`, `bash` — scoped to a sandboxed workspace | [Dev tools](devtools.md) |
+| **`adk-devtools`** | The inner-loop tools — `read_file`, `write_file`, `edit_file`, `glob`, `grep`, `bash` — scoped to a workspace directory | [Dev tools](devtools.md) |
 | **`CodingAgent`** (in `adk-agent`, feature `coding`) | A one-call harness wiring those tools + a planning `write_todos` tool + a minimal prompt onto an `LlmAgent` | [Harness](harness.md) |
 | **CLI** (`adk-rust code` / `goal` / `ultracode`) | Native commands: one-shot tasks, autonomous goal mode, and parallel ultra-review | [CLI](cli.md) |
 | **Graph workflows** (`adk-graph`) | Fan out to parallel specialist agents and synthesize — the "ultra" pattern | [Workflows](workflows.md) |
@@ -56,7 +56,7 @@ use adk_core::{Content, SessionId, UserId};
 use std::sync::Arc;
 
 # async fn run(model: std::sync::Arc<dyn adk_core::Llm>) -> anyhow::Result<()> {
-// One call builds a coding agent over a sandboxed workspace.
+// One call builds a coding agent over a confined workspace.
 let coding = CodingAgent::builder()
     .model(model)
     .workspace(Workspace::new("./my-repo"))


### PR DESCRIPTION
## What

A model-directed `bash` command can no longer read the agent's credentials, a timeout now kills everything the command started, and the surface is no longer described as sandboxed.

## Why

```rust
let mut child = tokio::process::Command::new("sh")
    .arg("-c").arg(&command)
    .current_dir(self.workspace.root())   // the only restriction
    .spawn()?;
```

Two concrete holes:

| Hole | Consequence |
|---|---|
| No `env_clear` | `env` printed the parent environment. An agent process routinely holds `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY` — a model-directed command could read all of them |
| `start_kill` on the direct child | A background build or spawned server outlived the tool call |

`run_check` in the CLI ran its own unrestricted `sh -c` for goal-mode `--until`, so the same exposure existed there.

## How

**Environment allowlist**, not a blanket clear: `PATH`, `HOME`, `LANG`, `LC_ALL`, `TMPDIR`, `TERM`, `USER`, `SHELL`. Clearing everything would break the tools an agent exists to run (cargo needs `PATH` and `HOME`), and none of these is a credential. `Workspace::inherit_env(true)` restores the old behaviour for callers who need it; `env_allowlist` replaces the set.

**Process group**: the child leads its own group (`process_group(0)`) and a timeout signals the group with `killpg`, so descendants die with it. Off Unix it falls back to signalling the child, which is all that is available.

`run_check` uses the same policy — a success check should not see credentials the agent cannot.

## The wording was the other half of the finding

"Sandboxed workspace" was doing work the implementation did not support. Corrected in the CLI help, the README, and four coding-agent docs, and `devtools.md` now carries an explicit table:

| Enforced | Not enforced |
|---|---|
| File tools cannot resolve outside the root, including through symlinks | `bash` can still use absolute paths — a working directory is not an OS boundary |
| The command cannot read the agent's environment | The command can reach the network |
| A timeout kills the command and its descendants | Nothing limits memory or CPU |

Real OS isolation means routing `bash` through `adk-sandbox`'s Seatbelt/bubblewrap profiles. `adk-devtools` does not depend on `adk-sandbox`, so that is a separate change; this PR closes the two holes that do not need it and stops overclaiming about the rest.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo nextest run -p adk-devtools` | 19 passed |
| `cargo nextest run --workspace --profile ci` | **3824 passed**, 83 skipped, 2 failed — pre-existing, see below |
| `RUSTDOCFLAGS=-D warnings cargo doc -p adk-devtools -p adk-cli` | exit 0 |
| doc-examples guard | exit 0 |

Five tests (`#![cfg(unix)]`). Against the previous implementation, **two fail** — and they are the two that matter:

- `a_command_cannot_read_an_inherited_secret` — injects `ADK_TEST_PROVIDER_KEY=super-secret-value` and runs `env`
- `a_timeout_kills_processes_the_command_started` — `sh` backgrounds a `sleep 30`, records its pid, then blocks; the test probes that pid with `kill(pid, 0)` after the timeout

The other three guard against over-restriction: `PATH` must still arrive, `inherit_env(true)` must still work, and an ordinary command must be unaffected by the process-group handling.

### The two failures are not from this PR

`adk-code::rust_sandbox_property_tests` timeout tests fail identically on clean `main`: the executor links `serde_json` from `target/debug/deps`, and the newest rlibs here were built by rustc 1.95.0 (from #479) while `main` uses 1.94.0, so rustc rejects the metadata in 0.08 s. Local artifact contamination; CI builds clean.

## Not addressed

From the finding: network denial and filesystem confinement for `bash` (needs an OS sandbox backend), and per-command confirmation for shell.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass (except the two pre-existing failures above)
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed
- [x] Examples added or updated for new features — n/a