### PR TITLE
docs: gate release statements on the workspace version, drop durability overclaim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,6 +289,12 @@ jobs:
         # must exist in adk-rust/Cargo.toml (catches stale "0.8.2" snippets and
         # phantom features like the removed `labs`).
         CI=true devenv shell bash scripts/check-doc-versions.sh
+        # Release-statement guard: the changelog heading, README banner, and
+        # roadmap "current" marker are all derived from one source — the
+        # workspace version — so a bump cannot land with any of them stale.
+        # check-doc-versions.sh skips CHANGELOG.md and never looked at the
+        # banner or roadmap, which is how those three drifted apart.
+        CI=true devenv shell bash scripts/check-release-consistency.sh
         # Publish-order guard: publish.sh tiers must satisfy the workspace
         # dependency graph, including versioned dev-deps (what broke v1.0.0).
         CI=true devenv shell bash scripts/check-publish-order.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,8 +162,8 @@ adk-action/      Action node definitions (14 node types), StandardProperties, va
 adk-enterprise/  Enterprise client SDK — lightweight HTTP/SSE client for the ADK-Rust Enterprise
                  Managed Agent Service. Zero adk-* runtime dependencies. Agents, sessions,
                  streaming, vaults, memory. Self-hosted support. EXPERIMENTAL.
-adk-managed/     Managed agent runtime — provider-neutral, durable, resumable agent execution
-                 engine. ManagedAgentRuntime trait, DefaultManagedAgentRuntime, declarative
+adk-managed/     Managed agent runtime — provider-neutral agent execution engine with in-process
+                 checkpointing (state does not survive process loss). ManagedAgentRuntime trait, DefaultManagedAgentRuntime, declarative
                  ManagedAgentDef, supervised session loop with checkpointing, custom tool
                  parking, event replay, ScriptedLlm test double, golden fixture tests.
                  Feature-gated: `managed-runtime` on umbrella crate. EXPERIMENTAL.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -426,6 +426,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Release statements are checked against one source.** The workspace version, the changelog
+  heading, the README release banner, and the README roadmap's "current" marker were
+  maintained independently. `scripts/check-doc-versions.sh` skips `CHANGELOG.md` and never
+  looked at the banner or the roadmap, so nothing detected drift between them. The new
+  `scripts/check-release-consistency.sh` derives all three from the workspace version and runs
+  in the PR-tier `docs` job. Its `--release` mode additionally requires a `v<version>` tag so a
+  published artifact can be attributed to an exact commit; outside release mode it reports the
+  commit a release would be cut from. There is currently **no `v2.0.0` tag**, which is why a
+  defect cannot be attributed to the published artifact from this repository alone.
+- **adk-managed no longer described as durable.** The crate README, crate docs, root README,
+  and AGENTS.md called managed execution durable, and the README claimed sessions "survive
+  process crashes with zero event loss". Checkpoints, the agent registry, and active sessions
+  are held in memory: they support replay and resume within a process and do not survive
+  process loss. The "atomic checkpoint persistence" wording is corrected too — it is a single
+  assignment under a lock, not a transaction with a persistent store.
+
 - **adk-server: background runs execute a workflow instead of reporting success.**
   `BackgroundRunner::run_with_timeout` received neither the workflow ID nor the input. It
   checked cancellation and returned `Completed` with an empty object, so a client got a

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ is running. See the [MCP guide](docs/official_docs/tools/mcp-tools.md).
 | `adk-auth` | Access control | Role-based permissions, declarative scope-based security, SSO/OAuth, audit logging |
 | `adk-sandbox` | Sandboxed code execution | Process/WASM backends, OS-level sandbox profiles (Seatbelt, bubblewrap, AppContainer) |
 | `adk-telemetry` | Observability | Structured logging, OpenTelemetry tracing, span helpers |
-| `adk-managed` | Managed agent runtime (Experimental) | Provider-neutral durable agent execution, checkpointing, event replay |
+| `adk-managed` | Managed agent runtime (Experimental) | Provider-neutral agent execution, in-process checkpointing and event replay (state does not survive process loss) |
 | `adk-enterprise` | Enterprise client SDK (Experimental) | HTTP/SSE client for managed agent service, zero runtime deps |
 
 > **Extracted to standalone repos:** [adk-ui](https://github.com/zavora-ai/adk-ui) (dynamic UI generation), [adk-studio](https://github.com/zavora-ai/adk-studio) (visual agent builder), [adk-playground](https://github.com/zavora-ai/adk-playground) (120+ examples).

--- a/adk-managed/README.md
+++ b/adk-managed/README.md
@@ -1,6 +1,12 @@
 # adk-managed
 
-Managed agent runtime for ADK-Rust — a provider-neutral, durable, resumable agent execution engine.
+Managed agent runtime for ADK-Rust — a provider-neutral agent execution engine with
+checkpointing, event replay, and a supervised session loop.
+
+> **Experimental.** Checkpoints, the agent registry, and active sessions are held **in
+> memory**. They survive pause, resume, and replay within a process; they do **not** survive
+> process loss, and a new process cannot resume a session started by another. Durable managed
+> state is not implemented.
 
 [![Crates.io](https://img.shields.io/crates/v/adk-managed.svg)](https://crates.io/crates/adk-managed)
 [![Documentation](https://docs.rs/adk-managed/badge.svg)](https://docs.rs/adk-managed)
@@ -8,14 +14,14 @@ Managed agent runtime for ADK-Rust — a provider-neutral, durable, resumable ag
 
 ## Overview
 
-`adk-managed` provides the `ManagedAgentRuntime` trait and its default implementation. It takes a declarative `ManagedAgentDef`, builds a runnable agent, and operates it as a durable, resumable, event-streaming background session. The runtime composes existing shipping components behind a unified lifecycle trait.
+`adk-managed` provides the `ManagedAgentRuntime` trait and its default implementation. It takes a declarative `ManagedAgentDef`, builds a runnable agent, and operates it as a resumable, event-streaming background session, checkpointed in memory. The runtime composes existing shipping components behind a unified lifecycle trait.
 
 This is the execution engine inside a managed agent service. It is a **library**, not a service — the platform hosts it.
 
 ## Key Capabilities
 
 - **Provider-neutral**: Identical event sequences regardless of LLM provider (Gemini, OpenAI, Anthropic, Ollama, OpenAI-compatible)
-- **Durable sessions**: Checkpoint after every event; survive process crashes with zero event loss
+- **Checkpointed sessions**: Checkpoint after every event, enabling replay and resume **within the process**. Checkpoints are in-memory and do not survive process loss.
 - **Resumable**: Rehydrate from checkpoint and continue from last consistent state
 - **Event streaming**: Uniform `SessionEvent` stream with monotonic sequence numbers and SSE replay support
 - **Custom tool parking**: Client-executed tools park the loop until results arrive (or timeout)
@@ -37,7 +43,7 @@ This is the execution engine inside a managed agent service. It is a **library**
 │  ManagedAgentRuntime trait + DefaultManagedAgentRuntime      │
 │  ───────────────────────────────────────────────────        │
 │  • Builds runnable agents from ManagedAgentDef              │
-│  • Runs supervised session loop (durable, resumable)        │
+│  • Runs supervised session loop (in-process checkpoints)    │
 │  • Emits provider-neutral SessionEvent stream               │
 │  • Manages custom tool parking, checkpoints, interrupts     │
 │  • Resolves ModelRef → Arc<dyn Llm>                         │

--- a/adk-managed/src/checkpoint.rs
+++ b/adk-managed/src/checkpoint.rs
@@ -1,4 +1,9 @@
-//! Checkpoint management for durable sessions.
+//! Checkpoint management for resumable sessions.
+//!
+//! Checkpoints are held in memory. They support replay and resume **within a process**; they
+//! do not survive process loss, so a new process cannot resume a session started by another.
+//! "Atomic" below means a single assignment under a lock, not a transaction with a persistent
+//! store.
 //!
 //! The [`CheckpointManager`] provides atomic checkpoint persistence so that
 //! a crash cannot leave an event emitted but un-checkpointed (or vice versa).
@@ -53,7 +58,7 @@ impl RunState {
     }
 }
 
-/// Manages atomic checkpoint persistence for durable sessions.
+/// Manages in-process checkpoint state for resumable sessions.
 ///
 /// Each checkpoint atomically stores an event and the updated run-state so that
 /// a crash cannot leave an event emitted but un-checkpointed (or vice versa).

--- a/adk-managed/src/lib.rs
+++ b/adk-managed/src/lib.rs
@@ -1,13 +1,13 @@
 //! # adk-managed
 //!
-//! Managed agent runtime for ADK-Rust — a provider-neutral, durable, resumable
+//! Managed agent runtime for ADK-Rust — a provider-neutral, resumable
 //! agent execution engine.
 //!
 //! ## Overview
 //!
 //! `adk-managed` provides the `ManagedAgentRuntime` trait and its default implementation.
 //! It takes a declarative `ManagedAgentDef`, builds a runnable agent, and operates it as
-//! a durable, resumable, event-streaming background session. The runtime composes existing
+//! a resumable, event-streaming background session. The runtime composes existing
 //! shipping components behind a unified lifecycle trait.
 //!
 //! ## Architecture

--- a/scripts/check-release-consistency.py
+++ b/scripts/check-release-consistency.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Check that every release statement agrees with the workspace version.
+
+The workspace version in the root `Cargo.toml` is the single source. The changelog
+heading, the README release banner, and the README roadmap's "current" marker are
+checked against it, so a version bump cannot land with any of them stale.
+
+`scripts/check-doc-versions.py` covers dependency snippets and feature names; it
+explicitly skips `CHANGELOG.md` and does not look at the banner or the roadmap, which
+is how those three drifted apart.
+
+Release mode (`--release`) additionally requires an annotated `v<version>` tag so a
+published artifact can be attributed to an exact commit. Without it the run reports the
+missing tag and the commit that would be tagged, but does not fail — a tag is a release
+action, not a pull-request gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def workspace_version() -> str:
+    """The version every other statement is checked against."""
+    with (ROOT / "Cargo.toml").open("rb") as handle:
+        manifest = tomllib.load(handle)
+    return manifest["workspace"]["package"]["version"]
+
+
+def changelog_heading_version() -> tuple[str, str] | None:
+    """The version and date of the topmost changelog release heading."""
+    pattern = re.compile(r"^## \[(\d+\.\d+\.\d+)\]\s*-\s*(\d{4}-\d{2}-\d{2})\s*$")
+    for line in (ROOT / "CHANGELOG.md").read_text().splitlines():
+        match = pattern.match(line)
+        if match:
+            return match.group(1), match.group(2)
+    return None
+
+
+def readme_banner_version() -> str | None:
+    """The version announced by the README release banner."""
+    match = re.search(r"v(\d+\.\d+\.\d+) Released!", (ROOT / "README.md").read_text())
+    return match.group(1) if match else None
+
+
+def readme_roadmap_current_version() -> str | None:
+    """The version the README roadmap marks as current."""
+    match = re.search(
+        r"\*\*v(\d+\.\d+\.\d+)\*\*\s*\(current\)", (ROOT / "README.md").read_text()
+    )
+    return match.group(1) if match else None
+
+
+def git(*args: str) -> str:
+    """Runs git and returns stdout, or an empty string when git is unavailable."""
+    try:
+        return subprocess.run(
+            ["git", *args], cwd=ROOT, capture_output=True, text=True, check=True
+        ).stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return ""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--release",
+        action="store_true",
+        help="also require a v<version> tag, for use when cutting a release",
+    )
+    args = parser.parse_args()
+
+    version = workspace_version()
+    failures: list[str] = []
+
+    heading = changelog_heading_version()
+    if heading is None:
+        failures.append("CHANGELOG.md has no `## [x.y.z] - YYYY-MM-DD` release heading")
+    elif heading[0] != version:
+        failures.append(
+            f"CHANGELOG.md's newest release heading is {heading[0]}, "
+            f"but the workspace version is {version}"
+        )
+
+    banner = readme_banner_version()
+    if banner is None:
+        failures.append("README.md has no `vX.Y.Z Released!` banner")
+    elif banner != version:
+        failures.append(
+            f"README.md's release banner announces v{banner}, "
+            f"but the workspace version is {version}"
+        )
+
+    roadmap = readme_roadmap_current_version()
+    if roadmap is None:
+        failures.append("README.md's roadmap has no `**vX.Y.Z** (current)` marker")
+    elif roadmap != version:
+        failures.append(
+            f"README.md's roadmap marks v{roadmap} as current, "
+            f"but the workspace version is {version}"
+        )
+
+    tag = f"v{version}"
+    tag_commit = git("rev-list", "-n", "1", tag)
+    if tag_commit:
+        print(f"release baseline: {tag} -> {tag_commit}")
+    elif args.release:
+        failures.append(
+            f"no {tag} tag exists, so the release cannot be attributed to a commit. "
+            f"Create it with: git tag -a {tag} -m 'Release {version}'"
+        )
+    else:
+        head = git("rev-parse", "HEAD") or "unknown"
+        print(
+            f"note: no {tag} tag yet; a release from this commit would be {head}. "
+            f"Run with --release to make this a failure."
+        )
+
+    if failures:
+        print(f"\nrelease statements disagree with the workspace version ({version}):\n")
+        for failure in failures:
+            print(f"  - {failure}")
+        sys.exit(1)
+
+    print(f"release statements agree on {version}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check-release-consistency.sh
+++ b/scripts/check-release-consistency.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+python3 "$ROOT/scripts/check-release-consistency.py" "$@"


### PR DESCRIPTION
## What

Resolves **DOC-01**. Release statements are now derived from one machine-checked source, and `adk-managed` stops being described as durable.

## Why

### Four independent statements of the same fact

The workspace version, the changelog heading, the README release banner, and the README roadmap's `(current)` marker each stated the release version. Nothing compared them:

```python
# scripts/check-doc-versions.py
def skip(rel: Path) -> bool:
    ...
    return rel.name == "CHANGELOG.md"
```

That guard covers dependency snippets and feature names, explicitly skips the changelog, and never looked at the banner or roadmap. Which is exactly how those three drifted apart.

### No release object

There is no `v2.0.0` tag:

```
$ python3 scripts/check-release-consistency.py
note: no v2.0.0 tag yet; a release from this commit would be e46e388ac9f764cafd5a34138a3d484f68bf5836.
release statements agree on 2.0.0
```

That is the concrete reason a defect found in this repository cannot be attributed to the published v2 artifact.

### `adk-managed` claimed durability it does not have

| Location | Claim |
|---|---|
| `adk-managed/README.md` | "provider-neutral, **durable**, resumable agent execution engine" |
| `adk-managed/README.md` | "**Durable sessions**: Checkpoint after every event; **survive process crashes with zero event loss**" |
| `adk-managed/src/checkpoint.rs` | "Manages **atomic checkpoint persistence** for durable sessions" |
| root `README.md`, `AGENTS.md` | "Provider-neutral **durable** agent execution" |

Checkpoints, the agent registry, and active sessions are `HashMap`s and `Vec`s in memory. They support replay and resume *within a process*. Nothing survives process loss, and "atomic" is one assignment under a lock, not a transaction with a persistent store.

## How

`scripts/check-release-consistency.py` takes the workspace version as the single source and checks the other three against it. Added to the PR-tier `docs` job next to the existing guards.

`--release` additionally requires a `v<version>` tag, so cutting a release fails without one:

```
$ python3 scripts/check-release-consistency.py --release
  - no v2.0.0 tag exists, so the release cannot be attributed to a commit.
    Create it with: git tag -a v2.0.0 -m 'Release 2.0.0'
```

Outside release mode it reports the commit a release would be cut from. **Tagging is left to a human** — it is a release action, not something a PR gate should do, and not something I should do unilaterally.

Documentation now describes what is implemented: in-process checkpointing, with an explicit note that state does not survive process loss and that a new process cannot resume another's session.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo nextest run --workspace --profile ci` | 3821 passed, 83 skipped, 0 failed |
| `RUSTDOCFLAGS=-D warnings cargo doc -p adk-managed --no-deps` | exit 0 |
| `scripts/check-release-consistency.sh` | exit 0 |
| `scripts/check-doc-versions.sh` | exit 0 |
| `scripts/check-doc-examples.sh` | exit 0 |
| `shellcheck scripts/check-release-consistency.sh` | exit 0 |

### Each check was verified to fail when broken

Mutating one statement at a time:

```
banner     exit=1  - README.md's release banner announces v1.9.0, but the workspace version is 2.0.0
changelog  exit=1  - CHANGELOG.md's newest release heading is 1.9.0, but the workspace version is 2.0.0
roadmap    exit=1  - README.md's roadmap marks v1.9.0 as current, but the workspace version is 2.0.0
```

A guard that passes on a healthy repository proves nothing on its own, so all three paths plus `--release` were exercised against deliberately broken inputs.

## Scope

The capability claims DOC-01 lists were corrected across earlier PRs: graph durable resume (#467), background runs (#477), coding workspace containment (#472, #483), AppContainer (#485). Managed durability was the last one standing, and it is corrected here rather than implemented — **MR-01 remains open**, so the honest move is to describe the current behaviour and label it.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate) — the guard is exercised against three broken inputs and release mode
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed — root README, `adk-managed/README.md`, AGENTS.md
- [x] Examples added or updated for new features