### PR TITLE
fix: require opt-in for MCP tool retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **adk-tool: MCP tool-call replay now requires explicit opt-in.** A transport
+  failure after request transmission can leave a mutating tool's external
+  result uncertain. `ConnectionRefresher` and `McpToolset` no longer replay
+  `tools/call` by default after reconnecting; callers may opt in with
+  `with_tool_call_retries()` for read-only or provider-idempotent operations.
+  Discovery and resource retries retain their existing reconnect behavior.
 - **adk-computer-use: security-relevant MCP responses are bound to the request that produced
   them.** `ControlLease`, `TargetReservation`, and `ExecutionReceipt` were deserialized and
   returned straight into graph state. Typed deserialization proves shape, not provenance, and

--- a/adk-tool/README.md
+++ b/adk-tool/README.md
@@ -301,6 +301,20 @@ The refresher handles these error conditions automatically:
 - Session not found (server restart)
 - Connection reset
 
+Discovery calls reconnect and retry automatically. `tools/call` does not replay
+by default because a lost response can leave a mutating tool's external result
+uncertain. Opt in only for read-only tools or operations protected by a stable
+provider idempotency guarantee:
+
+```rust
+let refresher = ConnectionRefresher::new(client, Arc::new(factory))
+    .with_tool_call_retries();
+
+let toolset = McpToolset::new(client)
+    .with_connection_factory(Arc::new(factory))
+    .with_tool_call_retries();
+```
+
 ### Google Search
 
 ```rust

--- a/adk-tool/src/mcp/reconnect.rs
+++ b/adk-tool/src/mcp/reconnect.rs
@@ -18,6 +18,10 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 use tracing::{debug, info, warn};
 
+/// Replay of `tools/call` is opt-in. Changing this default silently re-enables
+/// duplicate external writes; see #504.
+pub(crate) const DEFAULT_RETRY_TOOL_CALLS: bool = false;
+
 /// Errors that should trigger a connection refresh
 pub fn should_refresh_connection(error: &str) -> bool {
     let error_lower = error.to_lowercase();
@@ -197,7 +201,7 @@ where
             client: Arc::new(Mutex::new(Some(client))),
             factory,
             config: RefreshConfig::default(),
-            retry_tool_calls: false,
+            retry_tool_calls: DEFAULT_RETRY_TOOL_CALLS,
         }
     }
 
@@ -209,7 +213,7 @@ where
             client: Arc::new(Mutex::new(None)),
             factory,
             config: RefreshConfig::default(),
-            retry_tool_calls: false,
+            retry_tool_calls: DEFAULT_RETRY_TOOL_CALLS,
         }
     }
 
@@ -527,6 +531,13 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn tool_call_replay_is_disabled_by_default() {
+        const {
+            assert!(!DEFAULT_RETRY_TOOL_CALLS, "opt-in is the security boundary of #504");
+        }
+    }
 
     #[test]
     fn test_should_refresh_connection() {

--- a/adk-tool/src/mcp/reconnect.rs
+++ b/adk-tool/src/mcp/reconnect.rs
@@ -48,6 +48,19 @@ pub fn should_refresh_connection(error: &str) -> bool {
     false
 }
 
+pub(crate) fn should_retry_mcp_operation(
+    error: &str,
+    attempt: u32,
+    refresh_config: &RefreshConfig,
+    has_connection_factory: bool,
+    replay_allowed: bool,
+) -> bool {
+    replay_allowed
+        && has_connection_factory
+        && attempt < refresh_config.max_attempts
+        && should_refresh_connection(error)
+}
+
 /// Result of an operation with retry information
 #[derive(Debug, Clone)]
 pub struct RetryResult<T> {
@@ -144,9 +157,14 @@ where
 ///
 /// let refresher = ConnectionRefresher::new(initial_client, Arc::new(factory));
 ///
-/// // Operations automatically retry on connection failure
+/// // Read-only discovery automatically retries on connection failure.
 /// let tools = refresher.list_tools().await?;
-/// let result = refresher.call_tool(params).await?;
+///
+/// // Tool calls are not replayed unless the caller explicitly opts in.
+/// let result = refresher
+///     .with_tool_call_retries()
+///     .call_tool(params)
+///     .await?;
 /// ```
 pub struct ConnectionRefresher<S, F>
 where
@@ -159,6 +177,8 @@ where
     factory: Arc<F>,
     /// Configuration for refresh behavior
     config: RefreshConfig,
+    /// Whether ambiguous tool-call outcomes may be replayed after reconnection.
+    retry_tool_calls: bool,
 }
 
 impl<S, F> ConnectionRefresher<S, F>
@@ -177,6 +197,7 @@ where
             client: Arc::new(Mutex::new(Some(client))),
             factory,
             config: RefreshConfig::default(),
+            retry_tool_calls: false,
         }
     }
 
@@ -184,7 +205,12 @@ where
     ///
     /// The first operation will trigger a connection.
     pub fn lazy(factory: Arc<F>) -> Self {
-        Self { client: Arc::new(Mutex::new(None)), factory, config: RefreshConfig::default() }
+        Self {
+            client: Arc::new(Mutex::new(None)),
+            factory,
+            config: RefreshConfig::default(),
+            retry_tool_calls: false,
+        }
     }
 
     /// Set the refresh configuration.
@@ -196,6 +222,24 @@ where
     /// Set the maximum number of reconnection attempts.
     pub fn with_max_attempts(mut self, attempts: u32) -> Self {
         self.config.max_attempts = attempts;
+        self
+    }
+
+    /// Allow `tools/call` to be replayed after reconnecting.
+    ///
+    /// A transport failure after request transmission is an ambiguous outcome:
+    /// a mutating tool may have completed its external effect before the
+    /// response was lost. Enable this only for read-only tools or operations
+    /// protected by a stable provider idempotency guarantee.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let refresher = ConnectionRefresher::new(client, Arc::new(factory))
+    ///     .with_tool_call_retries();
+    /// ```
+    pub fn with_tool_call_retries(mut self) -> Self {
+        self.retry_tool_calls = true;
         self
     }
 
@@ -321,7 +365,11 @@ where
         }
     }
 
-    /// Call a tool on the MCP server with automatic reconnection.
+    /// Call a tool on the MCP server.
+    ///
+    /// Tool calls are not replayed by default after an ambiguous connection
+    /// failure. Use [`Self::with_tool_call_retries`] only when the operation is
+    /// known to be replay-safe.
     pub async fn call_tool(
         &self,
         params: CallToolRequestParams,
@@ -339,6 +387,13 @@ where
                         let error_str = e.to_string();
                         if !should_refresh_connection(&error_str) {
                             return Err(error_str);
+                        }
+                        if !self.retry_tool_calls {
+                            return Err(format!(
+                                "MCP tool call result is uncertain and was not replayed: \
+                                 {error_str}. Enable tool-call retries only for replay-safe \
+                                 operations"
+                            ));
                         }
                         if self.config.log_reconnections {
                             warn!(error = %error_str, tool = %params.name, "call_tool failed, will retry with reconnection");

--- a/adk-tool/src/mcp/toolset.rs
+++ b/adk-tool/src/mcp/toolset.rs
@@ -6,6 +6,7 @@
 // The McpToolset connects to an MCP server, discovers available tools,
 // and exposes them as ADK-compatible tools for use with LlmAgent.
 
+use super::reconnect::should_retry_mcp_operation;
 use super::task::{McpTaskConfig, TaskError, TaskStatus};
 use super::{ConnectionFactory, RefreshConfig, should_refresh_connection};
 use adk_core::{AdkError, ReadonlyContext, Result, Tool, ToolContext, Toolset};
@@ -109,15 +110,20 @@ fn call_tool_result_to_adk_value(
 /// Type alias for tool filter predicate
 pub type ToolFilter = Arc<dyn Fn(&str) -> bool + Send + Sync>;
 
-fn should_retry_mcp_operation(
+fn mcp_tool_call_error(
+    tool_name: &str,
     error: &str,
-    attempt: u32,
-    refresh_config: &RefreshConfig,
     has_connection_factory: bool,
-) -> bool {
-    has_connection_factory
-        && attempt < refresh_config.max_attempts
-        && should_refresh_connection(error)
+    replay_allowed: bool,
+) -> AdkError {
+    if has_connection_factory && !replay_allowed && should_refresh_connection(error) {
+        AdkError::tool(format!(
+            "MCP tool '{tool_name}' result is uncertain and was not replayed: {error}. \
+             Enable tool-call retries only for replay-safe operations"
+        ))
+    } else {
+        AdkError::tool(format!("Failed to call MCP tool '{tool_name}': {error}"))
+    }
 }
 
 /// Returns `true` when the `ServiceError` wraps an MCP `MethodNotFound` (-32601)
@@ -179,6 +185,8 @@ where
     connection_factory: Option<DynConnectionFactory<S>>,
     /// Reconnection/retry configuration.
     refresh_config: RefreshConfig,
+    /// Whether ambiguous tool-call outcomes may be replayed after reconnection.
+    retry_tool_calls: bool,
     /// Resource subscriptions restored after an automatic connection refresh.
     resource_subscriptions: Arc<RwLock<BTreeSet<String>>>,
 }
@@ -195,6 +203,7 @@ where
             task_config: self.task_config.clone(),
             connection_factory: self.connection_factory.clone(),
             refresh_config: self.refresh_config.clone(),
+            retry_tool_calls: self.retry_tool_calls,
             resource_subscriptions: Arc::clone(&self.resource_subscriptions),
         }
     }
@@ -229,6 +238,7 @@ where
             task_config: McpTaskConfig::default(),
             connection_factory: None,
             refresh_config: RefreshConfig::default(),
+            retry_tool_calls: false,
             resource_subscriptions: Arc::new(RwLock::new(BTreeSet::new())),
         }
     }
@@ -287,6 +297,26 @@ where
     /// Configure MCP reconnect/retry behavior.
     pub fn with_refresh_config(mut self, config: RefreshConfig) -> Self {
         self.refresh_config = config;
+        self
+    }
+
+    /// Allow MCP tool calls to be replayed after reconnecting.
+    ///
+    /// A transport failure after request transmission is an ambiguous outcome:
+    /// a mutating tool may have completed its external effect before the
+    /// response was lost. Enable this only for read-only tools or operations
+    /// protected by a stable provider idempotency guarantee. Discovery and
+    /// resource operations keep their normal reconnect behavior without this.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let toolset = McpToolset::new(client)
+    ///     .with_connection_factory(Arc::new(factory))
+    ///     .with_tool_call_retries();
+    /// ```
+    pub fn with_tool_call_retries(mut self) -> Self {
+        self.retry_tool_calls = true;
         self
     }
 
@@ -386,6 +416,7 @@ where
                         attempt,
                         &self.refresh_config,
                         self.connection_factory.is_some(),
+                        self.retry_tool_calls,
                     ) =>
                 {
                     if self.refresh_config.retry_delay_ms > 0 {
@@ -395,16 +426,22 @@ where
                         .await;
                     }
                     if !self.try_refresh_connection().await? {
-                        return Err(AdkError::tool(format!(
-                            "Failed to call MCP tool '{name}': {error}"
-                        )));
+                        return Err(mcp_tool_call_error(
+                            name,
+                            &error,
+                            self.connection_factory.is_some(),
+                            self.retry_tool_calls,
+                        ));
                     }
                     attempt += 1;
                 }
                 Err(error) => {
-                    return Err(AdkError::tool(format!(
-                        "Failed to call MCP tool '{name}': {error}"
-                    )));
+                    return Err(mcp_tool_call_error(
+                        name,
+                        &error,
+                        self.connection_factory.is_some(),
+                        self.retry_tool_calls,
+                    ));
                 }
             }
         };
@@ -631,6 +668,7 @@ where
                         attempt,
                         &self.refresh_config,
                         has_connection_factory,
+                        true,
                     ) {
                         return Err(AdkError::tool(format!("Failed to list MCP tools: {error}")));
                     }
@@ -697,6 +735,7 @@ where
                 client: self.client.clone(),
                 connection_factory: self.connection_factory.clone(),
                 refresh_config: self.refresh_config.clone(),
+                retry_tool_calls: self.retry_tool_calls,
                 task_support,
                 server_supports_tasks,
                 task_config: self.task_config.clone(),
@@ -886,6 +925,7 @@ where
     client: Arc<Mutex<RunningService<RoleClient, S>>>,
     connection_factory: Option<DynConnectionFactory<S>>,
     refresh_config: RefreshConfig,
+    retry_tool_calls: bool,
     /// Per-tool task contract published by the MCP server.
     task_support: TaskSupport,
     /// Whether the negotiated server capabilities permit task-augmented tool calls.
@@ -936,11 +976,14 @@ where
                         attempt,
                         &self.refresh_config,
                         has_connection_factory,
+                        self.retry_tool_calls,
                     ) {
-                        return Err(AdkError::tool(format!(
-                            "Failed to call MCP tool '{}': {error}",
-                            self.name
-                        )));
+                        return Err(mcp_tool_call_error(
+                            &self.name,
+                            &error,
+                            has_connection_factory,
+                            self.retry_tool_calls,
+                        ));
                     }
 
                     let retry_attempt = attempt + 1;
@@ -962,10 +1005,12 @@ where
                     }
 
                     if !self.try_refresh_connection().await? {
-                        return Err(AdkError::tool(format!(
-                            "Failed to call MCP tool '{}': {error}",
-                            self.name
-                        )));
+                        return Err(mcp_tool_call_error(
+                            &self.name,
+                            &error,
+                            has_connection_factory,
+                            self.retry_tool_calls,
+                        ));
                     }
                     attempt += 1;
                 }
@@ -1239,26 +1284,40 @@ mod tests {
     #[test]
     fn test_should_retry_mcp_operation_reconnectable_errors() {
         let config = RefreshConfig::default().with_max_attempts(3);
-        assert!(should_retry_mcp_operation("EOF", 0, &config, true));
-        assert!(should_retry_mcp_operation("connection reset by peer", 1, &config, true));
+        assert!(should_retry_mcp_operation("EOF", 0, &config, true, true));
+        assert!(should_retry_mcp_operation("connection reset by peer", 1, &config, true, true));
     }
 
     #[test]
     fn test_should_retry_mcp_operation_stops_at_max_attempts() {
         let config = RefreshConfig::default().with_max_attempts(2);
-        assert!(!should_retry_mcp_operation("EOF", 2, &config, true));
+        assert!(!should_retry_mcp_operation("EOF", 2, &config, true, true));
     }
 
     #[test]
     fn test_should_retry_mcp_operation_requires_factory() {
         let config = RefreshConfig::default().with_max_attempts(3);
-        assert!(!should_retry_mcp_operation("EOF", 0, &config, false));
+        assert!(!should_retry_mcp_operation("EOF", 0, &config, false, true));
     }
 
     #[test]
     fn test_should_retry_mcp_operation_non_reconnectable_error() {
         let config = RefreshConfig::default().with_max_attempts(3);
-        assert!(!should_retry_mcp_operation("invalid arguments for tool", 0, &config, true));
+        assert!(!should_retry_mcp_operation("invalid arguments for tool", 0, &config, true, true));
+    }
+
+    #[test]
+    fn test_should_retry_mcp_operation_requires_explicit_replay() {
+        let config = RefreshConfig::default().with_max_attempts(3);
+        assert!(!should_retry_mcp_operation("EOF", 0, &config, true, false));
+    }
+
+    #[test]
+    fn test_ambiguous_tool_call_error_explains_no_replay() {
+        let error = mcp_tool_call_error("create_record", "EOF", true, false);
+        let message = error.to_string();
+        assert!(message.contains("result is uncertain and was not replayed"));
+        assert!(message.contains("replay-safe operations"));
     }
 
     #[test]

--- a/adk-tool/src/mcp/toolset.rs
+++ b/adk-tool/src/mcp/toolset.rs
@@ -6,7 +6,7 @@
 // The McpToolset connects to an MCP server, discovers available tools,
 // and exposes them as ADK-compatible tools for use with LlmAgent.
 
-use super::reconnect::should_retry_mcp_operation;
+use super::reconnect::{DEFAULT_RETRY_TOOL_CALLS, should_retry_mcp_operation};
 use super::task::{McpTaskConfig, TaskError, TaskStatus};
 use super::{ConnectionFactory, RefreshConfig, should_refresh_connection};
 use adk_core::{AdkError, ReadonlyContext, Result, Tool, ToolContext, Toolset};
@@ -238,7 +238,7 @@ where
             task_config: McpTaskConfig::default(),
             connection_factory: None,
             refresh_config: RefreshConfig::default(),
-            retry_tool_calls: false,
+            retry_tool_calls: DEFAULT_RETRY_TOOL_CALLS,
             resource_subscriptions: Arc::new(RwLock::new(BTreeSet::new())),
         }
     }


### PR DESCRIPTION
## What

Require explicit opt-in before replaying MCP `tools/call` after reconnection. Discovery and resource operations keep their existing retry behavior.

## Why

A lost response does not prove a mutation failed. Automatic replay can duplicate an external write.

Fixes #504.

## Changes

- Tool-call replay defaults to off without changing public `RefreshConfig`
- `with_tool_call_retries()` enables replay for known-safe calls
- Uncertain results return an actionable error
- Rustdoc, README, changelog, and regression tests document the boundary

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p adk-tool --features mcp --lib mcp`: 87 passed
- `cargo clippy -p adk-tool --features mcp --all-targets -- -D warnings`

Workspace-wide gates are left to CI.

## PR Checklist

### Quality Gates (all required)

- [x] Code is formatted (Edition 2024)
- [ ] Workspace clippy: CI pending; affected crate passes
- [ ] Workspace tests: CI pending; 87 affected tests pass
- [ ] Workspace check: CI pending

### Code Quality

- [x] New code has tests
- [x] Public APIs have rustdoc examples
- [x] No `println!`/`eprintln!` in library code
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts
- [x] No unrelated changes
- [x] Branch name follows convention
- [x] Commits follow conventional format
- [x] PR targets `main`

### Documentation

- [x] Changelog updated
- [x] README updated
- [x] Rustdoc and README examples added