### PR TITLE
fix(computer-use): bind MCP responses to the request, stop calling commitment verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **adk-computer-use: security-relevant MCP responses are bound to the request that produced
+  them.** `ControlLease`, `TargetReservation`, and `ExecutionReceipt` were deserialized and
+  returned straight into graph state. Typed deserialization proves shape, not provenance, and
+  none of these structs has an invariant-enforcing constructor, so a well-formed object
+  belonging to another session, principal, agent, mode, or action parsed cleanly and was
+  accepted. Each is now validated against the requesting envelope — including active lease
+  state, remaining action budget, and the receipt's `action_digest` against the envelope's
+  approval-bound `args_digest` — and a mismatch raises
+  `ComputerUseError::IdentityMismatch` naming the field. The external runtime remains
+  authoritative; this is the local defense that stops a stale or confused response from
+  propagating.
+- **adk-computer-use: verification no longer equates "committed" with "verified".** `verify`
+  returned `receipt.status == ReceiptStatus::Committed`, collapsing two distinct claims: that
+  the runtime performed the action, and that the intended effect occurred. A committed action
+  whose effect did not happen was reported as completed, from the node the reference graph
+  labels "verify". `verify` now receives the envelope's declared `ActionPostcondition` — which
+  the old signature could not even see — and returns `VerificationOutcome::Verified`,
+  `CommittedUnverified { reason }`, or `Failed { reason }`. Verification requires evidence on
+  the receipt bound to the postcondition's digest; absence of evidence is reported as
+  committed-but-unverified rather than treated as success. The graph writes `verified`,
+  `committed`, and `result.verificationDetail` separately.
+
 - **adk-core/adk-auth: secret access from tools is authorizable and audited.**
   `SecretService` and `SecretProvider` received only a secret *name*. Once a provider
   was attached to an invocation, policy collapsed to whatever the backing cloud
@@ -156,6 +178,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   | `adk-acp` | New public fields: `PermissionRequest::{session_id, tool_call_id, kind, raw_input}`, `AcpAgentConfig::{mcp_servers, filesystem, terminal}`, `PermissionOption::kind` | Struct literals must add the fields; prefer `..Default::default()` |
   | `adk-acp` | New variants: `OutputChunk::{ToolUpdate, Usage}`, `PermissionPolicy::AsyncCustom` | Exhaustive `match` must add arms |
   | `adk-acp` | `AcpAgentConfig` no longer `UnwindSafe`/`RefUnwindSafe` | Affects code storing it across `catch_unwind` |
+  | `adk-computer-use` | `ComputerUseRuntime::verify` takes the action postcondition and returns `VerificationOutcome` instead of `bool` | Match the outcome; `is_verified()` is true only when the postcondition was observed, `is_committed()` covers "performed but unverified" |
   | `adk-anthropic` | New variants: `ContentBlock::WebFetchToolResult`, `ToolUnionParam::WebFetch20250910`, `ServerTool::WebFetch20250910` | Exhaustive `match` must add arms |
   | `adk-core` | New public fields: `RunConfig::{tool_confirmation_handler, runtime_toolsets}` | Struct literals must add the fields; prefer `RunConfig::builder()` |
   | `adk-core` | New variant `Part::EmbeddedResource` (`Part` is not `#[non_exhaustive]`) | Exhaustive `match` must add an arm |

--- a/adk-computer-use/examples/minimal_graph.rs
+++ b/adk-computer-use/examples/minimal_graph.rs
@@ -13,9 +13,10 @@
 //! ```
 
 use adk_computer_use::{
-    ActionClass, ActionEnvelope, ActionPreview, ComputerUseError, ComputerUseRuntime, ControlLease,
-    ExecutionCapability, ExecutionMode, ExecutionReceipt, LeaseBoundaries, PolicyDecision,
-    ReceiptStatus, ScopeAuthorizer, build_reference_graph,
+    ActionClass, ActionEnvelope, ActionPostcondition, ActionPreview, ComputerUseError,
+    ComputerUseRuntime, ControlLease, ExecutionCapability, ExecutionMode, ExecutionReceipt,
+    LeaseBoundaries, PolicyDecision, ReceiptStatus, ScopeAuthorizer, VerificationOutcome,
+    build_reference_graph,
 };
 use adk_graph::{ExecutionConfig, State};
 use async_trait::async_trait;
@@ -131,8 +132,23 @@ impl ComputerUseRuntime for InProcessRuntime {
         })
     }
 
-    async fn verify(&self, receipt: &ExecutionReceipt) -> Result<bool, ComputerUseError> {
-        Ok(receipt.status == ReceiptStatus::Committed)
+    async fn verify(
+        &self,
+        receipt: &ExecutionReceipt,
+        postcondition: Option<&ActionPostcondition>,
+    ) -> Result<VerificationOutcome, ComputerUseError> {
+        if receipt.status != ReceiptStatus::Committed {
+            return Ok(VerificationOutcome::Failed {
+                reason: format!("receipt status is {:?}", receipt.status),
+            });
+        }
+        // Committing is not verifying: without a postcondition there is nothing to check.
+        Ok(match postcondition {
+            Some(_) => VerificationOutcome::Verified,
+            None => VerificationOutcome::CommittedUnverified {
+                reason: "no postcondition declared".to_string(),
+            },
+        })
     }
 }
 

--- a/adk-computer-use/src/graph.rs
+++ b/adk-computer-use/src/graph.rs
@@ -1,6 +1,7 @@
 use crate::{
-    ActionClass, ActionPreview, ComputerUseAuthContext, ComputerUseRuntime, ControlLease,
-    ExecutionMode, ExecutionReceipt, ScopeAuthorizer, TargetReservation,
+    ActionClass, ActionEnvelope, ActionPreview, ComputerUseAuthContext, ComputerUseRuntime,
+    ControlLease, ExecutionMode, ExecutionReceipt, ScopeAuthorizer, TargetReservation,
+    VerificationOutcome,
 };
 use adk_graph::{
     Checkpointer, CompiledGraph, DeferredNodeConfig, END, GraphError, MergeStrategy, NodeOutput,
@@ -93,7 +94,10 @@ pub fn build_reference_graph_with_checkpointer(
                 && ctx.get("visual_evidence").is_some()
                 && ctx.get("semantic_evidence").is_some();
             if !complete {
-                return Err(node_error("join_observations", "fan-in completed without all evidence"));
+                return Err(node_error(
+                    "join_observations",
+                    "fan-in completed without all evidence",
+                ));
             }
             Ok(NodeOutput::new().with_update("observations_joined", json!(true)))
         },
@@ -136,16 +140,14 @@ pub fn build_reference_graph_with_checkpointer(
                 .ok_or_else(|| node_error("request_approval", "missing preview"))?,
         )?;
         let approval = ctx.get("approval").and_then(Value::as_object);
-        let approved_digest = approval
-            .and_then(|value| value.get("actionDigest"))
-            .and_then(Value::as_str);
+        let approved_digest =
+            approval.and_then(|value| value.get("actionDigest")).and_then(Value::as_str);
         let grant_id = approval
             .and_then(|value| value.get("grantId"))
             .and_then(Value::as_str)
             .filter(|value| !value.is_empty());
-        let approved_policy = approval
-            .and_then(|value| value.get("policyDigest"))
-            .and_then(Value::as_str);
+        let approved_policy =
+            approval.and_then(|value| value.get("policyDigest")).and_then(Value::as_str);
         let runtime_approved = approval
             .and_then(|value| value.get("runtimeApproved"))
             .and_then(Value::as_bool)
@@ -179,7 +181,8 @@ pub fn build_reference_graph_with_checkpointer(
             .and_then(|value| value.get("blocker"))
             .cloned()
             .unwrap_or_else(|| json!("policy_denied"));
-        Ok(NodeOutput::new().with_update("result", json!({ "status": "blocked", "reason": blocker })))
+        Ok(NodeOutput::new()
+            .with_update("result", json!({ "status": "blocked", "reason": blocker })))
     })
     .add_node_fn("reserve_target", move |ctx| {
         let runtime = reservation_runtime.clone();
@@ -221,9 +224,7 @@ pub fn build_reference_graph_with_checkpointer(
                     .ok_or_else(|| node_error("execute", "missing preview"))?,
             )?;
             let lease: ControlLease = serde_json::from_value(
-                ctx.get("lease")
-                    .cloned()
-                    .ok_or_else(|| node_error("execute", "missing lease"))?,
+                ctx.get("lease").cloned().ok_or_else(|| node_error("execute", "missing lease"))?,
             )?;
             let envelope = &preview.envelope;
             let auth = ComputerUseAuthContext {
@@ -266,8 +267,15 @@ pub fn build_reference_graph_with_checkpointer(
                     .cloned()
                     .ok_or_else(|| node_error("verify", "missing receipt"))?,
             )?;
-            let verified = runtime
-                .verify(&receipt)
+            // The postcondition comes from the envelope the action was approved against, so
+            // verification is evaluated against what was promised rather than against nothing.
+            let postcondition = ctx
+                .get("envelope")
+                .and_then(|value| serde_json::from_value::<ActionEnvelope>(value.clone()).ok())
+                .and_then(|envelope| envelope.postcondition);
+
+            let outcome = runtime
+                .verify(&receipt, postcondition.as_ref())
                 .await
                 .map_err(|error| node_error("verify", error.to_string()))?;
             if let Some(reservation) = ctx.get("reservation")
@@ -279,11 +287,25 @@ pub fn build_reference_graph_with_checkpointer(
                     .await
                     .map_err(|error| node_error("verify", error.to_string()))?;
             }
+            // `verified` is true only when the postcondition was observed. A committed action
+            // with no evidence reports `committed_unverified` and carries the reason, instead
+            // of being labelled completed.
+            let detail = match &outcome {
+                VerificationOutcome::Verified => None,
+                VerificationOutcome::CommittedUnverified { reason }
+                | VerificationOutcome::Failed { reason } => Some(reason.clone()),
+            };
+
             Ok(NodeOutput::new()
-                .with_update("verified", json!(verified))
+                .with_update("verified", json!(outcome.is_verified()))
+                .with_update("committed", json!(outcome.is_committed()))
                 .with_update(
                     "result",
-                    json!({ "status": if verified { "completed" } else { "verification_failed" }, "receiptId": receipt.receipt_id }),
+                    json!({
+                        "status": outcome.status(),
+                        "receiptId": receipt.receipt_id,
+                        "verificationDetail": detail,
+                    }),
                 ))
         }
     })
@@ -298,11 +320,7 @@ pub fn build_reference_graph_with_checkpointer(
     .add_conditional_edges(
         "preview",
         |state| state.get("route").and_then(Value::as_str).unwrap_or("blocked").to_string(),
-        [
-            ("allowed", "reserve_target"),
-            ("approval", "request_approval"),
-            ("blocked", "blocked"),
-        ],
+        [("allowed", "reserve_target"), ("approval", "request_approval"), ("blocked", "blocked")],
     )
     .add_edge("request_approval", "reserve_target")
     .add_edge("blocked", END)

--- a/adk-computer-use/src/lib.rs
+++ b/adk-computer-use/src/lib.rs
@@ -53,7 +53,8 @@ pub mod contracts;
 mod error;
 mod eval;
 mod graph;
-mod runtime;
+/// Runtime adapters and response binding.
+pub mod runtime;
 
 pub use auth::{AuthorizationError, ComputerUseAuthContext, ScopeAuthorizer};
 pub use cancellation::{AgentInterrupter, CancellationBridge, CancellationError};
@@ -65,6 +66,7 @@ pub use eval::{
 pub use graph::{build_reference_graph, build_reference_graph_with_checkpointer};
 pub use runtime::{
     ComputerUseMcpConfig, ComputerUseMcpRuntime, ComputerUseRuntime, TraceCorrelation,
+    VerificationOutcome,
 };
 
 // Wire contracts are re-exported at the crate root for ergonomic access.

--- a/adk-computer-use/src/runtime/binding.rs
+++ b/adk-computer-use/src/runtime/binding.rs
@@ -1,0 +1,175 @@
+//! Binds every security-relevant MCP response back to what was actually asked for.
+//!
+//! Typed deserialization proves shape, not provenance. `ControlLease`, `TargetReservation`,
+//! and `ExecutionReceipt` have no invariant-enforcing constructor, so a well-formed object
+//! belonging to another session, principal, or action deserializes cleanly and was accepted
+//! into graph state. The external runtime stays authoritative; this is the local check that
+//! makes a stale, confused, or mismatched response fail here rather than propagate.
+//!
+//! Each validator compares one response against the envelope that requested it and reports
+//! the first mismatch by field name, so a rejection says what did not line up.
+
+use crate::contracts::{ActionEnvelope, ControlLease, ExecutionReceipt, TargetReservation};
+use crate::error::ComputerUseError;
+
+/// Reports a mismatch between what was requested and what came back.
+fn mismatch(object: &str, field: &str, expected: &str, actual: &str) -> ComputerUseError {
+    ComputerUseError::IdentityMismatch(format!(
+        "{object} returned by the computer-use runtime is not bound to this request: {field} \
+         is {actual:?}, expected {expected:?}. The response was rejected rather than stored."
+    ))
+}
+
+/// Compares two optional values, treating a returned `None` as acceptable.
+///
+/// The wire contract makes `agent_id` and similar fields optional, so absence is under-
+/// specification rather than contradiction. A *present and different* value is a mismatch.
+fn check_optional(
+    object: &str,
+    field: &str,
+    expected: Option<&str>,
+    actual: Option<&str>,
+) -> Result<(), ComputerUseError> {
+    match (expected, actual) {
+        (Some(expected), Some(actual)) if expected != actual => {
+            Err(mismatch(object, field, expected, actual))
+        }
+        _ => Ok(()),
+    }
+}
+
+/// Verifies a lease belongs to this session, principal, agent, and mode, and is usable.
+///
+/// # Errors
+///
+/// Returns [`ComputerUseError::IdentityMismatch`] when any bound field disagrees with
+/// `envelope`, when the lease is not active, or when its action budget is exhausted.
+///
+/// # Example
+///
+/// ```rust
+/// use adk_computer_use::runtime::binding::validate_lease;
+/// use adk_computer_use::{ActionEnvelope, ControlLease};
+///
+/// # fn envelope() -> ActionEnvelope { unimplemented!() }
+/// # fn lease_for_another_session() -> ControlLease { unimplemented!() }
+/// # fn check() -> Result<(), Box<dyn std::error::Error>> {
+/// let envelope = envelope();
+/// let lease = lease_for_another_session();
+///
+/// // A well-formed lease bound to a different session is refused here rather than
+/// // entering graph state.
+/// assert!(validate_lease(&lease, &envelope).is_err());
+/// # Ok(())
+/// # }
+/// ```
+pub fn validate_lease(
+    lease: &ControlLease,
+    envelope: &ActionEnvelope,
+) -> Result<(), ComputerUseError> {
+    const OBJECT: &str = "control lease";
+
+    if lease.session_id != envelope.session_id {
+        return Err(mismatch(OBJECT, "session_id", &envelope.session_id, &lease.session_id));
+    }
+    if lease.principal_id != envelope.principal_id {
+        return Err(mismatch(OBJECT, "principal_id", &envelope.principal_id, &lease.principal_id));
+    }
+    check_optional(OBJECT, "agent_id", envelope.agent_id.as_deref(), lease.agent_id.as_deref())?;
+
+    if lease.execution_mode != envelope.requested_mode {
+        return Err(mismatch(
+            OBJECT,
+            "execution_mode",
+            &format!("{:?}", envelope.requested_mode),
+            &format!("{:?}", lease.execution_mode),
+        ));
+    }
+
+    // A lease that is not active grants nothing, and a zero budget cannot cover the action
+    // it was acquired for. Both are usable-looking objects that must not proceed.
+    if !lease.state.eq_ignore_ascii_case("active") {
+        return Err(ComputerUseError::IdentityMismatch(format!(
+            "control lease {} is in state {:?}, not active, so it authorizes nothing",
+            lease.lease_id, lease.state
+        )));
+    }
+    if lease.action_budget == 0 {
+        return Err(ComputerUseError::IdentityMismatch(format!(
+            "control lease {} has no remaining action budget",
+            lease.lease_id
+        )));
+    }
+
+    Ok(())
+}
+
+/// Verifies a reservation belongs to this session, principal, agent, and action.
+///
+/// # Errors
+///
+/// Returns [`ComputerUseError::IdentityMismatch`] when any bound field disagrees with
+/// `envelope`.
+pub fn validate_reservation(
+    reservation: &TargetReservation,
+    envelope: &ActionEnvelope,
+) -> Result<(), ComputerUseError> {
+    const OBJECT: &str = "target reservation";
+
+    if reservation.session_id != envelope.session_id {
+        return Err(mismatch(OBJECT, "session_id", &envelope.session_id, &reservation.session_id));
+    }
+    if reservation.principal_id != envelope.principal_id {
+        return Err(mismatch(
+            OBJECT,
+            "principal_id",
+            &envelope.principal_id,
+            &reservation.principal_id,
+        ));
+    }
+    check_optional(
+        OBJECT,
+        "agent_id",
+        envelope.agent_id.as_deref(),
+        reservation.agent_id.as_deref(),
+    )?;
+    check_optional(
+        OBJECT,
+        "execution_group_id",
+        envelope.execution_group_id.as_deref(),
+        reservation.execution_group_id.as_deref(),
+    )?;
+
+    Ok(())
+}
+
+/// Verifies a receipt describes the action that was actually submitted.
+///
+/// The digest is the strongest binding available: `ActionEnvelope::args_digest` is what
+/// approval was granted against, so a receipt carrying a different digest describes different
+/// work regardless of matching identifiers. An empty expected digest is treated as
+/// unavailable rather than as a match against an empty value.
+///
+/// # Errors
+///
+/// Returns [`ComputerUseError::IdentityMismatch`] when the session, action ID, or action
+/// digest disagrees with `envelope`.
+pub fn validate_receipt(
+    receipt: &ExecutionReceipt,
+    envelope: &ActionEnvelope,
+    expected_digest: &str,
+) -> Result<(), ComputerUseError> {
+    const OBJECT: &str = "execution receipt";
+
+    if receipt.session_id != envelope.session_id {
+        return Err(mismatch(OBJECT, "session_id", &envelope.session_id, &receipt.session_id));
+    }
+    if receipt.action_id != envelope.action_id {
+        return Err(mismatch(OBJECT, "action_id", &envelope.action_id, &receipt.action_id));
+    }
+    if !expected_digest.is_empty() && receipt.action_digest != expected_digest {
+        return Err(mismatch(OBJECT, "action_digest", expected_digest, &receipt.action_digest));
+    }
+
+    Ok(())
+}

--- a/adk-computer-use/src/runtime/mcp.rs
+++ b/adk-computer-use/src/runtime/mcp.rs
@@ -1,3 +1,5 @@
+use crate::runtime::VerificationOutcome;
+use crate::runtime::binding::{validate_lease, validate_receipt, validate_reservation};
 use crate::{
     ActionEnvelope, ActionPreview, ComputerUseError, ComputerUseRuntime, ControlLease,
     ExecutionReceipt, SessionDeletionResult, SessionFollowUp, SessionFollowUpPage,
@@ -269,6 +271,70 @@ fn object(value: Value) -> Result<Map<String, Value>, ComputerUseError> {
     Ok(value)
 }
 
+/// Decides what a committed receipt proves about its declared postcondition.
+///
+/// Looks for a `verification` object on the receipt result carrying the observed digest, and
+/// requires it to match the postcondition's expected digest. Anything less is reported as
+/// committed-but-unverified rather than as verification, so the absence of evidence is never
+/// mistaken for evidence of success.
+fn evaluate_postcondition_evidence(
+    receipt: &ExecutionReceipt,
+    postcondition: &crate::ActionPostcondition,
+) -> VerificationOutcome {
+    let expected = expected_digest(postcondition);
+
+    let Some(verification) = receipt.result.as_ref().and_then(|result| result.get("verification"))
+    else {
+        return VerificationOutcome::CommittedUnverified {
+            reason: "the receipt carried no verification evidence for the declared postcondition"
+                .to_string(),
+        };
+    };
+
+    // An explicit negative observation is a failure, not merely missing evidence.
+    if verification.get("satisfied").and_then(Value::as_bool) == Some(false) {
+        return VerificationOutcome::Failed {
+            reason: "the runtime reported the postcondition was not satisfied".to_string(),
+        };
+    }
+
+    let observed = verification.get("observedDigest").and_then(Value::as_str);
+
+    match (expected, observed) {
+        (Some(expected), Some(observed)) if expected == observed => VerificationOutcome::Verified,
+        (Some(expected), Some(observed)) => VerificationOutcome::Failed {
+            reason: format!(
+                "observed digest {observed:?} does not match the expected postcondition digest \
+                 {expected:?}"
+            ),
+        },
+        (Some(_), None) => VerificationOutcome::CommittedUnverified {
+            reason: "verification evidence carried no observed digest to compare".to_string(),
+        },
+        // A digest-free postcondition (existence only) is satisfied by an explicit
+        // affirmative observation.
+        (None, _) => match verification.get("satisfied").and_then(Value::as_bool) {
+            Some(true) => VerificationOutcome::Verified,
+            _ => VerificationOutcome::CommittedUnverified {
+                reason: "the postcondition declares no digest and the evidence made no explicit \
+                         satisfied claim"
+                    .to_string(),
+            },
+        },
+    }
+}
+
+/// The digest a postcondition expects, where it declares one.
+fn expected_digest(postcondition: &crate::ActionPostcondition) -> Option<&str> {
+    use crate::ActionPostcondition;
+    match postcondition {
+        ActionPostcondition::UiElement { value_digest, .. } => value_digest.as_deref(),
+        ActionPostcondition::Filesystem { content_digest, .. } => content_digest.as_deref(),
+        ActionPostcondition::Registry { value_digest, .. } => value_digest.as_deref(),
+        _ => None,
+    }
+}
+
 #[async_trait]
 impl<S> ComputerUseRuntime for ComputerUseMcpRuntime<S>
 where
@@ -352,7 +418,12 @@ where
             )
             .await?,
         );
-        Ok(serde_json::from_value(value.get("lease").cloned().unwrap_or(value))?)
+        let lease: ControlLease =
+            serde_json::from_value(value.get("lease").cloned().unwrap_or(value))?;
+        // Deserialization proves shape, not provenance: a well-formed lease for another
+        // session or principal parses cleanly. Bind it before it reaches graph state.
+        validate_lease(&lease, envelope)?;
+        Ok(lease)
     }
 
     async fn reserve_target(
@@ -377,7 +448,10 @@ where
             )
             .await?,
         );
-        Ok(Some(serde_json::from_value(value.get("reservation").cloned().unwrap_or(value))?))
+        let reservation: TargetReservation =
+            serde_json::from_value(value.get("reservation").cloned().unwrap_or(value))?;
+        validate_reservation(&reservation, envelope)?;
+        Ok(Some(reservation))
     }
 
     async fn release_target(
@@ -420,11 +494,37 @@ where
             runtime.action_digest = %receipt.action_digest,
             "computer-use action receipt"
         );
+        // The digest covers the envelope, so a receipt carrying a different one describes
+        // different work even when the identifiers line up.
+        validate_receipt(&receipt, envelope, &envelope.args_digest)?;
         Ok(receipt)
     }
 
-    async fn verify(&self, receipt: &ExecutionReceipt) -> Result<bool, ComputerUseError> {
-        Ok(receipt.status == crate::ReceiptStatus::Committed)
+    async fn verify(
+        &self,
+        receipt: &ExecutionReceipt,
+        postcondition: Option<&crate::ActionPostcondition>,
+    ) -> Result<VerificationOutcome, ComputerUseError> {
+        // A committed receipt says the runtime accepted and performed the action. It does not
+        // say the intended effect occurred. Returning `status == Committed` as "verified"
+        // reported a committed-but-ineffective action as completed.
+        if receipt.status != crate::ReceiptStatus::Committed {
+            return Ok(VerificationOutcome::Failed {
+                reason: format!("receipt status is {:?}, not committed", receipt.status),
+            });
+        }
+
+        let Some(postcondition) = postcondition else {
+            return Ok(VerificationOutcome::CommittedUnverified {
+                reason: "the action declared no postcondition, so there is nothing to verify"
+                    .to_string(),
+            });
+        };
+
+        // `computer-use-mcp` may verify before issuing a receipt, but that is its contract,
+        // not something this adapter can assume. Evidence has to be present and bound to the
+        // postcondition to count.
+        Ok(evaluate_postcondition_evidence(receipt, postcondition))
     }
 
     async fn pause_session(&self, session_id: &str, reason: &str) -> Result<(), ComputerUseError> {

--- a/adk-computer-use/src/runtime/mod.rs
+++ b/adk-computer-use/src/runtime/mod.rs
@@ -1,9 +1,12 @@
 //! The [`ComputerUseRuntime`] boundary and its concrete adapters.
 //!
 //! [`ComputerUseRuntime`] is the extension point driven by the deterministic
-//! graph in [`crate::build_reference_graph`]. The [`mcp`] submodule provides
+//! graph in [`crate::build_reference_graph`]. The [`mcp`](crate::runtime::mcp) submodule provides
 //! [`ComputerUseMcpRuntime`], backed by a live `computer-use-mcp` server.
 //! Tests and portable examples can supply an in-process implementation instead.
+
+/// Binds MCP responses back to the request that produced them.
+pub mod binding;
 
 pub mod mcp;
 
@@ -15,6 +18,56 @@ use crate::{
 };
 use async_trait::async_trait;
 use serde_json::Value;
+
+/// What is actually known about an action's effect after execution.
+///
+/// `verify` previously returned `bool`, computed as `receipt.status == Committed`. That
+/// collapsed two different claims: that the runtime accepted the action, and that the
+/// intended effect was observed. A committed action whose effect did not occur was reported
+/// as completed, and the reference graph labelled the node and its output "verification".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VerificationOutcome {
+    /// The declared postcondition was observed to hold, with evidence bound to it.
+    Verified,
+    /// The runtime committed the action, but no independent postcondition evidence is
+    /// available — either none was declared, or the receipt carried none.
+    CommittedUnverified {
+        /// Why verification could not be performed, for the operator reading the result.
+        reason: String,
+    },
+    /// The action did not commit, or the evidence contradicts the postcondition.
+    Failed {
+        /// What went wrong.
+        reason: String,
+    },
+}
+
+impl VerificationOutcome {
+    /// Whether the postcondition was independently observed.
+    ///
+    /// Deliberately false for [`VerificationOutcome::CommittedUnverified`]: a caller asking
+    /// "was this verified?" must not be told yes because the action merely committed.
+    pub fn is_verified(&self) -> bool {
+        matches!(self, VerificationOutcome::Verified)
+    }
+
+    /// Whether the action was performed, whether or not its effect was verified.
+    pub fn is_committed(&self) -> bool {
+        matches!(
+            self,
+            VerificationOutcome::Verified | VerificationOutcome::CommittedUnverified { .. }
+        )
+    }
+
+    /// A stable status string for the graph's `result.status` field.
+    pub fn status(&self) -> &'static str {
+        match self {
+            VerificationOutcome::Verified => "completed",
+            VerificationOutcome::CommittedUnverified { .. } => "committed_unverified",
+            VerificationOutcome::Failed { .. } => "verification_failed",
+        }
+    }
+}
 
 /// Runtime boundary implemented by the computer-use MCP server or an in-process adapter.
 ///
@@ -77,8 +130,20 @@ pub trait ComputerUseRuntime: Send + Sync {
         lease: &ControlLease,
         approval_grant_id: Option<&str>,
     ) -> Result<ExecutionReceipt, ComputerUseError>;
-    /// Independently verify the receipt returned by [`execute_action`](Self::execute_action).
-    async fn verify(&self, receipt: &ExecutionReceipt) -> Result<bool, ComputerUseError>;
+    /// Report whether the action's postcondition was independently observed to hold.
+    ///
+    /// A committed receipt is an acknowledgement that the runtime accepted and performed the
+    /// action. It is not evidence that the intended effect occurred, so the two are reported
+    /// separately: see [`VerificationOutcome`].
+    ///
+    /// `postcondition` is the envelope's declared expected state, or `None` when the action
+    /// declared none — in which case there is nothing to verify and the honest answer is
+    /// [`VerificationOutcome::CommittedUnverified`].
+    async fn verify(
+        &self,
+        receipt: &ExecutionReceipt,
+        postcondition: Option<&crate::ActionPostcondition>,
+    ) -> Result<VerificationOutcome, ComputerUseError>;
 
     /// Pause the session's desktop authority. Defaults to unsupported.
     async fn pause_session(

--- a/adk-computer-use/tests/reference_graph.rs
+++ b/adk-computer-use/tests/reference_graph.rs
@@ -1,8 +1,9 @@
 use adk_computer_use::{
-    ActionClass, ActionEnvelope, ActionPreview, CancellationBridge, ComputerUseError,
-    ComputerUseRuntime, ControlLease, ExecutionCapability, ExecutionMode, ExecutionReceipt,
-    LeaseBoundaries, PolicyDecision, ReceiptStatus, ScopeAuthorizer, TargetReservation,
-    TargetReservationScope, build_reference_graph, build_reference_graph_with_checkpointer,
+    ActionClass, ActionEnvelope, ActionPostcondition, ActionPreview, CancellationBridge,
+    ComputerUseError, ComputerUseRuntime, ControlLease, ExecutionCapability, ExecutionMode,
+    ExecutionReceipt, LeaseBoundaries, PolicyDecision, ReceiptStatus, ScopeAuthorizer,
+    TargetReservation, TargetReservationScope, VerificationOutcome, build_reference_graph,
+    build_reference_graph_with_checkpointer,
 };
 use adk_graph::{ExecutionConfig, GraphError, MemoryCheckpointer, State};
 use async_trait::async_trait;
@@ -207,8 +208,23 @@ impl ComputerUseRuntime for FakeRuntime {
         Ok(receipt)
     }
 
-    async fn verify(&self, receipt: &ExecutionReceipt) -> Result<bool, ComputerUseError> {
-        Ok(receipt.status == ReceiptStatus::Committed)
+    async fn verify(
+        &self,
+        receipt: &ExecutionReceipt,
+        postcondition: Option<&ActionPostcondition>,
+    ) -> Result<VerificationOutcome, ComputerUseError> {
+        if receipt.status != ReceiptStatus::Committed {
+            return Ok(VerificationOutcome::Failed {
+                reason: format!("receipt status is {:?}", receipt.status),
+            });
+        }
+        // Committing is not verifying: without a postcondition there is nothing to check.
+        Ok(match postcondition {
+            Some(_) => VerificationOutcome::Verified,
+            None => VerificationOutcome::CommittedUnverified {
+                reason: "no postcondition declared".to_string(),
+            },
+        })
     }
 
     async fn pause_session(&self, session_id: &str, reason: &str) -> Result<(), ComputerUseError> {
@@ -243,7 +259,11 @@ async fn graph_parallelizes_observation_and_has_one_executor_effect() {
     let graph = build_reference_graph(runtime.clone(), authorizer()).unwrap();
     let output = graph.invoke(input(), ExecutionConfig::new("thread-1")).await.unwrap();
 
-    assert_eq!(output.get("verified"), Some(&json!(true)));
+    // The fixture action declares no postcondition, so the graph reports it as committed
+    // without claiming verification. Previously `verified` was true here purely because the
+    // receipt committed, which is what CU-02 was about.
+    assert_eq!(output.get("committed"), Some(&json!(true)));
+    assert_eq!(output.get("verified"), Some(&json!(false)));
     assert!(runtime.max_observation_concurrency.load(Ordering::SeqCst) >= 2);
     assert_eq!(runtime.physical_mutations.load(Ordering::SeqCst), 1);
     assert_eq!(runtime.reservations.load(Ordering::SeqCst), 1);
@@ -289,7 +309,11 @@ async fn approval_resume_executes_only_the_original_digest_with_the_exact_grant(
         )
         .await
         .unwrap();
-    assert_eq!(output.get("verified"), Some(&json!(true)));
+    // The fixture action declares no postcondition, so the graph reports it as committed
+    // without claiming verification. Previously `verified` was true here purely because the
+    // receipt committed, which is what CU-02 was about.
+    assert_eq!(output.get("committed"), Some(&json!(true)));
+    assert_eq!(output.get("verified"), Some(&json!(false)));
     assert_eq!(runtime.physical_mutations.load(Ordering::SeqCst), 1);
     assert_eq!(runtime.last_approval_grant.lock().await.as_deref(), Some("grant-exact"));
 }
@@ -328,7 +352,11 @@ async fn approval_resume_can_delegate_bearer_handling_to_the_runtime() {
         )
         .await
         .unwrap();
-    assert_eq!(output.get("verified"), Some(&json!(true)));
+    // The fixture action declares no postcondition, so the graph reports it as committed
+    // without claiming verification. Previously `verified` was true here purely because the
+    // receipt committed, which is what CU-02 was about.
+    assert_eq!(output.get("committed"), Some(&json!(true)));
+    assert_eq!(output.get("verified"), Some(&json!(false)));
     assert_eq!(runtime.physical_mutations.load(Ordering::SeqCst), 1);
     assert_eq!(*runtime.last_approval_grant.lock().await, None);
 }
@@ -423,7 +451,11 @@ async fn graph_retry_after_post_commit_crash_does_not_duplicate_mutation() {
     assert!(graph.invoke(input(), ExecutionConfig::new("thread-crash-1")).await.is_err());
     let output = graph.invoke(input(), ExecutionConfig::new("thread-crash-2")).await.unwrap();
 
-    assert_eq!(output.get("verified"), Some(&json!(true)));
+    // The fixture action declares no postcondition, so the graph reports it as committed
+    // without claiming verification. Previously `verified` was true here purely because the
+    // receipt committed, which is what CU-02 was about.
+    assert_eq!(output.get("committed"), Some(&json!(true)));
+    assert_eq!(output.get("verified"), Some(&json!(false)));
     assert_eq!(runtime.physical_mutations.load(Ordering::SeqCst), 1);
 }
 
@@ -437,6 +469,10 @@ async fn graph_retry_after_pre_effect_crash_executes_exactly_once() {
     assert_eq!(runtime.physical_mutations.load(Ordering::SeqCst), 0);
     let output = graph.invoke(input(), ExecutionConfig::new("thread-pre-effect-2")).await.unwrap();
 
-    assert_eq!(output.get("verified"), Some(&json!(true)));
+    // The fixture action declares no postcondition, so the graph reports it as committed
+    // without claiming verification. Previously `verified` was true here purely because the
+    // receipt committed, which is what CU-02 was about.
+    assert_eq!(output.get("committed"), Some(&json!(true)));
+    assert_eq!(output.get("verified"), Some(&json!(false)));
     assert_eq!(runtime.physical_mutations.load(Ordering::SeqCst), 1);
 }

--- a/adk-computer-use/tests/response_binding_tests.rs
+++ b/adk-computer-use/tests/response_binding_tests.rs
@@ -1,0 +1,261 @@
+//! Responses must be bound to the request, and committing is not verifying.
+//!
+//! **CU-01.** The adapter deserialized `ControlLease`, `TargetReservation`, and
+//! `ExecutionReceipt` and returned them straight into graph state. Typed deserialization
+//! proves shape, not provenance, and none of these structs has an invariant-enforcing
+//! constructor — so a well-formed object belonging to another session, principal, action, or
+//! mode parsed cleanly and was accepted. The external runtime stays authoritative; this is
+//! the local check that stops a stale or confused response from propagating.
+//!
+//! **CU-02.** `verify()` returned `receipt.status == ReceiptStatus::Committed`. That collapses
+//! two different claims — that the runtime performed the action, and that the intended effect
+//! occurred — so a committed action whose effect did not happen was reported as completed,
+//! from a node the reference graph labels "verify".
+
+use adk_computer_use::runtime::binding::{validate_lease, validate_receipt, validate_reservation};
+use adk_computer_use::{
+    ActionClass, ActionEnvelope, ActionPostcondition, ControlLease, ExecutionMode,
+    ExecutionReceipt, LeaseBoundaries, ReceiptStatus, TargetReservation, TargetReservationScope,
+};
+
+/// The request every response below is checked against.
+fn envelope() -> ActionEnvelope {
+    ActionEnvelope {
+        action_id: "action-1".into(),
+        session_id: "session-1".into(),
+        execution_group_id: Some("group-1".into()),
+        principal_id: "principal-1".into(),
+        agent_id: Some("agent-1".into()),
+        tool: "computer".into(),
+        operation: "click".into(),
+        action_class: ActionClass::EditReversible,
+        requested_mode: ExecutionMode::Foreground,
+        target: None,
+        target_sensitivity: None,
+        postcondition: None,
+        reversible: true,
+        external_side_effect: false,
+        proposed_at: "2026-01-01T00:00:00Z".into(),
+        expires_at: "2099-01-01T00:00:00Z".into(),
+        args_digest: "a".repeat(64),
+        resource: None,
+        provenance: None,
+        data_labels: Vec::new(),
+    }
+}
+
+/// A lease correctly bound to [`envelope`].
+fn lease() -> ControlLease {
+    ControlLease {
+        lease_id: "lease-1".into(),
+        revision: 1,
+        session_id: "session-1".into(),
+        principal_id: "principal-1".into(),
+        agent_id: Some("agent-1".into()),
+        kind: "exclusive".into(),
+        execution_mode: ExecutionMode::Foreground,
+        state: "active".into(),
+        acquired_at: None,
+        expires_at: "2099-01-01T00:00:00Z".into(),
+        action_budget: 1,
+        actions_used: 0,
+        boundaries: LeaseBoundaries {
+            app_ids: Vec::new(),
+            window_ids: Vec::new(),
+            display_ids: Vec::new(),
+        },
+    }
+}
+
+/// A reservation correctly bound to [`envelope`].
+fn reservation() -> TargetReservation {
+    TargetReservation {
+        reservation_id: "res-1".into(),
+        revision: 1,
+        intent_id: "intent-1".into(),
+        session_id: "session-1".into(),
+        principal_id: "principal-1".into(),
+        execution_group_id: Some("group-1".into()),
+        agent_id: Some("agent-1".into()),
+        scope: TargetReservationScope { app_id: "app-1".into(), window_id: None },
+        state: "active".into(),
+        acquired_at: "2026-01-01T00:00:00Z".into(),
+        expires_at: "2099-01-01T00:00:00Z".into(),
+        terminal_reason: None,
+    }
+}
+
+/// A receipt correctly bound to [`envelope`].
+fn receipt() -> ExecutionReceipt {
+    ExecutionReceipt {
+        receipt_id: "receipt-1".into(),
+        session_id: "session-1".into(),
+        action_id: "action-1".into(),
+        action_digest: "a".repeat(64),
+        attempt: 1,
+        status: ReceiptStatus::Committed,
+        created_at: None,
+        updated_at: None,
+        result: None,
+        error: None,
+    }
+}
+
+// ── CU-01: one mismatched field at a time ─────────────────────────────
+
+#[test]
+fn a_correctly_bound_lease_is_accepted() {
+    assert!(validate_lease(&lease(), &envelope()).is_ok());
+}
+
+#[test]
+fn a_lease_for_another_session_is_rejected() {
+    let mut lease = lease();
+    lease.session_id = "session-2".into();
+    let error = validate_lease(&lease, &envelope()).expect_err("must reject");
+    assert!(error.to_string().contains("session_id"), "{error}");
+}
+
+#[test]
+fn a_lease_for_another_principal_is_rejected() {
+    let mut lease = lease();
+    lease.principal_id = "principal-2".into();
+    assert!(validate_lease(&lease, &envelope()).is_err());
+}
+
+#[test]
+fn a_lease_for_another_agent_is_rejected() {
+    let mut lease = lease();
+    lease.agent_id = Some("agent-2".into());
+    assert!(validate_lease(&lease, &envelope()).is_err());
+}
+
+#[test]
+fn a_lease_for_another_execution_mode_is_rejected() {
+    let mut lease = lease();
+    lease.execution_mode = ExecutionMode::Background;
+    let error = validate_lease(&lease, &envelope()).expect_err("must reject");
+    assert!(error.to_string().contains("execution_mode"), "{error}");
+}
+
+#[test]
+fn an_inactive_lease_is_rejected() {
+    for state in ["expired", "released", "revoked"] {
+        let mut lease = lease();
+        lease.state = state.into();
+        let error = validate_lease(&lease, &envelope())
+            .expect_err("a lease that is not active authorizes nothing");
+        assert!(error.to_string().contains("not active"), "{state}: {error}");
+    }
+}
+
+#[test]
+fn an_exhausted_lease_is_rejected() {
+    let mut lease = lease();
+    lease.action_budget = 0;
+    let error = validate_lease(&lease, &envelope()).expect_err("must reject");
+    assert!(error.to_string().contains("budget"), "{error}");
+}
+
+#[test]
+fn a_correctly_bound_reservation_is_accepted() {
+    assert!(validate_reservation(&reservation(), &envelope()).is_ok());
+}
+
+#[test]
+fn a_reservation_for_another_session_or_principal_or_group_is_rejected() {
+    let mut wrong_session = reservation();
+    wrong_session.session_id = "session-2".into();
+    assert!(validate_reservation(&wrong_session, &envelope()).is_err());
+
+    let mut wrong_principal = reservation();
+    wrong_principal.principal_id = "principal-2".into();
+    assert!(validate_reservation(&wrong_principal, &envelope()).is_err());
+
+    let mut wrong_group = reservation();
+    wrong_group.execution_group_id = Some("group-2".into());
+    assert!(validate_reservation(&wrong_group, &envelope()).is_err());
+}
+
+#[test]
+fn a_correctly_bound_receipt_is_accepted() {
+    let envelope = envelope();
+    assert!(validate_receipt(&receipt(), &envelope, &envelope.args_digest).is_ok());
+}
+
+#[test]
+fn a_receipt_for_another_action_is_rejected() {
+    let envelope = envelope();
+    let mut receipt = receipt();
+    receipt.action_id = "action-2".into();
+    let error =
+        validate_receipt(&receipt, &envelope, &envelope.args_digest).expect_err("must reject");
+    assert!(error.to_string().contains("action_id"), "{error}");
+}
+
+#[test]
+fn a_receipt_with_a_different_digest_is_rejected_even_when_ids_match() {
+    // The digest is what approval was granted against, so a mismatch means different work
+    // regardless of the identifiers lining up.
+    let envelope = envelope();
+    let mut receipt = receipt();
+    receipt.action_digest = "b".repeat(64);
+    let error =
+        validate_receipt(&receipt, &envelope, &envelope.args_digest).expect_err("must reject");
+    assert!(error.to_string().contains("action_digest"), "{error}");
+}
+
+#[test]
+fn a_receipt_for_another_session_is_rejected() {
+    let envelope = envelope();
+    let mut receipt = receipt();
+    receipt.session_id = "session-2".into();
+    assert!(validate_receipt(&receipt, &envelope, &envelope.args_digest).is_err());
+}
+
+// ── CU-02: committed is not verified ──────────────────────────────────
+
+/// The postcondition a verifiable action would declare.
+fn postcondition() -> ActionPostcondition {
+    ActionPostcondition::Filesystem {
+        path: "/tmp/report.txt".into(),
+        exists: true,
+        content_digest: Some("c".repeat(64)),
+    }
+}
+
+#[test]
+fn the_outcome_type_keeps_committed_and_verified_distinct() {
+    use adk_computer_use::VerificationOutcome;
+
+    let unverified = VerificationOutcome::CommittedUnverified { reason: "no evidence".to_string() };
+    assert!(unverified.is_committed(), "the action was performed");
+    assert!(
+        !unverified.is_verified(),
+        "but its effect was not observed, and a caller asking must not be told otherwise"
+    );
+    assert_eq!(unverified.status(), "committed_unverified");
+
+    assert!(VerificationOutcome::Verified.is_verified());
+    assert!(VerificationOutcome::Verified.is_committed());
+    assert_eq!(VerificationOutcome::Verified.status(), "completed");
+
+    let failed = VerificationOutcome::Failed { reason: "not committed".to_string() };
+    assert!(!failed.is_committed());
+    assert!(!failed.is_verified());
+    assert_eq!(failed.status(), "verification_failed");
+}
+
+#[test]
+fn a_declared_postcondition_carries_a_digest_to_bind_evidence_to() {
+    // Verification compares an observed digest against this. Without it, evidence cannot be
+    // bound to what was promised, which is why a digest-free postcondition can only be
+    // satisfied by an explicit affirmative observation.
+    match postcondition() {
+        ActionPostcondition::Filesystem { content_digest, exists, .. } => {
+            assert!(exists);
+            assert_eq!(content_digest.as_deref().map(str::len), Some(64));
+        }
+        other => panic!("unexpected postcondition: {other:?}"),
+    }
+}

--- a/docs/official_docs/computer-use/index.md
+++ b/docs/official_docs/computer-use/index.md
@@ -1,0 +1,72 @@
+# Governed Desktop Automation
+
+`adk-computer-use` is a governance layer over the `computer-use-mcp` desktop-automation
+server. It performs no actuation itself: it orders observation, approval, mutation, and
+verification as a deterministic graph, and checks what the external runtime returns.
+
+## Response binding
+
+The external runtime is authoritative, but its responses are checked locally before entering
+graph state. Typed deserialization proves shape, not provenance — `ControlLease`,
+`TargetReservation`, and `ExecutionReceipt` have no invariant-enforcing constructor, so a
+well-formed object belonging to a different session parses cleanly.
+
+Each response is bound back to the request that produced it:
+
+| Response | Checked against the envelope |
+|----------|------------------------------|
+| `ControlLease` | `session_id`, `principal_id`, `agent_id`, `execution_mode`, plus active state and remaining action budget |
+| `TargetReservation` | `session_id`, `principal_id`, `agent_id`, `execution_group_id` |
+| `ExecutionReceipt` | `session_id`, `action_id`, and `action_digest` against the envelope's `args_digest` |
+
+A mismatch produces `ComputerUseError::IdentityMismatch` naming the field, and the response is
+rejected rather than stored.
+
+```rust,ignore
+use adk_computer_use::runtime::binding::validate_lease;
+
+// Refuses a lease that is well-formed but belongs to another session.
+validate_lease(&lease, &envelope)?;
+```
+
+> **Note:** the digest is the strongest binding available. `args_digest` is what approval was
+> granted against, so a receipt carrying a different digest describes different work even when
+> every identifier matches.
+
+An optional field that comes back absent is treated as under-specification, not contradiction;
+a field that is present and different is a mismatch.
+
+## Verification is not commitment
+
+`ComputerUseRuntime::verify` returns a `VerificationOutcome`, not a boolean:
+
+| Outcome | Meaning | `is_verified()` | `is_committed()` | `status()` |
+|---------|---------|-----------------|------------------|------------|
+| `Verified` | The declared postcondition was observed to hold | `true` | `true` | `completed` |
+| `CommittedUnverified` | The runtime performed the action; no postcondition evidence | `false` | `true` | `committed_unverified` |
+| `Failed` | Not committed, or the evidence contradicts the postcondition | `false` | `false` | `verification_failed` |
+
+The graph's `verify` node writes `verified`, `committed`, and a `result.verificationDetail`
+explaining anything short of `Verified`.
+
+> **Important:** a committed receipt is an acknowledgement that the action was accepted and
+> performed. It is not evidence that the intended effect occurred. `verify` previously returned
+> `receipt.status == Committed`, which reported a committed-but-ineffective action as
+> completed — from a node labelled "verify".
+
+### What counts as evidence
+
+For a postcondition declaring a digest (`valueDigest`, `contentDigest`), verification requires
+a `verification.observedDigest` on the receipt result that matches it. For a postcondition
+declaring only existence, an explicit `verification.satisfied: true` is required.
+
+| Receipt evidence | Outcome |
+|------------------|---------|
+| `verification.satisfied: false` | `Failed` — an explicit negative observation |
+| `observedDigest` matches the expected digest | `Verified` |
+| `observedDigest` differs | `Failed` |
+| No `verification` object | `CommittedUnverified` |
+| `verification` present, no `observedDigest`, digest expected | `CommittedUnverified` |
+
+Absence of evidence is never treated as evidence of success. If `computer-use-mcp` verifies
+before issuing a receipt, that is its contract; this adapter does not assume it.


### PR DESCRIPTION
## What

Resolves **CU-01** and **CU-02**. Security-relevant MCP responses are now bound back to the request that produced them, and `verify` no longer reports a committed action as verified.

## CU-01 — responses entered graph state unchecked

```rust
Ok(serde_json::from_value(value.get("lease").cloned().unwrap_or(value))?)
```

That was the whole of `acquire_lease`'s handling. `reserve_target` and `execute_action` were the same shape. Typed deserialization proves **shape, not provenance**, and none of `ControlLease`, `TargetReservation`, or `ExecutionReceipt` has an invariant-enforcing constructor — so a well-formed object belonging to another session, principal, agent, mode, or action parsed cleanly and was accepted.

The adapter already re-checked identity on previews and follow-ups (`get_follow_ups` at `mcp.rs:169`), so the pattern existed; these three paths simply did not use it.

| Response | Now checked against the envelope |
|---|---|
| `ControlLease` | `session_id`, `principal_id`, `agent_id`, `execution_mode`, plus active state and non-zero action budget |
| `TargetReservation` | `session_id`, `principal_id`, `agent_id`, `execution_group_id` |
| `ExecutionReceipt` | `session_id`, `action_id`, `action_digest` vs the envelope's `args_digest` |

The digest is the strongest binding available: `args_digest` is what approval was granted against, so a mismatch means different work even when every identifier lines up.

An optional field returned absent is treated as under-specification, not contradiction. Present-and-different is a mismatch.

## CU-02 — "committed" was reported as "verified"

```rust
async fn verify(&self, receipt: &ExecutionReceipt) -> Result<bool, ComputerUseError> {
    Ok(receipt.status == crate::ReceiptStatus::Committed)
}
```

The trait doc said "Independently verify the receipt". The signature could not: it never received the postcondition. A committed action whose intended effect did not occur was reported as completed — from the node the reference graph labels `verify`.

`verify` now takes `Option<&ActionPostcondition>` and returns:

| Outcome | `is_verified()` | `is_committed()` | `status()` |
|---|---|---|---|
| `Verified` | true | true | `completed` |
| `CommittedUnverified { reason }` | **false** | true | `committed_unverified` |
| `Failed { reason }` | false | false | `verification_failed` |

Evidence rules, so absence of evidence is never success:

| Receipt evidence | Outcome |
|---|---|
| `verification.satisfied: false` | `Failed` |
| `observedDigest` matches the postcondition digest | `Verified` |
| `observedDigest` differs | `Failed` |
| No `verification` object | `CommittedUnverified` |
| `verification` present but no `observedDigest` where one is expected | `CommittedUnverified` |

`computer-use-mcp` may verify before issuing a receipt, but that is its contract, not something this adapter can assume.

### Five existing assertions were wrong and now say so

`reference_graph.rs` asserted `verified == true` five times for a fixture action with `postcondition: None`. Nothing was verified in any of them. They now assert `committed == true` and `verified == false`. That is the behaviour change this finding asks for: a consumer checking `verified` was previously told yes on the strength of an acknowledgement.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo nextest run --workspace --profile ci` | **3836 passed**, 83 skipped, 0 failed |
| `cargo nextest run -p adk-computer-use` | 39 passed |
| `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps` | exit 0 |
| `cargo test -p adk-computer-use --doc` | 3 passed |
| doc-examples guard | exit 0 |

### Ten of fifteen tests fail when the validators trust the response

Replacing each validator body with `Ok(())`:

```
Summary  15 tests run: 5 passed, 10 failed
```

The five that still pass are the positive cases — correctly bound lease, reservation, and receipt accepted, plus the outcome-type assertions. They guard the opposite direction: that binding does not reject valid responses.

The mismatch tests change **one field at a time** across session, principal, agent, execution mode, lease state, action budget, action ID, execution group, and digest.

## Breaking change recorded

| Crate | Change |
|---|---|
| `adk-computer-use` | `ComputerUseRuntime::verify` takes the postcondition and returns `VerificationOutcome` instead of `bool` |

`adk-computer-use` is unpublished (new in 2.0.0), so there is no released baseline to break; the row is in the CHANGELOG table for implementors of the trait. `runtime` became a public module so `runtime::binding` validators are callable and testable.

`adk-computer-use` had no entry under `docs/official_docs/`; `docs/official_docs/computer-use/index.md` is new and documents both the binding table and the verification semantics.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed — new `docs/official_docs/computer-use/index.md`
- [x] Examples added or updated for new features — `examples/minimal_graph.rs` updated for the new signature