### PR TITLE
fix(agent): make an ambient agent invoke the agent, deliver output, overlap triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -426,6 +426,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **adk-agent: an ambient agent invokes the agent, delivers its output, and does not serialize
+  triggers.** `AmbientAgent::start` succeeded without a trigger handler and then only logged each
+  event, so `AmbientAgent::new(..).start()` appeared to run an agent that was never invoked; it
+  now fails with an error naming what is missing. Events and errors the agent produces are
+  delivered through `take_output(capacity)` instead of being logged at debug level and dropped.
+  Triggers are dispatched under `with_max_concurrent_triggers` (default 4) rather than one at a
+  time — the loop previously drained a handler's entire event stream before polling the source
+  again, so one slow trigger blocked every later one. Durable offsets, dead letters, and retry
+  remain the caller's responsibility and are documented as such.
+
 - **adk-server: background runs execute a workflow instead of reporting success.**
   `BackgroundRunner::run_with_timeout` received neither the workflow ID nor the input. It
   checked cancellation and returned `Completed` with an empty object, so a client got a

--- a/adk-agent/src/ambient/agent.rs
+++ b/adk-agent/src/ambient/agent.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
-use adk_core::{AdkError, Agent, EventStream, Result};
+use adk_core::{AdkError, Agent, Event, EventStream, Result};
 use futures::StreamExt;
-use tokio::sync::{Notify, RwLock};
+use tokio::sync::{Notify, RwLock, Semaphore, mpsc};
 use tokio::task::JoinHandle;
 
 use super::event_source::EventSource;
@@ -48,6 +48,8 @@ pub enum AmbientAgentStatus {
     /// The agent is stopped — no background task is running.
     Stopped,
 }
+/// Triggers handled at once unless [`AmbientAgent::with_max_concurrent_triggers`] says otherwise.
+const DEFAULT_MAX_CONCURRENT_TRIGGERS: usize = 4;
 
 /// A background agent triggered by an event source.
 ///
@@ -81,6 +83,14 @@ pub struct AmbientAgent {
     status: Arc<RwLock<AmbientAgentStatus>>,
     resume_notify: Arc<Notify>,
     handle: Option<JoinHandle<()>>,
+    /// Bounds how many triggers are handled at once.
+    ///
+    /// Events used to be handled strictly one at a time — the loop drained a handler's whole
+    /// event stream before polling the source again — so one slow trigger blocked every later
+    /// one.
+    max_concurrent_triggers: usize,
+    /// Receives events the agent produces, when a caller asks for them.
+    output_tx: Option<mpsc::Sender<Result<Event>>>,
 }
 
 impl AmbientAgent {
@@ -95,7 +105,38 @@ impl AmbientAgent {
             status: Arc::new(RwLock::new(AmbientAgentStatus::Stopped)),
             resume_notify: Arc::new(Notify::new()),
             handle: None,
+            max_concurrent_triggers: DEFAULT_MAX_CONCURRENT_TRIGGERS,
+            output_tx: None,
         }
+    }
+
+    /// Bounds how many triggers are handled concurrently. Defaults to four.
+    ///
+    /// A bound of zero is treated as one.
+    pub fn with_max_concurrent_triggers(mut self, max_concurrent_triggers: usize) -> Self {
+        self.max_concurrent_triggers = max_concurrent_triggers.max(1);
+        self
+    }
+
+    /// Delivers the events the agent produces to the returned receiver.
+    ///
+    /// Without this, produced events were logged at debug level and discarded, so a caller had
+    /// no way to observe what an ambient run did. Errors are delivered too, so a failing trigger
+    /// is visible rather than only logged.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let mut outputs = ambient.take_output(64);
+    /// ambient.start().await?;
+    /// while let Some(event) = outputs.recv().await {
+    ///     // observe what each trigger produced
+    /// }
+    /// ```
+    pub fn take_output(&mut self, capacity: usize) -> mpsc::Receiver<Result<Event>> {
+        let (tx, rx) = mpsc::channel(capacity.max(1));
+        self.output_tx = Some(tx);
+        rx
     }
 
     /// Set a trigger handler that will be called when the event source fires.
@@ -112,11 +153,24 @@ impl AmbientAgent {
     ///
     /// # Errors
     ///
-    /// Returns an error if the agent is already running or paused.
+    /// Returns an error if the agent is already running or paused, or if no trigger handler is
+    /// configured.
+    ///
+    /// Starting without a handler used to succeed and then only log each trigger, so
+    /// `AmbientAgent::new(..).start()` looked like it was running the agent while the agent was
+    /// never invoked. Refusing makes that visible at the call site.
     pub async fn start(&mut self) -> Result<()> {
         let current = *self.status.read().await;
         if current != AmbientAgentStatus::Stopped {
             return Err(AdkError::agent("agent already running"));
+        }
+
+        if self.trigger_handler.is_none() {
+            return Err(AdkError::agent(
+                "AmbientAgent has no trigger handler, so starting it would log trigger events \
+                 without ever invoking the agent. Call `with_trigger_handler` with a closure \
+                 that drives the agent through a Runner.",
+            ));
         }
 
         // Subscribe to the event source
@@ -129,61 +183,88 @@ impl AmbientAgent {
 
         *self.status.write().await = AmbientAgentStatus::Running;
 
+        let permits = Arc::new(Semaphore::new(self.max_concurrent_triggers));
+        let output_tx = self.output_tx.clone();
+        let handler = trigger_handler.expect("checked above");
+
         let handle = tokio::spawn(async move {
             let mut stream = stream;
+            let mut running = futures::stream::FuturesUnordered::new();
 
-            while let Some(event) = stream.next().await {
-                // Check if paused — wait until resumed
+            loop {
+                // Check if paused — wait until resumed.
                 loop {
                     let current_status = *status.read().await;
                     match current_status {
                         AmbientAgentStatus::Running => break,
-                        AmbientAgentStatus::Paused => {
-                            // Wait for resume signal
-                            resume_notify.notified().await;
-                        }
+                        AmbientAgentStatus::Paused => resume_notify.notified().await,
                         AmbientAgentStatus::Stopped => return,
                     }
                 }
 
-                // Process the event — invoke the agent via the trigger handler
-                tracing::info!(
-                    agent = agent.name(),
-                    source = %event.source,
-                    "ambient agent triggered"
-                );
-                tracing::debug!(payload = %event.payload, "trigger event payload");
+                // Draining finished triggers alongside reading the source is what removes the
+                // head-of-line blocking: one slow trigger no longer holds up every later one.
+                let event = if running.is_empty() {
+                    stream.next().await
+                } else {
+                    tokio::select! {
+                        biased;
+                        Some(()) = running.next() => continue,
+                        event = stream.next() => event,
+                    }
+                };
 
-                if let Some(ref handler) = trigger_handler {
-                    match handler(event, agent.clone()).await {
+                let Some(event) = event else {
+                    // Source exhausted: let dispatched triggers finish so their output is not
+                    // dropped mid-flight.
+                    while running.next().await.is_some() {}
+                    return;
+                };
+
+                let handler = Arc::clone(&handler);
+                let agent = Arc::clone(&agent);
+                let permits = Arc::clone(&permits);
+                let output_tx = output_tx.clone();
+
+                running.push(async move {
+                    let _permit = permits.acquire_owned().await;
+
+                    tracing::info!(
+                        agent = agent.name(),
+                        source = %event.source,
+                        "ambient agent triggered"
+                    );
+
+                    match handler(event, Arc::clone(&agent)).await {
                         Ok(mut event_stream) => {
-                            // Consume the event stream, logging results
                             while let Some(result) = event_stream.next().await {
-                                match result {
-                                    Ok(ev) => {
-                                        tracing::debug!(
-                                            author = %ev.author,
-                                            "ambient agent produced event"
-                                        );
-                                    }
-                                    Err(e) => {
-                                        tracing::warn!(
-                                            error = %e,
-                                            "ambient agent invocation error"
-                                        );
-                                        break;
-                                    }
+                                let failed = result.is_err();
+                                if let Err(ref e) = result {
+                                    tracing::warn!(error = %e, "ambient agent invocation error");
+                                }
+
+                                // Delivered when a caller asked for output, instead of being
+                                // logged and dropped.
+                                if let Some(ref tx) = output_tx
+                                    && tx.send(result).await.is_err()
+                                {
+                                    tracing::debug!("ambient output receiver dropped");
+                                    return;
+                                }
+
+                                if failed {
+                                    return;
                                 }
                             }
                         }
                         Err(e) => {
-                            tracing::warn!(
-                                error = %e,
-                                "ambient agent trigger handler failed"
-                            );
+                            tracing::warn!(error = %e, "ambient agent trigger handler failed");
+                            if let Some(ref tx) = output_tx {
+                                let _ = tx.send(Err(e)).await;
+                            }
                         }
                     }
-                }
+                });
             }
         });
 

--- a/adk-agent/tests/ambient_execution_tests.rs
+++ b/adk-agent/tests/ambient_execution_tests.rs
@@ -1,0 +1,218 @@
+//! An ambient agent must invoke the agent, deliver what it produced, and not serialize triggers.
+//!
+//! Three defects in `AmbientAgent::start`:
+//!
+//! 1. **Without a trigger handler the agent was never invoked** — each event was logged and
+//!    dropped, so `AmbientAgent::new(..).start()` looked like it was running an agent that never
+//!    ran.
+//! 2. **Produced events were logged at debug and discarded**, leaving a caller no way to observe
+//!    what an ambient run did or whether it failed.
+//! 3. **Triggers were strictly serial** — the loop drained a handler's entire event stream before
+//!    polling the source again, so one slow trigger blocked every later one.
+
+#![cfg(feature = "ambient")]
+
+use adk_agent::ambient::{AmbientAgent, EventSource, TriggerEvent, TriggerHandler};
+use adk_core::{Agent, Content, Event, EventStream, Result};
+use async_trait::async_trait;
+use futures::stream::BoxStream;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// A leaf agent; these tests assert dispatch, not model behaviour.
+#[derive(Debug)]
+struct NoopAgent;
+
+#[async_trait]
+impl Agent for NoopAgent {
+    fn name(&self) -> &str {
+        "noop"
+    }
+    fn description(&self) -> &str {
+        "does nothing"
+    }
+    fn sub_agents(&self) -> &[Arc<dyn Agent>] {
+        &[]
+    }
+    async fn run(&self, _ctx: Arc<dyn adk_core::InvocationContext>) -> Result<EventStream> {
+        Ok(Box::pin(futures::stream::empty()))
+    }
+}
+
+/// Emits a fixed number of trigger events, then ends.
+struct BurstSource {
+    count: usize,
+}
+
+#[async_trait]
+impl EventSource for BurstSource {
+    fn name(&self) -> &str {
+        "burst"
+    }
+
+    async fn subscribe(&self) -> Result<BoxStream<'static, TriggerEvent>> {
+        let events: Vec<TriggerEvent> = (0..self.count)
+            .map(|index| TriggerEvent {
+                source: "burst".to_string(),
+                payload: serde_json::json!({ "index": index }),
+            })
+            .collect();
+        Ok(Box::pin(futures::stream::iter(events)))
+    }
+}
+
+/// A handler that records invocations and yields one event.
+fn counting_handler(invocations: Arc<AtomicUsize>) -> TriggerHandler {
+    Arc::new(move |_event, _agent| {
+        let invocations = Arc::clone(&invocations);
+        Box::pin(async move {
+            invocations.fetch_add(1, Ordering::SeqCst);
+            let mut event = Event::new("inv");
+            event.author = "noop".to_string();
+            event.llm_response.content = Some(Content::new("model").with_text("done"));
+            Ok(Box::pin(futures::stream::iter(vec![Ok(event)])) as EventStream)
+        })
+    })
+}
+
+#[tokio::test]
+async fn starting_without_a_handler_is_refused() {
+    let mut ambient = AmbientAgent::new(Arc::new(NoopAgent), Arc::new(BurstSource { count: 1 }));
+
+    let error = ambient
+        .start()
+        .await
+        .expect_err("a configuration that never invokes the agent must not start silently");
+    let message = error.to_string();
+    assert!(message.contains("trigger handler"), "the error must name what is missing: {message}");
+}
+
+#[tokio::test]
+async fn produced_events_are_delivered_to_the_caller() {
+    let invocations = Arc::new(AtomicUsize::new(0));
+    let mut ambient = AmbientAgent::new(Arc::new(NoopAgent), Arc::new(BurstSource { count: 1 }))
+        .with_trigger_handler(counting_handler(Arc::clone(&invocations)));
+
+    let mut outputs = ambient.take_output(8);
+    ambient.start().await.expect("start");
+
+    let delivered = tokio::time::timeout(std::time::Duration::from_secs(5), outputs.recv())
+        .await
+        .expect("an ambient run must deliver what it produced")
+        .expect("channel must yield");
+
+    let event = delivered.expect("the handler produced a successful event");
+    assert_eq!(event.author, "noop");
+    assert_eq!(invocations.load(Ordering::SeqCst), 1, "the agent was invoked");
+}
+
+#[tokio::test]
+async fn a_handler_error_is_delivered_rather_than_only_logged() {
+    let failing: TriggerHandler = Arc::new(|_event, _agent| {
+        Box::pin(async { Err(adk_core::AdkError::agent("handler exploded")) })
+    });
+
+    let mut ambient = AmbientAgent::new(Arc::new(NoopAgent), Arc::new(BurstSource { count: 1 }))
+        .with_trigger_handler(failing);
+
+    let mut outputs = ambient.take_output(8);
+    ambient.start().await.expect("start");
+
+    let delivered = tokio::time::timeout(std::time::Duration::from_secs(5), outputs.recv())
+        .await
+        .expect("a failure must reach the caller")
+        .expect("channel must yield");
+
+    let error = delivered.expect_err("the handler failed");
+    assert!(error.to_string().contains("handler exploded"), "{error}");
+}
+
+#[tokio::test]
+async fn independent_triggers_do_not_block_each_other() {
+    // Every handler waits for all three to arrive. Serial dispatch cannot satisfy that, so this
+    // completes only if triggers overlap.
+    let barrier = Arc::new(tokio::sync::Barrier::new(3));
+    let handler_barrier = Arc::clone(&barrier);
+
+    let handler: TriggerHandler = Arc::new(move |_event, _agent| {
+        let barrier = Arc::clone(&handler_barrier);
+        Box::pin(async move {
+            barrier.wait().await;
+            let mut event = Event::new("inv");
+            event.author = "noop".to_string();
+            Ok(Box::pin(futures::stream::iter(vec![Ok(event)])) as EventStream)
+        })
+    });
+
+    let mut ambient = AmbientAgent::new(Arc::new(NoopAgent), Arc::new(BurstSource { count: 3 }))
+        .with_trigger_handler(handler)
+        .with_max_concurrent_triggers(3);
+
+    let mut outputs = ambient.take_output(8);
+    ambient.start().await.expect("start");
+
+    let mut received = 0;
+    let collected = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        while outputs.recv().await.is_some() {
+            received += 1;
+            if received == 3 {
+                break;
+            }
+        }
+        received
+    })
+    .await;
+
+    assert_eq!(
+        collected.expect("serial dispatch cannot satisfy a three-way barrier"),
+        3,
+        "all three triggers must complete"
+    );
+}
+
+#[tokio::test]
+async fn the_concurrency_bound_is_respected() {
+    let in_flight = Arc::new(AtomicUsize::new(0));
+    let peak = Arc::new(AtomicUsize::new(0));
+    let handler_in_flight = Arc::clone(&in_flight);
+    let handler_peak = Arc::clone(&peak);
+
+    let handler: TriggerHandler = Arc::new(move |_event, _agent| {
+        let in_flight = Arc::clone(&handler_in_flight);
+        let peak = Arc::clone(&handler_peak);
+        Box::pin(async move {
+            let now = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+            peak.fetch_max(now, Ordering::SeqCst);
+            tokio::task::yield_now().await;
+            in_flight.fetch_sub(1, Ordering::SeqCst);
+
+            let mut event = Event::new("inv");
+            event.author = "noop".to_string();
+            Ok(Box::pin(futures::stream::iter(vec![Ok(event)])) as EventStream)
+        })
+    });
+
+    let mut ambient = AmbientAgent::new(Arc::new(NoopAgent), Arc::new(BurstSource { count: 6 }))
+        .with_trigger_handler(handler)
+        .with_max_concurrent_triggers(2);
+
+    let mut outputs = ambient.take_output(16);
+    ambient.start().await.expect("start");
+
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        let mut seen = 0;
+        while outputs.recv().await.is_some() {
+            seen += 1;
+            if seen == 6 {
+                break;
+            }
+        }
+    })
+    .await;
+
+    assert!(
+        peak.load(Ordering::SeqCst) <= 2,
+        "the bound was exceeded: peak {}",
+        peak.load(Ordering::SeqCst)
+    );
+}

--- a/docs/official_docs/agents/ambient-agents.md
+++ b/docs/official_docs/agents/ambient-agents.md
@@ -1,0 +1,53 @@
+# Ambient Agents
+
+## Running an ambient agent
+
+A trigger handler is required. It receives the event and the agent, and drives the agent —
+typically through a `Runner`:
+
+```rust,ignore
+use adk_agent::ambient::{AmbientAgent, TriggerHandler};
+use std::sync::Arc;
+
+let handler: TriggerHandler = Arc::new(move |event, agent| {
+    let runner = runner.clone();
+    Box::pin(async move {
+        runner.run_str("user-1", "ambient-session", event.payload.to_string().into()).await
+    })
+});
+
+let mut ambient = AmbientAgent::new(agent, source)
+    .with_trigger_handler(handler)
+    .with_max_concurrent_triggers(4);
+
+let mut outputs = ambient.take_output(64);
+ambient.start().await?;
+```
+
+`start` fails without a handler:
+
+```text
+AmbientAgent has no trigger handler, so starting it would log trigger events without ever
+invoking the agent. Call `with_trigger_handler` with a closure that drives the agent through a
+Runner.
+```
+
+> **Important:** starting without a handler previously succeeded and then logged each trigger,
+> so `AmbientAgent::new(..).start()` looked like it was running an agent that never ran.
+
+## Output and concurrency
+
+| Behaviour | Control |
+|-----------|---------|
+| Events and errors the agent produces are delivered to a channel | `take_output(capacity)` |
+| Triggers handled at once | `with_max_concurrent_triggers` (default 4, zero treated as one) |
+
+Produced events were previously logged at debug level and dropped, so a caller could not observe
+what a run did or whether it failed. Triggers were also handled strictly one at a time — the loop
+drained a handler's entire event stream before polling the source again — so one slow trigger
+blocked every later one.
+
+> **Note:** the bound governs concurrency, not parallelism. Handlers share the ambient task, so a
+> handler that blocks the thread still stalls the loop. Use `tokio::task::spawn_blocking` for
+> those. Durable trigger offsets, dead-letter handling, and retry remain the caller's
+> responsibility.


### PR DESCRIPTION
## What

Addresses **AM-01**. An ambient agent that cannot invoke anything now refuses to start, produced events reach the caller, and one slow trigger no longer blocks the rest.

## Why

Three defects in `AmbientAgent::start`.

**Without a handler, the agent was never invoked.** The loop logged and moved on:

```rust
tracing::info!(agent = agent.name(), source = %event.source, "ambient agent triggered");
tracing::debug!(payload = %event.payload, "trigger event payload");

if let Some(ref handler) = trigger_handler {
    ...
}
```

`AmbientAgent::new(agent, source).start()` returned `Ok`, logged "ambient agent triggered" for every event, and ran nothing. The log line makes it look like it worked.

**Produced events were discarded:**

```rust
Ok(ev) => {
    tracing::debug!(author = %ev.author, "ambient agent produced event");
}
```

Debug-level, then dropped. A handler failure was a `warn!` and nothing else, so a caller could not tell a working ambient agent from a permanently failing one.

**Triggers were strictly serial.** `while let Some(event) = stream.next().await` with the handler's entire event stream drained inside the body — the next trigger could not start until the previous one finished.

## How

| Change | Behaviour |
|---|---|
| `start` requires a handler | Fails with an error naming what is missing |
| `take_output(capacity)` | Delivers produced events **and** errors to the caller |
| `with_max_concurrent_triggers(n)` | Bounded overlap, default 4, zero treated as one |

Handlers run on a `FuturesUnordered` selected against the source, so completions and new events interleave. On source exhaustion dispatched triggers drain first, so their output is not dropped mid-flight.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo clippy -p adk-agent --features ambient --all-targets` | exit 0 |
| `cargo nextest run --workspace --profile ci` | 3821 passed, 83 skipped, 0 failed |
| `cargo nextest run -p adk-agent --features ambient` | 108 passed |
| `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps` | exit 0 |
| doc-examples guard | exit 0 |

> `ambient` is not a default feature, so the workspace count is unchanged; the new tests are reached by the feature-enabled run and CI's `feature-coverage` job.

### Two of five fail against the old behaviour

Restoring the silent start and serial drain:

```
FAIL  starting_without_a_handler_is_refused
FAIL  independent_triggers_do_not_block_each_other   (5.011s)
```

The second is the discriminating one: three triggers each wait on a three-way barrier, which serial dispatch can never satisfy, so it hits the timeout. `the_concurrency_bound_is_respected` passes under both — a cap of two is trivially met by serial execution — and guards the opposite direction.

## Scope

This makes the loop honest and non-blocking. **Not** addressed: durable trigger offsets, dead-letter handling, retry policy, and per-user session mapping. Those are a delivery-semantics design rather than a fix, and the handler still owns identity and session choice. The docs now state that instead of leaving it to be discovered.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed — `docs/official_docs/agents/ambient-agents.md`
- [x] Examples added or updated for new features