### PR TITLE
fix(sandbox): compile inside the boundary and report the isolation class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **adk-sandbox: Rust compilation runs inside the boundary, policy env is applied, and the
+  isolation class is reported.** `ProcessBackend` compiled Rust source with a command
+  built outside `run_command` and awaited with `output()`, so the compile phase had no
+  enforcer wrapper, no request timeout, and no process group. Compilation is not inert —
+  `include_str!` reads files and procedural macros run arbitrary code — so a configured OS
+  policy did not cover the phase that could already touch the host, and a compiler that
+  blocked ran past the requested timeout. Compilation now goes through the same path as
+  execution.
+
+  `SandboxPolicy::env` was never applied; only `ExecRequest::env` reached the child, so a
+  policy that set variables silently supplied none. The policy now supplies defaults and
+  the request overrides them, which the documentation states.
+
+  New `ProcessBackend::isolation()` returns `IsolationClass::SubprocessOnly` or
+  `OsEnforced`, so a caller can tell what it is getting rather than inferring it from the
+  crate name; `default()` is subprocess-only.
+
+  Programs are also resolved to an absolute path against the caller's `PATH` *before* the
+  environment is cleared. A bare `python3`, `node`, or `rustc` previously required the
+  caller to put `PATH` into `ExecRequest::env`, which also handed the executed code
+  everything else on that `PATH`. The compile phase additionally receives toolchain
+  variables when set, because `rustc` cannot invoke a linker without them; that widening
+  is documented, and an enforcer is what constrains it.
+
 - **adk-core/adk-auth: secret access from tools is authorizable and audited.**
   `SecretService` and `SecretProvider` received only a secret *name*. Once a provider
   was attached to an invocation, policy collapsed to whatever the backing cloud

--- a/adk-sandbox/src/lib.rs
+++ b/adk-sandbox/src/lib.rs
@@ -66,7 +66,7 @@ pub use tool::SandboxTool;
 pub use types::{ExecRequest, ExecResult, Language};
 
 #[cfg(feature = "process")]
-pub use process::{ProcessBackend, ProcessConfig};
+pub use process::{IsolationClass, ProcessBackend, ProcessConfig};
 
 #[cfg(feature = "wasm")]
 pub use wasm::WasmBackend;

--- a/adk-sandbox/src/process.rs
+++ b/adk-sandbox/src/process.rs
@@ -126,10 +126,58 @@ pub struct ProcessBackend {
     policy: Option<SandboxPolicy>,
 }
 
+/// How much isolation a backend actually provides.
+///
+/// Reported so a caller can tell the two apart rather than assuming the stronger one
+/// because the crate is named `adk-sandbox`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IsolationClass {
+    /// A child process with a cleared environment, a timeout, and its own process group.
+    ///
+    /// The OS applies no further restriction: the code can read the host filesystem and
+    /// reach the network. This is what [`ProcessBackend::default`] provides.
+    SubprocessOnly,
+    /// A child process wrapped by an OS enforcer — Seatbelt, bubblewrap, or AppContainer
+    /// — under a [`SandboxPolicy`].
+    OsEnforced,
+}
+
+/// Resolve a bare program name to an absolute path using the caller's `PATH`.
+///
+/// Returns `None` when the name already contains a path separator, or when nothing on
+/// `PATH` matches — in which case the command is left as it was so the spawn error still
+/// names the program the caller asked for.
+fn resolve_program(program: &OsStr) -> Option<std::path::PathBuf> {
+    let as_path = std::path::Path::new(program);
+    if as_path.components().count() > 1 {
+        return None;
+    }
+
+    let path_var = std::env::var_os("PATH")?;
+    std::env::split_paths(&path_var).find_map(|dir| {
+        let candidate = dir.join(program);
+        candidate.is_file().then_some(candidate)
+    })
+}
+
 impl ProcessBackend {
     /// Creates a new `ProcessBackend` with the given configuration.
+    ///
+    /// The result is [`IsolationClass::SubprocessOnly`] until an enforcer and policy are
+    /// attached; see [`ProcessBackend::isolation`].
     pub fn new(config: ProcessConfig) -> Self {
         Self { config, enforcer: None, policy: None }
+    }
+
+    /// How much isolation this backend applies.
+    ///
+    /// Check this before treating execution as sandboxed. Without an enforcer *and* a
+    /// policy, execution is subprocess isolation only.
+    pub fn isolation(&self) -> IsolationClass {
+        match (self.enforcer.is_some(), self.policy.is_some()) {
+            (true, true) => IsolationClass::OsEnforced,
+            _ => IsolationClass::SubprocessOnly,
+        }
     }
 
     /// Creates a new `ProcessBackend` with OS-level sandbox enforcement.
@@ -253,25 +301,21 @@ impl ProcessBackend {
 
         std::fs::write(&src_path, &request.code)?;
 
-        // Compile step
-        let compile_output = {
+        // Compile through the same path as execution. Building the command here and
+        // calling `output()` directly skipped the enforcer, the timeout, and the
+        // process group — and Rust compilation is not inert: `include_str!` and
+        // procedural macros read files and can run arbitrary code at compile time, so
+        // the compiler needs the same boundary as the binary it produces.
+        let compile_result = {
             let mut cmd = Command::new(&self.config.rustc_path);
-            cmd.arg(&src_path).arg("-o").arg(&bin_path).env_clear().kill_on_drop(true);
-            for (k, v) in &request.env {
-                cmd.env(k, v);
-            }
-            cmd.output().await?
+            cmd.arg(&src_path).arg("-o").arg(&bin_path);
+            self.run_command_with_env(cmd, request, &Self::toolchain_env()).await?
         };
 
-        if !compile_output.status.success() {
-            let stderr = truncate_utf8(compile_output.stderr, MAX_OUTPUT_BYTES);
-            let stdout = truncate_utf8(compile_output.stdout, MAX_OUTPUT_BYTES);
-            let exit_code = compile_output.status.code().unwrap_or(1);
-            let result =
-                ExecResult { stdout, stderr, exit_code, duration: std::time::Duration::ZERO };
-            Span::current().record("exit_code", exit_code);
-            Span::current().record("duration_ms", 0_u64);
-            return Ok(result);
+        if compile_result.exit_code != 0 {
+            Span::current().record("exit_code", compile_result.exit_code);
+            Span::current().record("duration_ms", compile_result.duration.as_millis() as u64);
+            return Ok(compile_result);
         }
 
         // Run the compiled binary
@@ -333,6 +377,31 @@ impl ProcessBackend {
         cmd: Command,
         request: &ExecRequest,
     ) -> Result<ExecResult, SandboxError> {
+        self.run_command_with_env(cmd, request, &[]).await
+    }
+
+    /// Variables a compiler needs to find its own tools.
+    ///
+    /// `rustc` shells out to a linker — `cc`, and `xcrun` on macOS — and resolves them
+    /// through the environment. With the environment cleared it cannot link at all, so
+    /// compilation gets these passed through from the caller when they are set.
+    ///
+    /// This widens what the compile phase can see compared with the run phase. An OS
+    /// enforcer is what constrains it; see [`ProcessBackend::isolation`].
+    fn toolchain_env() -> Vec<(String, String)> {
+        ["PATH", "DEVELOPER_DIR", "SDKROOT", "HOME", "TMPDIR", "RUSTUP_HOME", "CARGO_HOME"]
+            .iter()
+            .filter_map(|key| std::env::var(key).ok().map(|value| ((*key).to_string(), value)))
+            .collect()
+    }
+
+    /// Shared execution logic, with `extra_env` applied below policy and request values.
+    async fn run_command_with_env(
+        &self,
+        cmd: Command,
+        request: &ExecRequest,
+        extra_env: &[(String, String)],
+    ) -> Result<ExecResult, SandboxError> {
         // If a sandbox enforcer is configured, wrap the command.
         // We extract the program and args from the pre-built Command,
         // pass them through the enforcer, and create a new Command.
@@ -354,7 +423,32 @@ impl ProcessBackend {
             cmd
         };
 
+        // Resolve a bare program name against the caller's PATH *before* clearing the
+        // environment. Clearing first leaves the child with no PATH, and program
+        // resolution then fails with ENOENT — so a backend configured with `"rustc"`,
+        // `"python3"`, or `"node"` could not execute anything at all.
+        {
+            let program = cmd.as_std().get_program().to_owned();
+            if let Some(resolved) = resolve_program(&program) {
+                let args: Vec<OsString> = cmd.as_std().get_args().map(OsStr::to_owned).collect();
+                let mut resolved_cmd = Command::new(resolved);
+                resolved_cmd.args(&args);
+                cmd = resolved_cmd;
+            }
+        }
+
+        // Environment precedence: the policy supplies defaults for every execution, and
+        // the request overrides them per call. `SandboxPolicy::env` was previously
+        // ignored entirely, so a policy that set variables silently supplied none.
         cmd.env_clear();
+        for (k, v) in extra_env {
+            cmd.env(k, v);
+        }
+        if let Some(policy) = &self.policy {
+            for (k, v) in &policy.env {
+                cmd.env(k, v);
+            }
+        }
         for (k, v) in &request.env {
             cmd.env(k, v);
         }

--- a/adk-sandbox/tests/process_enforcement_tests.rs
+++ b/adk-sandbox/tests/process_enforcement_tests.rs
@@ -1,0 +1,112 @@
+//! What `ProcessBackend` actually enforces.
+//!
+//! Three gaps motivated these tests:
+//!
+//! 1. `ProcessBackend::default()` has no enforcer, so execution is subprocess isolation
+//!    only — but nothing said so, and the crate is named `adk-sandbox`.
+//! 2. Rust source was compiled by a `Command` built inline and run with `output()`,
+//!    bypassing `run_command`. That skipped the enforcer wrapper, the request timeout, and
+//!    the process group. Rust compilation is not inert: `include_str!` reads files and
+//!    procedural macros run arbitrary code, all before the produced binary ever enters the
+//!    runtime boundary.
+//! 3. `SandboxPolicy::env` was never applied. A policy that set variables silently
+//!    supplied none.
+
+use adk_sandbox::{ExecRequest, IsolationClass, Language, ProcessBackend, SandboxBackend};
+use std::time::Duration;
+
+fn rust_request(code: &str, timeout: Duration) -> ExecRequest {
+    ExecRequest {
+        language: Language::Rust,
+        code: code.to_string(),
+        timeout,
+        memory_limit_mb: None,
+        env: Default::default(),
+        stdin: None,
+    }
+}
+
+// ── The isolation class is explicit ───────────────────────────────────
+
+#[test]
+fn the_default_backend_reports_subprocess_isolation_only() {
+    assert_eq!(
+        ProcessBackend::default().isolation(),
+        IsolationClass::SubprocessOnly,
+        "a caller must be able to tell that the default applies no OS restriction"
+    );
+}
+
+// ── Compilation is bounded ────────────────────────────────────────────
+
+#[tokio::test]
+async fn a_compile_that_exceeds_the_timeout_is_stopped() {
+    // The timeout previously applied only to running the compiled binary, so a compile
+    // that blocked ran unbounded. A `const` evaluation loop keeps rustc busy without
+    // needing network or unusual features.
+    let code = r#"
+const fn spin(mut n: u64) -> u64 {
+    let mut acc = 0u64;
+    while n > 0 {
+        acc = acc.wrapping_add(n);
+        n -= 1;
+    }
+    acc
+}
+const HEAVY: u64 = spin(50_000_000);
+fn main() { println!("{}", HEAVY); }
+"#;
+
+    let backend = ProcessBackend::default();
+    let started = std::time::Instant::now();
+    let result = backend.execute(rust_request(code, Duration::from_millis(500))).await;
+    let elapsed = started.elapsed();
+
+    // Either the compile is killed by the timeout (an error or a non-zero exit) or it
+    // finished; what must not happen is running far past the requested budget.
+    assert!(
+        elapsed < Duration::from_secs(20),
+        "compilation ran {elapsed:?}, far beyond the 500ms request timeout"
+    );
+    // A successful, fast compile is acceptable on a very fast machine; a hang is not.
+    if let Ok(exec) = &result {
+        assert!(
+            exec.duration < Duration::from_secs(20),
+            "the reported duration ignores the request timeout: {:?}",
+            exec.duration
+        );
+    }
+}
+
+#[tokio::test]
+async fn a_compile_error_is_still_reported_as_a_failed_execution() {
+    // Routing compilation through the enforced path must not change how a compile error
+    // surfaces.
+    let backend = ProcessBackend::default();
+    let result = backend
+        .execute(rust_request("fn main() { this is not rust }", Duration::from_secs(60)))
+        .await
+        .expect("a compile error is a result, not an infrastructure error");
+
+    assert_ne!(result.exit_code, 0, "a compile error must be a non-zero exit");
+    assert!(
+        !result.stderr.is_empty(),
+        "the compiler's diagnostics must reach the caller: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn a_working_program_still_runs() {
+    // Guards against the compile rerouting breaking ordinary execution.
+    let backend = ProcessBackend::default();
+    let result = backend
+        .execute(rust_request(
+            r#"fn main() { println!("hello from rust"); }"#,
+            Duration::from_secs(120),
+        ))
+        .await
+        .expect("a valid program must execute");
+
+    assert_eq!(result.exit_code, 0, "stderr was: {}", result.stderr);
+    assert!(result.stdout.contains("hello from rust"));
+}

--- a/docs/official_docs/sandbox/index.md
+++ b/docs/official_docs/sandbox/index.md
@@ -13,6 +13,37 @@ The `adk-sandbox` crate provides isolated code execution for ADK agents, with tw
 | `ProcessBackend` + sandbox | Kernel-level | Same as above | `process` + `sandbox-native` |
 | `WasmBackend` | Full (memory, fs, network) | WASM only | `wasm` |
 
+### Which Isolation Are You Getting?
+
+`ProcessBackend::isolation()` reports it, so this is not something to infer from the
+crate name:
+
+| Result | Meaning |
+|--------|---------|
+| `IsolationClass::SubprocessOnly` | A child process with a cleared environment, a timeout, and its own process group. The OS applies no further restriction: the code can read the host filesystem and reach the network. This is what `ProcessBackend::default()` gives you. |
+| `IsolationClass::OsEnforced` | An enforcer **and** a policy are attached, so the OS restricts the child. |
+
+Two things about the process backend worth knowing:
+
+- **Programs are resolved before the environment is cleared.** A bare `python3`, `node`,
+  or `rustc` is looked up on the caller's `PATH` and passed to the child as an absolute
+  path. That means the child does not need a `PATH` of its own to start — previously a
+  caller had to put `PATH` in `ExecRequest::env`, which also let the executed code spawn
+  anything else on it.
+- **Compilation runs through the same boundary as execution.** Rust source used to be
+  compiled by a command built outside the shared path, so the compile had no enforcer
+  wrapper, no timeout, and no process group. That matters because compilation is not
+  inert: `include_str!` reads files and procedural macros run arbitrary code before the
+  produced binary exists. The compile phase does receive toolchain variables (`PATH`,
+  `SDKROOT`, `DEVELOPER_DIR`, `HOME`, `TMPDIR`, `RUSTUP_HOME`, `CARGO_HOME`) when they
+  are set, because `rustc` cannot invoke a linker without them; an OS enforcer is what
+  constrains that phase.
+
+### Environment Precedence
+
+`SandboxPolicy::env` supplies defaults for every execution and `ExecRequest::env`
+overrides them per call. The policy's variables were previously ignored entirely.
+
 ## OS Sandbox Profiles
 
 OS-level sandbox enforcement restricts child processes at the kernel level. This goes beyond environment isolation — the OS itself blocks unauthorized filesystem access, network connections, and process spawning.


### PR DESCRIPTION
## What

Rust compilation now runs through the same enforced path as execution, `SandboxPolicy::env` is applied, and `ProcessBackend` reports how much isolation it actually provides.

## Why

```rust
// execute_rust — the compile step
let compile_output = {
    let mut cmd = Command::new(&self.config.rustc_path);
    cmd.arg(&src_path).arg("-o").arg(&bin_path).env_clear().kill_on_drop(true);
    for (k, v) in &request.env { cmd.env(k, v); }
    cmd.output().await?          // never goes through run_command
};
...
self.run_binary(&bin_path, request).await   // this one does
```

So the **binary** got the enforcer wrapper, the request timeout, and the process group; the **compiler** got none of them. That is backwards: compilation is the phase that can already reach the host, because `include_str!` reads files and procedural macros run arbitrary code before the produced binary exists. A blocking compile also ran past the requested timeout.

Separately, `SandboxPolicy::env` was never read — only `ExecRequest::env` reached the child — so a policy that set variables silently supplied none.

## How

| Change | Effect |
|---|---|
| Compile goes through `run_command` | Enforcer wrapper, request timeout, and process group now cover the compiler |
| `SandboxPolicy::env` applied below `ExecRequest::env` | Policy supplies defaults, request overrides; precedence documented |
| `ProcessBackend::isolation()` → `IsolationClass` | `SubprocessOnly` vs `OsEnforced`, so a caller does not infer isolation from the crate name |

### A related improvement, described accurately

Programs are resolved to an absolute path against the caller's `PATH` **before** the environment is cleared. This was not a broken feature — the existing integration tests pass `PATH` in `ExecRequest::env` and work on `main` — but that was the only way to run a bare `python3`, `node`, or `rustc`, and handing the child a `PATH` also hands the executed code everything else on it. Resolving first removes the reason to grant it.

I initially thought execution was outright broken here and checked: `Command::new("rustc").env_clear()` fails with ENOENT, but the tests supply `PATH`, so they pass on `main`. Worth stating plainly rather than overclaiming.

### One honest widening

`rustc` shells out to a linker (`cc`, and `xcrun` on macOS) and finds it through the environment, so a fully cleared environment cannot link at all. The compile phase receives `PATH`, `SDKROOT`, `DEVELOPER_DIR`, `HOME`, `TMPDIR`, `RUSTUP_HOME`, and `CARGO_HOME` when set, at **lowest** precedence. That widens what the compile phase sees relative to the run phase; an OS enforcer is what constrains it, and the docs say so.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo nextest run -p adk-sandbox` | 37 passed |
| `cargo nextest run -p adk-sandbox --test process_integration --run-ignored all` | **5 passed** — the previously `#[ignore]`d execution tests, verified still green |
| `cargo nextest run --workspace --profile ci` | **3823 passed**, 83 skipped, 2 failed — pre-existing, see below |
| `RUSTDOCFLAGS=-D warnings cargo doc -p adk-sandbox` | exit 0 |
| doc-examples guard | exit 0 |

Four new tests: the default backend reports `SubprocessOnly`; a compile that exceeds its timeout does not run unbounded; a compile error still surfaces as a non-zero exit rather than an infrastructure error; and a working program still compiles and runs.

### The two failures are not from this PR

`adk-code::rust_sandbox_property_tests` timeout tests fail identically on clean `main`: that crate's own executor links `serde_json` from `target/debug/deps`, and the newest rlibs here were built by rustc 1.95.0 (from #479) while `main` uses 1.94.0.

## Not addressed

From the finding: memory limits for the process backend (only `WasmBackend` enforces `memory_limit_mb`), and requiring an enforcer at construction for any API *described* as sandboxed — reporting the class is a smaller step than refusing to build without one.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass (except the two pre-existing failures above)
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed — n/a
- [x] Examples added or updated for new features — n/a