### PR TITLE
feat(graph): give the functional interrupt a typed resume channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -426,6 +426,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **adk-graph: functional `TaskContext::interrupt` can be resumed with a typed value.** The method
+  emitted an event, saved a checkpoint, recorded an `__interrupt__` task, and then always returned
+  `InterruptTypeMismatch { message: "workflow interrupted" }` — its own comment deferred
+  suspension and resumption to future work, and nothing outside the method consumed a resume
+  value. The signature promised typed resumption that could not occur. Each interrupt site now
+  gets a continuation key from its position in the run (`interrupt-1`, `interrupt-2`, …), reported
+  in the new `FunctionalError::Suspended` and written to the checkpoint as `continuation_key`.
+  `TaskContext::with_resume_values` supplies values by key, and an interrupt whose key is present
+  returns the deserialized value at the call site. `InterruptTypeMismatch` now means what its name
+  says: the supplied value did not deserialize into the expected type.
+
 - **adk-server: background runs execute a workflow instead of reporting success.**
   `BackgroundRunner::run_with_timeout` received neither the workflow ID nor the input. It
   checked cancellation and returned `Completed` with an empty object, so a client got a

--- a/adk-graph/src/functional/context.rs
+++ b/adk-graph/src/functional/context.rs
@@ -69,6 +69,14 @@ pub struct TaskContext {
     /// Pending dynamic route targets set by `route_to()`.
     /// Consumed by the executor to populate `EventActions.route`.
     pending_route: Option<Vec<String>>,
+    /// Values supplied for interrupt sites, keyed by continuation key.
+    ///
+    /// Without this there was no resume channel at all: `interrupt` always returned an error and
+    /// nothing outside the method consumed a resume value, so the typed-resumption contract in
+    /// its signature could not be honoured.
+    resume_values: HashMap<String, Value>,
+    /// Counts interrupt calls so each site gets a stable key across a replay.
+    interrupt_ordinal: Arc<RwLock<usize>>,
 }
 
 impl TaskContext {
@@ -95,6 +103,8 @@ impl TaskContext {
             schema_validator: None,
             iteration_counters: HashMap::new(),
             pending_route: None,
+            resume_values: HashMap::new(),
+            interrupt_ordinal: Arc::new(RwLock::new(0)),
         }
     }
 
@@ -175,6 +185,30 @@ impl TaskContext {
     /// let approval: bool = ctx.interrupt("Please approve this action").await?;
     /// ```
     pub async fn interrupt<T: DeserializeOwned>(&self, message: &str) -> Result<T> {
+        // Each interrupt site gets a key from its position in the run. Replaying the same
+        // workflow reaches the same interrupts in the same order, so the key a caller was told
+        // to supply is the key the site looks for.
+        let continuation_key = {
+            let mut ordinal = self.interrupt_ordinal.write().await;
+            *ordinal += 1;
+            format!("interrupt-{ordinal}")
+        };
+
+        // Resume: a value supplied for this site is returned to the call site, which is what the
+        // signature promised and what previously could not happen.
+        if let Some(value) = self.resume_values.get(&continuation_key) {
+            return serde_json::from_value(value.clone()).map_err(|e| {
+                FunctionalError::InterruptTypeMismatch {
+                    task: continuation_key.clone(),
+                    message: format!(
+                        "the value supplied for {continuation_key} does not deserialize into the \
+                         type this interrupt expects: {e}"
+                    ),
+                }
+                .into()
+            });
+        }
+
         // Emit the interrupt event for stream listeners.
         self.emit(StreamEvent::interrupted("functional_task", message));
 
@@ -185,7 +219,8 @@ impl TaskContext {
             self.current_step().await,
             vec![],
         )
-        .with_metadata("interrupt_message", Value::String(message.to_string()));
+        .with_metadata("interrupt_message", Value::String(message.to_string()))
+        .with_metadata("continuation_key", Value::String(continuation_key.clone()));
 
         self.checkpointer.save(&checkpoint).await.map_err(|e| {
             FunctionalError::CheckpointFailed {
@@ -209,15 +244,34 @@ impl TaskContext {
             );
         }
 
-        // In a real runtime the workflow executor would suspend here and
-        // later provide the resume value. For now we return an error
-        // indicating the interrupt was requested — the macro-generated
-        // wrapper handles actual suspension/resumption.
-        Err(FunctionalError::InterruptTypeMismatch {
-            task: "interrupt".to_string(),
-            message: format!("workflow interrupted: {message}"),
-        }
-        .into())
+        Err(FunctionalError::Suspended { continuation_key, message: message.to_string() }.into())
+    }
+
+    /// Supplies values for interrupt sites, keyed by continuation key.
+    ///
+    /// Re-invoke the entrypoint with these set to resume: an interrupt whose key is present
+    /// returns the deserialized value instead of suspending.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// // First run suspends and reports its continuation key.
+    /// let Err(e) = run(ctx).await else { unreachable!() };
+    ///
+    /// // Second run supplies the value under that key.
+    /// let ctx = ctx.with_resume_values(HashMap::from([
+    ///     ("interrupt-1".to_string(), serde_json::json!({ "approved": true })),
+    /// ]));
+    /// let output = run(ctx).await?;
+    /// ```
+    pub fn with_resume_values(mut self, resume_values: HashMap<String, Value>) -> Self {
+        self.resume_values = resume_values;
+        self
+    }
+
+    /// The values available to interrupt sites in this context.
+    pub fn resume_values(&self) -> &HashMap<String, Value> {
+        &self.resume_values
     }
 
     /// Get the thread identifier for this context.

--- a/adk-graph/src/functional/error.rs
+++ b/adk-graph/src/functional/error.rs
@@ -27,6 +27,23 @@ pub enum FunctionalError {
         actual: String,
     },
 
+    /// The workflow suspended at an interrupt and needs a resume value.
+    ///
+    /// `continuation_key` identifies the interrupt site. Supply the value under that key via
+    /// `TaskContext::with_resume_values` and re-invoke the entrypoint; the interrupt call then
+    /// returns the value instead of this error.
+    ///
+    /// Previously an interrupt always produced `InterruptTypeMismatch`, so a caller could not
+    /// tell "needs input" from "the value you gave me was the wrong type" — and there was no
+    /// key to supply the value under.
+    #[error("workflow suspended at interrupt '{continuation_key}': {message}")]
+    Suspended {
+        /// Key identifying this interrupt site within the thread.
+        continuation_key: String,
+        /// The message passed to `interrupt`.
+        message: String,
+    },
+
     /// Interrupt deserialization error (wrong type provided on resume).
     #[error("interrupt resume type mismatch for task '{task}': {message}")]
     InterruptTypeMismatch {

--- a/adk-graph/tests/functional_interrupt_resume_tests.rs
+++ b/adk-graph/tests/functional_interrupt_resume_tests.rs
@@ -1,0 +1,158 @@
+//! A functional interrupt must be resumable with a typed value.
+//!
+//! `TaskContext::interrupt<T>` emitted an event, saved a checkpoint, recorded an `__interrupt__`
+//! task, and then *always* returned `InterruptTypeMismatch { message: "workflow interrupted" }`.
+//! Its own comment said the runtime would suspend "in a real runtime" and that the macro wrapper
+//! handled resumption; nothing outside the method consumed a resume value. So the signature
+//! promised typed resumption that could not occur, and callers had to read an error as control
+//! flow with no value ever delivered — and no key under which to supply one.
+
+#![cfg(feature = "functional")]
+
+use adk_graph::functional::{FunctionalError, TaskContext};
+use adk_graph::{Checkpointer, MemoryCheckpointer, State};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// What an approval interrupt would return.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct Approval {
+    approved: bool,
+    approver: String,
+}
+
+/// A context over an in-memory checkpointer.
+fn context() -> TaskContext {
+    let (event_tx, _rx) = tokio::sync::broadcast::channel(64);
+    TaskContext::new(
+        "thread-1".to_string(),
+        State::new(),
+        Arc::new(MemoryCheckpointer::new()) as Arc<dyn Checkpointer>,
+        event_tx,
+        Arc::new(tokio::sync::RwLock::new(adk_graph::functional::ExecutionLog::default())),
+        tokio_util::sync::CancellationToken::new(),
+        None,
+    )
+}
+
+#[tokio::test]
+async fn an_interrupt_without_a_resume_value_suspends_and_reports_its_key() {
+    let ctx = context();
+
+    let error = ctx
+        .interrupt::<Approval>("approve the refund")
+        .await
+        .expect_err("with no value supplied the workflow must suspend");
+
+    let message = error.to_string();
+    assert!(
+        message.contains("interrupt-1"),
+        "the caller needs the key to supply a value under: {message}"
+    );
+    assert!(
+        message.contains("approve the refund"),
+        "the interrupt's message must survive: {message}"
+    );
+    assert!(!message.contains("type mismatch"), "needing input is not a type mismatch: {message}");
+}
+
+#[tokio::test]
+async fn a_supplied_value_reaches_the_call_site_typed() {
+    let expected = Approval { approved: true, approver: "alice".to_string() };
+    let ctx = context().with_resume_values(HashMap::from([(
+        "interrupt-1".to_string(),
+        serde_json::to_value(&expected).unwrap(),
+    )]));
+
+    let approval: Approval =
+        ctx.interrupt("approve the refund").await.expect("a supplied value must resume the call");
+
+    assert_eq!(approval, expected, "the interrupt call must return the value, not an error");
+}
+
+#[tokio::test]
+async fn each_interrupt_site_gets_its_own_key() {
+    // Two interrupts in one run must be independently resumable, so their keys differ and are
+    // stable in call order — which is what makes a replayed workflow find the right value.
+    let first = Approval { approved: true, approver: "alice".to_string() };
+    let second = Approval { approved: false, approver: "bob".to_string() };
+
+    let ctx = context().with_resume_values(HashMap::from([
+        ("interrupt-1".to_string(), serde_json::to_value(&first).unwrap()),
+        ("interrupt-2".to_string(), serde_json::to_value(&second).unwrap()),
+    ]));
+
+    let a: Approval = ctx.interrupt("first").await.expect("first resumes");
+    let b: Approval = ctx.interrupt("second").await.expect("second resumes");
+
+    assert_eq!(a, first);
+    assert_eq!(b, second, "the second site must not receive the first site's value");
+}
+
+#[tokio::test]
+async fn a_partially_supplied_run_resumes_then_suspends_again() {
+    let first = Approval { approved: true, approver: "alice".to_string() };
+    let ctx = context().with_resume_values(HashMap::from([(
+        "interrupt-1".to_string(),
+        serde_json::to_value(&first).unwrap(),
+    )]));
+
+    let a: Approval = ctx.interrupt("first").await.expect("first resumes");
+    assert_eq!(a, first);
+
+    let error =
+        ctx.interrupt::<Approval>("second").await.expect_err("the unsupplied site must suspend");
+    assert!(
+        error.to_string().contains("interrupt-2"),
+        "the next key must be reported so the caller can supply it: {error}"
+    );
+}
+
+#[tokio::test]
+async fn a_wrong_typed_value_is_a_type_mismatch_not_a_suspension() {
+    // `InterruptTypeMismatch` now means what its name says. Previously every interrupt produced
+    // it, so it carried no information.
+    let ctx = context().with_resume_values(HashMap::from([(
+        "interrupt-1".to_string(),
+        serde_json::json!("not an approval object"),
+    )]));
+
+    let error = ctx
+        .interrupt::<Approval>("approve the refund")
+        .await
+        .expect_err("a value of the wrong shape must be rejected");
+
+    let message = error.to_string();
+    assert!(message.contains("type mismatch"), "{message}");
+    assert!(message.contains("interrupt-1"), "the failing site must be identified: {message}");
+}
+
+#[tokio::test]
+async fn suspension_and_type_mismatch_are_distinguishable_variants() {
+    let suspended = context().interrupt::<Approval>("needs input").await.expect_err("must suspend");
+    let mismatched = context()
+        .with_resume_values(HashMap::from([("interrupt-1".to_string(), serde_json::json!(42))]))
+        .interrupt::<Approval>("needs input")
+        .await
+        .expect_err("must reject");
+
+    // A caller deciding whether to prompt a human or fix its payload needs these apart. They are
+    // separate `FunctionalError` variants; `From<FunctionalError> for GraphError` still flattens
+    // to `GraphError::Other(String)`, so at this level they are distinguished by message.
+    let suspended = suspended.to_string();
+    let mismatched = mismatched.to_string();
+
+    assert!(suspended.contains("suspended at interrupt"), "{suspended}");
+    assert!(!suspended.contains("type mismatch"), "{suspended}");
+    assert!(mismatched.contains("type mismatch"), "{mismatched}");
+    assert!(!mismatched.contains("suspended at interrupt"), "{mismatched}");
+
+    // The variants themselves are distinct, which is what a caller matching on
+    // `FunctionalError` sees before the conversion flattens them.
+    let direct = FunctionalError::Suspended {
+        continuation_key: "interrupt-1".to_string(),
+        message: "needs input".to_string(),
+    };
+    assert!(matches!(direct, FunctionalError::Suspended { .. }));
+}

--- a/docs/official_docs/agents/functional-api.md
+++ b/docs/official_docs/agents/functional-api.md
@@ -240,3 +240,40 @@ cargo run --manifest-path examples/cron_scheduling/Cargo.toml
 ---
 
 **Previous**: [← Graph Agents](./graph-agents.md) | **Next**: [Realtime Agents →](./realtime-agents.md)
+
+## Interrupt and typed resume
+
+`TaskContext::interrupt<T>` suspends the workflow and, on a later run, returns the value supplied
+for that site.
+
+Each interrupt site gets a **continuation key** from its position in the run — `interrupt-1`,
+`interrupt-2`, and so on — so a replayed workflow reaches the same interrupts in the same order
+and finds the value it was given.
+
+```rust,ignore
+// First run: no value supplied, so the workflow suspends.
+let error = ctx.interrupt::<Approval>("approve the refund").await.unwrap_err();
+// workflow suspended at interrupt 'interrupt-1': approve the refund
+
+// Second run: supply the value under that key.
+let ctx = ctx.with_resume_values(HashMap::from([
+    ("interrupt-1".to_string(), serde_json::json!({ "approved": true, "approver": "alice" })),
+]));
+let approval: Approval = ctx.interrupt("approve the refund").await?;
+```
+
+The key is also written to the interrupt checkpoint under `continuation_key`.
+
+| Situation | Result |
+|-----------|--------|
+| No value for the key | `FunctionalError::Suspended { continuation_key, message }` |
+| A value that deserializes into `T` | `Ok(value)` |
+| A value that does not deserialize into `T` | `FunctionalError::InterruptTypeMismatch` naming the site |
+
+> **Important:** `interrupt` previously returned `InterruptTypeMismatch` with "workflow
+> interrupted" on **every** call, and nothing outside the method consumed a resume value. A caller
+> could not tell "needs input" from "your value was the wrong type", had no key to supply a value
+> under, and never received a typed value at the call site.
+
+> **Note:** `From<FunctionalError> for GraphError` flattens to `GraphError::Other(String)`, so a
+> caller matching structurally should match on `FunctionalError` before conversion.


### PR DESCRIPTION
## What

Resolves **GR-06**. `TaskContext::interrupt<T>` can now be resumed with a typed value, instead of always returning an error.

## Why

The whole tail of the method:

```rust
// In a real runtime the workflow executor would suspend here and
// later provide the resume value. For now we return an error
// indicating the interrupt was requested — the macro-generated
// wrapper handles actual suspension/resumption.
Err(FunctionalError::InterruptTypeMismatch {
    task: "interrupt".to_string(),
    message: format!("workflow interrupted: {message}"),
}.into())
```

The comment defers to a macro-generated wrapper. There isn't one — nothing outside this method consumed a resume value. So:

- The `-> Result<T>` signature promised a typed value that could never be delivered.
- A caller had to treat an error as control flow, with no key to supply a value under.
- `InterruptTypeMismatch` fired on *every* interrupt, so it carried no information — "needs human approval" and "your JSON was the wrong shape" were the same error.

## How

Each interrupt site takes a **continuation key** from its position in the run — `interrupt-1`, `interrupt-2`, … — so a replayed workflow reaches the same interrupts in the same order and finds the value it was given. This is the same deterministic-replay assumption the functional API already relies on for task memoization, so it is not a new one.

| Situation | Result |
|---|---|
| No value for the key | `FunctionalError::Suspended { continuation_key, message }` (new variant) |
| A value that deserializes into `T` | `Ok(value)` — returned at the call site |
| A value that does not deserialize into `T` | `InterruptTypeMismatch`, naming the site |

The key is reported in the error and written to the checkpoint as `continuation_key`, so a caller learns it from either. `TaskContext::with_resume_values` supplies values by key.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo clippy -p adk-graph --features functional --all-targets` | exit 0 |
| `cargo nextest run --workspace --profile ci` | 3821 passed, 83 skipped, 0 failed |
| `cargo nextest run -p adk-graph --features functional` | 149 → 155 passed |
| `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps` | exit 0 |
| `cargo semver-checks -p adk-graph --release-type minor` | no new breakage (additive variant + method) |
| doc-examples guard | exit 0 |

### Five of six tests fail against the always-error implementation

Removing the resume lookup and restoring the unconditional `InterruptTypeMismatch`:

```
Summary  6 tests run: 1 passed, 5 failed
```

The one that still passes asserts the mismatch case, which the old code produced for every input — it passes for the wrong reason there, and for the right one now.

The end-to-end case the finding asks for is `a_supplied_value_reaches_the_call_site_typed`: it supplies an `Approval` under `interrupt-1` and asserts `interrupt(...)` returns that exact struct. `a_partially_supplied_run_resumes_then_suspends_again` covers the interesting middle — one site resumes, the next reports its own key.

## Honest limits

- **`From<FunctionalError> for GraphError` flattens to `Other(String)`.** `Suspended` and `InterruptTypeMismatch` are distinct variants, but a caller matching structurally must match on `FunctionalError` before conversion. The docs say so, and the test asserts the distinction both structurally (pre-conversion) and by message (post-conversion).
- **Positional keys assume replay determinism.** A workflow that reaches its interrupts in a different order across runs would mismatch. That is already the functional API's model, but it is worth stating rather than leaving implicit.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed — new section in `docs/official_docs/agents/functional-api.md`
- [x] Examples added or updated for new features