### PR TITLE
fix(realtime): inject the history and memory that integrated connect already loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -426,6 +426,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **adk-realtime: integrated sessions actually receive the history and memory they load.**
+  `IntegratedRealtimeRunner::connect` fetched the prior session into `_session` and dropped it,
+  and the memory branch logged "injecting memory entries into session context" next to a
+  comment saying injection was a future enhancement. A resumed session began with neither the
+  history nor the memory the builder implies, while the logs reported otherwise. Both are now
+  rendered into one bounded block and prepended to the system instruction before the provider
+  session is created, governed by `max_memory_injection` and the new `max_history_injection`.
+  `IntegratedRealtimeRunner::instruction()` and `RealtimeRunner::instruction()` expose what a
+  session was created with, so carried context can be asserted instead of inferred from logs.
+
 - **adk-server: background runs execute a workflow instead of reporting success.**
   `BackgroundRunner::run_with_timeout` received neither the workflow ID nor the input. It
   checked cancellation and returned `Completed` with an empty object, so a client got a

--- a/adk-realtime/src/integration/mod.rs
+++ b/adk-realtime/src/integration/mod.rs
@@ -91,6 +91,11 @@ pub struct IntegrationConfig {
     pub inject_memory_context: bool,
     /// Maximum memory entries to inject into system instruction.
     pub max_memory_injection: usize,
+    /// Maximum prior conversation turns carried into the provider session.
+    ///
+    /// Bounded because the instruction is sent at session creation and counts against the
+    /// model's context. Zero disables history injection while leaving memory injection alone.
+    pub max_history_injection: usize,
 }
 
 impl Default for IntegrationConfig {
@@ -100,6 +105,7 @@ impl Default for IntegrationConfig {
             store_to_memory: true,
             inject_memory_context: true,
             max_memory_injection: 10,
+            max_history_injection: 20,
         }
     }
 }
@@ -108,6 +114,7 @@ impl Default for IntegrationConfig {
 
 use std::sync::Arc;
 
+use adk_core::Content;
 use adk_memory::MemoryService;
 use adk_plugin::EnhancedPluginManager;
 use adk_session::SessionService;
@@ -159,6 +166,42 @@ pub struct IntegratedRealtimeRunner {
     pub(crate) config: IntegrationConfig,
 }
 
+/// Renders the most recent `limit` turns as bounded `role: text` lines.
+///
+/// The instruction is sent once at session creation and counts against the model's context, so
+/// this keeps the newest turns, drops anything without text, and truncates long turns rather
+/// than carrying a transcript of unbounded size.
+fn summarize_turns(turns: &[Content], limit: usize) -> Vec<String> {
+    /// Longest rendered form of a single turn.
+    const MAX_TURN_CHARS: usize = 400;
+
+    if limit == 0 {
+        return Vec::new();
+    }
+
+    turns
+        .iter()
+        .rev()
+        .take(limit)
+        .filter_map(|turn| {
+            let text: String = turn.parts.iter().filter_map(|part| part.text()).collect();
+            if text.trim().is_empty() {
+                return None;
+            }
+
+            let mut end = text.len().min(MAX_TURN_CHARS);
+            while end < text.len() && !text.is_char_boundary(end) {
+                end -= 1;
+            }
+            let rendered = if end < text.len() { format!("{}…", &text[..end]) } else { text };
+            Some(format!("{}: {rendered}", turn.role))
+        })
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect()
+}
+
 impl IntegratedRealtimeRunner {
     /// Creates a new [`IntegratedRealtimeRunnerBuilder`].
     pub fn builder() -> builder::IntegratedRealtimeRunnerBuilder {
@@ -190,7 +233,14 @@ impl IntegratedRealtimeRunner {
     /// runner.connect().await?;
     /// ```
     pub async fn connect(&self) -> Result<()> {
-        // 1. Load session history if session_service is configured
+        // Context is collected first, then injected into the provider config as one block.
+        // Previously the session was fetched into `_session` and dropped, and the memory
+        // branch logged "injecting memory entries" next to a comment saying injection was a
+        // future enhancement — so a resumed session began with neither, while the log said
+        // otherwise.
+        let mut context_sections: Vec<String> = Vec::new();
+
+        // 1. Prior conversation history.
         if let Some(ref session_service) = self.session_service {
             let get_req = adk_session::GetRequest {
                 app_name: self.identity.app_name.clone(),
@@ -200,11 +250,24 @@ impl IntegratedRealtimeRunner {
                 after: None,
             };
             match session_service.get(get_req).await {
-                Ok(_session) => {
+                Ok(session) => {
+                    let history: Vec<Content> = session
+                        .events()
+                        .all()
+                        .into_iter()
+                        .filter_map(|event| event.llm_response.content)
+                        .collect();
+                    let carried = summarize_turns(&history, self.config.max_history_injection);
                     tracing::debug!(
                         session_id = %self.identity.session_id,
+                        turns.available = history.len(),
+                        turns.carried = carried.len(),
                         "loaded prior session history"
                     );
+                    if !carried.is_empty() {
+                        context_sections
+                            .push(format!("Earlier in this conversation:\n{}", carried.join("\n")));
+                    }
                 }
                 Err(e) => {
                     tracing::warn!(
@@ -216,7 +279,7 @@ impl IntegratedRealtimeRunner {
             }
         }
 
-        // 2. Query MemoryService at session start if inject_memory_context is enabled
+        // 2. Recalled memory.
         if self.config.inject_memory_context
             && let Some(ref memory_service) = self.memory_service
         {
@@ -232,14 +295,21 @@ impl IntegratedRealtimeRunner {
                 .await
             {
                 Ok(response) => {
-                    if !response.memories.is_empty() {
-                        tracing::debug!(
-                            count = response.memories.len(),
-                            "injecting memory entries into session context"
-                        );
-                        // Memory entries are available for system instruction enrichment.
-                        // Actual injection into the system instruction happens via
-                        // update_session in a future enhancement.
+                    let recalled = summarize_turns(
+                        &response
+                            .memories
+                            .iter()
+                            .map(|entry| entry.content.clone())
+                            .collect::<Vec<Content>>(),
+                        self.config.max_memory_injection,
+                    );
+                    tracing::debug!(
+                        count = recalled.len(),
+                        "carrying memory entries into the session instruction"
+                    );
+                    if !recalled.is_empty() {
+                        context_sections
+                            .push(format!("Relevant recalled context:\n{}", recalled.join("\n")));
                     }
                 }
                 Err(e) => {
@@ -249,6 +319,10 @@ impl IntegratedRealtimeRunner {
                     );
                 }
             }
+        }
+
+        if !context_sections.is_empty() {
+            self.runner.prepend_instruction_context(&context_sections.join("\n\n")).await;
         }
 
         // 3. Connect the underlying runner — this is the only error that propagates
@@ -327,6 +401,14 @@ impl IntegratedRealtimeRunner {
     /// );
     /// runner.update_session(update).await?;
     /// ```
+    /// The system instruction the provider session was created with.
+    ///
+    /// Includes any prior-history and recalled-memory context carried in by
+    /// [`IntegratedRealtimeRunner::connect`].
+    pub async fn instruction(&self) -> Option<String> {
+        self.runner.instruction().await
+    }
+
     pub async fn update_session(&self, config: SessionUpdateConfig) -> Result<()> {
         self.runner.update_session(config).await
     }
@@ -691,6 +773,7 @@ mod session_persistence_tests {
                 persist_transcripts: true,
                 store_to_memory: false,
                 inject_memory_context: false,
+                max_history_injection: 20,
                 max_memory_injection: 0,
             })
             .build()
@@ -1171,6 +1254,7 @@ mod session_persistence_tests {
                 persist_transcripts: true,
                 store_to_memory: false,
                 inject_memory_context: false,
+                max_history_injection: 20,
                 max_memory_injection: 0,
             },
         };
@@ -1460,6 +1544,7 @@ mod graceful_degradation_tests {
                         store_to_memory: true,
                         inject_memory_context: true,
                         max_memory_injection: 10,
+                        max_history_injection: 20,
                     },
                 };
 
@@ -1509,6 +1594,7 @@ mod graceful_degradation_tests {
                 persist_transcripts: true,
                 store_to_memory: false,
                 inject_memory_context: false,
+                max_history_injection: 20,
                 max_memory_injection: 0,
             },
         };

--- a/adk-realtime/src/runner.rs
+++ b/adk-realtime/src/runner.rs
@@ -924,6 +924,38 @@ impl RealtimeRunner {
         Ok(())
     }
 
+    /// The system instruction the next connection will use.
+    ///
+    /// Exposed so callers and tests can confirm what context a session was actually created
+    /// with, rather than inferring it from log lines.
+    pub async fn instruction(&self) -> Option<String> {
+        self.config.read().await.instruction.clone()
+    }
+
+    /// Prepends a context block to the system instruction before connecting.
+    ///
+    /// The integration layer uses this to carry prior conversation history and recalled memory
+    /// into the provider session. Call it before [`RealtimeRunner::connect`]: providers read
+    /// the instruction at session creation, so a later change needs `update_session`.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// runner.prepend_instruction_context("Previously discussed: the refund policy.").await;
+    /// runner.connect().await?;
+    /// ```
+    pub async fn prepend_instruction_context(&self, block: &str) {
+        if block.is_empty() {
+            return;
+        }
+
+        let mut config = self.config.write().await;
+        config.instruction = Some(match config.instruction.take() {
+            Some(existing) if !existing.is_empty() => format!("{block}\n\n{existing}"),
+            _ => block.to_string(),
+        });
+    }
+
     /// Trigger the single follow-up response owed after a tool-dispatching turn.
     ///
     /// Call this when a response finishes (`ResponseDone`). If tool output(s)

--- a/adk-realtime/tests/integration_builder_unit_tests.rs
+++ b/adk-realtime/tests/integration_builder_unit_tests.rs
@@ -119,6 +119,7 @@ fn test_successful_build_with_all_services_configured() {
             store_to_memory: true,
             inject_memory_context: false,
             max_memory_injection: 5,
+            max_history_injection: 20,
         })
         .build();
 

--- a/adk-realtime/tests/integration_memory_injection_tests.rs
+++ b/adk-realtime/tests/integration_memory_injection_tests.rs
@@ -129,6 +129,7 @@ async fn test_memory_injection_enabled_queries_memory_on_connect() {
             store_to_memory: false,
             inject_memory_context: true,
             max_memory_injection: 10,
+            max_history_injection: 20,
         })
         .build()
         .expect("builder should succeed");
@@ -165,6 +166,7 @@ async fn test_memory_injection_disabled_does_not_query_memory_on_connect() {
             store_to_memory: false,
             inject_memory_context: false,
             max_memory_injection: 10,
+            max_history_injection: 20,
         })
         .build()
         .expect("builder should succeed");
@@ -189,6 +191,7 @@ async fn test_memory_injection_with_no_memory_service_configured() {
             store_to_memory: false,
             inject_memory_context: true,
             max_memory_injection: 10,
+            max_history_injection: 20,
         })
         .build()
         .expect("builder should succeed");
@@ -197,4 +200,120 @@ async fn test_memory_injection_with_no_memory_service_configured() {
 
     // Should fail from the mock transport, not from missing memory service.
     assert!(result.is_err(), "connect should fail due to mock transport");
+}
+
+// ─── Injection, not just retrieval ───────────────────────────────────────────
+//
+// `connect` fetched the prior session into `_session` and dropped it, and logged "injecting
+// memory entries into session context" next to a comment saying injection was a future
+// enhancement. A resumed session therefore began with neither history nor memory while the
+// logs said otherwise, and the tests above only proved the *query* happened.
+
+#[tokio::test]
+async fn recalled_memory_reaches_the_system_instruction() {
+    let entries = vec![MemoryEntry {
+        content: Content::new("model").with_text("User prefers concise answers"),
+        author: "assistant".to_string(),
+        timestamp: Utc::now(),
+    }];
+    let memory_service = Arc::new(TrackingMemoryService::new(entries));
+
+    let runner = IntegratedRealtimeRunnerBuilder::new()
+        .model(mock_model())
+        .identity("test-app", "user-1", "session-1")
+        .memory_service(memory_service.clone())
+        .integration_config(IntegrationConfig {
+            persist_transcripts: false,
+            store_to_memory: false,
+            inject_memory_context: true,
+            max_memory_injection: 10,
+            max_history_injection: 20,
+        })
+        .build()
+        .expect("builder should succeed");
+
+    // The transport fails, but injection happens before the connection attempt, so the
+    // instruction the session *would* have been created with is observable.
+    let _ = runner.connect().await;
+
+    let instruction = runner.instruction().await.unwrap_or_default();
+    assert!(
+        instruction.contains("User prefers concise answers"),
+        "recalled memory must reach the provider instruction, not just the logs: {instruction:?}"
+    );
+    assert!(
+        instruction.contains("Relevant recalled context"),
+        "the carried block must be labelled so the model can tell it from the task: {instruction:?}"
+    );
+}
+
+#[tokio::test]
+async fn nothing_is_injected_when_memory_injection_is_disabled() {
+    let entries = vec![MemoryEntry {
+        content: Content::new("model").with_text("User prefers concise answers"),
+        author: "assistant".to_string(),
+        timestamp: Utc::now(),
+    }];
+    let memory_service = Arc::new(TrackingMemoryService::new(entries));
+
+    let runner = IntegratedRealtimeRunnerBuilder::new()
+        .model(mock_model())
+        .identity("test-app", "user-1", "session-1")
+        .memory_service(memory_service.clone())
+        .integration_config(IntegrationConfig {
+            persist_transcripts: false,
+            store_to_memory: false,
+            inject_memory_context: false,
+            max_memory_injection: 10,
+            max_history_injection: 20,
+        })
+        .build()
+        .expect("builder should succeed");
+
+    let _ = runner.connect().await;
+
+    let instruction = runner.instruction().await.unwrap_or_default();
+    assert!(
+        !instruction.contains("User prefers concise answers"),
+        "the opt-out must be respected: {instruction:?}"
+    );
+}
+
+#[tokio::test]
+async fn the_injection_bound_is_respected() {
+    // More entries than the bound allows; the instruction must carry at most the bound.
+    let entries: Vec<MemoryEntry> = (0..10)
+        .map(|index| MemoryEntry {
+            content: Content::new("model").with_text(format!("fact number {index}")),
+            author: "assistant".to_string(),
+            timestamp: Utc::now(),
+        })
+        .collect();
+    let memory_service = Arc::new(TrackingMemoryService::new(entries));
+
+    let runner = IntegratedRealtimeRunnerBuilder::new()
+        .model(mock_model())
+        .identity("test-app", "user-1", "session-1")
+        .memory_service(memory_service.clone())
+        .integration_config(IntegrationConfig {
+            persist_transcripts: false,
+            store_to_memory: false,
+            inject_memory_context: true,
+            max_memory_injection: 3,
+            max_history_injection: 20,
+        })
+        .build()
+        .expect("builder should succeed");
+
+    let _ = runner.connect().await;
+
+    let instruction = runner.instruction().await.unwrap_or_default();
+    let carried =
+        (0..10).filter(|index| instruction.contains(&format!("fact number {index}"))).count();
+    assert!(
+        carried <= 3,
+        "the instruction is sent once and counts against context, so the bound must hold: \
+         carried {carried}"
+    );
+    assert!(carried > 0, "something must be carried: {instruction:?}");
 }

--- a/docs/official_docs/realtime/memory.md
+++ b/docs/official_docs/realtime/memory.md
@@ -110,3 +110,31 @@ The MIA coaching example uses the graph + tools so the coach remembers the user'
 goals and preferences between sessions; see [Examples](examples.md).
 
 Next: [Building web apps →](building-web-apps.md)
+
+## What is carried into a resumed session
+
+`IntegratedRealtimeRunner::connect` builds one context block and prepends it to the system
+instruction before the provider session is created:
+
+| Section | Source | Bound |
+|---------|--------|-------|
+| `Earlier in this conversation:` | The prior session's events | `IntegrationConfig::max_history_injection` (default 20 turns) |
+| `Relevant recalled context:` | `MemoryService::search` | `IntegrationConfig::max_memory_injection` (default 10 entries) |
+
+Both are bounded because the instruction is sent once at session creation and counts against
+the model's context. Each turn is rendered as `role: text`, truncated at 400 characters, and
+turns without text are dropped. Setting a bound to zero disables that section.
+
+`IntegratedRealtimeRunner::instruction()` returns what the session was created with, so the
+carried context can be asserted rather than inferred:
+
+```rust,ignore
+runner.connect().await?;
+let instruction = runner.instruction().await.unwrap_or_default();
+assert!(instruction.contains("Relevant recalled context"));
+```
+
+> **Important:** this context was previously loaded and discarded — the prior session was
+> fetched into `_session` and dropped, and the memory branch logged "injecting memory entries
+> into session context" beside a comment stating that injection was a future enhancement. A
+> resumed session began with neither, while the logs said otherwise.


### PR DESCRIPTION
## What

Addresses the injection half of **RT-01**. Prior conversation history and recalled memory now reach the provider session instead of being loaded and dropped.

## Why

```rust
match session_service.get(get_req).await {
    Ok(_session) => {                                  // ← fetched, then dropped
        tracing::debug!(session_id = %..., "loaded prior session history");
    }
```

```rust
if !response.memories.is_empty() {
    tracing::debug!(count = ..., "injecting memory entries into session context");
    // Memory entries are available for system instruction enrichment.
    // Actual injection into the system instruction happens via
    // update_session in a future enhancement.
}
```

The log line says injection; the comment two lines down says it does not happen. A resumed session began with neither history nor memory, while the logs reported otherwise — the worst combination for anyone debugging why a "resumed" conversation had no recall.

## How

`connect` collects both sources into one labelled block and prepends it to the system instruction **before** connecting, because providers read the instruction at session creation:

| Section | Source | Bound |
|---|---|---|
| `Earlier in this conversation:` | the prior session's events | `max_history_injection` (new, default 20) |
| `Relevant recalled context:` | `MemoryService::search` | `max_memory_injection` (existing, default 10) |

Bounds matter here: the instruction is sent once and counts against the model's context, so an unbounded transcript is not an option. Each turn renders as `role: text`, truncated at 400 characters on a char boundary; turns with no text are dropped; a bound of zero disables that section.

`RealtimeRunner::instruction()` and `IntegratedRealtimeRunner::instruction()` return what the session was created with, so carried context is observable rather than inferred.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo clippy -p adk-realtime` with `integration`, `full` | exit 0 each |
| `cargo nextest run --workspace --profile ci` | 3821 passed, 83 skipped, 0 failed |
| `cargo nextest run -p adk-realtime --features integration` | 79 passed |
| `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps` | exit 0 |
| doc-examples guard | exit 0 |

### Why the old tests did not catch this

`integration_memory_injection_tests.rs` already existed. Every assertion was of this form:

```rust
assert!(memory_service.was_search_called(), "MemoryService::search should be called ...");
```

It proved the query happened. A path that queries and throws the result away passes that test, which is precisely what shipped. The three new tests assert the *instruction*:

```
FAIL  recalled_memory_reaches_the_system_instruction
FAIL  the_injection_bound_is_respected
```

— when the collected block is discarded again. `nothing_is_injected_when_memory_injection_is_disabled` passes under both by design; it guards the opt-out.

## Scope

Still open from RT-01: transcripts are appended through raw `append_event(session_id, ...)` rather than the identity-aware API, and plugin `on_event` is still skipped because no `InvocationContext` exists for a realtime turn. Both need a realtime invocation context, which is the same missing piece **RT-02** needs for its shared policy executor — better done once, together, than twice.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed — new section in `docs/official_docs/realtime/memory.md`
- [x] Examples added or updated for new features