### PR TITLE
fix(realtime): enforce the tool concurrency bound, keep the event loop live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -426,6 +426,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **adk-realtime: `max_concurrent_tools` is enforced, and tools no longer stall the event
+  loop.** The field defaulted to 4 and was read by nothing — no semaphore, no scheduler.
+  `FunctionCallDone` was awaited inline in `handle_event`, which the run loop awaited before
+  reading the next event, so tool calls ran strictly one at a time and blocked audio,
+  transcripts, and interruptions for the full duration of each call. Tool calls are now
+  dispatched onto the run loop under a semaphore sized by `max_concurrent_tools`, so event
+  intake continues while tools run. The single follow-up `create_response` owed after
+  automatic tool output is now issued once both the dispatching response has closed and
+  every dispatched tool has reported, in either order — previously the ordering was implicit
+  in the inline await and would have been lost.
+- **adk-realtime: transport loss is distinguishable from a graceful close.**
+  `EventHandler::on_disconnect` is called when the provider transport ends, before `run`
+  returns. `run` returns `Ok(())` for both cases, so a caller previously could not tell
+  them apart. The runner still does not reconnect automatically; the policy is documented.
+
 - **adk-server: background runs execute a workflow instead of reporting success.**
   `BackgroundRunner::run_with_timeout` received neither the workflow ID nor the input. It
   checked cancellation and returned `Completed` with an empty object, so a client got a

--- a/adk-realtime/Cargo.toml
+++ b/adk-realtime/Cargo.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 adk-core.workspace = true
 
 # Async runtime
-tokio = { workspace = true, features = ["sync", "net", "time", "rt"] }
+tokio = { workspace = true, features = ["sync", "net", "time", "rt", "macros"] }
 async-trait.workspace = true
 futures.workspace = true
 async-stream.workspace = true

--- a/adk-realtime/src/runner.rs
+++ b/adk-realtime/src/runner.rs
@@ -11,7 +11,7 @@ use crate::session::ContextMutationOutcome;
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use tokio::sync::RwLock;
 
 /// Internal state machine tracking the resumability status of the RealtimeRunner.
@@ -135,6 +135,26 @@ pub trait EventHandler: Send + Sync {
     }
 
     /// Called on any error.
+    /// Called when the provider transport ends and [`RealtimeRunner::run`] is returning.
+    ///
+    /// The runner does **not** reconnect automatically. Reconnection is deliberate: it
+    /// requires deciding what context to replay and, on Gemini, whether a resumption token
+    /// is still valid. Without this hook `run` returned `Ok(())` on transport loss, which a
+    /// caller could not tell apart from a graceful [`RealtimeRunner::close`].
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// async fn on_disconnect(&self) -> adk_realtime::Result<()> {
+    ///     tracing::warn!("realtime transport ended; reconnecting");
+    ///     self.reconnect.notify_one();
+    ///     Ok(())
+    /// }
+    /// ```
+    async fn on_disconnect(&self) -> Result<()> {
+        Ok(())
+    }
+
     async fn on_error(&self, _error: &RealtimeError) -> Result<()> {
         Ok(())
     }
@@ -146,6 +166,14 @@ pub struct NoOpEventHandler;
 
 #[async_trait]
 impl EventHandler for NoOpEventHandler {}
+
+/// A tool call the run loop still has to dispatch.
+#[derive(Debug, Clone)]
+struct PendingToolCall {
+    call_id: String,
+    name: String,
+    arguments: String,
+}
 
 /// Configuration for the RealtimeRunner.
 #[derive(Clone)]
@@ -273,6 +301,8 @@ impl RealtimeRunnerBuilder {
             config.tools = Some(tool_defs);
         }
 
+        let max_concurrent_tools = self.runner_config.max_concurrent_tools.max(1);
+
         Ok(RealtimeRunner {
             model,
             config: Arc::new(RwLock::new(config)),
@@ -282,6 +312,9 @@ impl RealtimeRunnerBuilder {
             session: Arc::new(RwLock::new(None)),
             state: Arc::new(RwLock::new(RunnerState::Idle)),
             pending_tool_response: AtomicBool::new(false),
+            tool_permits: Arc::new(tokio::sync::Semaphore::new(max_concurrent_tools)),
+            outstanding_tools: Arc::new(AtomicUsize::new(0)),
+            response_closed_awaiting_tools: Arc::new(AtomicBool::new(false)),
         })
     }
 }
@@ -334,6 +367,14 @@ pub struct RealtimeRunner {
     /// Set when tool output(s) have been sent for the in-flight response and a
     /// single follow-up `create_response` is owed once that response finishes.
     pending_tool_response: AtomicBool,
+    /// Bounds how many tool handlers run at once, from
+    /// [`RunnerConfig::max_concurrent_tools`].
+    tool_permits: Arc<tokio::sync::Semaphore>,
+    /// Tool calls dispatched for the current response and not yet finished.
+    outstanding_tools: Arc<AtomicUsize>,
+    /// Set when the dispatching response closed while tool calls were still running, so
+    /// the follow-up `create_response` is owed by whichever tool finishes last.
+    response_closed_awaiting_tools: Arc<AtomicBool>,
 }
 
 impl RealtimeRunner {
@@ -724,14 +765,38 @@ impl RealtimeRunner {
 
     /// Run the event loop, processing events until disconnected.
     pub async fn run(&self) -> Result<()> {
+        use futures::stream::{FuturesUnordered, StreamExt};
+
+        // Tool handlers run as futures on this set rather than inline, so reading the next
+        // provider event never waits for a tool. `max_concurrent_tools` bounds how many
+        // are past their permit acquisition at once.
+        let mut running_tools = FuturesUnordered::new();
+
         loop {
             let session = self.session_handle().await?;
             let old_session_id = session.session_id().to_string();
-            let event = session.next_event().await;
+
+            // With no tools in flight there is nothing to drain, and polling an empty
+            // `FuturesUnordered` in a `select!` would spin.
+            let event = if running_tools.is_empty() {
+                session.next_event().await
+            } else {
+                tokio::select! {
+                    biased;
+                    Some(finished) = running_tools.next() => {
+                        let () = finished?;
+                        continue;
+                    }
+                    event = session.next_event() => event,
+                }
+            };
 
             match event {
                 Some(Ok(event)) => {
-                    self.handle_event(event).await?;
+                    if let Some(call) = self.handle_event(event).await? {
+                        self.outstanding_tools.fetch_add(1, Ordering::AcqRel);
+                        running_tools.push(self.run_tool_call(call));
+                    }
                 }
                 Some(Err(e)) => {
                     self.event_handler.on_error(&e).await?;
@@ -746,7 +811,14 @@ impl RealtimeRunner {
                         // A new session handle was installed concurrently. Continue polling.
                         continue;
                     }
-                    // It was a real disconnect.
+                    // A real disconnect. Let dispatched tools finish so their output and
+                    // the follow-up response are not dropped mid-flight.
+                    while let Some(finished) = running_tools.next().await {
+                        finished?;
+                    }
+                    // Surfaced distinctly: `run` returning `Ok(())` alone cannot be told
+                    // apart from a graceful `close`.
+                    self.event_handler.on_disconnect().await?;
                     break;
                 }
             }
@@ -754,8 +826,29 @@ impl RealtimeRunner {
         Ok(())
     }
 
+    /// Run one dispatched tool call under the configured concurrency bound.
+    ///
+    /// The permit is acquired inside the future so queueing a call never blocks the event
+    /// loop; the bound applies to execution, not to admission.
+    async fn run_tool_call(&self, call: PendingToolCall) -> Result<()> {
+        let permit = Arc::clone(&self.tool_permits).acquire_owned().await;
+        let result = self.execute_tool_call(&call.call_id, &call.name, &call.arguments).await;
+        drop(permit);
+
+        // The follow-up response is owed once *every* dispatched tool is in and the
+        // dispatching response has closed, whichever happens last. Before tools ran
+        // concurrently, ordering was implicit: `ResponseDone` could not arrive until the
+        // inline await returned. It can now, so the last tool to finish issues it.
+        if self.outstanding_tools.fetch_sub(1, Ordering::AcqRel) == 1
+            && self.response_closed_awaiting_tools.swap(false, Ordering::AcqRel)
+        {
+            self.respond_after_tools().await?;
+        }
+        result
+    }
+
     /// Process a single event.
-    async fn handle_event(&self, event: ServerEvent) -> Result<()> {
+    async fn handle_event(&self, event: ServerEvent) -> Result<Option<PendingToolCall>> {
         // Track state transitions before forwarding the event
         match &event {
             ServerEvent::ResponseCreated { .. } => {
@@ -798,7 +891,9 @@ impl RealtimeRunner {
             }
             ServerEvent::FunctionCallDone { call_id, name, arguments, .. } => {
                 if self.runner_config.auto_execute_tools {
-                    self.execute_tool_call(&call_id, &name, &arguments).await?;
+                    // Returned rather than awaited: the run loop dispatches it so event
+                    // intake — audio deltas included — continues while the tool runs.
+                    return Ok(Some(PendingToolCall { call_id, name, arguments }));
                 }
             }
             ServerEvent::SessionUpdated { session, .. } => {
@@ -821,7 +916,7 @@ impl RealtimeRunner {
                 // Ignore other events
             }
         }
-        Ok(())
+        Ok(None)
     }
 
     /// Safely transitions the runner back to Idle and executes any queued resumptions.
@@ -933,6 +1028,15 @@ impl RealtimeRunner {
     /// than once per tool call. Gemini's `create_response` is a no-op, so this is
     /// safely uniform across providers. No-op when nothing is pending.
     pub async fn respond_after_tools(&self) -> Result<()> {
+        // Tools run concurrently with event intake, so this can be reached before their
+        // output is in. Defer to the last tool to finish rather than firing a response the
+        // model cannot yet answer — or, worse, dropping it because
+        // `pending_tool_response` is not set yet.
+        if self.outstanding_tools.load(Ordering::Acquire) > 0 {
+            self.response_closed_awaiting_tools.store(true, Ordering::Release);
+            return Ok(());
+        }
+
         if self.pending_tool_response.swap(false, Ordering::AcqRel)
             && let Ok(session) = self.session_handle().await
         {
@@ -1135,10 +1239,19 @@ mod runner_tests {
         *runner.session.write().await =
             Some(Arc::new(RecordingSession { counts: counts.clone() }) as Arc<dyn RealtimeSession>);
 
-        // One model response dispatching two tool calls, then ending.
-        runner.handle_event(function_call("c1", "get_weather")).await.unwrap();
-        runner.handle_event(function_call("c2", "get_time")).await.unwrap();
-        runner.handle_event(response_done()).await.unwrap();
+        // One model response dispatching two tool calls, then ending. Driven through
+        // `run`, because dispatch is the run loop's job now — `handle_event` returns the
+        // call rather than awaiting it, so event intake is not blocked by a tool.
+        let scripted = Arc::new(ScriptedSession::new(
+            counts.clone(),
+            vec![
+                function_call("c1", "get_weather"),
+                function_call("c2", "get_time"),
+                response_done(),
+            ],
+        ));
+        *runner.session.write().await = Some(scripted as Arc<dyn RealtimeSession>);
+        runner.run().await.unwrap();
 
         assert_eq!(counts.tool_output.load(Ordering::SeqCst), 2, "both outputs sent");
         assert_eq!(counts.create_response.load(Ordering::SeqCst), 1, "exactly one response");
@@ -1165,5 +1278,347 @@ mod runner_tests {
         runner.handle_event(response_done()).await.unwrap();
         assert_eq!(counts.create_response.load(Ordering::SeqCst), 0);
         assert_eq!(counts.tool_output.load(Ordering::SeqCst), 0);
+    }
+
+    // ── Bounded concurrent tool dispatch ──────────────────────────────────
+    //
+    // `RunnerConfig::max_concurrent_tools` defaulted to four and was read by nothing: no
+    // semaphore, no scheduler. `FunctionCallDone` was awaited inline inside `handle_event`,
+    // which the run loop awaited before reading the next event, so tool calls ran strictly
+    // one at a time *and* stalled audio and every other event for the duration.
+
+    /// A session that replays a scripted event sequence, then reports disconnect.
+    struct ScriptedSession {
+        counts: Arc<Counts>,
+        events: parking_lot::Mutex<std::collections::VecDeque<ServerEvent>>,
+    }
+
+    impl ScriptedSession {
+        fn new(counts: Arc<Counts>, events: Vec<ServerEvent>) -> Self {
+            Self { counts, events: parking_lot::Mutex::new(events.into()) }
+        }
+    }
+
+    #[async_trait]
+    impl RealtimeSession for ScriptedSession {
+        fn session_id(&self) -> &str {
+            "scripted-session"
+        }
+        fn is_connected(&self) -> bool {
+            true
+        }
+        async fn send_audio(&self, _audio: &AudioChunk) -> Result<()> {
+            Ok(())
+        }
+        async fn send_audio_base64(&self, _audio: &str) -> Result<()> {
+            Ok(())
+        }
+        async fn send_text(&self, _text: &str) -> Result<()> {
+            Ok(())
+        }
+        async fn send_tool_response(&self, _response: ToolResponse) -> Result<()> {
+            self.counts.tool_response.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+        async fn send_tool_output(&self, _response: ToolResponse) -> Result<()> {
+            self.counts.tool_output.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+        async fn commit_audio(&self) -> Result<()> {
+            Ok(())
+        }
+        async fn clear_audio(&self) -> Result<()> {
+            Ok(())
+        }
+        async fn create_response(&self) -> Result<()> {
+            self.counts.create_response.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+        async fn interrupt(&self) -> Result<()> {
+            Ok(())
+        }
+        async fn send_event(&self, _event: ClientEvent) -> Result<()> {
+            Ok(())
+        }
+        async fn next_event(&self) -> Option<Result<ServerEvent>> {
+            let event = self.events.lock().pop_front();
+            event.map(Ok)
+        }
+        fn events(&self) -> Pin<Box<dyn futures::Stream<Item = Result<ServerEvent>> + Send + '_>> {
+            Box::pin(futures::stream::empty())
+        }
+        async fn close(&self) -> Result<()> {
+            Ok(())
+        }
+        async fn mutate_context(&self, _config: RealtimeConfig) -> Result<ContextMutationOutcome> {
+            Ok(ContextMutationOutcome::Applied)
+        }
+    }
+
+    /// A tool that reports how many copies of itself run at once.
+    struct ConcurrencyProbe {
+        in_flight: Arc<AtomicUsize>,
+        peak: Arc<AtomicUsize>,
+        barrier: Option<Arc<tokio::sync::Barrier>>,
+    }
+
+    #[async_trait]
+    impl ToolHandler for ConcurrencyProbe {
+        async fn execute(&self, _call: &ToolCall) -> Result<serde_json::Value> {
+            let now = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+            self.peak.fetch_max(now, Ordering::SeqCst);
+
+            match &self.barrier {
+                // Every participant must be running for this to return, so it can only
+                // complete if the dispatcher truly overlaps them.
+                Some(barrier) => {
+                    barrier.wait().await;
+                }
+                None => {
+                    tokio::task::yield_now().await;
+                }
+            }
+
+            self.in_flight.fetch_sub(1, Ordering::SeqCst);
+            Ok(serde_json::json!({ "ok": true }))
+        }
+    }
+
+    fn audio_delta() -> ServerEvent {
+        ServerEvent::AudioDelta {
+            event_id: "evt".into(),
+            response_id: "resp".into(),
+            item_id: "item".into(),
+            output_index: 0,
+            content_index: 0,
+            delta: vec![1, 2, 3],
+        }
+    }
+
+    #[tokio::test]
+    async fn tool_calls_overlap_up_to_the_configured_bound() {
+        let counts = Arc::new(Counts::default());
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        // Only satisfiable if all three run at once, which serial dispatch cannot do.
+        let barrier = Arc::new(tokio::sync::Barrier::new(3));
+
+        let probe = || ConcurrencyProbe {
+            in_flight: Arc::clone(&in_flight),
+            peak: Arc::clone(&peak),
+            barrier: Some(Arc::clone(&barrier)),
+        };
+
+        let runner = RealtimeRunner::builder()
+            .model(Arc::new(MockModel) as BoxedModel)
+            .runner_config(RunnerConfig {
+                auto_execute_tools: true,
+                auto_respond_tools: true,
+                max_concurrent_tools: 3,
+            })
+            .tool(tool_def("a"), probe())
+            .tool(tool_def("b"), probe())
+            .tool(tool_def("c"), probe())
+            .build()
+            .unwrap();
+
+        let scripted = Arc::new(ScriptedSession::new(
+            Arc::clone(&counts),
+            vec![function_call("c1", "a"), function_call("c2", "b"), function_call("c3", "c")],
+        ));
+        *runner.session.write().await = Some(scripted as Arc<dyn RealtimeSession>);
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), runner.run())
+            .await
+            .expect("serial dispatch cannot satisfy a three-way barrier")
+            .unwrap();
+
+        assert_eq!(peak.load(Ordering::SeqCst), 3, "all three tools must overlap");
+        assert_eq!(counts.tool_output.load(Ordering::SeqCst), 3, "every output is sent");
+    }
+
+    #[tokio::test]
+    async fn the_bound_caps_how_many_tools_overlap() {
+        let counts = Arc::new(Counts::default());
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+
+        let probe = || ConcurrencyProbe {
+            in_flight: Arc::clone(&in_flight),
+            peak: Arc::clone(&peak),
+            barrier: None,
+        };
+
+        let runner = RealtimeRunner::builder()
+            .model(Arc::new(MockModel) as BoxedModel)
+            .runner_config(RunnerConfig {
+                auto_execute_tools: true,
+                auto_respond_tools: true,
+                max_concurrent_tools: 2,
+            })
+            .tool(tool_def("a"), probe())
+            .tool(tool_def("b"), probe())
+            .tool(tool_def("c"), probe())
+            .tool(tool_def("d"), probe())
+            .build()
+            .unwrap();
+
+        let scripted = Arc::new(ScriptedSession::new(
+            Arc::clone(&counts),
+            vec![
+                function_call("c1", "a"),
+                function_call("c2", "b"),
+                function_call("c3", "c"),
+                function_call("c4", "d"),
+            ],
+        ));
+        *runner.session.write().await = Some(scripted as Arc<dyn RealtimeSession>);
+
+        runner.run().await.unwrap();
+
+        assert!(
+            peak.load(Ordering::SeqCst) <= 2,
+            "the bound was exceeded: peak {}",
+            peak.load(Ordering::SeqCst)
+        );
+        assert_eq!(counts.tool_output.load(Ordering::SeqCst), 4, "all four still complete");
+    }
+
+    /// A tool that blocks until an audio event has been handled.
+    struct WaitsForAudio {
+        audio_seen: Arc<tokio::sync::Notify>,
+    }
+
+    #[async_trait]
+    impl ToolHandler for WaitsForAudio {
+        async fn execute(&self, _call: &ToolCall) -> Result<serde_json::Value> {
+            self.audio_seen.notified().await;
+            Ok(serde_json::json!({ "ok": true }))
+        }
+    }
+
+    /// Signals the tool once audio is delivered.
+    struct AudioSignaller {
+        audio_seen: Arc<tokio::sync::Notify>,
+        audio_events: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl EventHandler for AudioSignaller {
+        async fn on_audio(&self, _audio: &[u8], _item_id: &str) -> Result<()> {
+            self.audio_events.fetch_add(1, Ordering::SeqCst);
+            self.audio_seen.notify_waiters();
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn audio_keeps_flowing_while_a_tool_runs() {
+        let counts = Arc::new(Counts::default());
+        let audio_seen = Arc::new(tokio::sync::Notify::new());
+        let audio_events = Arc::new(AtomicUsize::new(0));
+
+        let runner = RealtimeRunner::builder()
+            .model(Arc::new(MockModel) as BoxedModel)
+            .tool(tool_def("slow"), WaitsForAudio { audio_seen: Arc::clone(&audio_seen) })
+            .event_handler(AudioSignaller {
+                audio_seen: Arc::clone(&audio_seen),
+                audio_events: Arc::clone(&audio_events),
+            })
+            .build()
+            .unwrap();
+
+        // The tool can only finish once the audio delta *after* it has been handled, so
+        // this sequence completes only if event intake continues during tool execution.
+        let scripted = Arc::new(ScriptedSession::new(
+            Arc::clone(&counts),
+            vec![function_call("c1", "slow"), audio_delta(), response_done()],
+        ));
+        *runner.session.write().await = Some(scripted as Arc<dyn RealtimeSession>);
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), runner.run())
+            .await
+            .expect("a tool awaiting a later event deadlocks when dispatch blocks intake")
+            .unwrap();
+
+        assert_eq!(audio_events.load(Ordering::SeqCst), 1, "the audio delta was handled");
+        assert_eq!(counts.tool_output.load(Ordering::SeqCst), 1, "the tool still reported output");
+    }
+
+    #[tokio::test]
+    async fn the_follow_up_response_waits_for_tools_that_outlive_the_response() {
+        let counts = Arc::new(Counts::default());
+        let audio_seen = Arc::new(tokio::sync::Notify::new());
+        let audio_events = Arc::new(AtomicUsize::new(0));
+
+        let runner = RealtimeRunner::builder()
+            .model(Arc::new(MockModel) as BoxedModel)
+            .tool(tool_def("slow"), WaitsForAudio { audio_seen: Arc::clone(&audio_seen) })
+            .event_handler(AudioSignaller {
+                audio_seen: Arc::clone(&audio_seen),
+                audio_events: Arc::clone(&audio_events),
+            })
+            .build()
+            .unwrap();
+
+        // `ResponseDone` arrives while the tool is still running — impossible before
+        // dispatch was concurrent, and the case that would silently drop the follow-up
+        // response, since `pending_tool_response` is only set once output is sent.
+        let scripted = Arc::new(ScriptedSession::new(
+            Arc::clone(&counts),
+            vec![function_call("c1", "slow"), response_done(), audio_delta()],
+        ));
+        *runner.session.write().await = Some(scripted as Arc<dyn RealtimeSession>);
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), runner.run())
+            .await
+            .expect("run must finish")
+            .unwrap();
+
+        assert_eq!(counts.tool_output.load(Ordering::SeqCst), 1, "the output was sent");
+        assert_eq!(
+            counts.create_response.load(Ordering::SeqCst),
+            1,
+            "exactly one follow-up response, issued after the last tool finished"
+        );
+    }
+
+    /// Records terminal disconnects.
+    #[derive(Default)]
+    struct DisconnectWatcher {
+        disconnects: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl EventHandler for DisconnectWatcher {
+        async fn on_disconnect(&self) -> Result<()> {
+            self.disconnects.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn a_terminal_disconnect_is_surfaced_once() {
+        let counts = Arc::new(Counts::default());
+        let disconnects = Arc::new(AtomicUsize::new(0));
+
+        let runner = RealtimeRunner::builder()
+            .model(Arc::new(MockModel) as BoxedModel)
+            .event_handler(DisconnectWatcher { disconnects: Arc::clone(&disconnects) })
+            .build()
+            .unwrap();
+
+        let scripted = Arc::new(ScriptedSession::new(Arc::clone(&counts), vec![response_done()]));
+        *runner.session.write().await = Some(scripted as Arc<dyn RealtimeSession>);
+
+        // `run` returns `Ok(())` on transport loss, which on its own is indistinguishable
+        // from a graceful `close`.
+        runner.run().await.unwrap();
+
+        assert_eq!(
+            disconnects.load(Ordering::SeqCst),
+            1,
+            "transport loss must be reported exactly once"
+        );
     }
 }

--- a/docs/official_docs/realtime/tools.md
+++ b/docs/official_docs/realtime/tools.md
@@ -134,3 +134,60 @@ example is a headless probe that exercises single-tool, parallel-tool, and
 calculator turns on both providers.
 
 Next: [Multimodal →](multimodal.md)
+
+## Tool concurrency
+
+`RunnerConfig::max_concurrent_tools` (default 4) bounds how many tool handlers run at
+once. When a response dispatches several calls, the runner queues each on its event loop
+and admits it to execution as a permit frees:
+
+```rust
+use adk_realtime::{RealtimeRunner, RunnerConfig};
+
+let runner = RealtimeRunner::builder()
+    .model(model)
+    .runner_config(RunnerConfig {
+        auto_execute_tools: true,
+        auto_respond_tools: true,
+        max_concurrent_tools: 3,
+    })
+    .build()?;
+```
+
+Two properties follow, and both are covered by tests:
+
+- **Event intake continues during tool execution.** Audio deltas, transcripts, and
+  interruptions are handled while tools run. A handler that waits on something arriving
+  later in the session no longer deadlocks the session.
+- **One follow-up response, after the last output.** When tool output is sent
+  automatically, the model is owed a single `create_response`. It is issued once both the
+  dispatching response has closed and every dispatched tool has reported — in either
+  order, since a response can now close while tools are still running.
+
+> **Important:** the bound governs concurrency, not parallelism. Handlers share the
+> runner's task, so a handler that blocks the thread — synchronous file or network I/O,
+> heavy computation — still stalls the loop. Use `tokio::task::spawn_blocking` for those.
+
+## Disconnect policy
+
+The runner does not reconnect automatically. On transport loss it lets dispatched tools
+finish, calls `EventHandler::on_disconnect`, and returns from `run`:
+
+```rust
+use adk_realtime::{EventHandler, Result};
+
+struct Reconnecting;
+
+#[async_trait::async_trait]
+impl EventHandler for Reconnecting {
+    async fn on_disconnect(&self) -> Result<()> {
+        tracing::warn!("realtime transport ended");
+        Ok(())
+    }
+}
+```
+
+Reconnection stays with the caller because it requires deciding what context to replay
+and, on Gemini, whether a stored resumption token is still valid. The `on_disconnect` hook
+exists so transport loss can be told apart from a graceful `close` — `run` returns
+`Ok(())` for both.


### PR DESCRIPTION
## What

Resolves **RT-04**. `max_concurrent_tools` now bounds real concurrency, tool execution no longer stalls event intake, and terminal disconnect is distinguishable from a graceful close.

## Why

Two defects, one of them severe.

**The bound was decorative.** `RunnerConfig::max_concurrent_tools` defaults to 4. Its only references in the entire crate were the field declaration and that default:

```
$ grep -rn 'max_concurrent_tools' --include='*.rs' adk-realtime/
adk-realtime/src/runner.rs:158:    pub max_concurrent_tools: usize,
adk-realtime/src/runner.rs:163:        Self { auto_execute_tools: true, auto_respond_tools: true, max_concurrent_tools: 4 }
$ grep -rn 'Semaphore' --include='*.rs' adk-realtime/src | wc -l
0
```

**Tool execution stalled the session.** `handle_event` awaited `execute_tool_call` inline, and `run` awaited `handle_event` before calling `next_event()` again. So a tool call blocked audio deltas, transcripts, and interruption events for its whole duration — and a handler waiting on anything arriving later in the session deadlocked it permanently.

## How

`handle_event` returns the pending call rather than running it; the run loop dispatches onto a `FuturesUnordered` while `select!`ing against `next_event`. The permit is acquired *inside* each future, so queueing never blocks intake — the bound applies to execution, not admission.

### The ordering that concurrency broke

This is the part worth reviewing. The single `create_response` owed after automatic tool output was triggered from `ResponseDone`. Under the old inline await, `ResponseDone` **could not** arrive until tools had finished, so the ordering held by accident. Once tools run concurrently it can arrive first — and `pending_tool_response` is only set *after* output is sent, so `respond_after_tools` would have found the flag false, done nothing, and the model would sit silent forever.

The response is now issued when both conditions hold, in whichever order they occur:

| Condition | Tracked by |
|---|---|
| Dispatching response has closed | `response_closed_awaiting_tools` |
| Every dispatched tool has reported | `outstanding_tools` reaching 0 |

Whichever completes last issues the response. `the_follow_up_response_waits_for_tools_that_outlive_the_response` covers exactly this.

### Disconnect

`run` returned `Ok(())` on real transport loss — identical to a graceful `close`. It now drains in-flight tools (so their output is not dropped mid-flight), calls the new defaulted `EventHandler::on_disconnect`, then returns. Automatic reconnection is deliberately **not** added: replaying context and judging whether a Gemini resumption token is still valid are caller decisions. The policy is now documented instead of implied by the resumption state machine.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo clippy -p adk-realtime` with `openai`, `gemini`, `full` | exit 0 each |
| `cargo check --workspace` | exit 0 |
| `cargo nextest run --workspace --profile ci` | **3826 passed**, 83 skipped, 0 failed |
| `cargo nextest run -p adk-realtime` | 54 passed |
| `RUSTDOCFLAGS=-D warnings cargo doc -p adk-realtime` | exit 0 |
| doc-examples guard | exit 0 |

### The tests fail against the old behaviour

Reverting only the dispatch (push, then drain immediately — semantically the old inline await) while keeping the new APIs so the tests still compile:

```
PASS  the_bound_caps_how_many_tools_overlap
FAIL  audio_keeps_flowing_while_a_tool_runs                          (5.010s)
      panicked: a tool awaiting a later event deadlocks when dispatch blocks intake: Elapsed(())
FAIL  the_follow_up_response_waits_for_tools_that_outlive_the_response (5.010s)
FAIL  tool_calls_overlap_up_to_the_configured_bound                   (5.010s)
```

Three of four fail, and the deadlock is the predicted one. The fourth passes under both because a *cap* of two is trivially satisfied by serial execution — it guards the opposite direction, that the bound is not exceeded.

The existing `parallel_tool_calls_trigger_a_single_response` was updated to drive `run` with a scripted session instead of calling `handle_event` directly, since dispatch is the loop's job now. That makes it cover the real path rather than a method in isolation.

## Notes for the reviewer

- **Concurrency, not parallelism.** Handlers share the runner's task. A handler that blocks the thread still stalls the loop; the docs say so and point at `spawn_blocking`. Making tools truly parallel would require `run(self: &Arc<Self>)` — a breaking signature change — for no benefit to the I/O-bound handlers this serves.
- **`cargo semver-checks -p adk-realtime` cannot run**, and not because of this change: building rustdoc for the **1.0.0 baseline** fails with `error[E0063]: missing field page_token in initializer of ListEgressRequest` — livekit API drift under the old pin. The current crate builds and documents cleanly. This change adds private fields to `RealtimeRunner` (builder-constructed) and a defaulted trait method, neither of which is breaking.
- `tokio` gains the `macros` feature in this crate for `select!`; `Cargo.lock` is unchanged.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed — new sections in `docs/official_docs/realtime/tools.md`
- [x] Examples added or updated for new features