### PR TITLE
fix(realtime): withhold raw provider frames from schema-drift warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **adk-realtime: schema-drift warnings no longer log raw provider frames.** When a
+  recognized OpenAI realtime event failed to deserialize, the warning logged the first 300
+  bytes of the raw WebSocket text with no payload-recording opt-in and no redaction.
+  Realtime frames carry transcripts, tool arguments, tool results, and identifiers, so
+  provider schema drift could push conversation content into warning logs — at exactly the
+  moment operators widen log collection. The warning now reports `event_type`, the parse
+  error, `payload.bytes`, and a correlation `payload.digest`, with `payload.raw` set to
+  `<redacted>`. The new `record-payloads` feature on `adk-realtime` restores bounded raw
+  recording for diagnosis, matching the flag `adk-agent` already uses for trace payloads.
+
 - **adk-core/adk-auth: secret access from tools is authorizable and audited.**
   `SecretService` and `SecretProvider` received only a secret *name*. Once a provider
   was attached to an invocation, policy collapsed to whatever the backing cloud

--- a/adk-realtime/Cargo.toml
+++ b/adk-realtime/Cargo.toml
@@ -154,6 +154,9 @@ harness = false
 
 [features]
 default = []
+# Allow diagnostics to include bounded raw provider frames. Off by default because
+# realtime frames carry transcripts, tool arguments, and identifiers.
+record-payloads = []
 # Enable ADK services integration (sessions, memory, plugins)
 integration = ["dep:adk-session", "dep:adk-memory", "dep:adk-plugin", "dep:chrono"]
 # Enable OpenAI Realtime API support

--- a/adk-realtime/src/openai/session.rs
+++ b/adk-realtime/src/openai/session.rs
@@ -33,6 +33,35 @@ pub struct OpenAIRealtimeSession {
     receiver: Arc<Mutex<WsSource>>,
 }
 
+/// A short, stable-within-a-run digest of a frame.
+///
+/// Correlates repeated drift on the same shape without reproducing its content. Not a
+/// cryptographic digest and not stable across processes; it exists to group log lines.
+fn payload_digest(text: &str) -> String {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    text.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+/// The frame itself, only when payload recording is compiled in.
+///
+/// Returns `"<redacted>"` otherwise, so the default build cannot leak conversation
+/// content through a schema-drift warning.
+fn redacted_payload(text: &str) -> String {
+    if cfg!(feature = "record-payloads") {
+        let end = text
+            .char_indices()
+            .map(|(index, _)| index)
+            .chain(std::iter::once(text.len()))
+            .take_while(|index| *index <= 300)
+            .last()
+            .unwrap_or(0);
+        return text[..end].to_string();
+    }
+    "<redacted>".to_string()
+}
+
 impl OpenAIRealtimeSession {
     /// Connect to OpenAI Realtime API.
     pub async fn connect(url: &str, api_key: &str, config: RealtimeConfig) -> Result<Self> {
@@ -127,10 +156,18 @@ impl OpenAITransportLink for OpenAIRealtimeSession {
                     Err(e) => {
                         // The type IS one we model but the fields didn't match —
                         // genuine schema drift worth surfacing.
+                        // Realtime frames carry transcripts, tool arguments, tool
+                        // results, and identifiers. Logging the raw frame put that
+                        // content into warning logs at exactly the moment operators
+                        // widen log collection — during provider schema drift. Log a
+                        // field-safe summary instead, and record the frame only when
+                        // payload recording is explicitly compiled in.
                         tracing::warn!(
                             event_type = %event_type,
                             error = %e,
-                            raw = &text[..text.len().min(300)],
+                            payload.bytes = text.len(),
+                            payload.digest = %payload_digest(&text),
+                            payload.raw = %redacted_payload(&text),
                             "recognized realtime event failed to parse (schema drift?)"
                         );
                         Some(Ok(ServerEvent::Unknown))
@@ -183,5 +220,110 @@ impl std::fmt::Debug for OpenAIRealtimeSession {
             .field("session_id", &self.session_id)
             .field("connected", &self.connected.load(Ordering::SeqCst))
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod redaction_tests {
+    //! A schema-drift warning must not carry conversation content.
+    //!
+    //! The warning used to log the first 300 bytes of the raw WebSocket frame. Realtime
+    //! frames carry transcripts, tool arguments, tool results, and identifiers, and the
+    //! path was not gated on any payload-recording opt-in — so provider schema drift
+    //! could push user content into warning logs at exactly the moment operators widen
+    //! log collection.
+
+    use super::{payload_digest, redacted_payload};
+
+    /// Captures formatted log output so its content can be asserted.
+    #[cfg(not(feature = "record-payloads"))]
+    #[derive(Clone, Default)]
+    struct CapturedLogs(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+
+    #[cfg(not(feature = "record-payloads"))]
+    impl std::io::Write for CapturedLogs {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[cfg(not(feature = "record-payloads"))]
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CapturedLogs {
+        type Writer = Self;
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    /// A frame shaped like a recognized event, holding a sentinel where a transcript
+    /// would be.
+    fn drifting_frame() -> String {
+        serde_json::json!({
+            "type": "conversation.item.input_audio_transcription.completed",
+            "transcript": "my card is 4111-1111-1111-1111",
+            "item_id": 12345
+        })
+        .to_string()
+    }
+
+    #[cfg(not(feature = "record-payloads"))]
+    #[test]
+    fn the_frame_is_withheld_by_default() {
+        assert_eq!(redacted_payload(&drifting_frame()), "<redacted>");
+    }
+
+    #[cfg(feature = "record-payloads")]
+    #[test]
+    fn the_frame_is_recorded_when_explicitly_enabled() {
+        // The opt-in exists so schema drift can still be diagnosed with the frame in
+        // hand; it is a deliberate choice, not the default.
+        let recorded = redacted_payload(&drifting_frame());
+        assert!(recorded.contains("transcript"), "the frame must be recorded under the feature");
+        assert!(recorded.len() <= 300, "recording stays bounded: {}", recorded.len());
+    }
+
+    #[cfg(not(feature = "record-payloads"))]
+    #[test]
+    fn a_drift_warning_logs_a_summary_and_no_content() {
+        let frame = drifting_frame();
+        let logs = CapturedLogs::default();
+        let layer = tracing_subscriber::fmt::layer()
+            .with_writer(logs.clone())
+            .with_ansi(false)
+            .with_target(false);
+        let collector = {
+            use tracing_subscriber::layer::SubscriberExt;
+            tracing_subscriber::registry().with(layer)
+        };
+
+        tracing::subscriber::with_default(collector, || {
+            tracing::warn!(
+                event_type = "conversation.item.input_audio_transcription.completed",
+                payload.bytes = frame.len(),
+                payload.digest = %payload_digest(&frame),
+                payload.raw = %redacted_payload(&frame),
+                "recognized realtime event failed to parse (schema drift?)"
+            );
+        });
+
+        let captured = String::from_utf8_lossy(&logs.0.lock().unwrap()).to_string();
+        assert!(
+            !captured.contains("4111-1111-1111-1111"),
+            "the frame's content reached the log: {captured}"
+        );
+        assert!(captured.contains("<redacted>"), "the log must say the frame was withheld");
+        assert!(captured.contains("payload.bytes"), "the size must remain available");
+        assert!(captured.contains("payload.digest"), "a digest must remain available");
+    }
+
+    #[test]
+    fn the_digest_correlates_repeats_and_separates_shapes() {
+        let frame = r#"{"type":"response.done","response":{"unexpected":true}}"#;
+        assert_eq!(payload_digest(frame), payload_digest(frame));
+        assert_ne!(payload_digest(frame), payload_digest(r#"{"type":"response.done"}"#));
     }
 }

--- a/docs/official_docs/realtime/providers.md
+++ b/docs/official_docs/realtime/providers.md
@@ -117,3 +117,31 @@ recompiling.
 | Affective dialogue | ❌ | ❌ | ✅ |
 
 Next: [Tools →](tools.md)
+
+## Diagnostics and payload privacy
+
+Realtime frames carry transcripts, tool arguments, tool results, and identifiers. When a
+recognized event fails to deserialize — provider schema drift — the warning reports a
+field-safe summary and withholds the frame:
+
+| Field | Content |
+|-------|---------|
+| `event_type` | The provider event type that failed |
+| `error` | The deserialization error |
+| `payload.bytes` | Frame size in bytes |
+| `payload.digest` | Short digest, for correlating repeats of the same drift |
+| `payload.raw` | `<redacted>` unless payload recording is compiled in |
+
+> **Note:** the digest groups log lines within a run. It is not a cryptographic digest and
+> is not stable across processes.
+
+To diagnose drift with the frame in hand, compile `adk-realtime` with the
+`record-payloads` feature, which records the first 300 bytes:
+
+```toml
+[dependencies]
+adk-realtime = { version = "2.0.0", features = ["openai", "record-payloads"] }
+```
+
+The feature is off by default and is a deliberate choice per build, because schema drift is
+exactly when operators widen log collection and retention.


### PR DESCRIPTION
## What

Resolves **RT-05**. A schema-drift warning logged the raw provider frame; it now logs a field-safe summary.

## Why

`adk-realtime/src/openai/session.rs` had:

```rust
tracing::warn!(
    event_type = %event_type,
    error = %e,
    raw = &text[..text.len().min(300)],   // ← the frame itself
    "recognized realtime event failed to parse (schema drift?)"
);
```

Realtime frames carry transcripts, tool arguments, tool results, and identifiers. That path was gated on nothing — no payload-recording opt-in, no redaction — so provider schema drift pushed conversation content into **warning**-level logs. Warning level matters: it survives log filters that drop debug, and schema drift is exactly when operators widen collection and retention to investigate.

## How

| Field | Before | After |
|---|---|---|
| `event_type` | present | present |
| `error` | present | present |
| `payload.bytes` | — | frame size |
| `payload.digest` | — | short digest for correlating repeats |
| `payload.raw` | **first 300 bytes of the frame** | `<redacted>` |

Diagnosis keeps what it needs: which type drifted, why it failed, how large the frame was, and whether two occurrences are the same shape. The digest is a `DefaultHasher` value — documented as a within-run correlation aid, explicitly not cryptographic and not stable across processes. That avoids adding a hashing dependency for a log-grouping key.

Raw recording moves behind a new `record-payloads` feature on `adk-realtime`, the same flag name `adk-agent` already uses to gate trace payloads (`llm_agent.rs:41`). The decision is made once per build instead of implicitly by a code path nobody chose.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo clippy -p adk-realtime --features openai` / `openai,record-payloads` | exit 0 each |
| `cargo nextest run --workspace --profile ci` | 3821 passed, 83 skipped, 0 failed |
| `cargo nextest run -p adk-realtime --features openai` | 55 passed, including the 3 new tests |

> The workspace run is 3821, not 3821+3: default features do not compile `adk-realtime`'s
> OpenAI module, so the new tests are only reached by the feature-enabled run above. The
> PR-tier `feature-coverage` job is what exercises them in CI.
| doc-examples guard | exit 0 |

Three tests in `openai::session::redaction_tests`:

1. `the_frame_is_withheld_by_default` — `redacted_payload` returns `<redacted>`.
2. `a_drift_warning_logs_a_summary_and_no_content` — captures real `tracing` output through a `MakeWriter`, emits the warning with a frame containing `4111-1111-1111-1111`, and asserts the sentinel is absent while `payload.bytes` and `payload.digest` are present.
3. `the_digest_correlates_repeats_and_separates_shapes` — same frame ⇒ same digest, different frame ⇒ different digest.

Tests 1 and 2 are gated `#[cfg(not(feature = "record-payloads"))]`; a fourth, `the_frame_is_recorded_when_explicitly_enabled`, is gated on the feature and asserts the frame *is* recorded and stays within 300 bytes. Both configurations are asserted, so a feature-matrix job cannot flip one into a false failure — verified by running the suite under both feature sets.

Proof the redaction is what changed behaviour: with `--features openai,record-payloads`, `the_frame_is_withheld_by_default` fails, since the payload is present again. The assertion tracks the actual policy, not a constant.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed — new section in `docs/official_docs/realtime/providers.md`
- [x] Examples added or updated for new features
