### PR TITLE
fix(server): authenticate A2A JSON-RPC and bind loopback by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **adk-server: A2A JSON-RPC routes now sit behind the configured authentication layer.**
+  `/a2a` and `/a2a/stream` were merged at the router root, outside the layer applied to `/api`,
+  in both `create_app_with_a2a` and `ServerBuilder::build`. A deployment that authenticated every
+  other mutation surface still allowed any client that could reach the port to drive the agent,
+  call its tools, and incur the cost. Discovery (`/.well-known/agent.json`) stays public, since
+  peers fetch the card before they hold a credential, and with no extractor configured the routes
+  remain open so existing deployments are unaffected.
+- **adk-server: `A2aServer` binds loopback by default.** The builder defaulted to
+  `0.0.0.0:8080`, publishing an agent-executing server to every interface on `build()`. It now
+  defaults to `127.0.0.1:8080`; `bind_addr` opts into a wider bind. The generated `a2a-server`
+  scaffold does the same and reads `BIND_HOST`.
+- **adk-server: `--features a2a-v1` and `--all-features` compile again.** Two test initializers
+  for `RemoteA2aV1Config` omitted the `streaming` field, so both configurations failed to build —
+  which also meant the A2A v1 surface had no executing test coverage.
+
 - **adk-computer-use: security-relevant MCP responses are bound to the request that produced
   them.** `ControlLease`, `TargetReservation`, and `ExecutionReceipt` were deserialized and
   returned straight into graph state. Typed deserialization proves shape, not provenance, and

--- a/adk-server/src/a2a/convenience.rs
+++ b/adk-server/src/a2a/convenience.rs
@@ -116,7 +116,7 @@ impl A2aServer {
 /// # Defaults
 ///
 /// - Session service: [`InMemorySessionService`]
-/// - Bind address: `0.0.0.0:8080`
+/// - Bind address: `127.0.0.1:8080` (loopback; call `bind_addr` to expose it)
 /// - Agent card name: from `agent.name()`
 /// - Agent card description: from `agent.description()`
 /// - Agent card version: `"1.0.0"`
@@ -140,7 +140,10 @@ impl Default for A2aServerBuilder {
         Self {
             agent: None,
             session_service: None,
-            bind_addr: "0.0.0.0:8080".to_string(),
+            // Loopback, not every interface. An A2A server executes agent and tool work, so
+            // exposing it beyond this host is a decision the operator should make explicitly
+            // — the previous default published it to the network on `build()`.
+            bind_addr: "127.0.0.1:8080".to_string(),
             agent_card_name: None,
             agent_card_description: None,
             agent_card_version: None,
@@ -446,7 +449,9 @@ mod tests {
     #[test]
     fn test_builder_defaults() {
         let builder = A2aServer::builder();
-        assert_eq!(builder.bind_addr, "0.0.0.0:8080");
+        // Loopback, deliberately. An A2A server runs agent and tool work, so publishing it
+        // to every interface is an explicit `bind_addr` call, not a default.
+        assert_eq!(builder.bind_addr, "127.0.0.1:8080");
         assert!(builder.streaming_enabled);
         assert!(!builder.push_notifications_enabled);
         assert!(builder.agent.is_none());
@@ -482,7 +487,7 @@ mod tests {
         let result = A2aServer::builder().agent(agent).build();
         assert!(result.is_ok());
         let app = result.unwrap();
-        assert_eq!(app.bind_addr(), "0.0.0.0:8080");
+        assert_eq!(app.bind_addr(), "127.0.0.1:8080", "the default must stay on loopback");
     }
 
     #[test]

--- a/adk-server/src/a2a/remote_agent.rs
+++ b/adk-server/src/a2a/remote_agent.rs
@@ -917,6 +917,8 @@ pub mod v1_remote {
                 name: "my-agent".to_string(),
                 description: "My remote agent".to_string(),
                 agent_card: card,
+                // The wire default: let the card decide rather than forcing a mode.
+                streaming: None,
             });
             assert_eq!(agent.name(), "my-agent");
             assert_eq!(agent.description(), "My remote agent");
@@ -929,6 +931,8 @@ pub mod v1_remote {
                 name: "test".to_string(),
                 description: "test".to_string(),
                 agent_card: card,
+                // The wire default: let the card decide rather than forcing a mode.
+                streaming: None,
             });
             assert!(agent.sub_agents().is_empty());
         }

--- a/adk-server/src/rest/mod.rs
+++ b/adk-server/src/rest/mod.rs
@@ -445,12 +445,20 @@ pub fn create_app_with_a2a(config: ServerConfig, a2a_base_url: Option<&str>) -> 
 
     if let Some(base_url) = a2a_base_url {
         let a2a_controller = A2aController::new(config.clone(), base_url);
-        let a2a_router = Router::new()
+        // Discovery stays public — an agent card is meant to be fetched by unknown peers.
+        // The JSON-RPC routes execute agent and tool work, so they carry the same
+        // authentication as every other mutation surface. They were previously merged at the
+        // root, outside the layer applied to `/api`, so anyone who could reach the port could
+        // drive the agent and incur its costs.
+        let a2a_discovery = Router::new()
             .route("/.well-known/agent.json", get(controllers::a2a::get_agent_card))
+            .with_state(a2a_controller.clone());
+        let a2a_rpc = Router::new()
             .route("/a2a", post(controllers::a2a::handle_jsonrpc))
             .route("/a2a/stream", post(controllers::a2a::handle_jsonrpc_stream))
-            .with_state(a2a_controller);
-        app = app.merge(a2a_router);
+            .with_state(a2a_controller)
+            .layer(auth_layer.clone());
+        app = app.merge(a2a_discovery).merge(a2a_rpc);
     }
 
     let cors_layer = build_cors_layer(&config);
@@ -762,7 +770,7 @@ impl ServerBuilder {
             let shutdown_router = Router::new()
                 .route("/shutdown", post(handle_shutdown))
                 .with_state(handle.token.clone())
-                .layer(auth_layer);
+                .layer(auth_layer.clone());
             api_router = api_router.merge(shutdown_router);
             Some(handle)
         } else {
@@ -785,12 +793,16 @@ impl ServerBuilder {
 
         if let Some(base_url) = &self.a2a_base_url {
             let a2a_controller = A2aController::new(config.clone(), base_url);
-            let a2a_router = Router::new()
+            // Same split as `create_app_with_a2a`: discovery is public, RPC is authenticated.
+            let a2a_discovery = Router::new()
                 .route("/.well-known/agent.json", get(controllers::a2a::get_agent_card))
+                .with_state(a2a_controller.clone());
+            let a2a_rpc = Router::new()
                 .route("/a2a", post(controllers::a2a::handle_jsonrpc))
                 .route("/a2a/stream", post(controllers::a2a::handle_jsonrpc_stream))
-                .with_state(a2a_controller);
-            app = app.merge(a2a_router);
+                .with_state(a2a_controller)
+                .layer(auth_layer.clone());
+            app = app.merge(a2a_discovery).merge(a2a_rpc);
         }
 
         let cors_layer = build_cors_layer(config);

--- a/adk-server/tests/a2a_auth_boundary_tests.rs
+++ b/adk-server/tests/a2a_auth_boundary_tests.rs
@@ -1,0 +1,194 @@
+//! A2A JSON-RPC must sit behind the configured authentication layer.
+//!
+//! The A2A routes were merged at the router root, outside the layer applied to `/api`, in both
+//! `create_app_with_a2a` and `ServerBuilder::build`. With an extractor configured, every other
+//! mutation surface required a credential and `/a2a` did not — so any client that could reach
+//! the port could drive the agent, call its tools, and incur the cost.
+//!
+//! Discovery is deliberately still public: an agent card exists to be fetched by peers that
+//! have no credential yet.
+
+use adk_core::{Agent, Event, EventStream, InvocationContext, Result};
+use adk_server::auth_bridge::{RequestContextError, RequestContextExtractor};
+use adk_server::{ServerConfig, create_app_with_a2a};
+use async_trait::async_trait;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use std::sync::Arc;
+use tower::ServiceExt;
+
+/// A leaf agent; these tests never reach execution.
+#[derive(Debug)]
+struct TestAgent;
+
+#[async_trait]
+impl Agent for TestAgent {
+    fn name(&self) -> &str {
+        "test_agent"
+    }
+    fn description(&self) -> &str {
+        "agent under an auth boundary"
+    }
+    fn sub_agents(&self) -> &[Arc<dyn Agent>] {
+        &[]
+    }
+    async fn run(&self, _ctx: Arc<dyn InvocationContext>) -> Result<EventStream> {
+        Ok(Box::pin(futures::stream::empty::<Result<Event>>()))
+    }
+}
+
+struct TestAgentLoader {
+    agent: Arc<dyn Agent>,
+}
+
+#[async_trait]
+impl adk_core::AgentLoader for TestAgentLoader {
+    fn root_agent(&self) -> Arc<dyn Agent> {
+        Arc::clone(&self.agent)
+    }
+    async fn load_agent(&self, name: &str) -> Result<Arc<dyn Agent>> {
+        if name == self.agent.name() {
+            Ok(Arc::clone(&self.agent))
+        } else {
+            Err(adk_core::AdkError::agent(format!("Agent not found: {name}")))
+        }
+    }
+    fn list_agents(&self) -> Vec<String> {
+        vec![self.agent.name().to_string()]
+    }
+}
+
+/// Rejects everything, standing in for any real extractor.
+#[derive(Debug)]
+struct DenyAllExtractor;
+
+#[async_trait]
+impl RequestContextExtractor for DenyAllExtractor {
+    async fn extract(
+        &self,
+        _parts: &axum::http::request::Parts,
+    ) -> std::result::Result<adk_core::RequestContext, RequestContextError> {
+        Err(RequestContextError::MissingAuth)
+    }
+}
+
+/// A server config with authentication configured.
+fn authenticated_config() -> ServerConfig {
+    let loader = Arc::new(TestAgentLoader { agent: Arc::new(TestAgent) });
+    let sessions = Arc::new(adk_session::InMemorySessionService::new());
+    ServerConfig::new(loader, sessions)
+        .with_request_context(Arc::new(DenyAllExtractor) as Arc<dyn RequestContextExtractor>)
+}
+
+/// A JSON-RPC body valid enough to reach the handler if auth let it through.
+fn rpc_body() -> Body {
+    Body::from(
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "message/send",
+            "params": { "message": { "role": "user", "parts": [{ "kind": "text", "text": "hi" }] } }
+        })
+        .to_string(),
+    )
+}
+
+#[tokio::test]
+async fn a2a_jsonrpc_requires_authentication() {
+    let app = create_app_with_a2a(authenticated_config(), Some("http://localhost:8080"));
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/a2a")
+        .header("content-type", "application/json")
+        .body(rpc_body())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::UNAUTHORIZED,
+        "an unauthenticated caller must not be able to drive the agent through /a2a"
+    );
+}
+
+#[tokio::test]
+async fn a2a_streaming_requires_authentication() {
+    let app = create_app_with_a2a(authenticated_config(), Some("http://localhost:8080"));
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/a2a/stream")
+        .header("content-type", "application/json")
+        .body(rpc_body())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::UNAUTHORIZED,
+        "the streaming route executes the same work and needs the same gate"
+    );
+}
+
+#[tokio::test]
+async fn the_agent_card_stays_public() {
+    // Discovery must not require a credential: peers fetch it before they have one.
+    let app = create_app_with_a2a(authenticated_config(), Some("http://localhost:8080"));
+
+    let request = Request::builder()
+        .method("GET")
+        .uri("/.well-known/agent.json")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "gating discovery would break A2A peer discovery"
+    );
+}
+
+#[tokio::test]
+async fn a2a_is_reachable_when_no_extractor_is_configured() {
+    // Without an extractor there is no authentication to apply, and the layer must not
+    // block traffic — otherwise adding the gate breaks every existing deployment.
+    let loader = Arc::new(TestAgentLoader { agent: Arc::new(TestAgent) });
+    let sessions = Arc::new(adk_session::InMemorySessionService::new());
+    let app =
+        create_app_with_a2a(ServerConfig::new(loader, sessions), Some("http://localhost:8080"));
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/a2a")
+        .header("content-type", "application/json")
+        .body(rpc_body())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_ne!(
+        response.status(),
+        StatusCode::UNAUTHORIZED,
+        "no extractor means no credential to demand"
+    );
+}
+
+// `A2aServer` is exported only with `a2a-v1`.
+#[cfg(feature = "a2a-v1")]
+#[tokio::test]
+async fn the_default_bind_address_is_loopback() {
+    // A server that runs agent work should not publish itself to every interface on build().
+    let agent: Arc<dyn Agent> = Arc::new(TestAgent);
+    let app = adk_server::A2aServer::builder().agent(agent).build().expect("build");
+
+    assert!(
+        app.bind_addr().starts_with("127.0.0.1"),
+        "default bind must be loopback, got {}",
+        app.bind_addr()
+    );
+}

--- a/cargo-adk/src/main.rs
+++ b/cargo-adk/src/main.rs
@@ -2390,7 +2390,11 @@ async fn main() -> anyhow::Result<()> {{
     let app = create_app(config);
 
     let port = std::env::var("PORT").unwrap_or_else(|_| "8080".to_string());
-    let addr = format!("0.0.0.0:{{}}", port);
+    // Loopback by default. Set BIND_HOST=0.0.0.0 to expose this agent, and configure
+    // authentication before you do: the A2A JSON-RPC routes run agent and tool work — and
+    // incur its cost — on behalf of whoever calls them.
+    let host = std::env::var("BIND_HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
+    let addr = format!("{{host}}:{{port}}");
     println!("ADK agent server running on http://{{addr}}");
     println!("  POST /chat          — send messages");
     println!("  GET  /health        — health check");
@@ -2474,7 +2478,11 @@ async fn main() -> anyhow::Result<()> {{
     );
 {yaml_commented_code}
     let port = std::env::var("PORT").unwrap_or_else(|_| "8080".to_string());
-    let addr = format!("0.0.0.0:{{}}", port);
+    // Loopback by default. Set BIND_HOST=0.0.0.0 to expose this agent, and configure
+    // authentication before you do: the A2A JSON-RPC routes run agent and tool work — and
+    // incur its cost — on behalf of whoever calls them.
+    let host = std::env::var("BIND_HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
+    let addr = format!("{{host}}:{{port}}");
 
     let server = A2aServer::builder()
         .agent(agent)

--- a/docs/official_docs/security/access-control.md
+++ b/docs/official_docs/security/access-control.md
@@ -511,3 +511,24 @@ match provider.validate(token).await {
 ---
 
 **Previous**: [← Evaluation](../evaluation/evaluation.md) | **Next**: [Tool Authorization →](tool-authorization.md)
+
+## A2A endpoints
+
+| Route | Authentication |
+|-------|----------------|
+| `GET /.well-known/agent.json` | **public** — peers fetch the card before they hold a credential |
+| `POST /a2a` | required, when a `RequestContextExtractor` is configured |
+| `POST /a2a/stream` | required, when a `RequestContextExtractor` is configured |
+
+The JSON-RPC routes execute agent and tool work, so they carry the same layer as the session,
+artifact, and debug routers. With no extractor configured there is no credential to demand and
+the routes stay open, so adding the gate does not break an existing deployment.
+
+> **Important:** these routes were previously merged at the router root, outside the layer
+> applied to `/api`. A deployment that authenticated every other mutation surface still let any
+> client that could reach the port drive the agent and incur its cost. This applied to both
+> `create_app_with_a2a` and `ServerBuilder::build`.
+
+`A2aServer::builder()` binds `127.0.0.1:8080` by default. Call `bind_addr` to expose it, and
+configure an extractor before you do. The generated `a2a-server` scaffold follows the same rule
+and reads `BIND_HOST` to opt into a wider bind.


### PR DESCRIPTION
Resolves the **Critical** finding that generated A2A servers are publicly reachable without authentication.

## Three defects

**1. A2A routes sat outside the auth layer.** In `ServerBuilder::build` the layer is attached through line 765; the A2A router was merged at 786 with none. `create_app_with_a2a` had the identical shape. A deployment that authenticated sessions, artifacts, debug, and shutdown still let an anonymous caller drive the agent and incur its cost.

**2. `A2aServer::builder()` defaulted to `0.0.0.0:8080`** — `build()` published an agent-executing server to every interface.

**3. `--features a2a-v1` and `--all-features` did not compile** — two `RemoteA2aV1Config` initializers omitted `streaming`, which also meant the A2A v1 surface had no executing test coverage.

## Approach

| Route | Auth |
|---|---|
| `GET /.well-known/agent.json` | public — peers fetch the card before holding a credential |
| `POST /a2a`, `POST /a2a/stream` | required when an extractor is configured |

With no extractor there is no credential to demand, so the routes stay open and existing deployments are unaffected. Bind default is now loopback; `bind_addr` opts out. Both `cargo-adk` scaffold templates bind loopback and read `BIND_HOST`.

## Verification

| Gate | Result |
|---|---|
| `cargo nextest run -p adk-server --all-features` | **476 passed** |
| `cargo nextest run -p adk-server --features a2a-v1` | **351 passed** |
| `cargo check -p adk-server --features a2a-v1 --all-targets` | 0 errors (was failing) |
| `cargo clippy -p adk-server -p cargo-adk --all-targets -- -D warnings` | exit 0 |

Three of five new tests fail against the old routing. Two existing tests asserted `0.0.0.0:8080` and were updated to state the new intent rather than deleted.