### PR TITLE
fix(managed): delete persisted sessions, report the status the loop writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -426,6 +426,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **adk-managed: deleting a session now deletes its persisted conversation.**
+  `delete_session` archived the session, cancelled its loop, and dropped the in-memory
+  handle, but never called `SessionService::delete` — even though `start_session` had seeded a
+  persistent session that the Runner appended every turn to. The API reported deletion while
+  the conversation remained in the configured backend, outliving the process that deleted it.
+  The identity used at creation is now recorded on the session and used for deletion, so a
+  change to session addressing cannot orphan data. If backend deletion fails, the error names
+  the app, user, and session that still hold data.
+- **adk-managed: session status reflects normal execution, not only control-plane calls.**
+  `ActiveSession` owned the `Arc<RwLock<SessionStatus>>` that `ManagedAgentRuntime::status`
+  reads, while `SessionLoop` owned a separate plain field, despite a comment claiming the two
+  were shared. Queued → running → idle transitions updated only the loop's copy, so a session
+  actively executing turns kept reporting `Queued`; only pause, resume, archive, and deletion
+  moved the public value. The loop now writes to the caller's handle via
+  `SessionLoop::with_shared_status`.
+
 - **adk-server: background runs execute a workflow instead of reporting success.**
   `BackgroundRunner::run_with_timeout` received neither the workflow ID nor the input. It
   checked cancellation and returned `Completed` with an empty object, so a client got a

--- a/adk-managed/src/default_runtime.rs
+++ b/adk-managed/src/default_runtime.rs
@@ -56,6 +56,21 @@ use crate::types::{ManagedAgentDef, RuntimeError, SessionEvent, SessionStatus, U
 
 // ─── ActiveSession ───────────────────────────────────────────────────────────
 
+/// The addressing a managed session's conversation was persisted under.
+///
+/// Deletion has to remove what creation wrote. Keeping the triple rather than rebuilding it
+/// means a change to how sessions are addressed cannot leave orphaned conversation data
+/// behind in the configured backend.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PersistedIdentity {
+    /// The app name the session was created under.
+    pub(crate) app_name: String,
+    /// The user the session was created for.
+    pub(crate) user_id: String,
+    /// The session's own identifier.
+    pub(crate) session_id: String,
+}
+
 /// Internal state for an active (or recently active) session.
 ///
 /// Each session spawns a background task running the [`SessionLoop`](crate::session_loop::SessionLoop).
@@ -77,6 +92,11 @@ pub(crate) struct ActiveSession {
     pub(crate) pause_notify: Arc<Notify>,
     /// Current session status (shared with the session loop).
     pub(crate) status: Arc<RwLock<SessionStatus>>,
+    /// The identity this session's conversation is persisted under.
+    ///
+    /// Recorded at creation so deletion removes exactly what creation wrote, rather than
+    /// re-deriving an identity and risking a mismatch that silently leaves data behind.
+    pub(crate) persisted_as: PersistedIdentity,
     /// Checkpoint manager for durable state.
     pub(crate) checkpoint: Arc<RwLock<CheckpointManager>>,
 }
@@ -327,17 +347,27 @@ impl ManagedAgentRuntime for DefaultManagedAgentRuntime {
         //    session to exist. We create it here with the same triple
         //    (app_name="managed", user_id="managed_user", session_id) that
         //    build_runner/run_str use in the session loop.
+        let persisted_as = PersistedIdentity {
+            app_name: "managed".to_string(),
+            user_id: "managed_user".to_string(),
+            session_id: session_id.clone(),
+        };
+
         self.session_service
             .create(CreateRequest {
-                app_name: "managed".to_string(),
-                user_id: "managed_user".to_string(),
+                app_name: persisted_as.app_name.clone(),
+                user_id: persisted_as.user_id.clone(),
                 session_id: Some(session_id.clone()),
                 state: std::collections::HashMap::new(),
             })
             .await
             .map_err(|e| RuntimeError::internal(format!("failed to seed session: {e}")))?;
 
-        // 8. Spawn SessionLoop as background task
+        // 8. Spawn SessionLoop as background task, sharing the status the caller observes
+        //    so normal queued → running → idle transitions are visible through
+        //    `ManagedAgentRuntime::status`.
+        let status = Arc::new(RwLock::new(SessionStatus::Queued));
+
         #[cfg(feature = "memory")]
         let session_loop = SessionLoop::with_pause_controls(
             session_id.clone(),
@@ -351,7 +381,8 @@ impl ManagedAgentRuntime for DefaultManagedAgentRuntime {
             Arc::clone(&agent_arc),
             Arc::clone(&self.session_service),
             self.memory.clone(),
-        );
+        )
+        .with_shared_status(Arc::clone(&status));
         #[cfg(not(feature = "memory"))]
         let session_loop = SessionLoop::with_pause_controls(
             session_id.clone(),
@@ -364,15 +395,14 @@ impl ManagedAgentRuntime for DefaultManagedAgentRuntime {
             Arc::clone(&checkpoint),
             Arc::clone(&agent_arc),
             Arc::clone(&self.session_service),
-        );
+        )
+        .with_shared_status(Arc::clone(&status));
         tokio::spawn(session_loop.run());
-
-        // 9. Set initial status to Queued
-        let status = Arc::new(RwLock::new(SessionStatus::Queued));
 
         // 10. Create and store ActiveSession
         let active_session = ActiveSession {
             agent: agent_arc,
+            persisted_as,
             event_tx,
             broadcast_tx,
             cancel_token,
@@ -514,11 +544,38 @@ impl ManagedAgentRuntime for DefaultManagedAgentRuntime {
 
         // Remove from sessions map
         let removed = self.sessions.write().await.remove(&session.0);
-        if removed.is_none() {
+        let Some(removed) = removed else {
             return Err(RuntimeError::NotFound { session_id: session.0.clone() });
-        }
+        };
 
-        debug!(session_id = %session.0, "session deleted");
+        // Deleting the handle is the control plane only. `start_session` seeded a persistent
+        // session and the Runner appended every turn to it, so stopping here reported
+        // deletion while the conversation stayed in the configured backend — surviving the
+        // process that "deleted" it. Delete under the identity creation used.
+        let identity = removed.persisted_as;
+        self.session_service
+            .delete(adk_session::DeleteRequest {
+                app_name: identity.app_name.clone(),
+                user_id: identity.user_id.clone(),
+                session_id: identity.session_id.clone(),
+            })
+            .await
+            .map_err(|e| {
+                // The handle is already gone, so the caller must be told the data is not.
+                RuntimeError::internal(format!(
+                    "session {} was removed from the runtime but its persisted conversation \
+                     could not be deleted: {e}. The data remains under app {} / user {} and \
+                     needs manual cleanup.",
+                    identity.session_id, identity.app_name, identity.user_id
+                ))
+            })?;
+
+        debug!(
+            session_id = %session.0,
+            app_name = %identity.app_name,
+            user_id = %identity.user_id,
+            "session deleted, including persisted conversation"
+        );
         Ok(())
     }
 }

--- a/adk-managed/src/session_loop.rs
+++ b/adk-managed/src/session_loop.rs
@@ -107,7 +107,11 @@ pub struct SessionLoop {
     /// Notify used to wake the loop after resume.
     pause_notify: Arc<Notify>,
     /// Current session status.
-    status: SessionStatus,
+    ///
+    /// Shared with the public session handle when the runtime installs its own via
+    /// [`SessionLoop::with_shared_status`]. Without that, the handle reported `Queued` for
+    /// the whole life of a session because the loop wrote to a field the handle never read.
+    status: Arc<RwLock<SessionStatus>>,
     /// The agent driving this session.
     agent: Arc<dyn Agent>,
     /// Session persistence backend (needed by the Runner).
@@ -151,7 +155,7 @@ impl SessionLoop {
             cancel_token,
             pause_flag: Arc::new(Mutex::new(false)),
             pause_notify: Arc::new(Notify::new()),
-            status: SessionStatus::Queued,
+            status: Arc::new(RwLock::new(SessionStatus::Queued)),
             agent,
             session_service,
             #[cfg(feature = "memory")]
@@ -190,7 +194,7 @@ impl SessionLoop {
             cancel_token,
             pause_flag,
             pause_notify,
-            status: SessionStatus::Queued,
+            status: Arc::new(RwLock::new(SessionStatus::Queued)),
             agent,
             session_service,
             memory,
@@ -225,11 +229,29 @@ impl SessionLoop {
             cancel_token,
             pause_flag,
             pause_notify,
-            status: SessionStatus::Queued,
+            status: Arc::new(RwLock::new(SessionStatus::Queued)),
             agent,
             session_service,
             usage_tracker: SessionUsageTracker::new(),
         }
+    }
+
+    /// Reports status into the handle the caller already holds.
+    ///
+    /// The runtime's `ActiveSession` owns the status a caller observes through
+    /// `ManagedAgentRuntime::status`. Installing it here is what makes normal
+    /// queued → running → idle transitions visible; without it the loop wrote to its own
+    /// field and the public handle stayed `Queued` through an entire session.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let session_loop = SessionLoop::with_pause_controls(/* ... */)
+    ///     .with_shared_status(Arc::clone(&active.status));
+    /// ```
+    pub fn with_shared_status(mut self, status: Arc<RwLock<SessionStatus>>) -> Self {
+        self.status = status;
+        self
     }
 
     /// Get a clone of the pause flag for external control.
@@ -375,7 +397,7 @@ impl SessionLoop {
     /// Process a single turn: emit status.running, invoke Runner, emit events, emit status.idle.
     async fn process_turn(&mut self, content: Vec<ContentBlock>) -> Result<(), RuntimeError> {
         // 1. Emit status.running
-        self.status = SessionStatus::Running;
+        *self.status.write().await = SessionStatus::Running;
         let running_event = SessionEvent::StatusRunning { seq: self.seq.next() };
         self.emit_event(running_event).await;
 
@@ -617,8 +639,11 @@ impl SessionLoop {
     /// Emit a session event: assign to checkpoint and broadcast.
     async fn emit_event(&mut self, event: SessionEvent) {
         // Checkpoint atomically via the shared manager.
-        let run_state =
-            RunState { seq: self.seq.current(), pending_tool_ids: Vec::new(), status: self.status };
+        let run_state = RunState {
+            seq: self.seq.current(),
+            pending_tool_ids: Vec::new(),
+            status: *self.status.read().await,
+        };
         self.checkpoint.write().await.checkpoint(event.clone(), run_state);
 
         // Broadcast to subscribers (ignore if no receivers).
@@ -627,7 +652,7 @@ impl SessionLoop {
 
     /// Emit a `status.idle` event and update internal status.
     async fn emit_idle(&mut self, stop_reason: Option<StopReason>, usage: Option<UsageReport>) {
-        self.status = SessionStatus::Idle;
+        *self.status.write().await = SessionStatus::Idle;
         let idle_event = SessionEvent::StatusIdle { seq: self.seq.next(), stop_reason, usage };
         self.emit_event(idle_event).await;
     }

--- a/adk-managed/tests/control_plane_tests.rs
+++ b/adk-managed/tests/control_plane_tests.rs
@@ -1,0 +1,179 @@
+//! The managed control plane must reflect the data plane.
+//!
+//! Two disconnects:
+//!
+//! 1. `delete_session` archived the handle and dropped it from the in-memory map, but never
+//!    called `SessionService::delete` — even though `start_session` seeded a persistent
+//!    session and the Runner appended every turn to it. The API reported deletion while the
+//!    conversation stayed in the configured backend, outliving the process that "deleted" it.
+//! 2. `ActiveSession` owned the `Arc<RwLock<SessionStatus>>` a caller reads, while
+//!    `SessionLoop` owned a separate plain field. Normal queued → running → idle transitions
+//!    updated only the loop's copy, so a session doing work kept reporting `Queued`. The
+//!    struct comment claimed the two were shared.
+
+use adk_core::{Content, FinishReason, Llm, LlmRequest, LlmResponse, LlmResponseStream};
+use adk_managed::resolver::{ModelResolver, ResolverResult};
+use adk_managed::types::{ContentBlock, ManagedAgentDef, ModelRef, SessionStatus, UserEvent};
+use adk_managed::{DefaultManagedAgentRuntime, ManagedAgentRuntime};
+use adk_session::InMemorySessionService;
+use adk_session::service::{GetRequest, SessionService};
+use async_trait::async_trait;
+use std::sync::Arc;
+
+/// A model that answers without a network call.
+struct SilentModel;
+
+#[async_trait]
+impl Llm for SilentModel {
+    fn name(&self) -> &str {
+        "silent"
+    }
+    async fn generate_content(
+        &self,
+        _request: LlmRequest,
+        _stream: bool,
+    ) -> adk_core::Result<LlmResponseStream> {
+        let response = LlmResponse {
+            content: Some(Content::new("model").with_text("ok")),
+            partial: false,
+            turn_complete: true,
+            finish_reason: Some(FinishReason::Stop),
+            ..Default::default()
+        };
+        Ok(Box::pin(async_stream::stream! { yield Ok(response); }))
+    }
+}
+
+/// Resolves every model reference to the silent model.
+struct SilentResolver;
+
+#[async_trait]
+impl ModelResolver for SilentResolver {
+    async fn resolve(&self, _model: &ModelRef) -> ResolverResult<Arc<dyn Llm>> {
+        Ok(Arc::new(SilentModel) as Arc<dyn Llm>)
+    }
+}
+
+/// The identity `start_session` persists a managed session under.
+const MANAGED_APP: &str = "managed";
+const MANAGED_USER: &str = "managed_user";
+
+/// Builds a runtime over a session service the test can inspect directly.
+fn runtime_with_service() -> (DefaultManagedAgentRuntime, Arc<InMemorySessionService>) {
+    let service = Arc::new(InMemorySessionService::new());
+    let runtime = DefaultManagedAgentRuntime::new(
+        Arc::new(SilentResolver) as Arc<dyn ModelResolver>,
+        Arc::clone(&service) as Arc<dyn SessionService>,
+    );
+    (runtime, service)
+}
+
+/// A minimal agent definition; no model call is made by these tests.
+fn agent_def(name: &str) -> ManagedAgentDef {
+    ManagedAgentDef::new(name, ModelRef::Shorthand("silent".to_string()))
+}
+
+/// Whether the backend still holds the session.
+async fn session_exists(service: &InMemorySessionService, session_id: &str) -> bool {
+    service
+        .get(GetRequest {
+            app_name: MANAGED_APP.to_string(),
+            user_id: MANAGED_USER.to_string(),
+            session_id: session_id.to_string(),
+            num_recent_events: None,
+            after: None,
+        })
+        .await
+        .map(|_| true)
+        .unwrap_or(false)
+}
+
+#[tokio::test]
+async fn deleting_a_managed_session_removes_its_persisted_conversation() {
+    let (runtime, service) = runtime_with_service();
+    let agent = runtime.create(agent_def("deleter")).await.expect("agent");
+    let session = runtime.start_session(&agent, None).await.expect("session");
+
+    assert!(
+        session_exists(&service, session.0.as_str()).await,
+        "start_session must seed a persistent session for the Runner to append to"
+    );
+
+    runtime.delete_session(&session).await.expect("delete");
+
+    assert!(
+        !session_exists(&service, session.0.as_str()).await,
+        "the persisted conversation survived a reported deletion"
+    );
+}
+
+#[tokio::test]
+async fn deleting_an_unknown_session_is_still_reported_as_not_found() {
+    let (runtime, _service) = runtime_with_service();
+    let agent = runtime.create(agent_def("deleter")).await.expect("agent");
+    let session = runtime.start_session(&agent, None).await.expect("session");
+
+    runtime.delete_session(&session).await.expect("first delete");
+
+    // The handle is gone, so a second delete must not silently succeed.
+    assert!(
+        runtime.delete_session(&session).await.is_err(),
+        "deleting an already-deleted session must report not found"
+    );
+}
+
+#[tokio::test]
+async fn a_new_session_reports_queued_through_the_public_handle() {
+    let (runtime, _service) = runtime_with_service();
+    let agent = runtime.create(agent_def("reporter")).await.expect("agent");
+    let session = runtime.start_session(&agent, None).await.expect("session");
+
+    // The starting point. What matters is that this handle is the one the loop writes to,
+    // asserted below.
+    assert_eq!(runtime.status(&session).await.expect("status"), SessionStatus::Queued);
+}
+
+#[tokio::test]
+async fn a_working_session_stops_reporting_queued() {
+    let (runtime, _service) = runtime_with_service();
+    let agent = runtime.create(agent_def("reporter")).await.expect("agent");
+    let session = runtime.start_session(&agent, None).await.expect("session");
+
+    runtime
+        .send_event(
+            &session,
+            UserEvent::Message { content: vec![ContentBlock::Text { text: "hi".into() }] },
+        )
+        .await
+        .expect("send");
+
+    // The loop transitions queued → running → idle. Before the status handle was shared,
+    // those writes landed on the loop's own field and this stayed `Queued` forever.
+    let moved_on = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            let status = runtime.status(&session).await.expect("status");
+            if status != SessionStatus::Queued {
+                return status;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await;
+
+    let status = moved_on.expect("a session that has done work must stop reporting Queued");
+    assert!(
+        matches!(status, SessionStatus::Running | SessionStatus::Idle),
+        "expected a normal working transition, saw {status:?}"
+    );
+}
+
+#[tokio::test]
+async fn archive_is_visible_through_the_public_handle() {
+    let (runtime, _service) = runtime_with_service();
+    let agent = runtime.create(agent_def("reporter")).await.expect("agent");
+    let session = runtime.start_session(&agent, None).await.expect("session");
+
+    runtime.archive(&session).await.expect("archive");
+
+    assert_eq!(runtime.status(&session).await.expect("status"), SessionStatus::Archived);
+}

--- a/docs/official_docs/managed-agents/runtime.md
+++ b/docs/official_docs/managed-agents/runtime.md
@@ -279,3 +279,42 @@ cargo run --manifest-path examples/managed_runtime_hello/Cargo.toml
 ```
 
 This runs fixture F-1 end-to-end with `ScriptedLlm` (no API key required).
+
+## Status reporting
+
+`ManagedAgentRuntime::status` reads the same handle the session loop writes to, so normal
+transitions are visible, not just control-plane ones:
+
+| Transition | Cause |
+|------------|-------|
+| `Queued` → `Running` | A turn begins |
+| `Running` → `Idle` | The turn completes and usage is recorded |
+| any → `Paused` | `pause` |
+| any → `Archived` | `archive` or `delete_session` |
+
+> **Note:** before this was one shared handle, `status` reported `Queued` for the entire life
+> of a session, including while it was executing turns. Control-plane transitions
+> (pause, resume, archive) were visible because they wrote to the handle directly.
+
+## Deletion semantics
+
+`delete_session` removes both planes:
+
+1. Sets the session terminal and cancels its loop.
+2. Removes the runtime handle.
+3. Deletes the persisted conversation through the injected `SessionService`, under the same
+   identity `start_session` created it with.
+
+If step 3 fails, `delete_session` returns an error naming the app, user, and session that
+still hold data — the handle is already gone at that point, so the caller has to be told
+what needs manual cleanup rather than being allowed to assume success.
+
+```rust,ignore
+runtime.delete_session(&session).await?;
+// The handle is gone and the conversation is no longer in the session backend.
+```
+
+> **Important:** managed sessions are persisted under a fixed app name `managed` and user
+> `managed_user`. Caller identity and `EnvironmentConfig` are not yet applied — see the
+> crate's experimental status. Deletion therefore removes the conversation for the session
+> ID, not for a tenant.


### PR DESCRIPTION
## What

Resolves **MR-04** and **MR-03**. Managed deletion now removes the persisted conversation, and `status` reflects normal execution rather than only control-plane calls.

## MR-04 — deletion removed the handle, not the data

`delete_session` archived the session, cancelled its loop, and dropped the in-memory entry. That was all:

```rust
let removed = self.sessions.write().await.remove(&session.0);
if removed.is_none() { return Err(RuntimeError::NotFound { .. }); }
debug!(session_id = %session.0, "session deleted");
Ok(())
```

`start_session` seeds a persistent session so the nested Runner can append to it — and every turn went there. Nothing ever called `SessionService::delete`, so the API reported deletion while the conversation stayed in the configured backend, **surviving the process that deleted it**.

Deletion now runs under the identity recorded at creation, stored on the session as `PersistedIdentity`, rather than rebuilding the triple at delete time. Deletion has to remove what creation wrote; re-deriving it means a future change to session addressing silently orphans data instead of failing.

When backend deletion fails the error names the app, user, and session still holding data. The handle is already gone by then, so the caller cannot be left to assume success.

## MR-03 — the status a caller reads was not the status the loop wrote

`ActiveSession` owned the `Arc<RwLock<SessionStatus>>` that `status()` reads. `SessionLoop` owned a separate plain `SessionStatus`. The struct comment said:

```rust
/// Current session status (shared with the session loop).
pub(crate) status: Arc<RwLock<SessionStatus>>,
```

It was not shared — the constructor never passed the Arc in. So:

| Transition | Wrote to | Visible via `status()` |
|---|---|---|
| queued → running → idle | the loop's own field | **no** |
| pause, resume, archive, delete | the public lock | yes |

A session actively executing turns reported `Queued` indefinitely. That the control-plane transitions *did* work is why the gap survived: the status looked functional under exactly the operations a lifecycle test would exercise.

Fixed by creating the handle before the loop and installing it with `SessionLoop::with_shared_status` — a builder method, since both `with_pause_controls` overloads already take 10–11 arguments under `#[allow(clippy::too_many_arguments)]` and a twelfth would make the call site unreadable.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo clippy -p adk-managed` with `memory`, `sandbox` | exit 0 each |
| `cargo nextest run --workspace --profile ci` | **3826 passed**, 83 skipped, 0 failed |
| `cargo nextest run -p adk-managed` | 239 passed |
| `RUSTDOCFLAGS=-D warnings cargo doc -p adk-managed` | exit 0 |
| `cargo semver-checks -p adk-managed --release-type minor` | **no semver update required** |
| doc-examples guard | exit 0 |

### Both fixes are covered by tests that fail without them

Removing only the persisted delete:

```
FAIL  deleting_a_managed_session_removes_its_persisted_conversation
      the persisted conversation survived a reported deletion
```

Giving the loop its own status again:

```
FAIL  a_working_session_stops_reporting_queued  (5.011s)
      a session that has done work must stop reporting Queued: Elapsed(())
```

The status test sends a real message and polls the public handle until it leaves `Queued`, driving an actual turn through a scripted model rather than asserting on a control-plane call. My first attempt at this test only exercised `archive` — which always worked — so it passed under sabotage and proved nothing. Worth noting since it is the kind of test that looks like coverage and is not.

## Scope

**MR-01** (durable managed state across process loss) and **MR-02** (caller identity and `EnvironmentConfig`) are untouched. Managed sessions remain persisted under a fixed app `managed` and user `managed_user`, and `start_session` still ignores its `_env` argument. The docs now state both plainly, including that deletion therefore removes the conversation for a session ID rather than for a tenant.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed — new sections in `docs/official_docs/managed-agents/runtime.md`
- [x] Examples added or updated for new features