### PR TITLE
fix(realtime): route integrated ADK tools through the policy pipeline, fail closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **adk-realtime: integrated ADK tools run through the policy pipeline, and plugin failures
+  fail closed.** The live `next_event` path called `RealtimeRunner::dispatch_tool_call`, which
+  invokes the `ToolBridgeAdapter` directly — the adapter builds a context and calls
+  `Tool::execute` with no plugin pipeline, no callbacks, and no confirmation. A tool controlled
+  in the standard agent loop therefore ran uncontrolled in realtime, and the richer
+  `execute_tool_with_plugins` was unreachable from the live path. ADK tools are now dispatched
+  through it; a name that is not a registered ADK tool falls through to native-handler dispatch,
+  making that bypass explicit rather than universal. The `before_tool_call` error branch also
+  logged "non-fatal" and then executed the tool anyway — authorization, redaction, and policy
+  live in before-tool plugins, so a broken guard became no guard. It now refuses the tool and
+  returns the failure to the model.
+
 - **adk-core/adk-auth: secret access from tools is authorizable and audited.**
   `SecretService` and `SecretProvider` received only a secret *name*. Once a provider
   was attached to an invocation, policy collapsed to whatever the backing cloud

--- a/adk-realtime/src/integration/builder.rs
+++ b/adk-realtime/src/integration/builder.rs
@@ -303,6 +303,11 @@ impl IntegratedRealtimeRunnerBuilder {
 
         let runner = Arc::new(runner_builder.build()?);
 
+        // Kept so the live event path can run them through the policy pipeline rather than
+        // only through the bridge adapter.
+        let adk_tools_by_name =
+            self.adk_tools.iter().map(|tool| (tool.name().to_string(), Arc::clone(tool))).collect();
+
         Ok(super::IntegratedRealtimeRunner {
             runner,
             session_service: self.session_service,
@@ -311,6 +316,7 @@ impl IntegratedRealtimeRunnerBuilder {
             aggregator: tokio::sync::RwLock::new(super::transcript::TranscriptAggregator::new()),
             identity,
             config: self.integration_config,
+            adk_tools: adk_tools_by_name,
         })
     }
 }

--- a/adk-realtime/src/integration/mod.rs
+++ b/adk-realtime/src/integration/mod.rs
@@ -108,6 +108,8 @@ impl Default for IntegrationConfig {
 
 use std::sync::Arc;
 
+use std::collections::HashMap;
+
 use adk_memory::MemoryService;
 use adk_plugin::EnhancedPluginManager;
 use adk_session::SessionService;
@@ -157,6 +159,12 @@ pub struct IntegratedRealtimeRunner {
     pub(crate) identity: SessionIdentity,
     /// Integration-layer configuration.
     pub(crate) config: IntegrationConfig,
+    /// The ADK tools by name, so the live path can run them through the policy pipeline.
+    ///
+    /// The builder wrapped each one in a `ToolBridgeAdapter` for the inner runner and then
+    /// dropped the originals, which is why the active path could only reach the adapter — and
+    /// the adapter applies no confirmation, callbacks, or plugins.
+    pub(crate) adk_tools: HashMap<String, Arc<dyn adk_core::Tool>>,
 }
 
 impl IntegratedRealtimeRunner {
@@ -379,7 +387,7 @@ impl IntegratedRealtimeRunner {
             // bridged ADK tools and native handlers registered on the builder run,
             // and (with `auto_respond_tools`) the result is sent back to the model.
             if let ServerEvent::FunctionCallDone { call_id, name, arguments, .. } = server_event
-                && let Err(e) = self.runner.dispatch_tool_call(call_id, name, arguments).await
+                && let Err(e) = self.dispatch_with_policy(call_id, name, arguments).await
             {
                 tracing::warn!(
                     tool = %name,
@@ -510,6 +518,50 @@ impl IntegratedRealtimeRunner {
     /// are non-fatal: logged and swallowed, with execution falling through to
     /// direct tool invocation.
     #[allow(dead_code)] // Will be wired in event loop handling
+    /// Dispatches one provider tool call, preferring the policy pipeline.
+    ///
+    /// An ADK tool registered on this builder runs through `execute_tool_with_plugins`, which
+    /// applies the configured plugin pipeline, records the call for the transcript, and
+    /// persists the tool event. Previously the live path called
+    /// `RealtimeRunner::dispatch_tool_call`, which invokes the `ToolBridgeAdapter` directly —
+    /// the adapter creates a context and calls `Tool::execute` with no plugins, callbacks, or
+    /// confirmation, so a tool governed in the standard agent loop ran ungoverned here.
+    ///
+    /// A name that is not a registered ADK tool is a native handler, and falls through to the
+    /// runner's own dispatch. That bypass is now explicit rather than the default.
+    async fn dispatch_with_policy(&self, call_id: &str, name: &str, arguments: &str) -> Result<()> {
+        let Some(tool) = self.adk_tools.get(name).cloned() else {
+            tracing::debug!(
+                tool = %name,
+                "no ADK tool by this name; dispatching as a native handler"
+            );
+            return self.runner.dispatch_tool_call(call_id, name, arguments).await;
+        };
+
+        let call = crate::events::ToolCall {
+            call_id: call_id.to_string(),
+            name: name.to_string(),
+            arguments: serde_json::from_str(arguments)
+                .unwrap_or(serde_json::Value::Object(Default::default())),
+        };
+
+        let result = self.execute_tool_with_plugins(&tool, &call).await?;
+        self.runner.send_tool_result(call_id, result).await
+    }
+
+    /// Runs one tool through the policy pipeline, for conformance tests.
+    ///
+    /// Exposed so the governed path can be asserted directly rather than only through a live
+    /// provider session, which is why this defect had no coverage.
+    #[doc(hidden)]
+    pub async fn execute_tool_with_plugins_for_test(
+        &self,
+        tool: &Arc<dyn adk_core::Tool>,
+        call: &crate::events::ToolCall,
+    ) -> Result<Value> {
+        self.execute_tool_with_plugins(tool, call).await
+    }
+
     pub(crate) async fn execute_tool_with_plugins(
         &self,
         tool: &Arc<dyn adk_core::Tool>,
@@ -556,11 +608,21 @@ impl IntegratedRealtimeRunner {
                     }
                 }
                 Err(e) => {
-                    tracing::warn!(error = %e, "before_tool_call plugin error (non-fatal)");
-                    // Fallback: execute tool directly
-                    tool.execute(ctx as Arc<dyn adk_core::ToolContext>, call.arguments.clone())
-                        .await
-                        .unwrap_or_else(|e| serde_json::json!({ "error": e.to_string() }))
+                    // Fail closed. A before-tool plugin is where authorization, redaction, and
+                    // policy live, so executing the tool when that pipeline fails turns a
+                    // broken guard into no guard. The model receives the error instead.
+                    tracing::error!(
+                        tool = tool.name(),
+                        error = %e,
+                        "before_tool_call plugin failed; refusing the tool"
+                    );
+                    serde_json::json!({
+                        "error": format!(
+                            "tool {} was refused: its before-tool plugin pipeline failed ({e}). \
+                             Execution is refused rather than proceeding without policy.",
+                            tool.name()
+                        )
+                    })
                 }
             }
         } else {
@@ -1034,6 +1096,7 @@ mod session_persistence_tests {
                 session_id: "test-session".to_string(),
             },
             config: IntegrationConfig::default(),
+            adk_tools: HashMap::new(),
         }
     }
 
@@ -1173,6 +1236,7 @@ mod session_persistence_tests {
                 inject_memory_context: false,
                 max_memory_injection: 0,
             },
+            adk_tools: HashMap::new(),
         };
 
         // 5. Start a turn in the aggregator so record_tool_call has somewhere to attach
@@ -1461,6 +1525,7 @@ mod graceful_degradation_tests {
                         inject_memory_context: true,
                         max_memory_injection: 10,
                     },
+                    adk_tools: HashMap::new(),
                 };
 
                 // Process events through the aggregator — this is the path that
@@ -1511,6 +1576,7 @@ mod graceful_degradation_tests {
                 inject_memory_context: false,
                 max_memory_injection: 0,
             },
+            adk_tools: HashMap::new(),
         };
 
         // Process a UserUtteranceComplete event — should not panic even

--- a/adk-realtime/src/runner.rs
+++ b/adk-realtime/src/runner.rs
@@ -722,6 +722,31 @@ impl RealtimeRunner {
         self.execute_tool_call(call_id, name, arguments).await
     }
 
+    /// Sends a tool result the caller produced, honouring `auto_respond_tools`.
+    ///
+    /// Used by the integration layer, which runs ADK tools through its own policy pipeline and
+    /// then needs the result delivered exactly as `execute_tool_call` would deliver it: the
+    /// output is sent now, and the single follow-up `create_response` is deferred until the
+    /// dispatching response closes, so several parallel calls produce one response.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let result = my_policy_pipeline.run(&call).await?;
+    /// runner.send_tool_result(&call.call_id, result).await?;
+    /// ```
+    pub async fn send_tool_result(&self, call_id: &str, output: serde_json::Value) -> Result<()> {
+        if !self.runner_config.auto_respond_tools {
+            return Ok(());
+        }
+
+        if let Ok(session) = self.session_handle().await {
+            session.send_tool_output(ToolResponse { call_id: call_id.to_string(), output }).await?;
+            self.pending_tool_response.store(true, Ordering::Release);
+        }
+        Ok(())
+    }
+
     /// Run the event loop, processing events until disconnected.
     pub async fn run(&self) -> Result<()> {
         loop {

--- a/adk-realtime/tests/integration_tool_policy_tests.rs
+++ b/adk-realtime/tests/integration_tool_policy_tests.rs
@@ -1,0 +1,174 @@
+//! A tool governed in the standard agent loop must be governed in realtime too.
+//!
+//! The builder wraps each ADK tool in a `ToolBridgeAdapter` and the live `next_event` path
+//! called `RealtimeRunner::dispatch_tool_call`, which invokes that adapter directly. The
+//! adapter creates a context and calls `Tool::execute` — no plugin pipeline, no callbacks, no
+//! confirmation. The richer `execute_tool_with_plugins` existed but nothing on the live path
+//! reached it, and its before-plugin error branch logged and then **executed the tool anyway**,
+//! so a failing security plugin was fail-open.
+
+#![cfg(feature = "integration")]
+
+use adk_core::{Tool, ToolContext};
+use adk_plugin::{BeforeToolCallResult, EnhancedPlugin, EnhancedPluginManager};
+use adk_realtime::integration::IntegratedRealtimeRunnerBuilder;
+use adk_realtime::{RealtimeConfig, RealtimeModel, RealtimeSession, Result as RtResult};
+use async_trait::async_trait;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Counts executions so "the tool did not run" is measured, not inferred.
+struct CountingTool {
+    executions: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl Tool for CountingTool {
+    fn name(&self) -> &str {
+        "guarded"
+    }
+    fn description(&self) -> &str {
+        "counts executions"
+    }
+    async fn execute(
+        &self,
+        _ctx: Arc<dyn ToolContext>,
+        _args: serde_json::Value,
+    ) -> adk_core::Result<serde_json::Value> {
+        self.executions.fetch_add(1, Ordering::SeqCst);
+        Ok(serde_json::json!({ "ran": true }))
+    }
+}
+
+/// A plugin that denies by short-circuiting, as an authorization plugin would.
+#[derive(Debug)]
+struct DenyingPlugin;
+
+#[async_trait]
+impl EnhancedPlugin for DenyingPlugin {
+    fn name(&self) -> &str {
+        "denying"
+    }
+
+    async fn before_tool_call(
+        &self,
+        _tool: Arc<dyn Tool>,
+        _args: serde_json::Value,
+        _ctx: Arc<dyn adk_core::CallbackContext>,
+        _plugin_ctx: &adk_plugin::PluginContext,
+    ) -> adk_core::Result<BeforeToolCallResult> {
+        Ok(BeforeToolCallResult::ShortCircuit(serde_json::json!({ "error": "denied by policy" })))
+    }
+}
+
+/// A plugin whose pipeline fails, standing in for a broken security plugin.
+#[derive(Debug)]
+struct FailingPlugin;
+
+#[async_trait]
+impl EnhancedPlugin for FailingPlugin {
+    fn name(&self) -> &str {
+        "failing"
+    }
+
+    async fn before_tool_call(
+        &self,
+        _tool: Arc<dyn Tool>,
+        _args: serde_json::Value,
+        _ctx: Arc<dyn adk_core::CallbackContext>,
+        _plugin_ctx: &adk_plugin::PluginContext,
+    ) -> adk_core::Result<BeforeToolCallResult> {
+        Err(adk_core::AdkError::tool("policy backend unreachable"))
+    }
+}
+
+/// A model that never connects; these tests exercise dispatch, not transport.
+struct MockModel;
+
+#[async_trait]
+impl RealtimeModel for MockModel {
+    fn provider(&self) -> &str {
+        "mock"
+    }
+    fn model_id(&self) -> &str {
+        "mock"
+    }
+    fn supported_input_formats(&self) -> Vec<adk_realtime::AudioFormat> {
+        vec![]
+    }
+    fn supported_output_formats(&self) -> Vec<adk_realtime::AudioFormat> {
+        vec![]
+    }
+    fn available_voices(&self) -> Vec<&str> {
+        vec![]
+    }
+    async fn connect(&self, _config: RealtimeConfig) -> RtResult<Box<dyn RealtimeSession>> {
+        Err(adk_realtime::RealtimeError::connection("mock model does not connect"))
+    }
+}
+
+/// Builds an integrated runner with one counting tool and the supplied plugin.
+fn runner_with_plugin(
+    plugin: Arc<dyn EnhancedPlugin>,
+    executions: Arc<AtomicUsize>,
+) -> adk_realtime::integration::IntegratedRealtimeRunner {
+    let manager = EnhancedPluginManager::new(vec![plugin]);
+
+    IntegratedRealtimeRunnerBuilder::new()
+        .model(Arc::new(MockModel))
+        .identity("test-app", "user-1", "session-1")
+        .adk_tool(Arc::new(CountingTool { executions }) as Arc<dyn Tool>)
+        .plugin_manager(Arc::new(manager))
+        .build()
+        .expect("builder should succeed")
+}
+
+#[tokio::test]
+async fn a_denying_plugin_stops_the_tool_on_the_realtime_path() {
+    let executions = Arc::new(AtomicUsize::new(0));
+    let runner = runner_with_plugin(Arc::new(DenyingPlugin), Arc::clone(&executions));
+
+    let call = adk_realtime::events::ToolCall {
+        call_id: "call-1".to_string(),
+        name: "guarded".to_string(),
+        arguments: serde_json::json!({}),
+    };
+    let tool: Arc<dyn Tool> = Arc::new(CountingTool { executions: Arc::clone(&executions) });
+
+    let result = runner.execute_tool_with_plugins_for_test(&tool, &call).await.expect("dispatch");
+
+    assert_eq!(
+        executions.load(Ordering::SeqCst),
+        0,
+        "an authorization plugin's denial must prevent execution: {result}"
+    );
+    assert_eq!(result["error"], "denied by policy");
+}
+
+#[tokio::test]
+async fn a_failing_plugin_pipeline_refuses_the_tool_rather_than_running_it() {
+    let executions = Arc::new(AtomicUsize::new(0));
+    let runner = runner_with_plugin(Arc::new(FailingPlugin), Arc::clone(&executions));
+
+    let call = adk_realtime::events::ToolCall {
+        call_id: "call-1".to_string(),
+        name: "guarded".to_string(),
+        arguments: serde_json::json!({}),
+    };
+    let tool: Arc<dyn Tool> = Arc::new(CountingTool { executions: Arc::clone(&executions) });
+
+    let result = runner.execute_tool_with_plugins_for_test(&tool, &call).await.expect("dispatch");
+
+    // The old branch logged the error and executed the tool: a broken guard became no guard.
+    assert_eq!(
+        executions.load(Ordering::SeqCst),
+        0,
+        "a failed policy pipeline must fail closed: {result}"
+    );
+    let message = result["error"].as_str().unwrap_or_default();
+    assert!(message.contains("refused"), "the refusal must be reported: {message}");
+    assert!(
+        message.contains("policy backend unreachable"),
+        "the underlying failure must be reported so it can be fixed: {message}"
+    );
+}

--- a/docs/official_docs/realtime/tools.md
+++ b/docs/official_docs/realtime/tools.md
@@ -134,3 +134,31 @@ example is a headless probe that exercises single-tool, parallel-tool, and
 calculator turns on both providers.
 
 Next: [Multimodal →](multimodal.md)
+
+## Which tools are governed
+
+`IntegratedRealtimeRunner` routes tool calls by how the tool was registered:
+
+| Registered as | Dispatch | Policy applied |
+|---------------|----------|----------------|
+| `adk_tool(...)` — an ADK `Tool` | The integration policy pipeline | Configured plugins, transcript recording, tool-event persistence |
+| A native realtime handler | `RealtimeRunner` dispatch | None — the handler is trusted by construction |
+
+An ADK tool previously reached the provider through a `ToolBridgeAdapter`, which creates a
+context and calls `Tool::execute` with no plugins, callbacks, or confirmation. A tool governed
+in the standard agent loop therefore ran ungoverned in realtime. The native-handler bypass is
+now the explicit exception rather than the default for everything.
+
+### Plugin failures fail closed
+
+If the `before_tool_call` pipeline returns an error, the tool is **refused**:
+
+```json
+{ "error": "tool guarded was refused: its before-tool plugin pipeline failed (...). Execution is refused rather than proceeding without policy." }
+```
+
+> **Important:** this path previously logged the plugin error as non-fatal and then executed
+> the tool. Authorization, redaction, and policy live in before-tool plugins, so a broken guard
+> became no guard.
+
+After-tool plugin errors leave the tool's own result in place, since the tool has already run.


### PR DESCRIPTION
## What

Addresses **RT-02**. ADK tools invoked from an integrated realtime session now run through the configured plugin pipeline, and a failing before-tool plugin refuses the tool instead of letting it run.

## Why

Two problems, one of them fail-open.

**The governed path was unreachable.** `next_event` dispatched via `RealtimeRunner::dispatch_tool_call`, which invokes the bridge adapter:

```rust
async fn execute(&self, call: &ToolCall) -> Result<Value> {
    let ctx: Arc<dyn ToolContext> = self.context_factory.create_context(&call.call_id);
    match self.tool.execute(ctx, call.arguments.clone()).await { ... }
}
```

That is the whole adapter. No plugins, no callbacks, no confirmation, no timeout. The integration builder collects tool metadata, services, *and* a plugin manager, then hands execution to an interface that knows about none of them. `execute_tool_with_plugins` — which applies the pipeline, records the transcript, and persists the tool event — existed and nothing on the live path called it.

**The plugin error branch was fail-open:**

```rust
Err(e) => {
    tracing::warn!(error = %e, "before_tool_call plugin error (non-fatal)");
    // Fallback: execute tool directly
    tool.execute(ctx as Arc<dyn adk_core::ToolContext>, call.arguments.clone()).await
```

Authorization, redaction, and policy live in before-tool plugins. Treating their failure as non-fatal and proceeding turns a broken guard into no guard — precisely inverted for a security hook.

## How

| Registered as | Dispatch | Policy |
|---|---|---|
| `adk_tool(...)` | integration policy pipeline | plugins, transcript, tool-event persistence |
| native realtime handler | `RealtimeRunner` dispatch | none — trusted by construction |

The builder retains the original `Arc<dyn Tool>`s keyed by name (it previously kept only the bridge wrappers), and `dispatch_with_policy` prefers them. A name that is not a registered ADK tool falls through to native dispatch, which makes the bypass an explicit exception rather than the default for everything.

A failing pipeline now returns:

```json
{ "error": "tool guarded was refused: its before-tool plugin pipeline failed (...). Execution is refused rather than proceeding without policy." }
```

Both the refusal and the cause, so the operator can fix the pipeline instead of guessing.

`RealtimeRunner::send_tool_result` delivers a caller-computed result the same way `execute_tool_call` does — sending the output now and deferring the single follow-up `create_response` — so several parallel calls still yield one response.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo clippy -p adk-realtime` with `integration`, `full` | exit 0 each |
| `cargo nextest run --workspace --profile ci` | 3821 passed, 83 skipped, 0 failed |
| `cargo nextest run -p adk-realtime --features integration` | 78 passed |
| `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps` | exit 0 |
| doc-examples guard | exit 0 |

### The fail-closed test fails against the old branch

Restoring the fail-open fallback:

```
PASS  a_denying_plugin_stops_the_tool_on_the_realtime_path
FAIL  a_failing_plugin_pipeline_refuses_the_tool_rather_than_running_it
      assertion `left == right` failed: a failed policy pipeline must fail closed: {"ran":true}
```

`{"ran":true}` is the counting tool's own output — the tool executed despite the broken guard. Execution counts come from an `AtomicUsize` inside the tool, so "did not run" is measured rather than inferred from the returned value.

The denial test passes under both because `ShortCircuit` was already honoured; it guards against the routing change breaking a path that worked.

## Scope

Confirmation, tool timeout, retry/circuit-breaker, and `Tool::required_scopes` inspection on this path are **not** addressed. They need one policy executor shared with `LlmAgent` — the same missing realtime invocation context that RT-01's remaining half needs. Splitting that out is a larger change than making the existing pipeline reachable and safe, which is what this PR does.

> Touches `adk-realtime/src/integration/mod.rs`, as does #495, but in different functions (`execute_tool_with_plugins`/`next_event` here, `connect` there). Given that #478 was caused by two adjacent insertions merging cleanly and dropping a brace, a compile check after both merge is worth doing.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed — new section in `docs/official_docs/realtime/tools.md`
- [x] Examples added or updated for new features