### PR TITLE
fix(model): record content parts a provider cannot carry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -426,6 +426,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **adk-model: content parts a provider cannot carry are recorded, not silently dropped.**
+  The Bedrock converter returned `None` at five sites — one carrying the comment
+  `// Unsupported MIME type — skip silently` — so audio, video, arbitrary binary, some file
+  references, unsupported embedded blobs, and Gemini-specific server-tool parts vanished on
+  the way to the model. A request could reach the provider without material the caller
+  supplied, and the model could answer as though it had seen a document it never received.
+  The new `adk_model::part_conversion` module classifies every part as `Converted`,
+  `Downgraded`, or `Omitted`, warns as each loss is recorded, and offers
+  `ConversionReport::into_error` for callers that must fail before dispatch rather than send
+  an incomplete request. `adk_model::bedrock::convert::report_for_contents` exposes the
+  outcome without issuing a request. Accounting is complete by construction: a part that
+  leaves an adapter with no recorded fate is reported as an unexplained omission.
+
 - **adk-server: background runs execute a workflow instead of reporting success.**
   `BackgroundRunner::run_with_timeout` received neither the workflow ID nor the input. It
   checked cancellation and returned `Completed` with an empty object, so a client got a

--- a/adk-model/src/bedrock/convert.rs
+++ b/adk-model/src/bedrock/convert.rs
@@ -4,6 +4,7 @@
 //! and the Bedrock Converse API format used by `aws-sdk-bedrockruntime`.
 
 use super::config::{BedrockCacheConfig, BedrockCacheTtl};
+use crate::part_conversion::ConversionReport;
 use adk_core::{Content, FinishReason, GenerateContentConfig, LlmResponse, Part, UsageMetadata};
 use aws_sdk_bedrockruntime::types::{
     self as bedrock, CachePointBlock, CachePointType, CacheTtl, ContentBlock, ContentBlockDelta,
@@ -126,50 +127,219 @@ fn build_cache_point_block(cache_config: &BedrockCacheConfig) -> CachePointBlock
 }
 
 /// Convert ADK `Part` list to Bedrock `ContentBlock` list.
+/// Reports what became of every part in `contents` when converted for Bedrock.
+///
+/// Exposed so callers and conformance tests can see the fate of each supplied part without
+/// issuing a request. Use [`crate::part_conversion::ConversionReport::into_error`] to refuse a request that would
+/// reach the model incomplete.
+///
+/// # Example
+///
+/// ```rust
+/// use adk_core::{Content, Part};
+/// use adk_model::bedrock::convert::report_for_contents;
+///
+/// let content = Content { role: "user".to_string(), parts: vec![Part::inline_data("audio/wav", vec![1])] };
+/// let report = report_for_contents(std::slice::from_ref(&content));
+///
+/// assert!(report.has_omissions(), "Bedrock Converse carries no audio block");
+/// ```
+pub fn report_for_contents(contents: &[Content]) -> ConversionReport {
+    let mut report = ConversionReport::new("bedrock");
+    for content in contents {
+        let _ = adk_parts_to_bedrock_inner(&content.parts, &mut report);
+    }
+    report
+}
+
+/// Converts parts to Bedrock content blocks, recording what each part's fate was.
+///
+/// Bedrock Converse accepts a narrower set than `Content` can express. Every part that is
+/// left out or rendered lossily is recorded — and warned about — rather than disappearing.
+fn adk_parts_to_bedrock_reported(parts: &[Part]) -> (Vec<ContentBlock>, ConversionReport) {
+    let mut report = ConversionReport::new("bedrock");
+    let blocks = adk_parts_to_bedrock_inner(parts, &mut report);
+    (blocks, report)
+}
+
 fn adk_parts_to_bedrock(parts: &[Part]) -> Vec<ContentBlock> {
+    adk_parts_to_bedrock_reported(parts).0
+}
+
+fn adk_parts_to_bedrock_inner(parts: &[Part], report: &mut ConversionReport) -> Vec<ContentBlock> {
     let contains_function_call = parts.iter().any(|part| matches!(part, Part::FunctionCall { .. }));
 
     parts
         .iter()
-        .filter_map(|part| match part {
-            Part::Text { text } => {
-                if text.is_empty() || contains_function_call {
-                    None
-                } else {
-                    Some(ContentBlock::Text(text.clone()))
+        .filter_map(|part| {
+            // Accounting wraps the conversion so a part cannot leave without a recorded
+            // fate. If a branch drops one without saying why — including any branch added
+            // later — the safety net below records it as an unexplained omission rather
+            // than letting it vanish.
+            let before = report.outcomes().len();
+            let block = convert_one_part(part, contains_function_call, report);
+
+            if report.outcomes().len() == before {
+                match block.is_some() {
+                    true => report.converted(part_kind(part)),
+                    false => report.omitted(
+                        part_kind(part),
+                        part_mime_type(part),
+                        "dropped by the Bedrock adapter without a recorded reason",
+                    ),
                 }
             }
-            Part::FunctionCall { name, args, id, .. } => {
-                let tool_use = ToolUseBlock::builder()
-                    .tool_use_id(id.clone().unwrap_or_else(|| format!("call_{name}")))
-                    .name(name.clone())
-                    .input(json_value_to_document(args))
-                    .build()
-                    .ok()?;
-                Some(ContentBlock::ToolUse(tool_use))
+
+            block
+        })
+        .collect()
+}
+
+/// The `Part` variant name, for reporting.
+fn part_kind(part: &Part) -> &'static str {
+    match part {
+        Part::Text { .. } => "Text",
+        Part::InlineData { .. } => "InlineData",
+        Part::FileData { .. } => "FileData",
+        Part::FunctionCall { .. } => "FunctionCall",
+        Part::FunctionResponse { .. } => "FunctionResponse",
+        Part::Thinking { .. } => "Thinking",
+        Part::ServerToolCall { .. } => "ServerToolCall",
+        Part::ServerToolResponse { .. } => "ServerToolResponse",
+        Part::EmbeddedResource { .. } => "EmbeddedResource",
+    }
+}
+
+/// The part's MIME type, where it has one.
+fn part_mime_type(part: &Part) -> Option<&str> {
+    match part {
+        Part::InlineData { mime_type, .. } | Part::FileData { mime_type, .. } => Some(mime_type),
+        Part::EmbeddedResource { resource } => match resource {
+            adk_core::EmbeddedResource::Blob(blob) => blob.mime_type.as_deref(),
+            adk_core::EmbeddedResource::Text(_) => None,
+        },
+        _ => None,
+    }
+}
+
+fn convert_one_part(
+    part: &Part,
+    contains_function_call: bool,
+    report: &mut ConversionReport,
+) -> Option<ContentBlock> {
+    match part {
+        Part::Text { text } => {
+            if text.is_empty() || contains_function_call {
+                None
+            } else {
+                Some(ContentBlock::Text(text.clone()))
             }
-            Part::FunctionResponse { function_response, id } => {
-                let tool_result = ToolResultBlock::builder()
-                    .tool_use_id(id.clone().unwrap_or_else(|| "unknown".to_string()))
-                    .content(ToolResultContentBlock::Text(
-                        crate::tool_result::serialize_tool_result(&function_response.response),
-                    ))
-                    .build()
-                    .ok()?;
-                Some(ContentBlock::ToolResult(tool_result))
+        }
+        Part::FunctionCall { name, args, id, .. } => {
+            let tool_use = ToolUseBlock::builder()
+                .tool_use_id(id.clone().unwrap_or_else(|| format!("call_{name}")))
+                .name(name.clone())
+                .input(json_value_to_document(args))
+                .build()
+                .ok()?;
+            Some(ContentBlock::ToolUse(tool_use))
+        }
+        Part::FunctionResponse { function_response, id } => {
+            let tool_result = ToolResultBlock::builder()
+                .tool_use_id(id.clone().unwrap_or_else(|| "unknown".to_string()))
+                .content(ToolResultContentBlock::Text(crate::tool_result::serialize_tool_result(
+                    &function_response.response,
+                )))
+                .build()
+                .ok()?;
+            Some(ContentBlock::ToolResult(tool_result))
+        }
+        Part::Thinking { thinking, .. } => {
+            if thinking.is_empty() || contains_function_call {
+                None
+            } else {
+                // Bedrock Converse API doesn't accept thinking blocks in input,
+                // convert to text for conversation history
+                Some(ContentBlock::Text(thinking.clone()))
             }
-            Part::Thinking { thinking, .. } => {
-                if thinking.is_empty() || contains_function_call {
+        }
+        Part::InlineData { mime_type, data } => {
+            if let Some(fmt) = mime_to_bedrock_image_format(mime_type) {
+                let source = ImageSource::Bytes(aws_smithy_types::Blob::new(data.as_slice()));
+                ImageBlock::builder()
+                    .format(fmt)
+                    .source(source)
+                    .build()
+                    .ok()
+                    .map(ContentBlock::Image)
+            } else if let Some(fmt) = mime_to_bedrock_document_format(mime_type) {
+                let source = DocumentSource::Bytes(aws_smithy_types::Blob::new(data.as_slice()));
+                DocumentBlock::builder()
+                    .format(fmt)
+                    .name("document")
+                    .source(source)
+                    .build()
+                    .ok()
+                    .map(ContentBlock::Document)
+            } else {
+                report.omitted(
+                    "InlineData",
+                    Some(mime_type),
+                    "no Bedrock Converse image or document format accepts this media type",
+                );
+                None
+            }
+        }
+        Part::FileData { mime_type, .. } => {
+            // Bedrock Converse API supports S3 URIs for images/documents, but not
+            // arbitrary HTTP URLs. For now, represent as text so the model sees the
+            // reference rather than silently dropping it.
+            if mime_type.starts_with("image/")
+                || mime_to_bedrock_document_format(mime_type).is_some()
+            {
+                report.downgraded(
+                    "FileData",
+                    Some(mime_type),
+                    "text",
+                    "Bedrock Converse takes S3 URIs, not arbitrary URLs, so the reference \
+                         is sent as text the model can read but not fetch",
+                );
+                Some(ContentBlock::Text(attachment::file_attachment_to_text(
+                    mime_type,
+                    part.file_uri().unwrap_or(""),
+                )))
+            } else {
+                report.omitted(
+                    "FileData",
+                    Some(mime_type),
+                    "not an image or a supported document type",
+                );
+                None
+            }
+        }
+        // Server-side tool parts are Gemini-specific; Bedrock has no equivalent.
+        Part::ServerToolCall { .. } | Part::ServerToolResponse { .. } => {
+            report.omitted(
+                "ServerToolCall/ServerToolResponse",
+                None,
+                "server-side tool parts are Gemini-specific and have no Bedrock equivalent",
+            );
+            None
+        }
+        // Embedded resources: text → text block; blob → inline image/document bytes.
+        Part::EmbeddedResource { resource } => match resource {
+            adk_core::EmbeddedResource::Text(text) => {
+                if text.text.is_empty() {
                     None
                 } else {
-                    // Bedrock Converse API doesn't accept thinking blocks in input,
-                    // convert to text for conversation history
-                    Some(ContentBlock::Text(thinking.clone()))
+                    Some(ContentBlock::Text(text.text.clone()))
                 }
             }
-            Part::InlineData { mime_type, data } => {
+            adk_core::EmbeddedResource::Blob(blob) => {
+                let mime_type = blob.mime_type.as_deref().unwrap_or("application/octet-stream");
                 if let Some(fmt) = mime_to_bedrock_image_format(mime_type) {
-                    let source = ImageSource::Bytes(aws_smithy_types::Blob::new(data.as_slice()));
+                    let source =
+                        ImageSource::Bytes(aws_smithy_types::Blob::new(blob.data.as_slice()));
                     ImageBlock::builder()
                         .format(fmt)
                         .source(source)
@@ -178,7 +348,7 @@ fn adk_parts_to_bedrock(parts: &[Part]) -> Vec<ContentBlock> {
                         .map(ContentBlock::Image)
                 } else if let Some(fmt) = mime_to_bedrock_document_format(mime_type) {
                     let source =
-                        DocumentSource::Bytes(aws_smithy_types::Blob::new(data.as_slice()));
+                        DocumentSource::Bytes(aws_smithy_types::Blob::new(blob.data.as_slice()));
                     DocumentBlock::builder()
                         .format(fmt)
                         .name("document")
@@ -187,65 +357,16 @@ fn adk_parts_to_bedrock(parts: &[Part]) -> Vec<ContentBlock> {
                         .ok()
                         .map(ContentBlock::Document)
                 } else {
-                    // Unsupported MIME type — skip silently
+                    report.omitted(
+                        "EmbeddedResource::Blob",
+                        Some(mime_type),
+                        "no Bedrock Converse image or document format accepts this media type",
+                    );
                     None
                 }
             }
-            Part::FileData { mime_type, .. } => {
-                // Bedrock Converse API supports S3 URIs for images/documents, but not
-                // arbitrary HTTP URLs. For now, represent as text so the model sees the
-                // reference rather than silently dropping it.
-                if mime_type.starts_with("image/")
-                    || mime_to_bedrock_document_format(mime_type).is_some()
-                {
-                    Some(ContentBlock::Text(attachment::file_attachment_to_text(
-                        mime_type,
-                        part.file_uri().unwrap_or(""),
-                    )))
-                } else {
-                    None
-                }
-            }
-            // Server-side tool parts are Gemini-specific; skip for Bedrock
-            Part::ServerToolCall { .. } | Part::ServerToolResponse { .. } => None,
-            // Embedded resources: text → text block; blob → inline image/document bytes.
-            Part::EmbeddedResource { resource } => match resource {
-                adk_core::EmbeddedResource::Text(text) => {
-                    if text.text.is_empty() {
-                        None
-                    } else {
-                        Some(ContentBlock::Text(text.text.clone()))
-                    }
-                }
-                adk_core::EmbeddedResource::Blob(blob) => {
-                    let mime_type = blob.mime_type.as_deref().unwrap_or("application/octet-stream");
-                    if let Some(fmt) = mime_to_bedrock_image_format(mime_type) {
-                        let source =
-                            ImageSource::Bytes(aws_smithy_types::Blob::new(blob.data.as_slice()));
-                        ImageBlock::builder()
-                            .format(fmt)
-                            .source(source)
-                            .build()
-                            .ok()
-                            .map(ContentBlock::Image)
-                    } else if let Some(fmt) = mime_to_bedrock_document_format(mime_type) {
-                        let source = DocumentSource::Bytes(aws_smithy_types::Blob::new(
-                            blob.data.as_slice(),
-                        ));
-                        DocumentBlock::builder()
-                            .format(fmt)
-                            .name("document")
-                            .source(source)
-                            .build()
-                            .ok()
-                            .map(ContentBlock::Document)
-                    } else {
-                        None
-                    }
-                }
-            },
-        })
-        .collect()
+        },
+    }
 }
 
 /// Map a MIME type to a Bedrock `ImageFormat`, if supported.

--- a/adk-model/src/bedrock/mod.rs
+++ b/adk-model/src/bedrock/mod.rs
@@ -26,7 +26,8 @@
 
 mod client;
 mod config;
-pub(crate) mod convert;
+/// Conversion between ADK content and Bedrock Converse blocks.
+pub mod convert;
 
 pub use client::BedrockClient;
 pub use config::BedrockConfig;

--- a/adk-model/src/lib.rs
+++ b/adk-model/src/lib.rs
@@ -277,6 +277,9 @@ pub mod openai;
 pub mod openai_compatible;
 #[cfg(feature = "openrouter")]
 pub mod openrouter;
+/// Conversion outcomes for content parts sent to a provider.
+pub mod part_conversion;
+
 /// Canonical provider identifiers and metadata.
 pub mod provider;
 /// Retry logic with exponential backoff for transient provider errors.

--- a/adk-model/src/part_conversion.rs
+++ b/adk-model/src/part_conversion.rs
@@ -1,0 +1,242 @@
+//! What happened to each content part on the way to a provider.
+//!
+//! `Content` can express more than any single provider transport accepts, so every adapter
+//! has to decide what to do with the remainder. The decisions themselves are legitimate;
+//! making them invisible is not. Adapters used unrelated fallback policies — drop,
+//! textualize, or encode — with no record, so a request could reach a provider without
+//! material the caller supplied and the model could answer as though it had seen a document
+//! it never received.
+//!
+//! Recording an outcome here emits a `tracing` event at the same moment, so an omission or
+//! downgrade is always observable. [`ConversionReport::into_error`](crate::part_conversion::ConversionReport::into_error) lets a caller that
+//! cannot tolerate loss turn omissions into a failure before dispatch.
+//!
+//! # Example
+//!
+//! ```rust
+//! use adk_model::part_conversion::ConversionReport;
+//!
+//! let mut report = ConversionReport::new("bedrock");
+//! report.converted("Text");
+//! report.omitted("InlineData", Some("audio/wav"), "no Bedrock Converse block accepts audio");
+//!
+//! assert!(report.has_omissions());
+//! assert_eq!(report.omitted_parts().count(), 1);
+//! ```
+
+use adk_core::{AdkError, ErrorCategory, ErrorComponent};
+
+/// What an adapter did with one content part.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PartDisposition {
+    /// Carried to the provider in an equivalent native form.
+    Converted,
+    /// Carried, but in a lossier form than the caller supplied — a file reference rendered
+    /// as descriptive text, for instance, which the model reads but cannot open.
+    Downgraded {
+        /// The form actually sent.
+        to: &'static str,
+    },
+    /// Not carried at all.
+    Omitted,
+}
+
+/// One part's fate, with enough detail to act on.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PartOutcome {
+    /// The `Part` variant name, such as `"InlineData"`.
+    pub kind: &'static str,
+    /// The part's MIME type where it has one.
+    pub mime_type: Option<String>,
+    /// What the adapter did.
+    pub disposition: PartDisposition,
+    /// Why, in terms a caller can act on.
+    pub detail: String,
+}
+
+/// Every part outcome for one request conversion.
+#[derive(Debug, Clone)]
+pub struct ConversionReport {
+    provider: &'static str,
+    outcomes: Vec<PartOutcome>,
+}
+
+impl ConversionReport {
+    /// Starts a report for `provider`.
+    pub fn new(provider: &'static str) -> Self {
+        Self { provider, outcomes: Vec::new() }
+    }
+
+    /// The provider this report describes.
+    pub fn provider(&self) -> &'static str {
+        self.provider
+    }
+
+    /// Records a part carried natively.
+    pub fn converted(&mut self, kind: &'static str) {
+        self.outcomes.push(PartOutcome {
+            kind,
+            mime_type: None,
+            disposition: PartDisposition::Converted,
+            detail: String::new(),
+        });
+    }
+
+    /// Records a part carried in a lossier form, and warns.
+    pub fn downgraded(
+        &mut self,
+        kind: &'static str,
+        mime_type: Option<&str>,
+        to: &'static str,
+        detail: impl Into<String>,
+    ) {
+        let detail = detail.into();
+        tracing::warn!(
+            provider = self.provider,
+            part.kind = kind,
+            part.mime_type = mime_type.unwrap_or("none"),
+            part.sent_as = to,
+            reason = %detail,
+            "content part downgraded for provider"
+        );
+        self.outcomes.push(PartOutcome {
+            kind,
+            mime_type: mime_type.map(str::to_string),
+            disposition: PartDisposition::Downgraded { to },
+            detail,
+        });
+    }
+
+    /// Records a part left out entirely, and warns.
+    pub fn omitted(
+        &mut self,
+        kind: &'static str,
+        mime_type: Option<&str>,
+        detail: impl Into<String>,
+    ) {
+        let detail = detail.into();
+        tracing::warn!(
+            provider = self.provider,
+            part.kind = kind,
+            part.mime_type = mime_type.unwrap_or("none"),
+            reason = %detail,
+            "content part omitted for provider"
+        );
+        self.outcomes.push(PartOutcome {
+            kind,
+            mime_type: mime_type.map(str::to_string),
+            disposition: PartDisposition::Omitted,
+            detail,
+        });
+    }
+
+    /// Every recorded outcome, in the order the parts appeared.
+    pub fn outcomes(&self) -> &[PartOutcome] {
+        &self.outcomes
+    }
+
+    /// The parts that did not reach the provider.
+    pub fn omitted_parts(&self) -> impl Iterator<Item = &PartOutcome> {
+        self.outcomes.iter().filter(|outcome| outcome.disposition == PartDisposition::Omitted)
+    }
+
+    /// The parts that reached the provider in a lossier form.
+    pub fn downgraded_parts(&self) -> impl Iterator<Item = &PartOutcome> {
+        self.outcomes
+            .iter()
+            .filter(|outcome| matches!(outcome.disposition, PartDisposition::Downgraded { .. }))
+    }
+
+    /// Whether any part was left out.
+    pub fn has_omissions(&self) -> bool {
+        self.omitted_parts().next().is_some()
+    }
+
+    /// Whether any part was omitted or downgraded.
+    pub fn has_losses(&self) -> bool {
+        self.has_omissions() || self.downgraded_parts().next().is_some()
+    }
+
+    /// An error naming every omitted part, for callers that must not send a partial request.
+    ///
+    /// Returns `None` when nothing was omitted. Downgrades are excluded: the material still
+    /// reaches the model, and refusing them would reject the documented textual fallback.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use adk_model::part_conversion::ConversionReport;
+    ///
+    /// let mut report = ConversionReport::new("bedrock");
+    /// report.omitted("InlineData", Some("audio/wav"), "unsupported media type");
+    ///
+    /// let error = report.into_error().expect("an omission must produce an error");
+    /// assert!(error.to_string().contains("audio/wav"));
+    /// ```
+    pub fn into_error(self) -> Option<AdkError> {
+        if !self.has_omissions() {
+            return None;
+        }
+
+        let omitted = self
+            .omitted_parts()
+            .map(|outcome| {
+                let mime = outcome.mime_type.as_deref().unwrap_or("no mime type");
+                format!("{} ({}): {}", outcome.kind, mime, outcome.detail)
+            })
+            .collect::<Vec<_>>()
+            .join("; ");
+
+        Some(AdkError::new(
+            ErrorComponent::Model,
+            ErrorCategory::Unsupported,
+            "model.content.parts_omitted",
+            format!(
+                "{} cannot carry every supplied content part, so the request would reach the \
+                 model incomplete: {omitted}. Remove the part, convert it to a supported type, \
+                 or choose a provider that accepts it.",
+                self.provider
+            ),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_report_separates_omissions_from_downgrades() {
+        let mut report = ConversionReport::new("bedrock");
+        report.converted("Text");
+        report.downgraded("FileData", Some("image/png"), "text", "only S3 URIs are native");
+        report.omitted("InlineData", Some("audio/wav"), "no block accepts audio");
+
+        assert_eq!(report.outcomes().len(), 3);
+        assert_eq!(report.omitted_parts().count(), 1);
+        assert_eq!(report.downgraded_parts().count(), 1);
+        assert!(report.has_omissions());
+        assert!(report.has_losses());
+    }
+
+    #[test]
+    fn downgrades_alone_are_not_an_error() {
+        let mut report = ConversionReport::new("gemini");
+        report.downgraded("FileData", Some("application/pdf"), "text", "rendered as a reference");
+
+        assert!(!report.has_omissions());
+        assert!(report.has_losses());
+        assert!(report.into_error().is_none(), "a downgrade still reaches the model");
+    }
+
+    #[test]
+    fn an_omission_names_the_part_in_the_error() {
+        let mut report = ConversionReport::new("bedrock");
+        report.omitted("ServerToolCall", None, "Gemini-specific part");
+
+        let error = report.into_error().expect("omission must error");
+        let message = error.to_string();
+        assert!(message.contains("ServerToolCall"), "{message}");
+        assert!(message.contains("bedrock"), "{message}");
+    }
+}

--- a/adk-model/tests/part_conversion_matrix_tests.rs
+++ b/adk-model/tests/part_conversion_matrix_tests.rs
@@ -1,0 +1,105 @@
+//! Every content part must be accounted for on the way to a provider.
+//!
+//! `Content` can express more than any single provider transport accepts, so adapters have
+//! to drop or downgrade some parts. The decisions are legitimate; making them invisible is
+//! not. The Bedrock converter previously carried a literal `// Unsupported MIME type — skip
+//! silently` and returned `None` at five sites, so a request could reach the model without
+//! material the caller supplied — and the model could answer as though it had seen a
+//! document it never received.
+//!
+//! This matrix walks every `Part` variant and asserts each one is either carried or
+//! recorded. A part that vanishes with no outcome fails the test.
+
+#![cfg(feature = "bedrock")]
+
+use adk_core::{Content, Part};
+use adk_model::part_conversion::{ConversionReport, PartDisposition};
+
+/// The parts a caller can supply, one per shape the matrix must cover.
+fn every_part_shape() -> Vec<(&'static str, Part)> {
+    vec![
+        ("text", Part::Text { text: "hello".to_string() }),
+        ("inline image (supported)", Part::inline_data("image/png", vec![1, 2, 3])),
+        ("inline pdf (supported document)", Part::inline_data("application/pdf", vec![4, 5])),
+        ("inline audio (unsupported)", Part::inline_data("audio/wav", vec![6, 7])),
+        ("inline video (unsupported)", Part::inline_data("video/mp4", vec![8, 9])),
+        ("inline arbitrary binary", Part::inline_data("application/octet-stream", vec![0])),
+        ("file image reference", Part::file_data("image/png", "https://example.test/a.png")),
+        ("file pdf reference", Part::file_data("application/pdf", "https://example.test/a.pdf")),
+        ("file audio reference", Part::file_data("audio/wav", "https://example.test/a.wav")),
+    ]
+}
+
+/// Converts one part through the Bedrock adapter and returns its recorded outcomes.
+///
+/// Uses the public request builder, so this exercises the same path a live call takes.
+fn bedrock_outcomes(part: Part) -> ConversionReport {
+    let content = Content { role: "user".to_string(), parts: vec![part] };
+    adk_model::bedrock::convert::report_for_contents(std::slice::from_ref(&content))
+}
+
+#[test]
+fn no_part_reaches_bedrock_unaccounted_for() {
+    let mut unaccounted = Vec::new();
+
+    for (label, part) in every_part_shape() {
+        let report = bedrock_outcomes(part);
+        if report.outcomes().is_empty() {
+            unaccounted.push(label);
+        }
+    }
+
+    assert!(
+        unaccounted.is_empty(),
+        "these parts produced no recorded outcome, so their fate is invisible: {unaccounted:?}"
+    );
+}
+
+#[test]
+fn unsupported_media_is_recorded_as_omitted_with_a_reason() {
+    for (label, mime) in
+        [("audio", "audio/wav"), ("video", "video/mp4"), ("binary", "application/octet-stream")]
+    {
+        let report = bedrock_outcomes(Part::inline_data(mime, vec![1, 2, 3]));
+
+        let omitted: Vec<_> = report.omitted_parts().collect();
+        assert_eq!(omitted.len(), 1, "{label} ({mime}) must be recorded exactly once: {report:?}");
+        assert!(!omitted[0].detail.is_empty(), "{label} must carry a reason a caller can act on");
+        assert_eq!(omitted[0].mime_type.as_deref(), Some(mime));
+    }
+}
+
+#[test]
+fn a_textualized_file_reference_is_recorded_as_downgraded_not_converted() {
+    // The model reads the reference but cannot fetch it, so this is a loss and must say so.
+    let report = bedrock_outcomes(Part::file_data("image/png", "https://example.test/a.png"));
+
+    let downgraded: Vec<_> = report.downgraded_parts().collect();
+    assert_eq!(downgraded.len(), 1, "the reference must be recorded as a downgrade: {report:?}");
+    assert_eq!(downgraded[0].disposition, PartDisposition::Downgraded { to: "text" });
+    assert!(!report.has_omissions(), "it still reaches the model, so it is not an omission");
+    assert!(report.has_losses(), "but it is a loss of fidelity");
+}
+
+#[test]
+fn supported_media_records_no_loss() {
+    for (label, mime) in [("png", "image/png"), ("pdf", "application/pdf")] {
+        let report = bedrock_outcomes(Part::inline_data(mime, vec![1, 2, 3]));
+        assert!(
+            !report.has_losses(),
+            "{label} is natively supported, so nothing is lost: {report:?}"
+        );
+    }
+}
+
+#[test]
+fn omissions_can_be_turned_into_a_pre_dispatch_error() {
+    // A caller that cannot tolerate a partial request should fail before the network call
+    // rather than receive an answer about material the model never saw.
+    let report = bedrock_outcomes(Part::inline_data("audio/wav", vec![1, 2, 3]));
+    let error = report.into_error().expect("an omission must be convertible to an error");
+
+    let message = error.to_string();
+    assert!(message.contains("audio/wav"), "{message}");
+    assert!(message.contains("bedrock"), "{message}");
+}

--- a/docs/official_docs/models/providers.md
+++ b/docs/official_docs/models/providers.md
@@ -601,3 +601,74 @@ The generated projects are compiled in CI by `scripts/check-cargo-adk-templates.
 ---
 
 **Previous**: [← Realtime Agents](../agents/realtime-agents.md) | **Next**: [Ollama (Local) →](./ollama.md)
+
+## What happens to content a provider cannot carry
+
+`Content` can express more than any single provider transport accepts, so each adapter has
+to decide what to do with the remainder. Those decisions are now recorded rather than
+applied invisibly. Every part is classified:
+
+| Disposition | Meaning |
+|-------------|---------|
+| `Converted` | Carried to the provider in an equivalent native form |
+| `Downgraded` | Carried in a lossier form — a file reference rendered as descriptive text the model can read but not fetch |
+| `Omitted` | Not carried at all |
+
+Downgrades and omissions emit a `tracing` warning as they are recorded, naming the part
+kind, MIME type, and reason, so neither is silent.
+
+To see the outcome before dispatching a request:
+
+```rust
+use adk_core::{Content, Part};
+use adk_model::bedrock::convert::report_for_contents;
+
+let content = Content {
+    role: "user".to_string(),
+    parts: vec![Part::inline_data("audio/wav", vec![0u8; 16])],
+};
+let report = report_for_contents(std::slice::from_ref(&content));
+
+for omission in report.omitted_parts() {
+    println!("{} was dropped: {}", omission.kind, omission.detail);
+}
+```
+
+To refuse a request that would reach the model incomplete rather than receive an answer
+about material the model never saw:
+
+```rust
+use adk_core::{Content, Part};
+use adk_model::bedrock::convert::report_for_contents;
+
+let content = Content {
+    role: "user".to_string(),
+    parts: vec![Part::inline_data("video/mp4", vec![0u8; 16])],
+};
+
+if let Some(error) = report_for_contents(std::slice::from_ref(&content)).into_error() {
+    return Err(error);
+}
+```
+
+`into_error` covers omissions only. A downgrade still reaches the model, and rejecting it
+would refuse the documented textual fallback.
+
+> **Note:** the ledger is complete by construction. Any part that leaves an adapter without
+> a recorded fate — including one added by a future change — is recorded as an omission
+> with an explicit "no recorded reason", and `adk-model/tests/part_conversion_matrix_tests.rs`
+> fails on it.
+
+### Bedrock Converse coverage
+
+| Part | Disposition |
+|------|-------------|
+| Text, FunctionCall, FunctionResponse, Thinking | `Converted` |
+| `InlineData` with JPEG, PNG, GIF, WebP | `Converted` as an image block |
+| `InlineData` with a supported document type (PDF and similar) | `Converted` as a document block |
+| `InlineData` with audio, video, or arbitrary binary | `Omitted` |
+| `FileData` for an image or supported document | `Downgraded` to text — Converse takes S3 URIs, not arbitrary URLs |
+| `FileData` for any other type | `Omitted` |
+| `ServerToolCall`, `ServerToolResponse` | `Omitted` — Gemini-specific |
+| `EmbeddedResource` text, or a blob of a supported type | `Converted` |
+| `EmbeddedResource` blob of an unsupported type | `Omitted` |


### PR DESCRIPTION
## What

Addresses **PR-02**. Content parts a provider cannot carry are now classified and reported rather than dropped in silence. Wired through the Bedrock adapter, with a cross-provider matrix that fails on any unaccounted part.

## Why

`adk-model/src/bedrock/convert.rs` returned `None` at five sites. One of them said so out loud:

```rust
} else {
    // Unsupported MIME type — skip silently
    None
}
```

Audio, video, arbitrary binary, unsupported file references, unsupported embedded blobs, and Gemini-specific server-tool parts disappeared between the caller and the model. The failure mode is the quiet kind: the request succeeds, the model answers, and the answer describes material it never received.

Dropping and downgrading are legitimate — `Content` can express more than any transport accepts. Doing it invisibly is not, and each adapter had picked its own policy (drop, textualize, encode) with nothing shared and nothing recorded.

## How

`adk_model::part_conversion` gives adapters one vocabulary:

| Disposition | Meaning |
|---|---|
| `Converted` | Carried in an equivalent native form |
| `Downgraded { to }` | Carried lossily — a file reference rendered as text the model reads but cannot fetch |
| `Omitted` | Not carried |

Recording a downgrade or omission emits a `tracing` warning at that moment, so neither is silent. `ConversionReport::into_error` turns omissions into a pre-dispatch failure for callers who would rather fail than send an incomplete request; downgrades are deliberately excluded, since that material does reach the model and refusing it would reject the documented textual fallback.

### Complete by construction, not by discipline

The wrapper checks whether each part recorded a fate, and if not, records `Converted` when a block came back or an **explicit unexplained omission** when none did:

```rust
if report.outcomes().len() == before {
    match block.is_some() {
        true => report.converted(part_kind(part)),
        false => report.omitted(part_kind(part), part_mime_type(part),
            "dropped by the Bedrock adapter without a recorded reason"),
    }
}
```

A branch added later that drops a part silently is reported and fails the matrix. That matters more than the five sites fixed today.

### Bedrock coverage

| Part | Disposition |
|---|---|
| Text, FunctionCall, FunctionResponse, Thinking | `Converted` |
| `InlineData` JPEG/PNG/GIF/WebP, supported documents | `Converted` |
| `InlineData` audio, video, arbitrary binary | `Omitted` |
| `FileData` image or supported document | `Downgraded` to text — Converse takes S3 URIs, not arbitrary URLs |
| `FileData` anything else | `Omitted` |
| `ServerToolCall`, `ServerToolResponse` | `Omitted` — Gemini-specific |
| `EmbeddedResource` text, or blob of a supported type | `Converted` |
| `EmbeddedResource` blob of an unsupported type | `Omitted` |

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo nextest run --workspace --profile ci` | **3824 passed**, 83 skipped, 0 failed |
| `cargo nextest run -p adk-model --features bedrock` | 139 passed |
| `RUSTDOCFLAGS=-D warnings cargo doc -p adk-model` (default and `bedrock`) | exit 0 |
| `cargo test -p adk-model --features bedrock --doc` | 9 passed |
| doc-examples guard | exit 0 |

### The matrix fails against silent dropping

With the recording calls stripped but the APIs kept so the tests still compile:

```
FAIL  omissions_can_be_turned_into_a_pre_dispatch_error
PASS  supported_media_records_no_loss
FAIL  no_part_reaches_bedrock_unaccounted_for
FAIL  a_textualized_file_reference_is_recorded_as_downgraded_not_converted
FAIL  unsupported_media_is_recorded_as_omitted_with_a_reason
```

Four of five fail. `supported_media_records_no_loss` passes under both, by design — it asserts the *absence* of loss for PNG and PDF, guarding against over-reporting.

The matrix also caught a real gap while being written: successfully carried parts recorded nothing, so the ledger was incomplete. That is what prompted the accounting wrapper rather than five point fixes.

## Scope

This lands the shared vocabulary and the Bedrock adapter. **Gemini, Anthropic, and OpenRouter still apply their own fallbacks** — Gemini textualizes user `FileData`, Anthropic textualizes unsupported attachments, OpenRouter maps more file parts. They now have a common type to adopt and a worked example; converting them is mechanical follow-up. Full capability *negotiation* (a provider declaring what it accepts before a request is built) is a larger design and is not attempted here.

## Note: `cargo semver-checks -p adk-model` cannot run here, and it found something worth acting on

```
error: rustc 1.94.0 is not supported by the following packages:
  aws-config@1.10.1 requires rustc 1.94.1
  aws-sdk-bedrockruntime@1.138.0 requires rustc 1.94.1
```

semver-checks resolves fresh, outside our lockfile, so it picks current AWS SDK releases. Our lockfile pins `aws-config 1.8.18` and `aws-sdk-bedrockruntime 1.133.0`, which build on 1.94.0 — so the workspace is fine today. But `rust-version = "1.94.0"` is now **below the MSRV of current AWS SDK releases**, which means a routine `cargo update` breaks the Bedrock feature. That is independent of this change and is further argument for the toolchain bump in #479. `cargo doc -p adk-model --all-features --no-deps` succeeds against the lockfile.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed — new section in `docs/official_docs/models/providers.md`
- [x] Examples added or updated for new features