### PR TITLE
fix(computer-use): enforce lease expiry, remaining budget, and target boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **adk-computer-use: lease validation enforces expiry, remaining budget, and target
+  boundaries.** `validate_lease` checked session, principal, agent, execution mode, and
+  `state == "active"`, plus `action_budget == 0` — the *total* budget, so a lease with
+  `action_budget: 1, actions_used: 1` passed while authorizing nothing. It never read
+  `expires_at` or `boundaries`, so an expired lease and a lease scoped to a different application
+  were accepted as well. All three are now checked, and an expiry that cannot be parsed is
+  rejected rather than skipped.
+
 - **adk-computer-use: security-relevant MCP responses are bound to the request that produced
   them.** `ControlLease`, `TargetReservation`, and `ExecutionReceipt` were deserialized and
   returned straight into graph state. Typed deserialization proves shape, not provenance, and

--- a/adk-computer-use/Cargo.toml
+++ b/adk-computer-use/Cargo.toml
@@ -21,6 +21,8 @@ adk-eval.workspace = true
 async-trait.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+# Lease expiry is an RFC 3339 timestamp that must be compared, not merely stored.
+chrono.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["sync"] }
@@ -30,7 +32,6 @@ tracing.workspace = true
 
 [dev-dependencies]
 proptest = "1.5"
-chrono.workspace = true
 # Path-only (no version) on purpose: a versioned internal dev-dependency has to be
 # published before this crate can be, which constrains — and can deadlock — the
 # release order. Cargo strips path-only dev-dependencies when packaging.

--- a/adk-computer-use/src/runtime/binding.rs
+++ b/adk-computer-use/src/runtime/binding.rs
@@ -94,11 +94,60 @@ pub fn validate_lease(
             lease.lease_id, lease.state
         )));
     }
-    if lease.action_budget == 0 {
+    // Remaining budget, not total. Checking `action_budget == 0` accepted a lease whose budget
+    // was fully consumed — `action_budget: 1, actions_used: 1` passed while authorizing nothing.
+    if lease.actions_used >= lease.action_budget {
         return Err(ComputerUseError::IdentityMismatch(format!(
-            "control lease {} has no remaining action budget",
-            lease.lease_id
+            "control lease {} has no remaining action budget: {} of {} used",
+            lease.lease_id, lease.actions_used, lease.action_budget
         )));
+    }
+
+    // An expired lease is a well-formed object that authorizes nothing. Rejecting an
+    // unparseable timestamp is deliberate: a lease whose expiry cannot be read is a lease
+    // whose validity cannot be established.
+    match chrono::DateTime::parse_from_rfc3339(&lease.expires_at) {
+        Ok(expires_at) => {
+            if expires_at <= chrono::Utc::now() {
+                return Err(ComputerUseError::IdentityMismatch(format!(
+                    "control lease {} expired at {}",
+                    lease.lease_id, lease.expires_at
+                )));
+            }
+        }
+        Err(e) => {
+            return Err(ComputerUseError::IdentityMismatch(format!(
+                "control lease {} has an unreadable expiry {:?}: {e}",
+                lease.lease_id, lease.expires_at
+            )));
+        }
+    }
+
+    // Target boundaries. A lease scoped to one application must not authorize an action against
+    // another, which is the whole point of scoping it.
+    if let Some(target) = &envelope.target {
+        if !lease.boundaries.app_ids.is_empty()
+            && !lease.boundaries.app_ids.contains(&target.app_id)
+        {
+            return Err(mismatch(
+                OBJECT,
+                "boundaries.app_ids",
+                &target.app_id,
+                &format!("{:?}", lease.boundaries.app_ids),
+            ));
+        }
+
+        if let Some(window_id) = &target.window_id
+            && !lease.boundaries.window_ids.is_empty()
+            && !lease.boundaries.window_ids.contains(window_id)
+        {
+            return Err(mismatch(
+                OBJECT,
+                "boundaries.window_ids",
+                &format!("{window_id}"),
+                &format!("{:?}", lease.boundaries.window_ids),
+            ));
+        }
     }
 
     Ok(())

--- a/adk-computer-use/tests/response_binding_tests.rs
+++ b/adk-computer-use/tests/response_binding_tests.rs
@@ -259,3 +259,114 @@ fn a_declared_postcondition_carries_a_digest_to_bind_evidence_to() {
         other => panic!("unexpected postcondition: {other:?}"),
     }
 }
+
+// ── Lease limits: expiry, remaining budget, target boundaries ──────────
+//
+// The first version of `validate_lease` checked session, principal, agent, mode, `state ==
+// "active"`, and `action_budget == 0`. The struct also carries `expires_at`, `actions_used`, and
+// `boundaries`, and none were read — so an expired lease, a fully-consumed lease, and a lease
+// scoped to a different application all passed. The PR that added the validator claimed it
+// checked "remaining action budget"; it checked the total.
+
+/// A target naming one application, for boundary checks.
+fn target_for(app_id: &str) -> adk_computer_use::TargetEvidence {
+    adk_computer_use::TargetEvidence {
+        platform: "macos".into(),
+        app_id: app_id.into(),
+        pid: None,
+        window_id: None,
+        window_title_digest: None,
+        display_id: None,
+        role: None,
+        label_digest: None,
+        bounds: None,
+        observation_id: "obs-1".into(),
+        screenshot_hash: None,
+        ui_tree_revision: None,
+        confidence: 1.0,
+        captured_at: "2026-01-01T00:00:00Z".into(),
+    }
+}
+
+/// A lease bound to [`envelope`], expiring far in the future, with room in its budget.
+fn usable_lease() -> ControlLease {
+    let mut lease = lease();
+    lease.expires_at = "2099-01-01T00:00:00Z".into();
+    lease.action_budget = 5;
+    lease.actions_used = 0;
+    lease
+}
+
+#[test]
+fn an_expired_lease_is_rejected() {
+    let mut lease = usable_lease();
+    lease.expires_at = "2020-01-01T00:00:00Z".into();
+
+    let error =
+        validate_lease(&lease, &envelope()).expect_err("an expired lease authorizes nothing");
+    assert!(error.to_string().contains("expired"), "{error}");
+}
+
+#[test]
+fn a_lease_with_an_unreadable_expiry_is_rejected() {
+    // If validity cannot be established, the lease is not valid.
+    let mut lease = usable_lease();
+    lease.expires_at = "whenever".into();
+
+    let error = validate_lease(&lease, &envelope()).expect_err("must reject");
+    assert!(error.to_string().contains("unreadable expiry"), "{error}");
+}
+
+#[test]
+fn a_fully_consumed_budget_is_rejected_even_though_the_total_is_nonzero() {
+    // This is the case the original `action_budget == 0` check let through.
+    let mut lease = usable_lease();
+    lease.action_budget = 1;
+    lease.actions_used = 1;
+
+    let error = validate_lease(&lease, &envelope()).expect_err("must reject");
+    let message = error.to_string();
+    assert!(message.contains("no remaining action budget"), "{message}");
+    assert!(message.contains("1 of 1 used"), "the counts must be reported: {message}");
+}
+
+#[test]
+fn a_partially_consumed_budget_is_accepted() {
+    let mut lease = usable_lease();
+    lease.action_budget = 3;
+    lease.actions_used = 2;
+
+    assert!(validate_lease(&lease, &envelope()).is_ok(), "one action still remains");
+}
+
+#[test]
+fn a_lease_scoped_to_another_app_is_rejected() {
+    let mut envelope = envelope();
+    envelope.target = Some(target_for("com.example.editor"));
+
+    let mut lease = usable_lease();
+    lease.boundaries.app_ids = vec!["com.example.browser".into()];
+
+    let error = validate_lease(&lease, &envelope).expect_err("must reject");
+    assert!(error.to_string().contains("boundaries.app_ids"), "{error}");
+}
+
+#[test]
+fn a_lease_scoped_to_the_requested_app_is_accepted() {
+    let mut envelope = envelope();
+    envelope.target = Some(target_for("com.example.editor"));
+
+    let mut lease = usable_lease();
+    lease.boundaries.app_ids = vec!["com.example.editor".into()];
+
+    assert!(validate_lease(&lease, &envelope).is_ok());
+}
+
+#[test]
+fn an_unbounded_lease_still_authorizes_any_target() {
+    // Empty boundaries mean "not scoped", which must not be read as "scoped to nothing".
+    let mut envelope = envelope();
+    envelope.target = Some(target_for("com.example.editor"));
+
+    assert!(validate_lease(&usable_lease(), &envelope).is_ok());
+}

--- a/docs/official_docs/computer-use/index.md
+++ b/docs/official_docs/computer-use/index.md
@@ -15,7 +15,7 @@ Each response is bound back to the request that produced it:
 
 | Response | Checked against the envelope |
 |----------|------------------------------|
-| `ControlLease` | `session_id`, `principal_id`, `agent_id`, `execution_mode`, plus active state and remaining action budget |
+| `ControlLease` | `session_id`, `principal_id`, `agent_id`, `execution_mode`, active state, **unexpired** `expires_at`, **remaining** budget (`actions_used < action_budget`), and target within `boundaries` |
 | `TargetReservation` | `session_id`, `principal_id`, `agent_id`, `execution_group_id` |
 | `ExecutionReceipt` | `session_id`, `action_id`, and `action_digest` against the envelope's `args_digest` |
 
@@ -70,3 +70,23 @@ declaring only existence, an explicit `verification.satisfied: true` is required
 
 Absence of evidence is never treated as evidence of success. If `computer-use-mcp` verifies
 before issuing a receipt, that is its contract; this adapter does not assume it.
+
+### Lease limits
+
+A lease is refused unless all of these hold:
+
+| Check | Rejected when |
+|-------|---------------|
+| Expiry | `expires_at` is in the past, or cannot be parsed as RFC 3339 |
+| Remaining budget | `actions_used >= action_budget` |
+| Target boundary | the envelope's `target.app_id` is absent from a non-empty `boundaries.app_ids` |
+| Window boundary | the envelope's `target.window_id` is absent from a non-empty `boundaries.window_ids` |
+
+Empty boundaries mean "not scoped" and authorize any target — absence of a restriction is not a
+restriction to nothing.
+
+> **Important:** the first version of this validator checked `action_budget == 0`, which is the
+> *total* budget, so a lease with `action_budget: 1, actions_used: 1` passed while authorizing
+> nothing. It also never read `expires_at` or `boundaries`, so an expired lease and a lease scoped
+> to a different application were both accepted. An unparseable expiry is rejected rather than
+> ignored: a lease whose validity cannot be established is not valid.


### PR DESCRIPTION
Resolves the **High** finding that computer-use lease validation ignores expiry, consumed budgets, and target boundaries. This is a gap in code I added in #492.

## What passed validation that should not have

`validate_lease` bound a lease by session, principal, agent, and execution mode, checked `state == \"active\"`, then checked `action_budget == 0`. `ControlLease` also carries `expires_at`, `actions_used`, and `boundaries` — none were read.

| Lease | Why it should fail | Old result |
|---|---|---|
| `action_budget: 1, actions_used: 1` | nothing left to spend | accepted |
| `expires_at: 2020-01-01` | long expired | accepted |
| `boundaries.app_ids: [\"browser\"]`, target = editor | scoped elsewhere | accepted |

The budget case is the one I described wrongly: #492's body said the validator checked "remaining action budget". It checked the **total**, which passes the exhausted case.

## Fix

- `actions_used >= action_budget` is rejected, with the counts in the error
- `expires_at` compared against now; an expiry that cannot be parsed as RFC 3339 is **rejected**, since a lease whose validity cannot be established is not valid
- target `app_id`/`window_id` checked against non-empty boundaries

Empty boundaries still authorize any target — absence of a restriction is not a restriction to nothing.

## Verification

| Gate | Result |
|---|---|
| `cargo nextest run -p adk-computer-use` | **46 passed** |
| `cargo clippy -p adk-computer-use --all-targets -- -D warnings` | exit 0 |

Four of seven new tests fail against the original validator. `chrono` moves from dev-dependencies to dependencies, since comparing an expiry is production behaviour now.