### PR TITLE
feat(managed): add a state store seam that reports its own durability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **adk-managed: managed state has a store seam that reports its own durability.**
+  `CheckpointManager` held events in a `Vec` and run state in a field while documenting
+  `checkpoint` as "atomically persist" with a guarantee that "replay will see a consistent view
+  after any crash", and describing a load as returning "everything needed to reconstruct a
+  session after a restart". Neither held: both operated on in-memory fields with no transaction
+  against any persistent store, so a crash lost event history, sequence position, parked-tool
+  state, and lifecycle status. The new `ManagedStateStore` trait carries a `Durability`
+  (`ProcessLocal` or `CrashDurable`) that a caller can check instead of inferring durability from
+  the presence of checkpointing. `InMemoryManagedStateStore` is the shipped backend, named as
+  such and reporting `ProcessLocal`; `CheckpointManager::with_store`, `flush`, and `restore`
+  connect a manager to one. A crash-durable implementation is not provided — the seam and the
+  honest reporting come first, so callers requiring resume-after-restart can detect its absence.
+
 - **adk-computer-use: governed computer-use orchestration crate.** First-party
   ADK-Rust graph, wire contracts, scope authorization, cancellation bridge, and
   tamper-evident evaluation receipts for the `computer-use-mcp` desktop-automation

--- a/adk-managed/src/checkpoint.rs
+++ b/adk-managed/src/checkpoint.rs
@@ -14,7 +14,10 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::types::{SessionEvent, SessionStatus};
+use std::sync::Arc;
+
+use crate::state_store::{ManagedSessionState, ManagedStateStore};
+use crate::types::{RuntimeError, SessionEvent, SessionStatus};
 
 /// Run-state persisted with each checkpoint.
 ///
@@ -76,10 +79,12 @@ impl RunState {
 pub struct CheckpointManager {
     /// The session ID this manager is checkpointing for.
     session_id: String,
-    /// The event log (in-memory implementation).
+    /// The event log held by this manager.
     events: Vec<SessionEvent>,
     /// Current run state.
     run_state: RunState,
+    /// Where [`CheckpointManager::flush`] writes, when a store is configured.
+    store: Option<Arc<dyn ManagedStateStore>>,
 }
 
 impl CheckpointManager {
@@ -88,22 +93,98 @@ impl CheckpointManager {
     /// Initializes with an empty event log and the initial run state
     /// (seq=0, no pending tools, queued status).
     pub fn new(session_id: String) -> Self {
-        Self { session_id, events: Vec::new(), run_state: RunState::initial() }
+        Self { session_id, events: Vec::new(), run_state: RunState::initial(), store: None }
     }
 
-    /// Atomically persist an event and updated run-state.
+    /// Writes flushed checkpoints to `store`.
     ///
-    /// Both the event and the new state are stored together in one operation,
-    /// guaranteeing that replay will see a consistent view after any crash.
+    /// Check [`ManagedStateStore::durability`] to learn whether those writes survive process
+    /// loss. With the shipped [`InMemoryManagedStateStore`](crate::InMemoryManagedStateStore)
+    /// they do not.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use adk_managed::{CheckpointManager, InMemoryManagedStateStore};
+    /// use std::sync::Arc;
+    ///
+    /// let manager = CheckpointManager::new("session-1".to_string())
+    ///     .with_store(Arc::new(InMemoryManagedStateStore::new()));
+    /// assert!(manager.store().is_some());
+    /// ```
+    pub fn with_store(mut self, store: Arc<dyn ManagedStateStore>) -> Self {
+        self.store = Some(store);
+        self
+    }
+
+    /// The configured store, if any.
+    pub fn store(&self) -> Option<&Arc<dyn ManagedStateStore>> {
+        self.store.as_ref()
+    }
+
+    /// Writes the current snapshot to the configured store.
+    ///
+    /// A no-op without a store. Separate from [`CheckpointManager::checkpoint`] because that
+    /// method is synchronous and a store write is not; a caller that needs the snapshot
+    /// externally visible must flush.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RuntimeError`] when the store rejects the write.
+    pub async fn flush(&self) -> Result<(), RuntimeError> {
+        let Some(store) = &self.store else {
+            return Ok(());
+        };
+
+        store
+            .save(
+                &self.session_id,
+                ManagedSessionState {
+                    events: self.events.clone(),
+                    run_state: self.run_state.clone(),
+                },
+            )
+            .await
+    }
+
+    /// Rebuilds a manager for `session_id` from `store`.
+    ///
+    /// Returns a manager with the stored snapshot when one exists, and an empty one otherwise.
+    /// Whether anything is found across a restart depends entirely on the store's durability —
+    /// with the in-memory backend a new process finds nothing.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RuntimeError`] when the store cannot be read.
+    pub async fn restore(
+        session_id: String,
+        store: Arc<dyn ManagedStateStore>,
+    ) -> Result<Self, RuntimeError> {
+        let restored = store.load(&session_id).await?;
+        let (events, run_state) = match restored {
+            Some(state) => (state.events, state.run_state),
+            None => (Vec::new(), RunState::initial()),
+        };
+
+        Ok(Self { session_id, events, run_state, store: Some(store) })
+    }
+
+    /// Records an event and the updated run state together.
+    ///
+    /// The pair is applied in one call, so replay never sees an event without its state. This
+    /// is a write to this manager's own fields, **not** a transaction with a persistent store:
+    /// it says nothing about surviving a crash. Call [`CheckpointManager::flush`] to write the
+    /// snapshot out, and check the store's durability to learn what that write guarantees.
     pub fn checkpoint(&mut self, event: SessionEvent, run_state: RunState) {
         self.events.push(event);
         self.run_state = run_state;
     }
 
-    /// Load the last checkpoint for resume.
+    /// The events and run state this manager holds, for resume within the process.
     ///
-    /// Returns all stored events and the current run state, providing
-    /// everything needed to reconstruct a session after a restart.
+    /// Reconstructing a session in a *different* process requires a crash-durable
+    /// [`ManagedStateStore`] and [`CheckpointManager::restore`]; this method reads local
+    /// fields only.
     pub fn load_checkpoint(&self) -> (Vec<SessionEvent>, RunState) {
         (self.events.clone(), self.run_state.clone())
     }

--- a/adk-managed/src/lib.rs
+++ b/adk-managed/src/lib.rs
@@ -44,6 +44,7 @@ pub mod runtime;
 pub mod schema_normalization;
 pub mod sequence;
 pub mod session_loop;
+pub mod state_store;
 pub mod testing;
 pub mod types;
 pub mod usage;
@@ -61,5 +62,8 @@ pub use runtime::{AgentHandle, EnvironmentConfig, ManagedAgentRuntime, SessionHa
 pub use schema_normalization::{normalize_for_provider, representative_mcp_schema};
 pub use sequence::SequenceCounter;
 pub use session_loop::SessionLoop;
+pub use state_store::{
+    Durability, InMemoryManagedStateStore, ManagedSessionState, ManagedStateStore,
+};
 pub use testing::{ScriptedLlm, ScriptedToolCall, ScriptedTurn};
 pub use usage::{SessionUsageTracker, UsageReport};

--- a/adk-managed/src/state_store.rs
+++ b/adk-managed/src/state_store.rs
@@ -1,0 +1,228 @@
+//! Where managed session state lives, and whether it survives the process.
+//!
+//! [`CheckpointManager`](crate::CheckpointManager) holds events and run state in a `Vec` and a
+//! struct field. That supports replay and resume *within* a process and nothing more: a crash
+//! loses event history, parked-tool state, sequence position, and lifecycle status even when the
+//! nested Runner has already written conversation events through the `SessionService`. A new
+//! process cannot resume a session another process started.
+//!
+//! The problem was not the in-memory implementation — it is a reasonable default — but that
+//! nothing distinguished it from a durable one. There was no seam to implement against, no way
+//! for a caller to ask what guarantee it had, and the crate described itself as durable.
+//!
+//! [`ManagedStateStore`] is that seam. [`InMemoryManagedStateStore`] is the in-memory backend,
+//! named as such, reporting [`Durability::ProcessLocal`]. A durable implementation is not
+//! shipped; a caller can now detect that instead of assuming otherwise.
+//!
+//! # Example
+//!
+//! ```rust
+//! use adk_managed::state_store::{Durability, InMemoryManagedStateStore, ManagedStateStore};
+//!
+//! let store = InMemoryManagedStateStore::new();
+//! assert_eq!(store.durability(), Durability::ProcessLocal);
+//! assert!(!store.durability().survives_process_loss());
+//! ```
+
+use crate::checkpoint::RunState;
+use crate::types::{RuntimeError, SessionEvent};
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+/// What a store guarantees about state after the writing process ends.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Durability {
+    /// State lives only in this process. Replay and resume work while it runs; a crash loses
+    /// everything the store held, and another process cannot resume its sessions.
+    ProcessLocal,
+    /// State is written to a backing store before the write is acknowledged, so another
+    /// process can reconstruct a session after loss.
+    CrashDurable,
+}
+
+impl Durability {
+    /// Whether state written to this store outlives the process that wrote it.
+    ///
+    /// Callers that require durability should check this at startup rather than infer it from
+    /// the presence of checkpointing.
+    pub fn survives_process_loss(&self) -> bool {
+        matches!(self, Durability::CrashDurable)
+    }
+}
+
+/// A snapshot of one managed session's state.
+///
+/// Not `PartialEq`: `SessionEvent` is `#[non_exhaustive]` and not comparable, so compare the
+/// `run_state` and event count rather than whole snapshots.
+#[derive(Debug, Clone)]
+pub struct ManagedSessionState {
+    /// Events recorded for the session, in order.
+    pub events: Vec<SessionEvent>,
+    /// Sequence position, parked tool calls, and lifecycle status.
+    pub run_state: RunState,
+}
+
+/// Storage for managed session state.
+///
+/// Implementations decide the durability guarantee and must report it truthfully through
+/// [`ManagedStateStore::durability`], because that is what a caller uses to decide whether
+/// resume-after-restart is available.
+#[async_trait]
+pub trait ManagedStateStore: Send + Sync + std::fmt::Debug {
+    /// What this store guarantees after process loss.
+    fn durability(&self) -> Durability;
+
+    /// Records the state of `session_id`, replacing any previous snapshot.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RuntimeError`] when the backing store rejects the write. A durable
+    /// implementation must not acknowledge before the write is persisted, since the whole
+    /// point of the guarantee is that an acknowledged checkpoint is recoverable.
+    async fn save(&self, session_id: &str, state: ManagedSessionState) -> Result<(), RuntimeError>;
+
+    /// The recorded state for `session_id`, or `None` when nothing is stored.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RuntimeError`] when the backing store cannot be read.
+    async fn load(&self, session_id: &str) -> Result<Option<ManagedSessionState>, RuntimeError>;
+
+    /// Removes any state for `session_id`.
+    ///
+    /// Succeeds when nothing was stored, so deletion is idempotent.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RuntimeError`] when the backing store cannot complete the removal.
+    async fn delete(&self, session_id: &str) -> Result<(), RuntimeError>;
+
+    /// The sessions this store holds state for.
+    ///
+    /// A durable implementation uses this at startup to reconstruct sessions; a process-local
+    /// one only ever reports sessions from the current process.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RuntimeError`] when the backing store cannot be enumerated.
+    async fn session_ids(&self) -> Result<Vec<String>, RuntimeError>;
+}
+
+/// The in-memory managed state store.
+///
+/// The default, and the only implementation that ships. Named explicitly so its guarantee is
+/// visible at the call site rather than implied by the absence of an alternative.
+#[derive(Debug, Default)]
+pub struct InMemoryManagedStateStore {
+    sessions: Arc<RwLock<HashMap<String, ManagedSessionState>>>,
+}
+
+impl InMemoryManagedStateStore {
+    /// Creates an empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl ManagedStateStore for InMemoryManagedStateStore {
+    fn durability(&self) -> Durability {
+        Durability::ProcessLocal
+    }
+
+    async fn save(&self, session_id: &str, state: ManagedSessionState) -> Result<(), RuntimeError> {
+        self.sessions.write().await.insert(session_id.to_string(), state);
+        Ok(())
+    }
+
+    async fn load(&self, session_id: &str) -> Result<Option<ManagedSessionState>, RuntimeError> {
+        Ok(self.sessions.read().await.get(session_id).cloned())
+    }
+
+    async fn delete(&self, session_id: &str) -> Result<(), RuntimeError> {
+        self.sessions.write().await.remove(session_id);
+        Ok(())
+    }
+
+    async fn session_ids(&self) -> Result<Vec<String>, RuntimeError> {
+        Ok(self.sessions.read().await.keys().cloned().collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::checkpoint::RunState;
+    use crate::types::SessionStatus;
+
+    fn state() -> ManagedSessionState {
+        ManagedSessionState {
+            events: Vec::new(),
+            run_state: RunState {
+                seq: 7,
+                pending_tool_ids: vec!["call-1".to_string()],
+                status: SessionStatus::Running,
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn the_in_memory_store_reports_its_own_guarantee() {
+        let store = InMemoryManagedStateStore::new();
+        assert_eq!(store.durability(), Durability::ProcessLocal);
+        assert!(
+            !store.durability().survives_process_loss(),
+            "a caller requiring resume-after-restart must be able to detect that it is absent"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_saved_snapshot_round_trips() {
+        let store = InMemoryManagedStateStore::new();
+        store.save("session-1", state()).await.unwrap();
+
+        let loaded = store.load("session-1").await.unwrap().expect("saved state must load");
+        assert_eq!(loaded.run_state, state().run_state);
+        assert_eq!(loaded.events.len(), state().events.len());
+        assert_eq!(store.session_ids().await.unwrap(), vec!["session-1".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn an_unknown_session_loads_as_none_and_deletes_without_error() {
+        let store = InMemoryManagedStateStore::new();
+        assert!(store.load("missing").await.unwrap().is_none());
+        assert!(store.delete("missing").await.is_ok(), "deletion is idempotent");
+    }
+
+    #[tokio::test]
+    async fn saving_twice_replaces_the_snapshot() {
+        let store = InMemoryManagedStateStore::new();
+        store.save("session-1", state()).await.unwrap();
+
+        let mut later = state();
+        later.run_state.seq = 9;
+        store.save("session-1", later.clone()).await.unwrap();
+
+        let loaded = store.load("session-1").await.unwrap().expect("state must load");
+        assert_eq!(loaded.run_state.seq, later.run_state.seq);
+        assert_eq!(store.session_ids().await.unwrap().len(), 1, "not appended twice");
+    }
+
+    #[tokio::test]
+    async fn a_new_store_shares_nothing_with_the_old_one() {
+        // This is the shape of the gap: state written by one store is invisible to another,
+        // which is what happens across a process restart. A `CrashDurable` implementation
+        // backed by shared storage would find the session here.
+        let first = InMemoryManagedStateStore::new();
+        first.save("session-1", state()).await.unwrap();
+
+        let second = InMemoryManagedStateStore::new();
+        assert!(
+            second.load("session-1").await.unwrap().is_none(),
+            "process-local state does not cross process boundaries"
+        );
+        assert!(second.session_ids().await.unwrap().is_empty());
+    }
+}

--- a/adk-managed/tests/checkpoint_store_tests.rs
+++ b/adk-managed/tests/checkpoint_store_tests.rs
@@ -1,0 +1,131 @@
+//! Managed checkpoints are process-local, and now say so.
+//!
+//! `CheckpointManager` held events in a `Vec` and run state in a struct field, with doc comments
+//! claiming that checkpointing "guarantees that replay will see a consistent view after any
+//! crash" and that a load returns "everything needed to reconstruct a session after a restart".
+//! Neither was true: a crash lost event history, parked-tool state, sequence position, and
+//! lifecycle status even when the nested Runner had already written conversation events through
+//! the `SessionService`, and a new process could not resume another's session.
+//!
+//! The in-memory implementation is a reasonable default. The problem was that nothing
+//! distinguished it from a durable one — there was no seam to implement against and no way for a
+//! caller to ask what guarantee it had.
+
+use adk_managed::state_store::{Durability, InMemoryManagedStateStore, ManagedStateStore};
+use adk_managed::types::SessionStatus;
+use adk_managed::{CheckpointManager, RunState};
+use std::sync::Arc;
+
+/// A run state distinguishable from the initial one.
+fn advanced_state() -> RunState {
+    RunState {
+        seq: 12,
+        pending_tool_ids: vec!["call-7".to_string()],
+        status: SessionStatus::Running,
+    }
+}
+
+/// An event to checkpoint.
+fn idle_event() -> adk_managed::types::SessionEvent {
+    adk_managed::types::SessionEvent::StatusIdle { seq: 12, stop_reason: None, usage: None }
+}
+
+#[tokio::test]
+async fn a_manager_without_a_store_flushes_without_error() {
+    // Flushing is a no-op rather than a failure, so the store stays optional.
+    let mut manager = CheckpointManager::new("session-1".to_string());
+    manager.checkpoint(idle_event(), advanced_state());
+
+    assert!(manager.store().is_none());
+    assert!(manager.flush().await.is_ok());
+}
+
+#[tokio::test]
+async fn a_flushed_snapshot_is_visible_in_the_store() {
+    let store = Arc::new(InMemoryManagedStateStore::new());
+    let mut manager =
+        CheckpointManager::new("session-1".to_string()).with_store(store.clone() as Arc<_>);
+
+    manager.checkpoint(idle_event(), advanced_state());
+    manager.flush().await.expect("flush");
+
+    let stored = store.load("session-1").await.unwrap().expect("snapshot must be stored");
+    assert_eq!(stored.run_state.seq, 12);
+    assert_eq!(stored.run_state.pending_tool_ids, vec!["call-7".to_string()]);
+    assert_eq!(stored.events.len(), 1);
+}
+
+#[tokio::test]
+async fn a_checkpoint_is_not_in_the_store_until_flushed() {
+    // `checkpoint` writes local fields. Calling it "atomic persistence" implied otherwise.
+    let store = Arc::new(InMemoryManagedStateStore::new());
+    let mut manager =
+        CheckpointManager::new("session-1".to_string()).with_store(store.clone() as Arc<_>);
+
+    manager.checkpoint(idle_event(), advanced_state());
+
+    assert!(
+        store.load("session-1").await.unwrap().is_none(),
+        "a local checkpoint is not a store write"
+    );
+}
+
+#[tokio::test]
+async fn restore_rebuilds_a_manager_from_the_store() {
+    let store: Arc<dyn ManagedStateStore> = Arc::new(InMemoryManagedStateStore::new());
+
+    let mut original =
+        CheckpointManager::new("session-1".to_string()).with_store(Arc::clone(&store));
+    original.checkpoint(idle_event(), advanced_state());
+    original.flush().await.expect("flush");
+
+    let restored = CheckpointManager::restore("session-1".to_string(), Arc::clone(&store))
+        .await
+        .expect("restore");
+
+    assert_eq!(restored.run_state().seq, 12);
+    assert_eq!(restored.events().len(), 1);
+    assert_eq!(restored.session_id(), "session-1");
+}
+
+#[tokio::test]
+async fn restoring_an_unknown_session_yields_an_empty_manager() {
+    let store: Arc<dyn ManagedStateStore> = Arc::new(InMemoryManagedStateStore::new());
+    let restored = CheckpointManager::restore("never-seen".to_string(), store)
+        .await
+        .expect("restore must not fail on a missing session");
+
+    assert_eq!(restored.run_state().seq, 0);
+    assert!(restored.events().is_empty());
+}
+
+#[tokio::test]
+async fn the_shipped_store_reports_that_it_does_not_survive_process_loss() {
+    // This is the finding, made checkable: the guarantee is now reportable rather than implied
+    // by the presence of checkpointing.
+    let store = InMemoryManagedStateStore::new();
+    assert_eq!(store.durability(), Durability::ProcessLocal);
+    assert!(!store.durability().survives_process_loss());
+}
+
+#[tokio::test]
+async fn a_separate_store_instance_sees_nothing_which_is_the_restart_case() {
+    let first: Arc<dyn ManagedStateStore> = Arc::new(InMemoryManagedStateStore::new());
+    let mut manager =
+        CheckpointManager::new("session-1".to_string()).with_store(Arc::clone(&first));
+    manager.checkpoint(idle_event(), advanced_state());
+    manager.flush().await.expect("flush");
+
+    // A fresh store stands in for a fresh process. A `CrashDurable` implementation backed by
+    // shared storage would find the session; the shipped one cannot.
+    let second: Arc<dyn ManagedStateStore> = Arc::new(InMemoryManagedStateStore::new());
+    let restored =
+        CheckpointManager::restore("session-1".to_string(), second).await.expect("restore");
+
+    assert_eq!(
+        restored.run_state().seq,
+        0,
+        "process-local state does not cross a process boundary"
+    );
+    assert!(restored.events().is_empty());
+}

--- a/docs/official_docs/managed-agents/runtime.md
+++ b/docs/official_docs/managed-agents/runtime.md
@@ -279,3 +279,50 @@ cargo run --manifest-path examples/managed_runtime_hello/Cargo.toml
 ```
 
 This runs fixture F-1 end-to-end with `ScriptedLlm` (no API key required).
+
+## Managed state durability
+
+Managed session state — the event log, sequence position, parked tool calls, and lifecycle
+status — lives in a `ManagedStateStore`. The store reports its own guarantee:
+
+| Durability | Meaning |
+|------------|---------|
+| `ProcessLocal` | Replay and resume work while the process runs. A crash loses the state, and another process cannot resume the session. |
+| `CrashDurable` | State is written to a backing store before the write is acknowledged, so another process can reconstruct the session. |
+
+**Only `InMemoryManagedStateStore` ships, and it is `ProcessLocal`.** Check the guarantee rather
+than inferring it from the presence of checkpointing:
+
+```rust
+use adk_managed::{Durability, InMemoryManagedStateStore, ManagedStateStore};
+
+let store = InMemoryManagedStateStore::new();
+assert_eq!(store.durability(), Durability::ProcessLocal);
+assert!(!store.durability().survives_process_loss());
+```
+
+### Checkpointing versus flushing
+
+`CheckpointManager::checkpoint` records an event and the new run state together, so replay never
+sees one without the other. That is a write to the manager's own fields. `flush` writes the
+snapshot to the configured store, and `restore` rebuilds a manager from it:
+
+```rust
+use adk_managed::{CheckpointManager, InMemoryManagedStateStore, ManagedStateStore};
+use std::sync::Arc;
+
+# async fn example() -> Result<(), adk_managed::types::RuntimeError> {
+let store: Arc<dyn ManagedStateStore> = Arc::new(InMemoryManagedStateStore::new());
+let manager = CheckpointManager::new("session-1".to_string()).with_store(Arc::clone(&store));
+manager.flush().await?;
+
+let restored = CheckpointManager::restore("session-1".to_string(), store).await?;
+# Ok(())
+# }
+```
+
+> **Important:** `checkpoint` was documented as "atomically persist" with a guarantee that
+> "replay will see a consistent view after any crash", and loading was described as returning
+> "everything needed to reconstruct a session after a restart". Neither held: both operated on
+> in-memory fields with no transaction against any persistent store. With the shipped store,
+> `restore` in a new process finds nothing.


### PR DESCRIPTION
## What

Addresses **MR-01**. Managed session state now lives behind a `ManagedStateStore` that reports whether it survives process loss, and the doc comments stop claiming crash durability that was never there.

## Why

`CheckpointManager` is a `Vec` and a struct field, documented as persistence:

```rust
/// Atomically persist an event and updated run-state.
///
/// Both the event and the new state are stored together in one operation,
/// guaranteeing that replay will see a consistent view after any crash.
pub fn checkpoint(&mut self, event: SessionEvent, run_state: RunState) {
    self.events.push(event);
    self.run_state = run_state;
}
```

```rust
/// Load the last checkpoint for resume.
///
/// Returns all stored events and the current run state, providing
/// everything needed to reconstruct a session after a restart.
```

Neither claim holds. "Atomic" is two field assignments. There is no transaction with the injected `SessionService`, no load of managed state at startup, and no reconstruction of active sessions or registered agents after process loss. A crash loses event history, sequence position, parked-tool state, and lifecycle status — even when the nested Runner has already durably written the conversation events.

**The in-memory implementation is not the problem.** It is a reasonable default. The problem is that nothing distinguished it from a durable one: no trait to implement a durable backend against, and no way for a caller to ask what guarantee it had.

## How

| Durability | Meaning |
|---|---|
| `ProcessLocal` | Replay and resume work while the process runs; a crash loses the state |
| `CrashDurable` | Written to a backing store before acknowledgement, so another process can reconstruct |

`InMemoryManagedStateStore` is the shipped backend, named for what it is, reporting `ProcessLocal`. `Durability::survives_process_loss()` gives a caller a direct check instead of an inference.

`CheckpointManager` gains `with_store`, `flush`, and `restore`. `checkpoint` stays synchronous and local — its doc now says so explicitly, and that recording a checkpoint is not a store write.

### Why no durable backend in this PR

Implementing one requires choosing a store, defining transactional ordering against the `SessionService` (including what happens when the event write succeeds and the state write does not), and reconstructing registries and active sessions at startup. That is a design task, not a fix. Shipping the seam and the honest guarantee first means a caller that requires resume-after-restart can **detect its absence today** rather than during an incident. The remaining work now has something to build against.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo nextest run --workspace --profile ci` | **3833 passed**, 83 skipped, 0 failed |
| `cargo nextest run -p adk-managed` | 239 → 251 passed |
| `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps` | exit 0 |
| `cargo test -p adk-managed --doc` | 25 passed |
| `cargo semver-checks -p adk-managed --release-type minor` | no semver update required (additive) |
| doc-examples guard | exit 0 |

Twelve tests across the store and the manager. Two encode the finding rather than the fix:

- `a_checkpoint_is_not_in_the_store_until_flushed` — proves `checkpoint` is a local write, which "atomically persist" implied otherwise.
- `a_separate_store_instance_sees_nothing_which_is_the_restart_case` — a fresh store stands in for a fresh process; `restore` returns seq 0 and no events. A `CrashDurable` backend over shared storage would find the session, which is exactly the difference the trait now names.

`the_shipped_store_reports_that_it_does_not_survive_process_loss` asserts the guarantee is reportable — the thing that was missing.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed — new section in `docs/official_docs/managed-agents/runtime.md`
- [x] Examples added or updated for new features