### PR TITLE
fix(agent): restore the ambient build broken by two independently-green PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,16 @@ jobs:
           - { package: adk-agent, features: codeact }
           - { package: adk-model, features: openrouter }
           - { package: adk-sandbox, features: wasm }
+          # sandbox-linux is Linux-only *and* feature-gated, so nothing built it until a
+          # container run found the bubblewrap probe could never succeed and that its
+          # property tests did not compile.
+          - { package: adk-sandbox, features: sandbox-linux }
+          # ambient and integration carry the webhook trigger, the ambient loop, and the
+          # realtime integration layer. Two individually-green PRs broke the ambient build
+          # in combination because no job compiled it.
+          - { package: adk-agent, features: ambient }
+          - { package: adk-realtime, features: integration }
+          - { package: adk-managed, features: memory }
           - { package: adk-audio, features: fx }
           - { package: adk-rag, features: lancedb }
     steps:

--- a/adk-agent/tests/ambient_execution_tests.rs
+++ b/adk-agent/tests/ambient_execution_tests.rs
@@ -55,6 +55,8 @@ impl EventSource for BurstSource {
             .map(|index| TriggerEvent {
                 source: "burst".to_string(),
                 payload: serde_json::json!({ "index": index }),
+                // A synthetic burst has no authenticated caller.
+                principal: None,
             })
             .collect();
         Ok(Box::pin(futures::stream::iter(events)))


### PR DESCRIPTION
## What

`main` does not build with `--features ambient`. Fixes that, and adds the four feature combinations that no CI job compiles.

## Why

```
adk-agent/tests/ambient_execution_tests.rs:55:26: error[E0063]:
  missing field `principal` in initializer of `adk_agent::TriggerEvent`
```

#490 added `TriggerEvent::principal`. #498 added a test constructing `TriggerEvent` without it. Both were green alone, git merged them without a conflict, and the combination doesn't compile — the same failure shape as #478.

`cargo clippy --workspace --all-targets` passes, because `ambient` is not a default feature. So even making the existing workspace clippy a required check would not have caught this. The gap is the feature-coverage matrix.

## Added to feature-coverage

| Package | Feature | Why it was missing |
|---|---|---|
| `adk-agent` | `ambient` | This break |
| `adk-sandbox` | `sandbox-linux` | Linux-only **and** feature-gated — the intersection nothing built, which is how a bubblewrap probe that could never succeed survived, plus property tests that never compiled (#501) |
| `adk-realtime` | `integration` | Four PRs touched it this cycle |
| `adk-managed` | `memory` | Two PRs touched it this cycle |

## Verification

| Command | Result |
|---|---|
| `cargo clippy -p adk-agent --features ambient --all-targets -- -D warnings` | exit 0 |
| `cargo nextest run -p adk-agent --features ambient` | 117 passed |
| `cargo clippy -p adk-sandbox --features sandbox-linux` | exit 0 |
| `cargo clippy -p adk-realtime --features integration` | exit 0 |
| `cargo clippy -p adk-managed --features memory` | exit 0 |

## Note

`main` is not branch-protected — `gh api repos/.../branches/main/protection` returns `Branch not protected`. So the "PR tier gates merges" statement in CONTRIBUTING.md and AGENTS.md is not enforced by anything. That is worth fixing separately, and is the reason a post-merge compile gate matters: `ci-merge.yml` already runs on `push: main` but nothing requires it to pass.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes — build repair, no user-facing behaviour change
- [x] README updated if crate capabilities changed
- [x] Examples added or updated for new features