### PR TITLE
fix(awp): stop disclosing subscription HMAC secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **adk-awp: subscription HMAC secrets no longer leave the process.** `EventSubscription`
+  serialized `secret` as a plain field and `GET /awp/events/subscriptions` returned
+  `Json(subs)`, so listing subscriptions disclosed every subscriber's signing key — on an
+  endpoint with no authentication, meaning anyone who could reach it could collect the keys and
+  forge signed webhook deliveries. The field is now `skip_serializing`, and a hand-written
+  `Debug` redacts it so capturing a subscription in a `tracing` call cannot write a live
+  credential to the logs. The secret remains available in-process for signing.
+- **adk-awp: management routes are separated from the public ones.** `awp_routes` mounted
+  discovery, manifest, health, A2A, and subscription CRUD as one unauthenticated router. The new
+  `awp_public_routes` and `awp_management_routes` let an auth layer be applied to the half that
+  creates, enumerates, and deletes webhook destinations. `awp_routes` still returns everything
+  for local development, and its rustdoc says why that is not a production shape.
+
 - **adk-computer-use: security-relevant MCP responses are bound to the request that produced
   them.** `ControlLease`, `TargetReservation`, and `ExecutionReceipt` were deserialized and
   returned straight into graph state. Typed deserialization proves shape, not provenance, and

--- a/adk-awp/src/events.rs
+++ b/adk-awp/src/events.rs
@@ -26,7 +26,12 @@ pub struct AwpEvent {
 }
 
 /// A webhook subscription for AWP events.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// The HMAC secret never leaves this process: it is skipped on serialization and redacted in
+/// `Debug`. Listing subscriptions previously returned every subscriber's signing secret in the
+/// response body, which let anyone who could read the list forge signed deliveries to that
+/// endpoint.
+#[derive(Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EventSubscription {
     /// Unique subscription identifier.
@@ -38,7 +43,27 @@ pub struct EventSubscription {
     /// Event types this subscription listens for.
     pub event_types: Vec<String>,
     /// Shared secret for HMAC-SHA256 signing.
+    ///
+    /// Skipped on serialization so it cannot reach an HTTP response. Deserialization still
+    /// accepts it, defaulting to empty, so a stored subscription can be loaded.
+    #[serde(skip_serializing, default)]
     pub secret: String,
+}
+
+impl std::fmt::Debug for EventSubscription {
+    /// Redacts the signing secret.
+    ///
+    /// The derived implementation printed it, so any `tracing` call that captured a
+    /// subscription would have written a live credential to the logs.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EventSubscription")
+            .field("id", &self.id)
+            .field("subscriber", &self.subscriber)
+            .field("callback_url", &self.callback_url)
+            .field("event_types", &self.event_types)
+            .field("secret", &"<redacted>")
+            .finish()
+    }
 }
 
 /// Trait for managing event subscriptions and delivering events.

--- a/adk-awp/src/lib.rs
+++ b/adk-awp/src/lib.rs
@@ -55,6 +55,6 @@ pub use health::{HealthState, HealthStateMachine, HealthStateSnapshot};
 pub use loader::BusinessContextLoader;
 pub use manifest::build_manifest;
 pub use rate_limit::{InMemoryRateLimiter, RateLimitConfig, RateLimiter};
-pub use router::awp_routes;
+pub use router::{awp_management_routes, awp_public_routes, awp_routes};
 pub use state::{AwpState, AwpStateBuilder};
 pub use trust::{DefaultTrustAssigner, TrustLevelAssigner};

--- a/adk-awp/src/router.rs
+++ b/adk-awp/src/router.rs
@@ -8,27 +8,64 @@ use crate::handlers;
 use crate::middleware::version_negotiation;
 use crate::state::AwpState;
 
-/// Build an Axum [`Router`] with all AWP protocol endpoints.
+/// Build an Axum [`Router`] with the publicly reachable AWP endpoints.
 ///
-/// Registers the following routes:
 /// - `GET  /.well-known/awp.json` — discovery document
 /// - `GET  /awp/manifest` — capability manifest
 /// - `GET  /awp/health` — health state
-/// - `POST /awp/events/subscribe` — create event subscription
-/// - `GET  /awp/events/subscriptions` — list subscriptions
-/// - `DELETE /awp/events/subscriptions/{id}` — delete subscription
 /// - `POST /awp/a2a` — A2A message handler
 ///
-/// Version negotiation middleware is applied to all routes.
-pub fn awp_routes(state: AwpState) -> Router {
+/// These are safe to expose: discovery, manifest, and health are read-only descriptions of the
+/// service, and agents fetch them before they hold any credential.
+///
+/// Subscription management is **not** included — see [`awp_management_routes`].
+pub fn awp_public_routes(state: AwpState) -> Router {
     Router::new()
         .route("/.well-known/awp.json", get(handlers::discovery))
         .route("/awp/manifest", get(handlers::manifest))
         .route("/awp/health", get(handlers::health))
-        .route("/awp/events/subscribe", post(handlers::subscribe))
-        .route("/awp/events/subscriptions", get(handlers::list_subscriptions))
-        .route("/awp/events/subscriptions/{id}", delete(handlers::delete_subscription))
         .route("/awp/a2a", post(handlers::a2a_message))
         .layer(from_fn(version_negotiation))
         .with_state(state)
+}
+
+/// Build an Axum [`Router`] with the AWP subscription-management endpoints.
+///
+/// - `POST   /awp/events/subscribe` — create event subscription
+/// - `GET    /awp/events/subscriptions` — list subscriptions
+/// - `DELETE /awp/events/subscriptions/{id}` — delete subscription
+///
+/// # Authentication
+///
+/// These routes are returned **without any authentication layer**, because this crate has no
+/// authentication model of its own. Apply one before serving them:
+///
+/// ```rust,ignore
+/// let app = Router::new()
+///     .merge(awp_public_routes(state.clone()))
+///     .merge(awp_management_routes(state).layer(your_auth_layer));
+/// ```
+///
+/// They create, enumerate, and delete webhook destinations for this service. An unauthenticated
+/// caller could point deliveries at a host of their choosing or remove a legitimate
+/// subscriber's, which is why they are separated from the public set rather than mounted
+/// alongside it.
+pub fn awp_management_routes(state: AwpState) -> Router {
+    Router::new()
+        .route("/awp/events/subscribe", post(handlers::subscribe))
+        .route("/awp/events/subscriptions", get(handlers::list_subscriptions))
+        .route("/awp/events/subscriptions/{id}", delete(handlers::delete_subscription))
+        .layer(from_fn(version_negotiation))
+        .with_state(state)
+}
+
+/// Build an Axum [`Router`] with every AWP endpoint, management included.
+///
+/// # Authentication
+///
+/// The management routes carry no authentication. Prefer composing
+/// [`awp_public_routes`] with [`awp_management_routes`] so an auth layer can be applied to the
+/// half that needs it; this function exists for local development and tests.
+pub fn awp_routes(state: AwpState) -> Router {
+    Router::new().merge(awp_public_routes(state.clone())).merge(awp_management_routes(state))
 }

--- a/adk-awp/tests/subscription_secret_tests.rs
+++ b/adk-awp/tests/subscription_secret_tests.rs
@@ -1,0 +1,88 @@
+//! A subscription's HMAC secret must never leave this process.
+//!
+//! `EventSubscription` derived `Serialize` with a plain `pub secret: String`, and
+//! `list_subscriptions` returned `Json(subs)`. Listing therefore handed every subscriber's
+//! signing secret to the caller — and the endpoint carried no authentication, so anyone who
+//! could reach it could collect the secrets and forge signed deliveries. The derived `Debug`
+//! printed the secret too, so any `tracing` call capturing a subscription wrote a live
+//! credential to the logs.
+
+use adk_awp::{EventSubscription, InMemoryEventSubscriptionService};
+use uuid::Uuid;
+
+fn subscription() -> EventSubscription {
+    EventSubscription {
+        id: Uuid::now_v7(),
+        subscriber: "partner".to_string(),
+        callback_url: "https://partner.test/hook".to_string(),
+        event_types: vec!["order.created".to_string()],
+        secret: "super-secret-hmac-key".to_string(),
+    }
+}
+
+#[test]
+fn serializing_a_subscription_omits_the_secret() {
+    let json = serde_json::to_string(&subscription()).expect("serialize");
+
+    assert!(
+        !json.contains("super-secret-hmac-key"),
+        "the signing secret reached a serialized payload: {json}"
+    );
+    assert!(json.contains("partner"), "the rest of the record must still serialize: {json}");
+    assert!(json.contains("https://partner.test/hook"));
+}
+
+#[test]
+fn the_list_response_shape_contains_no_secret() {
+    // This is the exact value `list_subscriptions` serializes.
+    let subs = vec![subscription(), subscription()];
+    let json = serde_json::to_string(&subs).expect("serialize");
+
+    assert!(
+        !json.contains("super-secret-hmac-key"),
+        "listing subscriptions must not disclose signing secrets: {json}"
+    );
+}
+
+#[test]
+fn debug_output_redacts_the_secret() {
+    let rendered = format!("{:?}", subscription());
+
+    assert!(
+        !rendered.contains("super-secret-hmac-key"),
+        "Debug must not print the secret, or logging a subscription leaks it: {rendered}"
+    );
+    assert!(rendered.contains("<redacted>"), "the redaction must be visible: {rendered}");
+    assert!(rendered.contains("partner"), "non-secret fields stay useful for diagnosis");
+}
+
+#[tokio::test]
+async fn the_secret_is_still_usable_in_process_for_signing() {
+    // Redaction must not break delivery signing: the value has to survive storage and retrieval
+    // inside the process, it just must not be serialized outward.
+    use adk_awp::EventSubscriptionService;
+
+    let service = InMemoryEventSubscriptionService::new();
+    let created = subscription();
+    let id = service.create(created.clone()).await.expect("create");
+
+    let listed = service.list().await.expect("list");
+    let found = listed.iter().find(|s| s.id == id).expect("subscription must be stored");
+
+    assert_eq!(
+        found.secret, "super-secret-hmac-key",
+        "the secret must remain available in-process for HMAC signing"
+    );
+}
+
+#[test]
+fn a_stored_subscription_round_trips_without_its_secret() {
+    // Deserialization accepts a payload with no `secret` field, so a serialized record can be
+    // read back — with an empty secret, which a caller must treat as "not available" rather
+    // than as a valid key.
+    let json = serde_json::to_string(&subscription()).expect("serialize");
+    let restored: EventSubscription = serde_json::from_str(&json).expect("deserialize");
+
+    assert_eq!(restored.subscriber, "partner");
+    assert!(restored.secret.is_empty(), "a serialized record carries no secret to restore");
+}


### PR DESCRIPTION
Resolves the **High** finding that listing AWP subscriptions serializes their HMAC secrets.

## The leak

`EventSubscription` derived `Serialize` over `pub secret: String`, and `list_subscriptions` returns `Json(subs)`. So `GET /awp/events/subscriptions` handed the caller every subscriber's signing key — from an endpoint with no authentication. Anyone able to reach it could collect the keys and forge signed deliveries.

The derived `Debug` printed it too, so any `tracing` call capturing a subscription wrote a live credential to the logs.

## Fix

`secret` is `skip_serializing` with a hand-written `Debug` that redacts it. It still deserializes (defaulting to empty) so a stored record loads, and an empty secret is honest about not having one. A test asserts the value remains usable **in-process** for signing, so the redaction cannot be "fixed" by breaking delivery.

Separately, `awp_routes` mounted read-only endpoints and subscription CRUD in one unauthenticated router. This crate has no auth model of its own, so rather than invent one it now exposes `awp_public_routes` and `awp_management_routes`; the caller applies its own layer to the management half.

## Verification

| Gate | Result |
|---|---|
| `cargo nextest run -p adk-awp --all-features` | **125 passed** |
| `cargo clippy -p adk-awp --all-targets -- -D warnings` | exit 0 |

Three of five new tests fail when `secret` serializes again.

## Not addressed

`POST /awp/a2a` still returns a placeholder acknowledgment and webhook delivery only logs what it would send. Both are documented placeholders behind a production-labelled surface; they need implementing, not redacting, and are tracked separately.