### PR TITLE
fix(agent): give WebhookTrigger a trust boundary and a bounded lifetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **adk-agent: `WebhookTrigger` has a trust boundary and a bounded lifetime.** The trigger
+  bound `0.0.0.0:<port>` and accepted every POST on its path — no signature check, no
+  authentication hook, no principal, no body policy — so any caller who could reach the port
+  could start application-defined agent work, and a malformed body was wrapped as a JSON
+  string and delivered as a trigger event indistinguishable from a deliberate one. It now
+  binds loopback by default, and serving any wider address requires a `WebhookVerifier`;
+  subscribing without one fails with `agent.ambient.webhook_unauthenticated` rather than
+  exposing an open trigger. Verified requests carry their principal on
+  `TriggerEvent::principal`. Rejections return a bare `401` with the reason logged, so the
+  endpoint cannot be used to probe which part of a credential was wrong. Bodies are capped
+  (1 MiB by default, `with_max_body_bytes`) and non-JSON bodies are rejected with `400`
+  unless `accept_non_json()` is set.
+
+  The HTTP listener also outlived its consumer: `axum::serve` was spawned with no shutdown
+  signal, so dropping the event stream left the port bound, accepting requests it could not
+  deliver and blocking a restart on the same port. The server's lifetime is now tied to the
+  subscription stream, which shuts it down gracefully on drop.
+
 - **adk-core/adk-auth: secret access from tools is authorizable and audited.**
   `SecretService` and `SecretProvider` received only a secret *name*. Once a provider
   was attached to an invocation, policy collapsed to whatever the backing cloud
@@ -156,6 +174,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   | `adk-acp` | New public fields: `PermissionRequest::{session_id, tool_call_id, kind, raw_input}`, `AcpAgentConfig::{mcp_servers, filesystem, terminal}`, `PermissionOption::kind` | Struct literals must add the fields; prefer `..Default::default()` |
   | `adk-acp` | New variants: `OutputChunk::{ToolUpdate, Usage}`, `PermissionPolicy::AsyncCustom` | Exhaustive `match` must add arms |
   | `adk-acp` | `AcpAgentConfig` no longer `UnwindSafe`/`RefUnwindSafe` | Affects code storing it across `catch_unwind` |
+  | `adk-agent` | `TriggerEvent` gains a public `principal` field | Add `principal: None` to struct literals; webhook events carry the verified principal |
+  | `adk-agent` | `WebhookTrigger` binds loopback by default, requires a verifier for any wider address, and rejects non-JSON bodies | Call `with_bind_address` plus `with_verifier` to expose it; `accept_non_json()` restores the old body handling |
+  | `adk-agent` | `WebhookTrigger` no longer `UnwindSafe`/`RefUnwindSafe` | It now holds a verifier behind `Arc<dyn ...>`; affects code storing it across `catch_unwind` |
   | `adk-anthropic` | New variants: `ContentBlock::WebFetchToolResult`, `ToolUnionParam::WebFetch20250910`, `ServerTool::WebFetch20250910` | Exhaustive `match` must add arms |
   | `adk-core` | New public fields: `RunConfig::{tool_confirmation_handler, runtime_toolsets}` | Struct literals must add the fields; prefer `RunConfig::builder()` |
   | `adk-core` | New variant `Part::EmbeddedResource` (`Part` is not `#[non_exhaustive]`) | Exhaustive `match` must add an arm |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,12 +117,14 @@ dependencies = [
  "jsonschema 0.28.3",
  "notify",
  "proptest",
+ "reqwest 0.12.28",
  "schemars 1.2.1",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 

--- a/adk-agent/Cargo.toml
+++ b/adk-agent/Cargo.toml
@@ -34,6 +34,8 @@ jsonschema = { version = "0.28", default-features = false }
 cron = { version = "0.15", optional = true }
 notify = { version = "8", optional = true }
 axum = { version = "0.8", optional = true }
+# Graceful shutdown for the webhook trigger's owned HTTP listener.
+tokio-util = { version = "0.7", optional = true }
 
 [features]
 default = ["skills"]
@@ -44,9 +46,11 @@ sandbox = ["dep:adk-sandbox", "adk-sandbox/workspace"]
 coding = ["dep:adk-devtools"]
 codeact = []
 record-payloads = []
-ambient = ["dep:cron", "dep:notify", "dep:axum"]
+ambient = ["dep:cron", "dep:notify", "dep:axum", "dep:tokio-util"]
 
 [dev-dependencies]
+# Drives the webhook trigger over real HTTP in the trust-boundary tests.
+reqwest = { workspace = true }
 # Internal dev-deps are path-only (no version) so cargo strips them from the
 # published manifest — they can never block or reorder a crates.io publish.
 adk-model = { path = "../adk-model", features = ["gemini", "gemini-interactions", "openai"] }

--- a/adk-agent/src/ambient/cron_trigger.rs
+++ b/adk-agent/src/ambient/cron_trigger.rs
@@ -76,6 +76,8 @@ impl EventSource for CronTrigger {
                         "expression": expression,
                         "tick": chrono::Utc::now().to_rfc3339(),
                     }),
+                    // A schedule has no caller.
+                    principal: None,
                 };
             }
         };

--- a/adk-agent/src/ambient/event_source.rs
+++ b/adk-agent/src/ambient/event_source.rs
@@ -13,6 +13,13 @@ pub struct TriggerEvent {
     pub source: String,
     /// Source-specific metadata.
     pub payload: Value,
+    /// The verified principal this event is attributed to, when the source authenticates.
+    ///
+    /// `None` for sources with no notion of a caller — a cron tick or a file change. For
+    /// [`WebhookTrigger`](super::WebhookTrigger) this is whatever its verifier returned, so
+    /// a handler can tell an authorized trigger from an anonymous one instead of treating
+    /// every event as equally trusted.
+    pub principal: Option<String>,
 }
 
 /// A source of trigger events for ambient agents.

--- a/adk-agent/src/ambient/file_watch_trigger.rs
+++ b/adk-agent/src/ambient/file_watch_trigger.rs
@@ -156,6 +156,8 @@ impl EventSource for FileWatchTrigger {
                                 "event": event_kind,
                                 "path": event_path.display().to_string(),
                             }),
+                            // A filesystem change has no caller.
+                            principal: None,
                         };
 
                         if tx.send(trigger_event).await.is_err() {

--- a/adk-agent/src/ambient/mod.rs
+++ b/adk-agent/src/ambient/mod.rs
@@ -28,4 +28,4 @@ pub use agent::{AmbientAgent, AmbientAgentStatus, TriggerHandler};
 pub use cron_trigger::CronTrigger;
 pub use event_source::{EventSource, TriggerEvent};
 pub use file_watch_trigger::FileWatchTrigger;
-pub use webhook_trigger::WebhookTrigger;
+pub use webhook_trigger::{WebhookRequest, WebhookTrigger, WebhookVerifier};

--- a/adk-agent/src/ambient/webhook_trigger.rs
+++ b/adk-agent/src/ambient/webhook_trigger.rs
@@ -1,36 +1,156 @@
-use adk_core::Result;
+use adk_core::{AdkError, ErrorCategory, ErrorComponent, Result};
 use async_trait::async_trait;
 use futures::stream::BoxStream;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
 use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
 
 use super::event_source::{EventSource, TriggerEvent};
 
-/// Emits trigger events when HTTP POST requests arrive on the configured path.
+/// Decides whether an inbound webhook request is allowed to trigger agent work.
 ///
-/// Spawns a minimal `axum` HTTP listener on the configured port. Each POST body
-/// becomes a [`TriggerEvent`] payload.
+/// A webhook that reaches an agent is a remote code path into application logic, so the
+/// decision needs to be explicit. Implement this to check a provider signature, validate a
+/// bearer token, or consult an allowlist, and return the principal the request speaks for.
 ///
 /// # Example
 ///
-/// ```rust,ignore
-/// use adk_agent::ambient::WebhookTrigger;
+/// ```rust
+/// use adk_agent::ambient::{WebhookRequest, WebhookVerifier};
 ///
-/// let trigger = WebhookTrigger::new(8080, "/webhook");
+/// #[derive(Debug)]
+/// struct SharedToken(String);
+///
+/// impl WebhookVerifier for SharedToken {
+///     fn verify(&self, request: &WebhookRequest<'_>) -> Result<String, String> {
+///         match request.header("authorization") {
+///             Some(value) if value == format!("Bearer {}", self.0) => Ok("ci".to_string()),
+///             Some(_) => Err("token mismatch".to_string()),
+///             None => Err("missing authorization header".to_string()),
+///         }
+///     }
+/// }
 /// ```
-pub struct WebhookTrigger {
-    port: u16,
-    path: String,
-    name: String,
+pub trait WebhookVerifier: Send + Sync + std::fmt::Debug {
+    /// Returns the verified principal, or the reason the request is rejected.
+    ///
+    /// The reason is logged, never returned to the caller: a rejected request receives a
+    /// bare `401` so it cannot be used to probe which part of a credential was wrong.
+    fn verify(&self, request: &WebhookRequest<'_>) -> std::result::Result<String, String>;
 }
 
-impl WebhookTrigger {
-    /// Create a webhook trigger listening on the given port and path.
+/// An inbound webhook request, as presented to a [`WebhookVerifier`].
+pub struct WebhookRequest<'a> {
+    headers: &'a axum::http::HeaderMap,
+    body: &'a [u8],
+}
+
+impl<'a> WebhookRequest<'a> {
+    /// A header value as UTF-8, or `None` when absent or not UTF-8.
+    pub fn header(&self, name: &str) -> Option<&str> {
+        self.headers.get(name).and_then(|value| value.to_str().ok())
+    }
+
+    /// The raw request body.
     ///
-    /// The path should start with `/`.
+    /// Signature schemes are computed over the exact bytes received, so this is deliberately
+    /// the unparsed body.
+    pub fn body(&self) -> &'a [u8] {
+        self.body
+    }
+}
+
+impl std::fmt::Debug for WebhookRequest<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Headers and body carry credentials and caller data; report only shape.
+        f.debug_struct("WebhookRequest")
+            .field("header_count", &self.headers.len())
+            .field("body_bytes", &self.body.len())
+            .finish()
+    }
+}
+
+/// Emits trigger events when authorized HTTP POST requests arrive on the configured path.
+///
+/// Binds loopback by default. Serving a non-loopback address requires a
+/// [`WebhookVerifier`], because a reachable unauthenticated webhook lets any caller start
+/// application-defined agent work.
+///
+/// # Example
+///
+/// ```rust
+/// use adk_agent::ambient::WebhookTrigger;
+///
+/// // Local development: loopback, no verifier required.
+/// let trigger = WebhookTrigger::new(8080, "/webhook");
+/// assert!(trigger.bind_address().ip().is_loopback());
+/// ```
+pub struct WebhookTrigger {
+    path: String,
+    name: String,
+    bind_address: SocketAddr,
+    verifier: Option<Arc<dyn WebhookVerifier>>,
+    accept_non_json: bool,
+    max_body_bytes: usize,
+}
+
+/// Bodies above this size are rejected before parsing.
+const DEFAULT_MAX_BODY_BYTES: usize = 1024 * 1024;
+
+impl WebhookTrigger {
+    /// Creates a webhook trigger on loopback at the given port and path.
+    ///
+    /// The path is prefixed with `/` when it is not already.
     pub fn new(port: u16, path: &str) -> Self {
         let path = if path.starts_with('/') { path.to_string() } else { format!("/{path}") };
 
-        Self { port, name: format!("webhook:{path}"), path }
+        Self {
+            name: format!("webhook:{path}"),
+            path,
+            // Loopback, not `0.0.0.0`: binding every interface is a decision the caller
+            // should have to make, alongside supplying a verifier.
+            bind_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port),
+            verifier: None,
+            accept_non_json: false,
+            max_body_bytes: DEFAULT_MAX_BODY_BYTES,
+        }
+    }
+
+    /// Serves on `address` instead of loopback.
+    ///
+    /// A non-loopback address requires [`WebhookTrigger::with_verifier`]; without one,
+    /// [`EventSource::subscribe`] fails rather than exposing an open trigger.
+    pub fn with_bind_address(mut self, address: SocketAddr) -> Self {
+        self.bind_address = address;
+        self
+    }
+
+    /// Requires every request to be authorized by `verifier`.
+    pub fn with_verifier(mut self, verifier: Arc<dyn WebhookVerifier>) -> Self {
+        self.verifier = Some(verifier);
+        self
+    }
+
+    /// Accepts bodies that are not valid JSON, wrapping them as a JSON string.
+    ///
+    /// Off by default. Coercing a malformed body into a string produces a trigger event
+    /// indistinguishable from a deliberate one, so unparseable input is rejected with `400`
+    /// unless a caller opts in.
+    pub fn accept_non_json(mut self) -> Self {
+        self.accept_non_json = true;
+        self
+    }
+
+    /// Sets the largest accepted body, in bytes. Defaults to 1 MiB.
+    pub fn with_max_body_bytes(mut self, max_body_bytes: usize) -> Self {
+        self.max_body_bytes = max_body_bytes;
+        self
+    }
+
+    /// The address this trigger serves on.
+    pub fn bind_address(&self) -> SocketAddr {
+        self.bind_address
     }
 }
 
@@ -41,65 +161,133 @@ impl EventSource for WebhookTrigger {
     }
 
     async fn subscribe(&self) -> Result<BoxStream<'static, TriggerEvent>> {
+        // Fail closed. An exposed webhook with no verifier is a remote trigger for anyone
+        // who can reach the port, and refusing at subscribe time is the only point where
+        // the mistake is still cheap.
+        if !self.bind_address.ip().is_loopback() && self.verifier.is_none() {
+            return Err(AdkError::new(
+                ErrorComponent::Agent,
+                ErrorCategory::InvalidInput,
+                "agent.ambient.webhook_unauthenticated",
+                format!(
+                    "WebhookTrigger is set to serve {}, which is reachable beyond this host, \
+                     with no verifier. Any caller able to reach the port could start agent \
+                     work. Call `with_verifier`, or leave the default loopback bind.",
+                    self.bind_address
+                ),
+            ));
+        }
+
         let (tx, mut rx) = mpsc::channel::<TriggerEvent>(256);
         let source_name = self.name.clone();
         let path = self.path.clone();
-        let port = self.port;
+        let bind_address = self.bind_address;
+        let verifier = self.verifier.clone();
+        let accept_non_json = self.accept_non_json;
+        let max_body_bytes = self.max_body_bytes;
 
-        // Spawn the HTTP listener in the background
+        // Bind before spawning so a port conflict is reported to the caller instead of
+        // vanishing into a background log line.
+        let listener = tokio::net::TcpListener::bind(bind_address).await.map_err(|e| {
+            AdkError::new(
+                ErrorComponent::Agent,
+                ErrorCategory::Unavailable,
+                "agent.ambient.webhook_bind_failed",
+                format!("WebhookTrigger could not bind {bind_address}: {e}"),
+            )
+        })?;
+
+        // The server's lifetime is tied to the stream the caller holds. Dropping the stream
+        // fires this token, `axum` shuts down gracefully, and the port is released — before,
+        // the server stayed bound after the consumer went away, so a restart on the same
+        // port failed while requests kept being accepted and discarded.
+        let shutdown = CancellationToken::new();
+        let server_shutdown = shutdown.clone();
+
         tokio::spawn(async move {
             use axum::Router;
             use axum::body::Bytes;
+            use axum::http::{HeaderMap, StatusCode};
             use axum::routing::post;
-
-            let tx_clone = tx.clone();
-            let source_for_handler = source_name.clone();
 
             let app = Router::new().route(
                 &path,
-                post(move |body: Bytes| {
-                    let tx = tx_clone.clone();
-                    let source = source_for_handler.clone();
+                post(move |headers: HeaderMap, body: Bytes| {
+                    let tx = tx.clone();
+                    let source = source_name.clone();
+                    let verifier = verifier.clone();
                     async move {
+                        if body.len() > max_body_bytes {
+                            tracing::warn!(
+                                body.bytes = body.len(),
+                                limit = max_body_bytes,
+                                "webhook body rejected as oversized"
+                            );
+                            return StatusCode::PAYLOAD_TOO_LARGE;
+                        }
+
+                        let principal = match &verifier {
+                            Some(verifier) => {
+                                let request =
+                                    WebhookRequest { headers: &headers, body: body.as_ref() };
+                                match verifier.verify(&request) {
+                                    Ok(principal) => Some(principal),
+                                    Err(reason) => {
+                                        // Logged, not returned: the response must not reveal
+                                        // which part of a credential failed.
+                                        tracing::warn!(
+                                            reason = %reason,
+                                            "webhook request rejected by verifier"
+                                        );
+                                        return StatusCode::UNAUTHORIZED;
+                                    }
+                                }
+                            }
+                            None => None,
+                        };
+
                         let payload = match serde_json::from_slice::<serde_json::Value>(&body) {
-                            Ok(v) => v,
-                            Err(_) => {
-                                // If not valid JSON, wrap as a string
-                                serde_json::Value::String(
-                                    String::from_utf8_lossy(&body).to_string(),
-                                )
+                            Ok(value) => value,
+                            Err(_) if accept_non_json => serde_json::Value::String(
+                                String::from_utf8_lossy(&body).to_string(),
+                            ),
+                            Err(e) => {
+                                tracing::warn!(
+                                    error = %e,
+                                    "webhook body rejected as malformed JSON"
+                                );
+                                return StatusCode::BAD_REQUEST;
                             }
                         };
 
-                        let event = TriggerEvent { source, payload };
+                        let event = TriggerEvent { source, payload, principal };
 
                         if tx.send(event).await.is_err() {
-                            tracing::debug!("webhook subscriber dropped, stopping listener");
+                            tracing::debug!("webhook subscriber dropped, refusing the request");
+                            return StatusCode::SERVICE_UNAVAILABLE;
                         }
 
-                        axum::http::StatusCode::OK
+                        StatusCode::OK
                     }
                 }),
             );
 
-            let addr = std::net::SocketAddr::from(([0, 0, 0, 0], port));
-            let listener = match tokio::net::TcpListener::bind(addr).await {
-                Ok(l) => l,
-                Err(e) => {
-                    tracing::warn!("webhook trigger failed to bind on port {port}: {e}");
-                    return;
-                }
-            };
+            tracing::info!(address = %bind_address, path = %path, "webhook trigger listening");
 
-            tracing::info!("webhook trigger listening on {addr}{path}");
+            let served = axum::serve(listener, app)
+                .with_graceful_shutdown(async move { server_shutdown.cancelled().await })
+                .await;
 
-            if let Err(e) = axum::serve(listener, app).await {
-                tracing::warn!("webhook trigger server error: {e}");
+            if let Err(e) = served {
+                tracing::warn!(error = %e, "webhook trigger server error");
             }
+            tracing::debug!(address = %bind_address, "webhook trigger stopped");
         });
 
-        // Convert the mpsc receiver into a stream
+        // Cancels on drop, which is what releases the port.
+        let guard = shutdown.drop_guard();
         let stream = async_stream::stream! {
+            let _guard = guard;
             while let Some(event) = rx.recv().await {
                 yield event;
             }
@@ -112,8 +300,11 @@ impl EventSource for WebhookTrigger {
 impl std::fmt::Debug for WebhookTrigger {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("WebhookTrigger")
-            .field("port", &self.port)
+            .field("bind_address", &self.bind_address)
             .field("path", &self.path)
+            .field("verifier", &self.verifier)
+            .field("accept_non_json", &self.accept_non_json)
+            .field("max_body_bytes", &self.max_body_bytes)
             .finish()
     }
 }

--- a/adk-agent/tests/webhook_trust_boundary_tests.rs
+++ b/adk-agent/tests/webhook_trust_boundary_tests.rs
@@ -1,0 +1,221 @@
+//! A webhook that starts agent work needs a trust boundary and a bounded lifetime.
+//!
+//! `WebhookTrigger` bound `0.0.0.0:<port>` and accepted every POST on its path. There was no
+//! signature check, no authentication hook, no principal, and no body policy — a malformed
+//! body was wrapped as a JSON string and delivered as a trigger event indistinguishable from
+//! a deliberate one. Any caller who could reach the port could start application-defined
+//! agent work.
+//!
+//! The listener also outlived its consumer. `axum::serve` was spawned with no shutdown
+//! signal, so dropping the event stream left the port bound: handlers logged that the
+//! subscriber was gone, returned `200`, and discarded the request, while a restart on the
+//! same port failed.
+
+#![cfg(feature = "ambient")]
+
+use adk_agent::ambient::{EventSource, WebhookRequest, WebhookTrigger, WebhookVerifier};
+use futures::StreamExt;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Accepts only requests carrying the expected token.
+#[derive(Debug)]
+struct TokenVerifier {
+    token: String,
+    calls: Arc<AtomicUsize>,
+}
+
+impl WebhookVerifier for TokenVerifier {
+    fn verify(&self, request: &WebhookRequest<'_>) -> Result<String, String> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        match request.header("x-token") {
+            Some(value) if value == self.token => Ok("trusted-caller".to_string()),
+            Some(_) => Err("token mismatch".to_string()),
+            None => Err("missing x-token".to_string()),
+        }
+    }
+}
+
+/// A free port, released before the trigger binds it.
+async fn free_port() -> u16 {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    port
+}
+
+/// Posts `body` with optional headers and returns the status code.
+async fn post(port: u16, path: &str, body: &str, headers: &[(&str, &str)]) -> u16 {
+    let mut request = reqwest::Client::new()
+        .post(format!("http://127.0.0.1:{port}{path}"))
+        .body(body.to_string());
+    for (name, value) in headers {
+        request = request.header(*name, *value);
+    }
+    request.send().await.expect("request must reach the listener").status().as_u16()
+}
+
+// ── The trust boundary ────────────────────────────────────────────────
+
+#[tokio::test]
+async fn an_externally_reachable_webhook_without_a_verifier_refuses_to_start() {
+    // The dangerous configuration must fail where the mistake is still cheap, rather than
+    // silently exposing a remote trigger.
+    let trigger = WebhookTrigger::new(0, "/hook")
+        .with_bind_address(SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0));
+
+    let message = match trigger.subscribe().await {
+        Ok(_) => panic!("an unauthenticated externally reachable webhook must not start"),
+        Err(error) => error.to_string(),
+    };
+    assert!(message.contains("verifier"), "the error must say what is missing: {message}");
+}
+
+#[tokio::test]
+async fn the_default_bind_is_loopback_not_every_interface() {
+    let trigger = WebhookTrigger::new(8080, "/hook");
+    assert!(
+        trigger.bind_address().ip().is_loopback(),
+        "binding every interface must be an explicit choice, not the default"
+    );
+}
+
+#[tokio::test]
+async fn an_externally_reachable_webhook_with_a_verifier_starts() {
+    let port = free_port().await;
+    let trigger = WebhookTrigger::new(0, "/hook")
+        .with_bind_address(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port))
+        .with_verifier(Arc::new(TokenVerifier {
+            token: "secret".to_string(),
+            calls: Arc::new(AtomicUsize::new(0)),
+        }));
+
+    assert!(trigger.subscribe().await.is_ok(), "a verified trigger must start");
+}
+
+#[tokio::test]
+async fn an_unauthorized_request_is_rejected_and_produces_no_event() {
+    let port = free_port().await;
+    let calls = Arc::new(AtomicUsize::new(0));
+    let trigger = WebhookTrigger::new(port, "/hook").with_verifier(Arc::new(TokenVerifier {
+        token: "secret".to_string(),
+        calls: Arc::clone(&calls),
+    }));
+
+    let mut stream = trigger.subscribe().await.expect("subscribe");
+    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+
+    assert_eq!(post(port, "/hook", r#"{"a":1}"#, &[]).await, 401, "no credential");
+    assert_eq!(
+        post(port, "/hook", r#"{"a":1}"#, &[("x-token", "wrong")]).await,
+        401,
+        "wrong credential"
+    );
+
+    // No event may be delivered for a rejected request.
+    let delivered =
+        tokio::time::timeout(std::time::Duration::from_millis(300), stream.next()).await;
+    assert!(delivered.is_err(), "a rejected request must not trigger agent work");
+    assert_eq!(calls.load(Ordering::SeqCst), 2, "the verifier saw both attempts");
+}
+
+#[tokio::test]
+async fn an_authorized_request_carries_its_principal() {
+    let port = free_port().await;
+    let trigger = WebhookTrigger::new(port, "/hook").with_verifier(Arc::new(TokenVerifier {
+        token: "secret".to_string(),
+        calls: Arc::new(AtomicUsize::new(0)),
+    }));
+
+    let mut stream = trigger.subscribe().await.expect("subscribe");
+    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+
+    let status = post(port, "/hook", r#"{"a":1}"#, &[("x-token", "secret")]).await;
+    assert_eq!(status, 200);
+
+    let event = tokio::time::timeout(std::time::Duration::from_secs(5), stream.next())
+        .await
+        .expect("an authorized request must produce an event")
+        .expect("stream must yield");
+
+    assert_eq!(
+        event.principal.as_deref(),
+        Some("trusted-caller"),
+        "a handler must be able to tell an authorized trigger from an anonymous one"
+    );
+    assert_eq!(event.payload, serde_json::json!({ "a": 1 }));
+}
+
+// ── Body policy ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn a_malformed_body_is_rejected_rather_than_wrapped_as_a_string() {
+    let port = free_port().await;
+    let trigger = WebhookTrigger::new(port, "/hook");
+    let mut stream = trigger.subscribe().await.expect("subscribe");
+    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+
+    assert_eq!(post(port, "/hook", "not json at all", &[]).await, 400);
+
+    let delivered =
+        tokio::time::timeout(std::time::Duration::from_millis(300), stream.next()).await;
+    assert!(delivered.is_err(), "unparseable input must not become a trigger event");
+}
+
+#[tokio::test]
+async fn a_malformed_body_is_accepted_when_the_caller_opts_in() {
+    let port = free_port().await;
+    let trigger = WebhookTrigger::new(port, "/hook").accept_non_json();
+    let mut stream = trigger.subscribe().await.expect("subscribe");
+    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+
+    assert_eq!(post(port, "/hook", "plain text", &[]).await, 200);
+
+    let event = tokio::time::timeout(std::time::Duration::from_secs(5), stream.next())
+        .await
+        .expect("the opt-in must still deliver")
+        .expect("stream must yield");
+    assert_eq!(event.payload, serde_json::json!("plain text"));
+}
+
+#[tokio::test]
+async fn an_oversized_body_is_rejected() {
+    let port = free_port().await;
+    let trigger = WebhookTrigger::new(port, "/hook").with_max_body_bytes(16);
+    let _stream = trigger.subscribe().await.expect("subscribe");
+    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+
+    let big = format!(r#"{{"a":"{}"}}"#, "x".repeat(256));
+    assert_eq!(post(port, "/hook", &big, &[]).await, 413);
+}
+
+// ── Lifecycle ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn dropping_the_stream_releases_the_port() {
+    let port = free_port().await;
+
+    {
+        let trigger = WebhookTrigger::new(port, "/hook");
+        let stream = trigger.subscribe().await.expect("subscribe");
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        assert_eq!(post(port, "/hook", r#"{"a":1}"#, &[]).await, 200, "listening");
+        drop(stream);
+    }
+
+    // Rebinding is the observable consequence: before, the server kept the port after its
+    // consumer went away, so a restart on the same port failed.
+    let rebound = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            let trigger = WebhookTrigger::new(port, "/hook");
+            if let Ok(stream) = trigger.subscribe().await {
+                return stream;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    })
+    .await;
+
+    assert!(rebound.is_ok(), "the port was still held after the consumer was dropped");
+}

--- a/docs/official_docs/agents/ambient-agents.md
+++ b/docs/official_docs/agents/ambient-agents.md
@@ -1,0 +1,102 @@
+# Ambient Agents
+
+Ambient agents react to events instead of to a user turn. An `EventSource` produces
+`TriggerEvent`s and the agent runs for each one.
+
+Requires the `ambient` feature:
+
+```toml
+[dependencies]
+adk-agent = { version = "2.0.0", features = ["ambient"] }
+```
+
+## Event sources
+
+| Source | Fires on | Principal |
+|--------|----------|-----------|
+| `CronTrigger` | A cron schedule | `None` — a schedule has no caller |
+| `FileWatchTrigger` | A matching filesystem change | `None` — a file change has no caller |
+| `WebhookTrigger` | An authorized HTTP POST | The verifier's result |
+
+`TriggerEvent::principal` lets a handler distinguish an authorized trigger from an anonymous
+one rather than treating every event as equally trusted.
+
+## Webhook triggers
+
+A reachable webhook is a remote entry point into application logic, so `WebhookTrigger`
+defaults to loopback and refuses to serve a wider address without a verifier.
+
+### Local development
+
+```rust
+use adk_agent::ambient::WebhookTrigger;
+
+// Binds 127.0.0.1 — reachable only from this host.
+let trigger = WebhookTrigger::new(8080, "/webhook");
+```
+
+### Exposed listeners require a verifier
+
+```rust
+use adk_agent::ambient::{WebhookRequest, WebhookTrigger, WebhookVerifier};
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+#[derive(Debug)]
+struct SharedToken(String);
+
+impl WebhookVerifier for SharedToken {
+    fn verify(&self, request: &WebhookRequest<'_>) -> Result<String, String> {
+        match request.header("x-webhook-token") {
+            Some(value) if value == self.0 => Ok("ci-system".to_string()),
+            Some(_) => Err("token mismatch".to_string()),
+            None => Err("missing x-webhook-token".to_string()),
+        }
+    }
+}
+
+let address: SocketAddr = "0.0.0.0:8080".parse().unwrap();
+let trigger = WebhookTrigger::new(8080, "/webhook")
+    .with_bind_address(address)
+    .with_verifier(Arc::new(SharedToken(std::env::var("WEBHOOK_TOKEN").unwrap_or_default())));
+```
+
+Subscribing to a non-loopback address without a verifier fails with
+`agent.ambient.webhook_unauthenticated`. The check happens at subscribe time, where the
+mistake is still cheap.
+
+> **Important:** a verifier receives the raw body via `WebhookRequest::body`, because
+> signature schemes are computed over the exact bytes received. Verify before trusting any
+> parsed form of the request.
+
+### Request handling
+
+| Condition | Response | Event |
+|-----------|----------|-------|
+| Body over the limit (1 MiB default, `with_max_body_bytes`) | `413` | none |
+| Verifier rejects | `401` | none |
+| Body is not valid JSON | `400` | none |
+| Body is not valid JSON, `accept_non_json()` set | `200` | payload is a JSON string |
+| Subscriber has gone away | `503` | none |
+| Otherwise | `200` | payload is the parsed JSON |
+
+A `401` carries no detail about which part of a credential failed; the reason is logged
+instead, so the endpoint cannot be used to probe credentials.
+
+`accept_non_json` is off by default because a malformed body wrapped as a string produces a
+trigger event indistinguishable from a deliberate one.
+
+### Lifetime
+
+The HTTP listener belongs to the stream returned by `subscribe`. Dropping the stream shuts
+the server down gracefully and releases the port, so the same port can be rebound:
+
+```rust,ignore
+let stream = trigger.subscribe().await?;
+// ... consume events ...
+drop(stream); // the listener stops and the port is free
+```
+
+> **Note:** the listener previously outlived its consumer. Dropping the stream left the
+> server bound, still accepting requests it could not deliver, and a restart on the same port
+> failed.


### PR DESCRIPTION
## What

Resolves **AM-02**. `WebhookTrigger` was an unauthenticated remote trigger for agent work, bound on every interface, whose listener outlived its consumer.

## Why

Both halves are visible in the old 119-line file:

```rust
let addr = std::net::SocketAddr::from(([0, 0, 0, 0], port));   // every interface
...
post(move |body: Bytes| { ... })                                // no headers, no verifier
...
Err(_) => serde_json::Value::String(String::from_utf8_lossy(&body).to_string()),
...
if tx.send(event).await.is_err() {
    tracing::debug!("webhook subscriber dropped, stopping listener");   // logs, does not stop
}
axum::http::StatusCode::OK                                      // and answers 200 anyway
...
axum::serve(listener, app).await                                // no shutdown signal
```

- **No trust boundary.** Any caller who could reach the port started application-defined agent work. No signature check, no authentication hook, no principal, no replay window, no body limit.
- **Malformed input became a real event.** A body that was not valid JSON was wrapped as a JSON string and delivered, indistinguishable from a deliberate trigger.
- **The listener outlived its consumer.** Dropping the stream left the port bound. The handler logged that the subscriber was gone, returned `200`, and discarded the request — so a restart on the same port failed while callers kept getting success.

## How

### Fail closed on exposure

Default bind is loopback. Any wider address requires a `WebhookVerifier`; otherwise `subscribe` fails with `agent.ambient.webhook_unauthenticated`. The check is at subscribe time, the last point where the mistake is cheap — a bind failure was previously only a background `warn!`.

```rust
let trigger = WebhookTrigger::new(8080, "/webhook")
    .with_bind_address("0.0.0.0:8080".parse()?)
    .with_verifier(Arc::new(SharedToken(token)));
```

`WebhookVerifier` receives the **raw body**, because signature schemes are computed over the exact bytes received. It returns the principal, which lands on `TriggerEvent::principal` so a handler can distinguish an authorized trigger from an anonymous one instead of trusting all events equally.

### Request handling

| Condition | Response | Event |
|---|---|---|
| Body over the limit (1 MiB default) | `413` | none |
| Verifier rejects | `401` | none |
| Not valid JSON | `400` | none |
| Not valid JSON, `accept_non_json()` | `200` | JSON string |
| Subscriber gone | `503` | none |
| Otherwise | `200` | parsed JSON |

A `401` says nothing about *which* part of a credential failed — the reason is logged instead, so the endpoint cannot be used to probe credentials. `WebhookRequest`'s `Debug` reports only header count and body size for the same reason.

### Lifetime

The server's shutdown is tied to the subscription stream through a `CancellationToken` drop guard, so dropping the stream shuts `axum` down gracefully and frees the port.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo clippy -p adk-agent --features ambient --all-targets` | exit 0 |
| `cargo nextest run --workspace --profile ci` | 3821 passed, 83 skipped, 0 failed |
| `cargo nextest run -p adk-agent --features ambient` | 103 passed; the 9 new tests pass under `--features ambient` |
| `RUSTDOCFLAGS=-D warnings cargo doc -p adk-agent --features ambient` | exit 0 |
| `cargo test -p adk-agent --features ambient --doc` | 3 passed |
| `cargo check -p adk-agent --features ambient --target x86_64-pc-windows-msvc` | exit 0 |
| doc-examples guard | exit 0 |

> The workspace run is 3821 because `ambient` is not a default feature, so these tests are reached by the feature-enabled run above and by CI's `feature-coverage` job.

### Four of nine tests fail against the old posture

Restoring the old bind, the open subscribe, the JSON coercion, and the missing shutdown:

```
FAIL  the_default_bind_is_loopback_not_every_interface
FAIL  an_externally_reachable_webhook_without_a_verifier_refuses_to_start
FAIL  a_malformed_body_is_rejected_rather_than_wrapped_as_a_string
FAIL  an_unauthorized_request_is_rejected_and_produces_no_event
```

The tests drive real HTTP against a real bound port, including `dropping_the_stream_releases_the_port`, which drops the subscription and then retries `subscribe` on the same port until it succeeds or a 5-second timeout expires.

## Breaking changes recorded

| Crate | Change |
|---|---|
| `adk-agent` | `TriggerEvent` gains a public `principal` field |
| `adk-agent` | `WebhookTrigger` binds loopback by default, requires a verifier for wider addresses, rejects non-JSON bodies |
| `adk-agent` | `WebhookTrigger` no longer `UnwindSafe`/`RefUnwindSafe` (it holds `Arc<dyn WebhookVerifier>`) |

`cargo semver-checks -p adk-agent` reports exactly these; all three are in the CHANGELOG breaking-change table.

Behaviour changes are deliberate for a High-severity security finding: the previous default silently exposed a remote trigger, and a caller who wants the old handling can ask for it explicitly.

## Scope

**AM-01** (the `AmbientAgent` runtime shell) is untouched. Ambient agents had no documentation at all, so `docs/official_docs/agents/ambient-agents.md` is new.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed — new `docs/official_docs/agents/ambient-agents.md`
- [x] Examples added or updated for new features