### PR TITLE
fix(managed): require a session owner, refuse unhonourable environment config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   | `adk-acp` | New public fields: `PermissionRequest::{session_id, tool_call_id, kind, raw_input}`, `AcpAgentConfig::{mcp_servers, filesystem, terminal}`, `PermissionOption::kind` | Struct literals must add the fields; prefer `..Default::default()` |
   | `adk-acp` | New variants: `OutputChunk::{ToolUpdate, Usage}`, `PermissionPolicy::AsyncCustom` | Exhaustive `match` must add arms |
   | `adk-acp` | `AcpAgentConfig` no longer `UnwindSafe`/`RefUnwindSafe` | Affects code storing it across `catch_unwind` |
+  | `adk-managed` | `ManagedAgentRuntime::start_session` requires a `ManagedOwner`, and rejects an `EnvironmentConfig` it cannot honour | Pass an owner; supply `None` for `env` unless a sandboxed runtime is configured |
   | `adk-anthropic` | New variants: `ContentBlock::WebFetchToolResult`, `ToolUnionParam::WebFetch20250910`, `ServerTool::WebFetch20250910` | Exhaustive `match` must add arms |
   | `adk-core` | New public fields: `RunConfig::{tool_confirmation_handler, runtime_toolsets}` | Struct literals must add the fields; prefer `RunConfig::builder()` |
   | `adk-core` | New variant `Part::EmbeddedResource` (`Part` is not `#[non_exhaustive]`) | Exhaustive `match` must add an arm |
@@ -425,6 +426,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   entries, so no plan update is emitted today.
 
 ### Fixed
+
+- **adk-managed: sessions belong to an owner, and ignored environment configuration is
+  refused.** `start_session` named its environment argument `_env` and never read it, so a
+  caller supplying environment variables or a working directory received a session that
+  silently ignored them. Every session was also persisted under the constants `managed` /
+  `managed_user`, and the session loop repeated them for each Runner call, so all managed
+  sessions shared one logical namespace: lookup, memory, and deletion could not be scoped to a
+  caller and no session could be attributed to one. `start_session` now requires a validated
+  `ManagedOwner`, persists the session under it, and makes Runner calls with it;
+  `EnvironmentConfig` requesting anything is rejected with an explanation, because sessions run
+  in-process and applying it would mutate state shared with every other session.
 
 - **adk-managed: deleting a session now deletes its persisted conversation.**
   `delete_session` archived the session, cancelled its loop, and dropped the in-memory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -426,6 +426,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **adk-managed: deleting a session now deletes its persisted conversation.**
+  `delete_session` archived the session, cancelled its loop, and dropped the in-memory
+  handle, but never called `SessionService::delete` — even though `start_session` had seeded a
+  persistent session that the Runner appended every turn to. The API reported deletion while
+  the conversation remained in the configured backend, outliving the process that deleted it.
+  The identity used at creation is now recorded on the session and used for deletion, so a
+  change to session addressing cannot orphan data. If backend deletion fails, the error names
+  the app, user, and session that still hold data.
+- **adk-managed: session status reflects normal execution, not only control-plane calls.**
+  `ActiveSession` owned the `Arc<RwLock<SessionStatus>>` that `ManagedAgentRuntime::status`
+  reads, while `SessionLoop` owned a separate plain field, despite a comment claiming the two
+  were shared. Queued → running → idle transitions updated only the loop's copy, so a session
+  actively executing turns kept reporting `Queued`; only pause, resume, archive, and deletion
+  moved the public value. The loop now writes to the caller's handle via
+  `SessionLoop::with_shared_status`.
+
 - **adk-server: background runs execute a workflow instead of reporting success.**
   `BackgroundRunner::run_with_timeout` received neither the workflow ID nor the input. It
   checked cancellation and returned `Completed` with an empty object, so a client got a

--- a/adk-managed/src/default_runtime.rs
+++ b/adk-managed/src/default_runtime.rs
@@ -56,6 +56,21 @@ use crate::types::{ManagedAgentDef, RuntimeError, SessionEvent, SessionStatus, U
 
 // ─── ActiveSession ───────────────────────────────────────────────────────────
 
+/// The addressing a managed session's conversation was persisted under.
+///
+/// Deletion has to remove what creation wrote. Keeping the triple rather than rebuilding it
+/// means a change to how sessions are addressed cannot leave orphaned conversation data
+/// behind in the configured backend.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PersistedIdentity {
+    /// The app name the session was created under.
+    pub(crate) app_name: String,
+    /// The user the session was created for.
+    pub(crate) user_id: String,
+    /// The session's own identifier.
+    pub(crate) session_id: String,
+}
+
 /// Internal state for an active (or recently active) session.
 ///
 /// Each session spawns a background task running the [`SessionLoop`](crate::session_loop::SessionLoop).
@@ -77,6 +92,11 @@ pub(crate) struct ActiveSession {
     pub(crate) pause_notify: Arc<Notify>,
     /// Current session status (shared with the session loop).
     pub(crate) status: Arc<RwLock<SessionStatus>>,
+    /// The identity this session's conversation is persisted under.
+    ///
+    /// Recorded at creation so deletion removes exactly what creation wrote, rather than
+    /// re-deriving an identity and risking a mismatch that silently leaves data behind.
+    pub(crate) persisted_as: PersistedIdentity,
     /// Checkpoint manager for durable state.
     pub(crate) checkpoint: Arc<RwLock<CheckpointManager>>,
 }
@@ -327,17 +347,27 @@ impl ManagedAgentRuntime for DefaultManagedAgentRuntime {
         //    session to exist. We create it here with the same triple
         //    (app_name="managed", user_id="managed_user", session_id) that
         //    build_runner/run_str use in the session loop.
+        let persisted_as = PersistedIdentity {
+            app_name: "managed".to_string(),
+            user_id: "managed_user".to_string(),
+            session_id: session_id.clone(),
+        };
+
         self.session_service
             .create(CreateRequest {
-                app_name: "managed".to_string(),
-                user_id: "managed_user".to_string(),
+                app_name: persisted_as.app_name.clone(),
+                user_id: persisted_as.user_id.clone(),
                 session_id: Some(session_id.clone()),
                 state: std::collections::HashMap::new(),
             })
             .await
             .map_err(|e| RuntimeError::internal(format!("failed to seed session: {e}")))?;
 
-        // 8. Spawn SessionLoop as background task
+        // 8. Spawn SessionLoop as background task, sharing the status the caller observes
+        //    so normal queued → running → idle transitions are visible through
+        //    `ManagedAgentRuntime::status`.
+        let status = Arc::new(RwLock::new(SessionStatus::Queued));
+
         #[cfg(feature = "memory")]
         let session_loop = SessionLoop::with_pause_controls(
             session_id.clone(),
@@ -351,7 +381,8 @@ impl ManagedAgentRuntime for DefaultManagedAgentRuntime {
             Arc::clone(&agent_arc),
             Arc::clone(&self.session_service),
             self.memory.clone(),
-        );
+        )
+        .with_shared_status(Arc::clone(&status));
         #[cfg(not(feature = "memory"))]
         let session_loop = SessionLoop::with_pause_controls(
             session_id.clone(),
@@ -364,15 +395,14 @@ impl ManagedAgentRuntime for DefaultManagedAgentRuntime {
             Arc::clone(&checkpoint),
             Arc::clone(&agent_arc),
             Arc::clone(&self.session_service),
-        );
+        )
+        .with_shared_status(Arc::clone(&status));
         tokio::spawn(session_loop.run());
-
-        // 9. Set initial status to Queued
-        let status = Arc::new(RwLock::new(SessionStatus::Queued));
 
         // 10. Create and store ActiveSession
         let active_session = ActiveSession {
             agent: agent_arc,
+            persisted_as,
             event_tx,
             broadcast_tx,
             cancel_token,
@@ -514,11 +544,38 @@ impl ManagedAgentRuntime for DefaultManagedAgentRuntime {
 
         // Remove from sessions map
         let removed = self.sessions.write().await.remove(&session.0);
-        if removed.is_none() {
+        let Some(removed) = removed else {
             return Err(RuntimeError::NotFound { session_id: session.0.clone() });
-        }
+        };
 
-        debug!(session_id = %session.0, "session deleted");
+        // Deleting the handle is the control plane only. `start_session` seeded a persistent
+        // session and the Runner appended every turn to it, so stopping here reported
+        // deletion while the conversation stayed in the configured backend — surviving the
+        // process that "deleted" it. Delete under the identity creation used.
+        let identity = removed.persisted_as;
+        self.session_service
+            .delete(adk_session::DeleteRequest {
+                app_name: identity.app_name.clone(),
+                user_id: identity.user_id.clone(),
+                session_id: identity.session_id.clone(),
+            })
+            .await
+            .map_err(|e| {
+                // The handle is already gone, so the caller must be told the data is not.
+                RuntimeError::internal(format!(
+                    "session {} was removed from the runtime but its persisted conversation \
+                     could not be deleted: {e}. The data remains under app {} / user {} and \
+                     needs manual cleanup.",
+                    identity.session_id, identity.app_name, identity.user_id
+                ))
+            })?;
+
+        debug!(
+            session_id = %session.0,
+            app_name = %identity.app_name,
+            user_id = %identity.user_id,
+            "session deleted, including persisted conversation"
+        );
         Ok(())
     }
 }

--- a/adk-managed/src/default_runtime.rs
+++ b/adk-managed/src/default_runtime.rs
@@ -50,7 +50,9 @@ use crate::checkpoint::CheckpointManager;
 use crate::parking::ToolParkingLot;
 use crate::replay::create_event_stream;
 use crate::resolver::ModelResolver;
-use crate::runtime::{AgentHandle, EnvironmentConfig, ManagedAgentRuntime, SessionHandle};
+use crate::runtime::{
+    AgentHandle, EnvironmentConfig, ManagedAgentRuntime, ManagedOwner, SessionHandle,
+};
 use crate::session_loop::SessionLoop;
 use crate::types::{ManagedAgentDef, RuntimeError, SessionEvent, SessionStatus, UserEvent};
 
@@ -314,8 +316,27 @@ impl ManagedAgentRuntime for DefaultManagedAgentRuntime {
     async fn start_session(
         &self,
         agent: &AgentHandle,
-        _env: Option<EnvironmentConfig>,
+        owner: &ManagedOwner,
+        env: Option<EnvironmentConfig>,
     ) -> Result<SessionHandle, RuntimeError> {
+        // Environment configuration was accepted and discarded — the parameter was named
+        // `_env`. Applying `env_vars` or `working_dir` to an in-process session loop would
+        // mutate process-global state shared with every other session, so the runtime refuses
+        // rather than pretending. A sandboxed execution boundary is what would make this
+        // honourable.
+        if let Some(env) = &env
+            && (!env.env_vars.is_empty() || env.working_dir.is_some())
+        {
+            return Err(RuntimeError::InvalidRequest {
+                message: "EnvironmentConfig cannot be honoured by this runtime: sessions run \
+                          in-process, so per-session environment variables and working \
+                          directories would have to mutate process-global state shared with \
+                          other sessions. Pass `None`, or configure a sandboxed runtime."
+                    .to_string(),
+                param: Some("env".to_string()),
+            });
+        }
+
         // 1. Look up agent from registry
         let agents = self.agents.read().await;
         let registered = agents
@@ -345,11 +366,11 @@ impl ManagedAgentRuntime for DefaultManagedAgentRuntime {
         // 7. Seed the session in the SessionService.
         //    The Runner's run() calls session_service.get() which requires the
         //    session to exist. We create it here with the same triple
-        //    (app_name="managed", user_id="managed_user", session_id) that
+        //    (owner app, owner user, session_id) that
         //    build_runner/run_str use in the session loop.
         let persisted_as = PersistedIdentity {
-            app_name: "managed".to_string(),
-            user_id: "managed_user".to_string(),
+            app_name: owner.app_name().to_string(),
+            user_id: owner.user_id().to_string(),
             session_id: session_id.clone(),
         };
 
@@ -382,7 +403,8 @@ impl ManagedAgentRuntime for DefaultManagedAgentRuntime {
             Arc::clone(&self.session_service),
             self.memory.clone(),
         )
-        .with_shared_status(Arc::clone(&status));
+        .with_shared_status(Arc::clone(&status))
+        .with_owner(owner.app_name(), owner.user_id());
         #[cfg(not(feature = "memory"))]
         let session_loop = SessionLoop::with_pause_controls(
             session_id.clone(),
@@ -396,7 +418,8 @@ impl ManagedAgentRuntime for DefaultManagedAgentRuntime {
             Arc::clone(&agent_arc),
             Arc::clone(&self.session_service),
         )
-        .with_shared_status(Arc::clone(&status));
+        .with_shared_status(Arc::clone(&status))
+        .with_owner(owner.app_name(), owner.user_id());
         tokio::spawn(session_loop.run());
 
         // 10. Create and store ActiveSession
@@ -644,6 +667,10 @@ mod tests {
         }
     }
 
+    fn test_owner() -> ManagedOwner {
+        ManagedOwner::new("app", "user").expect("valid owner")
+    }
+
     fn create_test_runtime() -> DefaultManagedAgentRuntime {
         let resolver: Arc<dyn ModelResolver> = Arc::new(MockResolver);
         let sessions = mock_session_service();
@@ -830,7 +857,10 @@ mod tests {
         };
 
         let agent = runtime.create(def).await.unwrap();
-        let session = runtime.start_session(&agent, None).await.unwrap();
+        let session = runtime
+            .start_session(&agent, &ManagedOwner::new("app", "user").unwrap(), None)
+            .await
+            .unwrap();
         assert!(!session.0.is_empty());
     }
 
@@ -851,7 +881,10 @@ mod tests {
         };
 
         let agent = runtime.create(def).await.unwrap();
-        let session = runtime.start_session(&agent, None).await.unwrap();
+        let session = runtime
+            .start_session(&agent, &ManagedOwner::new("app", "user").unwrap(), None)
+            .await
+            .unwrap();
 
         let status = runtime.status(&session).await.unwrap();
         assert_eq!(status, SessionStatus::Queued);
@@ -862,7 +895,7 @@ mod tests {
         let runtime = create_test_runtime();
 
         let fake_agent = AgentHandle("nonexistent".to_string());
-        let result = runtime.start_session(&fake_agent, None).await;
+        let result = runtime.start_session(&fake_agent, &test_owner(), None).await;
         assert!(result.is_err());
     }
 
@@ -885,7 +918,10 @@ mod tests {
         };
 
         let agent = runtime.create(def).await.unwrap();
-        let session = runtime.start_session(&agent, None).await.unwrap();
+        let session = runtime
+            .start_session(&agent, &ManagedOwner::new("app", "user").unwrap(), None)
+            .await
+            .unwrap();
 
         let event =
             UserEvent::Message { content: vec![ContentBlock::Text { text: "Hello".to_string() }] };
@@ -925,7 +961,10 @@ mod tests {
         };
 
         let agent = runtime.create(def).await.unwrap();
-        let session = runtime.start_session(&agent, None).await.unwrap();
+        let session = runtime
+            .start_session(&agent, &ManagedOwner::new("app", "user").unwrap(), None)
+            .await
+            .unwrap();
 
         // Subscribe to stream
         let mut stream = runtime.stream_events(&session, None).await.unwrap();
@@ -975,7 +1014,10 @@ mod tests {
         };
 
         let agent = runtime.create(def).await.unwrap();
-        let session = runtime.start_session(&agent, None).await.unwrap();
+        let session = runtime
+            .start_session(&agent, &ManagedOwner::new("app", "user").unwrap(), None)
+            .await
+            .unwrap();
 
         let result = runtime.interrupt(&session).await;
         assert!(result.is_ok());
@@ -998,7 +1040,10 @@ mod tests {
         };
 
         let agent = runtime.create(def).await.unwrap();
-        let session = runtime.start_session(&agent, None).await.unwrap();
+        let session = runtime
+            .start_session(&agent, &ManagedOwner::new("app", "user").unwrap(), None)
+            .await
+            .unwrap();
 
         runtime.pause(&session).await.unwrap();
         let status = runtime.status(&session).await.unwrap();
@@ -1022,7 +1067,10 @@ mod tests {
         };
 
         let agent = runtime.create(def).await.unwrap();
-        let session = runtime.start_session(&agent, None).await.unwrap();
+        let session = runtime
+            .start_session(&agent, &ManagedOwner::new("app", "user").unwrap(), None)
+            .await
+            .unwrap();
 
         runtime.pause(&session).await.unwrap();
         assert_eq!(runtime.status(&session).await.unwrap(), SessionStatus::Paused);
@@ -1048,7 +1096,10 @@ mod tests {
         };
 
         let agent = runtime.create(def).await.unwrap();
-        let session = runtime.start_session(&agent, None).await.unwrap();
+        let session = runtime
+            .start_session(&agent, &ManagedOwner::new("app", "user").unwrap(), None)
+            .await
+            .unwrap();
 
         runtime.archive(&session).await.unwrap();
         let status = runtime.status(&session).await.unwrap();
@@ -1072,7 +1123,10 @@ mod tests {
         };
 
         let agent = runtime.create(def).await.unwrap();
-        let session = runtime.start_session(&agent, None).await.unwrap();
+        let session = runtime
+            .start_session(&agent, &ManagedOwner::new("app", "user").unwrap(), None)
+            .await
+            .unwrap();
 
         runtime.delete_session(&session).await.unwrap();
 

--- a/adk-managed/src/lib.rs
+++ b/adk-managed/src/lib.rs
@@ -57,7 +57,9 @@ pub use event_mapping::{
 pub use parking::ToolParkingLot;
 pub use replay::{create_event_stream, get_seq};
 pub use resolver::{DefaultModelResolver, ModelResolver, ResolverError, ResolverResult};
-pub use runtime::{AgentHandle, EnvironmentConfig, ManagedAgentRuntime, SessionHandle};
+pub use runtime::{
+    AgentHandle, EnvironmentConfig, ManagedAgentRuntime, ManagedOwner, SessionHandle,
+};
 pub use schema_normalization::{normalize_for_provider, representative_mcp_schema};
 pub use sequence::SequenceCounter;
 pub use session_loop::SessionLoop;

--- a/adk-managed/src/runtime.rs
+++ b/adk-managed/src/runtime.rs
@@ -19,7 +19,7 @@
 //! async fn example(runtime: &dyn ManagedAgentRuntime) {
 //!     let def = ManagedAgentDef::default();
 //!     let agent = runtime.create(def).await.unwrap();
-//!     let session = runtime.start_session(&agent, None).await.unwrap();
+//!     let session = runtime.start_session(&agent, &ManagedOwner::new("app", "user").unwrap(), None).await.unwrap();
 //!     let status = runtime.status(&session).await.unwrap();
 //!     println!("Session status: {status:?}");
 //! }
@@ -66,6 +66,77 @@ pub struct AgentHandle(pub String);
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SessionHandle(pub String);
+
+/// Who a managed session belongs to.
+///
+/// Every managed session was previously persisted under the constants `managed` /
+/// `managed_user`, so all sessions shared one logical namespace: session lookup, memory, and
+/// deletion could not be scoped to a caller, and audit could not attribute a session to
+/// anyone. The runtime needs this at creation because the underlying `SessionService` is
+/// addressed by app and user, and substituting constants to satisfy that contract is what
+/// erased the caller.
+///
+/// # Example
+///
+/// ```rust
+/// use adk_managed::ManagedOwner;
+///
+/// let owner = ManagedOwner::new("support-console", "user-42")?;
+/// assert_eq!(owner.app_name(), "support-console");
+///
+/// // Blank components are rejected, since they would silently re-create a shared namespace.
+/// assert!(ManagedOwner::new("", "user-42").is_err());
+/// # Ok::<(), adk_managed::types::RuntimeError>(())
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ManagedOwner {
+    app_name: String,
+    user_id: String,
+}
+
+impl ManagedOwner {
+    /// Validates and builds an owner identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RuntimeError::InvalidRequest`] when either component is empty or whitespace.
+    pub fn new(
+        app_name: impl Into<String>,
+        user_id: impl Into<String>,
+    ) -> Result<Self, RuntimeError> {
+        let app_name = app_name.into();
+        let user_id = user_id.into();
+
+        if app_name.trim().is_empty() {
+            return Err(RuntimeError::InvalidRequest {
+                message: "a managed session needs a non-empty app name to be addressable and \
+                          auditable"
+                    .to_string(),
+                param: Some("app_name".to_string()),
+            });
+        }
+        if user_id.trim().is_empty() {
+            return Err(RuntimeError::InvalidRequest {
+                message: "a managed session needs a non-empty user id; without one, sessions \
+                          share a namespace and cannot be scoped to a caller"
+                    .to_string(),
+                param: Some("user_id".to_string()),
+            });
+        }
+
+        Ok(Self { app_name, user_id })
+    }
+
+    /// The app this session belongs to.
+    pub fn app_name(&self) -> &str {
+        &self.app_name
+    }
+
+    /// The user this session belongs to.
+    pub fn user_id(&self) -> &str {
+        &self.user_id
+    }
+}
 
 // ─── EnvironmentConfig ───────────────────────────────────────────────────────
 
@@ -136,6 +207,7 @@ pub trait ManagedAgentRuntime: Send + Sync {
     async fn start_session(
         &self,
         agent: &AgentHandle,
+        owner: &ManagedOwner,
         env: Option<EnvironmentConfig>,
     ) -> Result<SessionHandle, RuntimeError>;
 

--- a/adk-managed/src/session_loop.rs
+++ b/adk-managed/src/session_loop.rs
@@ -107,7 +107,11 @@ pub struct SessionLoop {
     /// Notify used to wake the loop after resume.
     pause_notify: Arc<Notify>,
     /// Current session status.
-    status: SessionStatus,
+    ///
+    /// Shared with the public session handle when the runtime installs its own via
+    /// [`SessionLoop::with_shared_status`]. Without that, the handle reported `Queued` for
+    /// the whole life of a session because the loop wrote to a field the handle never read.
+    status: Arc<RwLock<SessionStatus>>,
     /// The agent driving this session.
     agent: Arc<dyn Agent>,
     /// Session persistence backend (needed by the Runner).
@@ -151,7 +155,7 @@ impl SessionLoop {
             cancel_token,
             pause_flag: Arc::new(Mutex::new(false)),
             pause_notify: Arc::new(Notify::new()),
-            status: SessionStatus::Queued,
+            status: Arc::new(RwLock::new(SessionStatus::Queued)),
             agent,
             session_service,
             #[cfg(feature = "memory")]
@@ -190,7 +194,7 @@ impl SessionLoop {
             cancel_token,
             pause_flag,
             pause_notify,
-            status: SessionStatus::Queued,
+            status: Arc::new(RwLock::new(SessionStatus::Queued)),
             agent,
             session_service,
             memory,
@@ -225,11 +229,29 @@ impl SessionLoop {
             cancel_token,
             pause_flag,
             pause_notify,
-            status: SessionStatus::Queued,
+            status: Arc::new(RwLock::new(SessionStatus::Queued)),
             agent,
             session_service,
             usage_tracker: SessionUsageTracker::new(),
         }
+    }
+
+    /// Reports status into the handle the caller already holds.
+    ///
+    /// The runtime's `ActiveSession` owns the status a caller observes through
+    /// `ManagedAgentRuntime::status`. Installing it here is what makes normal
+    /// queued → running → idle transitions visible; without it the loop wrote to its own
+    /// field and the public handle stayed `Queued` through an entire session.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let session_loop = SessionLoop::with_pause_controls(/* ... */)
+    ///     .with_shared_status(Arc::clone(&active.status));
+    /// ```
+    pub fn with_shared_status(mut self, status: Arc<RwLock<SessionStatus>>) -> Self {
+        self.status = status;
+        self
     }
 
     /// Get a clone of the pause flag for external control.
@@ -375,7 +397,7 @@ impl SessionLoop {
     /// Process a single turn: emit status.running, invoke Runner, emit events, emit status.idle.
     async fn process_turn(&mut self, content: Vec<ContentBlock>) -> Result<(), RuntimeError> {
         // 1. Emit status.running
-        self.status = SessionStatus::Running;
+        *self.status.write().await = SessionStatus::Running;
         let running_event = SessionEvent::StatusRunning { seq: self.seq.next() };
         self.emit_event(running_event).await;
 
@@ -617,8 +639,11 @@ impl SessionLoop {
     /// Emit a session event: assign to checkpoint and broadcast.
     async fn emit_event(&mut self, event: SessionEvent) {
         // Checkpoint atomically via the shared manager.
-        let run_state =
-            RunState { seq: self.seq.current(), pending_tool_ids: Vec::new(), status: self.status };
+        let run_state = RunState {
+            seq: self.seq.current(),
+            pending_tool_ids: Vec::new(),
+            status: *self.status.read().await,
+        };
         self.checkpoint.write().await.checkpoint(event.clone(), run_state);
 
         // Broadcast to subscribers (ignore if no receivers).
@@ -627,7 +652,7 @@ impl SessionLoop {
 
     /// Emit a `status.idle` event and update internal status.
     async fn emit_idle(&mut self, stop_reason: Option<StopReason>, usage: Option<UsageReport>) {
-        self.status = SessionStatus::Idle;
+        *self.status.write().await = SessionStatus::Idle;
         let idle_event = SessionEvent::StatusIdle { seq: self.seq.next(), stop_reason, usage };
         self.emit_event(idle_event).await;
     }

--- a/adk-managed/src/session_loop.rs
+++ b/adk-managed/src/session_loop.rs
@@ -106,6 +106,13 @@ pub struct SessionLoop {
     pause_flag: Arc<Mutex<bool>>,
     /// Notify used to wake the loop after resume.
     pause_notify: Arc<Notify>,
+    /// The owner this session's Runner calls are made under.
+    ///
+    /// Defaults to the historical `managed` / `managed_user` constants so an existing loop
+    /// keeps working, and is replaced by [`SessionLoop::with_owner`] when the runtime knows
+    /// who the session belongs to. Hardcoding the constants is what put every managed session
+    /// in one namespace.
+    owner: (String, String),
     /// Current session status.
     ///
     /// Shared with the public session handle when the runtime installs its own via
@@ -155,6 +162,7 @@ impl SessionLoop {
             cancel_token,
             pause_flag: Arc::new(Mutex::new(false)),
             pause_notify: Arc::new(Notify::new()),
+            owner: ("managed".to_string(), "managed_user".to_string()),
             status: Arc::new(RwLock::new(SessionStatus::Queued)),
             agent,
             session_service,
@@ -194,6 +202,7 @@ impl SessionLoop {
             cancel_token,
             pause_flag,
             pause_notify,
+            owner: ("managed".to_string(), "managed_user".to_string()),
             status: Arc::new(RwLock::new(SessionStatus::Queued)),
             agent,
             session_service,
@@ -229,11 +238,28 @@ impl SessionLoop {
             cancel_token,
             pause_flag,
             pause_notify,
+            owner: ("managed".to_string(), "managed_user".to_string()),
             status: Arc::new(RwLock::new(SessionStatus::Queued)),
             agent,
             session_service,
             usage_tracker: SessionUsageTracker::new(),
         }
+    }
+
+    /// Makes this loop's Runner calls under `owner`.
+    ///
+    /// Without this the loop used the constants `managed` / `managed_user`, so every managed
+    /// session shared one logical namespace and no session could be attributed to a caller.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let session_loop = SessionLoop::with_pause_controls(/* ... */)
+    ///     .with_owner(owner.app_name(), owner.user_id());
+    /// ```
+    pub fn with_owner(mut self, app_name: impl Into<String>, user_id: impl Into<String>) -> Self {
+        self.owner = (app_name.into(), user_id.into());
+        self
     }
 
     /// Reports status into the handle the caller already holds.
@@ -414,7 +440,7 @@ impl SessionLoop {
         let runner = self.build_runner()?;
 
         let event_stream = runner
-            .run_str("managed_user", &self.session_id, user_content)
+            .run_str(&self.owner.1, &self.session_id, user_content)
             .await
             .map_err(|e| RuntimeError::internal(format!("runner invocation failed: {e}")))?;
 
@@ -477,7 +503,7 @@ impl SessionLoop {
     fn build_runner(&self) -> Result<Runner, RuntimeError> {
         #[allow(unused_mut)]
         let mut builder = Runner::builder()
-            .app_name("managed")
+            .app_name(self.owner.0.as_str())
             .agent(Arc::clone(&self.agent))
             .session_service(Arc::clone(&self.session_service))
             .cancellation_token(self.cancel_token.clone());

--- a/adk-managed/tests/control_plane_tests.rs
+++ b/adk-managed/tests/control_plane_tests.rs
@@ -14,7 +14,9 @@
 use adk_core::{Content, FinishReason, Llm, LlmRequest, LlmResponse, LlmResponseStream};
 use adk_managed::resolver::{ModelResolver, ResolverResult};
 use adk_managed::types::{ContentBlock, ManagedAgentDef, ModelRef, SessionStatus, UserEvent};
-use adk_managed::{DefaultManagedAgentRuntime, ManagedAgentRuntime};
+use adk_managed::{
+    DefaultManagedAgentRuntime, EnvironmentConfig, ManagedAgentRuntime, ManagedOwner,
+};
 use adk_session::InMemorySessionService;
 use adk_session::service::{GetRequest, SessionService};
 use async_trait::async_trait;
@@ -68,6 +70,11 @@ fn runtime_with_service() -> (DefaultManagedAgentRuntime, Arc<InMemorySessionSer
     (runtime, service)
 }
 
+/// The owner every session in these tests belongs to.
+fn test_owner() -> ManagedOwner {
+    ManagedOwner::new(MANAGED_APP, MANAGED_USER).expect("valid owner")
+}
+
 /// A minimal agent definition; no model call is made by these tests.
 fn agent_def(name: &str) -> ManagedAgentDef {
     ManagedAgentDef::new(name, ModelRef::Shorthand("silent".to_string()))
@@ -92,7 +99,7 @@ async fn session_exists(service: &InMemorySessionService, session_id: &str) -> b
 async fn deleting_a_managed_session_removes_its_persisted_conversation() {
     let (runtime, service) = runtime_with_service();
     let agent = runtime.create(agent_def("deleter")).await.expect("agent");
-    let session = runtime.start_session(&agent, None).await.expect("session");
+    let session = runtime.start_session(&agent, &test_owner(), None).await.expect("session");
 
     assert!(
         session_exists(&service, session.0.as_str()).await,
@@ -111,7 +118,7 @@ async fn deleting_a_managed_session_removes_its_persisted_conversation() {
 async fn deleting_an_unknown_session_is_still_reported_as_not_found() {
     let (runtime, _service) = runtime_with_service();
     let agent = runtime.create(agent_def("deleter")).await.expect("agent");
-    let session = runtime.start_session(&agent, None).await.expect("session");
+    let session = runtime.start_session(&agent, &test_owner(), None).await.expect("session");
 
     runtime.delete_session(&session).await.expect("first delete");
 
@@ -126,7 +133,7 @@ async fn deleting_an_unknown_session_is_still_reported_as_not_found() {
 async fn a_new_session_reports_queued_through_the_public_handle() {
     let (runtime, _service) = runtime_with_service();
     let agent = runtime.create(agent_def("reporter")).await.expect("agent");
-    let session = runtime.start_session(&agent, None).await.expect("session");
+    let session = runtime.start_session(&agent, &test_owner(), None).await.expect("session");
 
     // The starting point. What matters is that this handle is the one the loop writes to,
     // asserted below.
@@ -137,7 +144,7 @@ async fn a_new_session_reports_queued_through_the_public_handle() {
 async fn a_working_session_stops_reporting_queued() {
     let (runtime, _service) = runtime_with_service();
     let agent = runtime.create(agent_def("reporter")).await.expect("agent");
-    let session = runtime.start_session(&agent, None).await.expect("session");
+    let session = runtime.start_session(&agent, &test_owner(), None).await.expect("session");
 
     runtime
         .send_event(
@@ -171,9 +178,106 @@ async fn a_working_session_stops_reporting_queued() {
 async fn archive_is_visible_through_the_public_handle() {
     let (runtime, _service) = runtime_with_service();
     let agent = runtime.create(agent_def("reporter")).await.expect("agent");
-    let session = runtime.start_session(&agent, None).await.expect("session");
+    let session = runtime.start_session(&agent, &test_owner(), None).await.expect("session");
 
     runtime.archive(&session).await.expect("archive");
 
     assert_eq!(runtime.status(&session).await.expect("status"), SessionStatus::Archived);
+}
+
+// ── Owner identity and environment ────────────────────────────────────
+//
+// `start_session` named its environment argument `_env` and never read it, and every session
+// was persisted under the constants `managed` / `managed_user`. All managed sessions therefore
+// shared one logical namespace: lookup, memory, and deletion could not be scoped to a caller,
+// and no session could be attributed to one.
+
+#[tokio::test]
+async fn two_owners_persist_into_separate_namespaces() {
+    let (runtime, service) = runtime_with_service();
+    let agent = runtime.create(agent_def("shared")).await.expect("agent");
+
+    let alice = ManagedOwner::new("console", "alice").unwrap();
+    let bob = ManagedOwner::new("console", "bob").unwrap();
+
+    let alice_session = runtime.start_session(&agent, &alice, None).await.expect("alice");
+    let bob_session = runtime.start_session(&agent, &bob, None).await.expect("bob");
+
+    // Each session exists only under its own owner.
+    assert!(exists_for(&service, &alice, alice_session.0.as_str()).await);
+    assert!(exists_for(&service, &bob, bob_session.0.as_str()).await);
+    assert!(
+        !exists_for(&service, &bob, alice_session.0.as_str()).await,
+        "one owner's session must not be addressable as another's"
+    );
+}
+
+#[tokio::test]
+async fn deleting_one_owners_session_leaves_the_others_intact() {
+    let (runtime, service) = runtime_with_service();
+    let agent = runtime.create(agent_def("shared")).await.expect("agent");
+
+    let alice = ManagedOwner::new("console", "alice").unwrap();
+    let bob = ManagedOwner::new("console", "bob").unwrap();
+    let alice_session = runtime.start_session(&agent, &alice, None).await.expect("alice");
+    let bob_session = runtime.start_session(&agent, &bob, None).await.expect("bob");
+
+    runtime.delete_session(&alice_session).await.expect("delete");
+
+    assert!(!exists_for(&service, &alice, alice_session.0.as_str()).await);
+    assert!(
+        exists_for(&service, &bob, bob_session.0.as_str()).await,
+        "deleting one owner's session must not remove another's"
+    );
+}
+
+#[tokio::test]
+async fn an_owner_needs_both_components() {
+    assert!(
+        ManagedOwner::new("", "user").is_err(),
+        "a blank app name recreates a shared namespace"
+    );
+    assert!(ManagedOwner::new("app", "").is_err(), "a blank user id cannot be scoped to a caller");
+    assert!(ManagedOwner::new("   ", "user").is_err(), "whitespace is not an identity");
+    assert!(ManagedOwner::new("app", "user").is_ok());
+}
+
+#[tokio::test]
+async fn environment_configuration_is_refused_rather_than_ignored() {
+    let (runtime, _service) = runtime_with_service();
+    let agent = runtime.create(agent_def("env")).await.expect("agent");
+    let owner = ManagedOwner::new("console", "alice").unwrap();
+
+    let mut env = EnvironmentConfig::default();
+    env.env_vars.insert("API_KEY".to_string(), "value".to_string());
+
+    let error = runtime
+        .start_session(&agent, &owner, Some(env))
+        .await
+        .expect_err("configuration the runtime cannot honour must not be silently discarded");
+    assert!(error.to_string().contains("in-process"), "{error}");
+
+    // An empty configuration asks for nothing, so it is accepted.
+    assert!(
+        runtime.start_session(&agent, &owner, Some(EnvironmentConfig::default())).await.is_ok()
+    );
+}
+
+/// Whether the backend holds `session_id` under `owner`.
+async fn exists_for(
+    service: &InMemorySessionService,
+    owner: &ManagedOwner,
+    session_id: &str,
+) -> bool {
+    service
+        .get(GetRequest {
+            app_name: owner.app_name().to_string(),
+            user_id: owner.user_id().to_string(),
+            session_id: session_id.to_string(),
+            num_recent_events: None,
+            after: None,
+        })
+        .await
+        .map(|_| true)
+        .unwrap_or(false)
 }

--- a/adk-managed/tests/control_plane_tests.rs
+++ b/adk-managed/tests/control_plane_tests.rs
@@ -1,0 +1,179 @@
+//! The managed control plane must reflect the data plane.
+//!
+//! Two disconnects:
+//!
+//! 1. `delete_session` archived the handle and dropped it from the in-memory map, but never
+//!    called `SessionService::delete` — even though `start_session` seeded a persistent
+//!    session and the Runner appended every turn to it. The API reported deletion while the
+//!    conversation stayed in the configured backend, outliving the process that "deleted" it.
+//! 2. `ActiveSession` owned the `Arc<RwLock<SessionStatus>>` a caller reads, while
+//!    `SessionLoop` owned a separate plain field. Normal queued → running → idle transitions
+//!    updated only the loop's copy, so a session doing work kept reporting `Queued`. The
+//!    struct comment claimed the two were shared.
+
+use adk_core::{Content, FinishReason, Llm, LlmRequest, LlmResponse, LlmResponseStream};
+use adk_managed::resolver::{ModelResolver, ResolverResult};
+use adk_managed::types::{ContentBlock, ManagedAgentDef, ModelRef, SessionStatus, UserEvent};
+use adk_managed::{DefaultManagedAgentRuntime, ManagedAgentRuntime};
+use adk_session::InMemorySessionService;
+use adk_session::service::{GetRequest, SessionService};
+use async_trait::async_trait;
+use std::sync::Arc;
+
+/// A model that answers without a network call.
+struct SilentModel;
+
+#[async_trait]
+impl Llm for SilentModel {
+    fn name(&self) -> &str {
+        "silent"
+    }
+    async fn generate_content(
+        &self,
+        _request: LlmRequest,
+        _stream: bool,
+    ) -> adk_core::Result<LlmResponseStream> {
+        let response = LlmResponse {
+            content: Some(Content::new("model").with_text("ok")),
+            partial: false,
+            turn_complete: true,
+            finish_reason: Some(FinishReason::Stop),
+            ..Default::default()
+        };
+        Ok(Box::pin(async_stream::stream! { yield Ok(response); }))
+    }
+}
+
+/// Resolves every model reference to the silent model.
+struct SilentResolver;
+
+#[async_trait]
+impl ModelResolver for SilentResolver {
+    async fn resolve(&self, _model: &ModelRef) -> ResolverResult<Arc<dyn Llm>> {
+        Ok(Arc::new(SilentModel) as Arc<dyn Llm>)
+    }
+}
+
+/// The identity `start_session` persists a managed session under.
+const MANAGED_APP: &str = "managed";
+const MANAGED_USER: &str = "managed_user";
+
+/// Builds a runtime over a session service the test can inspect directly.
+fn runtime_with_service() -> (DefaultManagedAgentRuntime, Arc<InMemorySessionService>) {
+    let service = Arc::new(InMemorySessionService::new());
+    let runtime = DefaultManagedAgentRuntime::new(
+        Arc::new(SilentResolver) as Arc<dyn ModelResolver>,
+        Arc::clone(&service) as Arc<dyn SessionService>,
+    );
+    (runtime, service)
+}
+
+/// A minimal agent definition; no model call is made by these tests.
+fn agent_def(name: &str) -> ManagedAgentDef {
+    ManagedAgentDef::new(name, ModelRef::Shorthand("silent".to_string()))
+}
+
+/// Whether the backend still holds the session.
+async fn session_exists(service: &InMemorySessionService, session_id: &str) -> bool {
+    service
+        .get(GetRequest {
+            app_name: MANAGED_APP.to_string(),
+            user_id: MANAGED_USER.to_string(),
+            session_id: session_id.to_string(),
+            num_recent_events: None,
+            after: None,
+        })
+        .await
+        .map(|_| true)
+        .unwrap_or(false)
+}
+
+#[tokio::test]
+async fn deleting_a_managed_session_removes_its_persisted_conversation() {
+    let (runtime, service) = runtime_with_service();
+    let agent = runtime.create(agent_def("deleter")).await.expect("agent");
+    let session = runtime.start_session(&agent, None).await.expect("session");
+
+    assert!(
+        session_exists(&service, session.0.as_str()).await,
+        "start_session must seed a persistent session for the Runner to append to"
+    );
+
+    runtime.delete_session(&session).await.expect("delete");
+
+    assert!(
+        !session_exists(&service, session.0.as_str()).await,
+        "the persisted conversation survived a reported deletion"
+    );
+}
+
+#[tokio::test]
+async fn deleting_an_unknown_session_is_still_reported_as_not_found() {
+    let (runtime, _service) = runtime_with_service();
+    let agent = runtime.create(agent_def("deleter")).await.expect("agent");
+    let session = runtime.start_session(&agent, None).await.expect("session");
+
+    runtime.delete_session(&session).await.expect("first delete");
+
+    // The handle is gone, so a second delete must not silently succeed.
+    assert!(
+        runtime.delete_session(&session).await.is_err(),
+        "deleting an already-deleted session must report not found"
+    );
+}
+
+#[tokio::test]
+async fn a_new_session_reports_queued_through_the_public_handle() {
+    let (runtime, _service) = runtime_with_service();
+    let agent = runtime.create(agent_def("reporter")).await.expect("agent");
+    let session = runtime.start_session(&agent, None).await.expect("session");
+
+    // The starting point. What matters is that this handle is the one the loop writes to,
+    // asserted below.
+    assert_eq!(runtime.status(&session).await.expect("status"), SessionStatus::Queued);
+}
+
+#[tokio::test]
+async fn a_working_session_stops_reporting_queued() {
+    let (runtime, _service) = runtime_with_service();
+    let agent = runtime.create(agent_def("reporter")).await.expect("agent");
+    let session = runtime.start_session(&agent, None).await.expect("session");
+
+    runtime
+        .send_event(
+            &session,
+            UserEvent::Message { content: vec![ContentBlock::Text { text: "hi".into() }] },
+        )
+        .await
+        .expect("send");
+
+    // The loop transitions queued → running → idle. Before the status handle was shared,
+    // those writes landed on the loop's own field and this stayed `Queued` forever.
+    let moved_on = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            let status = runtime.status(&session).await.expect("status");
+            if status != SessionStatus::Queued {
+                return status;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await;
+
+    let status = moved_on.expect("a session that has done work must stop reporting Queued");
+    assert!(
+        matches!(status, SessionStatus::Running | SessionStatus::Idle),
+        "expected a normal working transition, saw {status:?}"
+    );
+}
+
+#[tokio::test]
+async fn archive_is_visible_through_the_public_handle() {
+    let (runtime, _service) = runtime_with_service();
+    let agent = runtime.create(agent_def("reporter")).await.expect("agent");
+    let session = runtime.start_session(&agent, None).await.expect("session");
+
+    runtime.archive(&session).await.expect("archive");
+
+    assert_eq!(runtime.status(&session).await.expect("status"), SessionStatus::Archived);
+}

--- a/docs/official_docs/managed-agents/runtime.md
+++ b/docs/official_docs/managed-agents/runtime.md
@@ -279,3 +279,42 @@ cargo run --manifest-path examples/managed_runtime_hello/Cargo.toml
 ```
 
 This runs fixture F-1 end-to-end with `ScriptedLlm` (no API key required).
+
+## Status reporting
+
+`ManagedAgentRuntime::status` reads the same handle the session loop writes to, so normal
+transitions are visible, not just control-plane ones:
+
+| Transition | Cause |
+|------------|-------|
+| `Queued` → `Running` | A turn begins |
+| `Running` → `Idle` | The turn completes and usage is recorded |
+| any → `Paused` | `pause` |
+| any → `Archived` | `archive` or `delete_session` |
+
+> **Note:** before this was one shared handle, `status` reported `Queued` for the entire life
+> of a session, including while it was executing turns. Control-plane transitions
+> (pause, resume, archive) were visible because they wrote to the handle directly.
+
+## Deletion semantics
+
+`delete_session` removes both planes:
+
+1. Sets the session terminal and cancels its loop.
+2. Removes the runtime handle.
+3. Deletes the persisted conversation through the injected `SessionService`, under the same
+   identity `start_session` created it with.
+
+If step 3 fails, `delete_session` returns an error naming the app, user, and session that
+still hold data — the handle is already gone at that point, so the caller has to be told
+what needs manual cleanup rather than being allowed to assume success.
+
+```rust,ignore
+runtime.delete_session(&session).await?;
+// The handle is gone and the conversation is no longer in the session backend.
+```
+
+> **Important:** managed sessions are persisted under a fixed app name `managed` and user
+> `managed_user`. Caller identity and `EnvironmentConfig` are not yet applied — see the
+> crate's experimental status. Deletion therefore removes the conversation for the session
+> ID, not for a tenant.

--- a/docs/official_docs/managed-agents/runtime.md
+++ b/docs/official_docs/managed-agents/runtime.md
@@ -314,7 +314,47 @@ runtime.delete_session(&session).await?;
 // The handle is gone and the conversation is no longer in the session backend.
 ```
 
-> **Important:** managed sessions are persisted under a fixed app name `managed` and user
-> `managed_user`. Caller identity and `EnvironmentConfig` are not yet applied — see the
-> crate's experimental status. Deletion therefore removes the conversation for the session
-> ID, not for a tenant.
+> **Important:** deletion removes the conversation for the session under its owner. See
+> [Session ownership](#session-ownership).
+
+## Session ownership
+
+`start_session` requires a `ManagedOwner`. The session is persisted under that identity, and
+every Runner call the session loop makes uses it:
+
+```rust
+use adk_managed::{ManagedAgentRuntime, ManagedOwner};
+
+# async fn start(runtime: &dyn ManagedAgentRuntime, agent: &adk_managed::AgentHandle)
+# -> Result<(), adk_managed::RuntimeError> {
+let owner = ManagedOwner::new("support-console", "user-42")?;
+let session = runtime.start_session(agent, &owner, None).await?;
+# Ok(())
+# }
+```
+
+Both components are required and must be non-blank. Sessions belonging to different owners are
+addressed separately, so lookup and deletion are scoped to one owner and cannot reach another's
+data.
+
+> **Note:** every managed session was previously persisted under the constants `managed` /
+> `managed_user`, so all of them shared one logical namespace: nothing could be scoped to a
+> caller and no session could be attributed to one.
+
+## Environment configuration
+
+`EnvironmentConfig` carries `env_vars` and `working_dir`. This runtime **rejects** a
+configuration that requests either:
+
+```text
+invalid request: EnvironmentConfig cannot be honoured by this runtime: sessions run
+in-process, so per-session environment variables and working directories would have to mutate
+process-global state shared with other sessions. Pass `None`, or configure a sandboxed runtime.
+```
+
+Sessions run in-process, so applying per-session environment variables or a working directory
+would mutate state shared with every other session. Refusing is the honest outcome; a sandboxed
+execution boundary is what would make the request satisfiable.
+
+> **Note:** the argument was previously named `_env` and discarded, so a caller supplying
+> environment configuration received a session that silently ignored it.


### PR DESCRIPTION
## What

Resolves **MR-02**. Managed sessions belong to a validated owner, and environment configuration the runtime cannot honour is refused instead of discarded.

> **Stacked on #489** (`fix/managed-deletion-and-status`), because both change `default_runtime.rs` and `session_loop.rs` in the same regions. Merge #489 first; this then retargets to `main` automatically.

## Why

```rust
async fn start_session(
    &self,
    agent: &AgentHandle,
    _env: Option<EnvironmentConfig>,   // ← accepted, never read
) -> Result<SessionHandle, RuntimeError> {
```

And the identity, in four places:

```
default_runtime.rs:332    app_name: "managed".to_string(),
default_runtime.rs:333    user_id: "managed_user".to_string(),
session_loop.rs:395       .run_str("managed_user", &self.session_id, user_content)
session_loop.rs:458       .app_name("managed")
```

- **Environment configuration was a no-op.** A caller passing `env_vars` or `working_dir` got a session that ignored them, with no error and no warning.
- **Every session shared one namespace.** Lookup, memory, and deletion could not be scoped to a caller; no session could be attributed to one. Random session IDs reduce collisions but do not restore identity.

## How

`ManagedOwner::new(app_name, user_id)` validates both components — blank or whitespace is rejected, since a blank component silently recreates the shared namespace. `start_session` requires it, persists the session under it, and hands the same identity to the session loop via `with_owner`, so the Runner calls use it too.

`EnvironmentConfig` requesting anything is refused:

```text
invalid request: EnvironmentConfig cannot be honoured by this runtime: sessions run
in-process, so per-session environment variables and working directories would have to mutate
process-global state shared with other sessions. Pass `None`, or configure a sandboxed runtime.
```

Refusing rather than implementing is deliberate. Sessions run in-process, so honouring the request means mutating state shared with every other session — worse than not honouring it. An empty configuration asks for nothing and is accepted. The error names what would make it satisfiable.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo nextest run --workspace --profile ci` | **3830 passed**, 83 skipped, 0 failed |
| `cargo nextest run -p adk-managed` | 243 passed |
| `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps` | exit 0 |
| `cargo test -p adk-managed --doc` | 24 passed |
| doc-examples guard | exit 0 |

### Three of nine control-plane tests fail with the identity hardcoded again

Keeping the new signature but restoring `"managed"` / `"managed_user"` and the ignored `env`:

```
Summary  9 tests run: 6 passed, 3 failed
```

The isolation tests assert through the **session backend**, not through the runtime: `exists_for(&service, &owner, session_id)` queries `InMemorySessionService` directly under each owner's app and user, so "alice's session is not addressable as bob's" is measured against stored data rather than inferred.

## Scope

**MR-01** (durable managed state across process loss) is untouched — checkpoints and registries remain in-memory. That needs a durable managed-state store with transactional writes and startup reconstruction, which is a design task rather than a fix.

Also corrected: the note added by #489 saying caller identity is not applied. It is now, and the docs describe ownership and the environment policy.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets the branch it is stacked on

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed — two new sections in `docs/official_docs/managed-agents/runtime.md`
- [x] Examples added or updated for new features