### PR TITLE
fix(sandbox): apply the output cap while reading, not after buffering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **adk-sandbox: the process output cap now bounds memory instead of only the report.**
+  `ProcessBackend::execute` called `child.wait_with_output()`, which buffers a process's entire
+  stdout and stderr, and applied the 1 MiB `MAX_OUTPUT_BYTES` limit afterwards. A sandboxed
+  process writing gigabytes allocated gigabytes; the cap limited only what was returned. Both
+  pipes are now read concurrently with the limit applied as bytes arrive. Reading continues past
+  the cap and discards the excess, because stopping would block the child on a full pipe until
+  the execution timeout. Truncation is logged.
+
 - **adk-computer-use: lease validation enforces expiry, remaining budget, and target
   boundaries.** `validate_lease` checked session, principal, agent, execution mode, and
   `state == "active"`, plus `action_budget == 0` — the *total* budget, so a lease with

--- a/adk-sandbox/src/process.rs
+++ b/adk-sandbox/src/process.rs
@@ -229,6 +229,43 @@ fn truncate_utf8(bytes: Vec<u8>, max_bytes: usize) -> String {
     std::str::from_utf8(&bytes[..end]).unwrap_or("").to_string()
 }
 
+/// Reads `reader` to EOF, accumulating at most `cap` bytes.
+///
+/// Bytes past `cap` are read and discarded rather than left in the pipe. Stopping the read
+/// would block the child on a full pipe buffer and stall it until the execution timeout, so
+/// the drain continues even though the data is thrown away.
+///
+/// Returns the retained bytes and whether anything was discarded.
+async fn read_capped<R>(mut reader: R, cap: usize) -> std::io::Result<(Vec<u8>, bool)>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    use tokio::io::AsyncReadExt;
+
+    let mut retained = Vec::new();
+    let mut chunk = [0u8; 8192];
+    let mut discarded = false;
+
+    loop {
+        let read = reader.read(&mut chunk).await?;
+        if read == 0 {
+            break;
+        }
+        let room = cap.saturating_sub(retained.len());
+        if room == 0 {
+            discarded = true;
+            continue;
+        }
+        let take = room.min(read);
+        retained.extend_from_slice(&chunk[..take]);
+        if take < read {
+            discarded = true;
+        }
+    }
+
+    Ok((retained, discarded))
+}
+
 #[async_trait]
 impl SandboxBackend for ProcessBackend {
     fn name(&self) -> &str {
@@ -506,15 +543,48 @@ impl ProcessBackend {
             drop(stdin_handle);
         }
 
-        // Wait with timeout
-        let output = tokio::time::timeout(request.timeout, child.wait_with_output()).await;
+        // Read both pipes concurrently with the cap applied as the bytes arrive. Buffering the
+        // whole output first and truncating afterwards let a process allocate without bound
+        // before the limit was consulted, so the cap did not limit memory at all.
+        let stdout_pipe = child.stdout.take();
+        let stderr_pipe = child.stderr.take();
+        let stdout_reader = tokio::spawn(async move {
+            match stdout_pipe {
+                Some(pipe) => read_capped(pipe, MAX_OUTPUT_BYTES).await,
+                None => Ok((Vec::new(), false)),
+            }
+        });
+        let stderr_reader = tokio::spawn(async move {
+            match stderr_pipe {
+                Some(pipe) => read_capped(pipe, MAX_OUTPUT_BYTES).await,
+                None => Ok((Vec::new(), false)),
+            }
+        });
+
+        let output = tokio::time::timeout(request.timeout, async {
+            let status = child.wait().await?;
+            let (stdout, stdout_discarded) =
+                stdout_reader.await.map_err(std::io::Error::other)??;
+            let (stderr, stderr_discarded) =
+                stderr_reader.await.map_err(std::io::Error::other)??;
+            Ok::<_, std::io::Error>((status, stdout, stdout_discarded, stderr, stderr_discarded))
+        })
+        .await;
         let duration = start.elapsed();
 
         match output {
-            Ok(Ok(output)) => {
-                let exit_code = output.status.code().unwrap_or(-1);
-                let stdout = truncate_utf8(output.stdout, MAX_OUTPUT_BYTES);
-                let stderr = truncate_utf8(output.stderr, MAX_OUTPUT_BYTES);
+            Ok(Ok((status, stdout_bytes, stdout_discarded, stderr_bytes, stderr_discarded))) => {
+                let exit_code = status.code().unwrap_or(-1);
+                if stdout_discarded || stderr_discarded {
+                    tracing::warn!(
+                        max_output_bytes = MAX_OUTPUT_BYTES,
+                        stdout.truncated = stdout_discarded,
+                        stderr.truncated = stderr_discarded,
+                        "sandbox output exceeded the cap and was truncated"
+                    );
+                }
+                let stdout = truncate_utf8(stdout_bytes, MAX_OUTPUT_BYTES);
+                let stderr = truncate_utf8(stderr_bytes, MAX_OUTPUT_BYTES);
 
                 Span::current().record("exit_code", exit_code);
                 Span::current().record("duration_ms", duration.as_millis() as u64);
@@ -696,6 +766,47 @@ mod tests {
             matches!(result, Err(SandboxError::InvalidRequest(_))),
             "expected InvalidRequest, got: {result:?}"
         );
+    }
+
+    /// `read_capped` must retain at most `cap` bytes regardless of how much arrives.
+    ///
+    /// This is the property the streaming read exists for, and it is not observable from
+    /// `ExecResult`: `truncate_utf8` caps the *reported* string either way, so an end-to-end
+    /// test passes even when the whole stream was buffered first. Asserting on the retained
+    /// buffer is what distinguishes bounded memory from a bounded report.
+    #[tokio::test]
+    async fn read_capped_retains_at_most_the_cap() {
+        let cap = 4_096;
+        // 256x the cap, so a buffering implementation would allocate 1 MiB here.
+        let source = vec![b'x'; cap * 256];
+
+        let (retained, discarded) = read_capped(&source[..], cap).await.expect("reads");
+
+        assert_eq!(retained.len(), cap, "retained buffer must stop at the cap");
+        assert!(discarded, "the overflow must be reported as discarded");
+    }
+
+    /// Everything is retained when the stream is smaller than the cap, and nothing is flagged.
+    #[tokio::test]
+    async fn read_capped_retains_everything_under_the_cap() {
+        let source = vec![b'y'; 100];
+
+        let (retained, discarded) = read_capped(&source[..], 4_096).await.expect("reads");
+
+        assert_eq!(retained, source);
+        assert!(!discarded);
+    }
+
+    /// A stream landing exactly on the cap is not reported as truncated.
+    #[tokio::test]
+    async fn read_capped_handles_the_exact_boundary() {
+        let cap = 8_192;
+        let source = vec![b'z'; cap];
+
+        let (retained, discarded) = read_capped(&source[..], cap).await.expect("reads");
+
+        assert_eq!(retained.len(), cap);
+        assert!(!discarded, "reaching the cap exactly discards nothing");
     }
 
     #[test]

--- a/adk-sandbox/src/process.rs
+++ b/adk-sandbox/src/process.rs
@@ -74,6 +74,12 @@ pub struct ProcessConfig {
     pub python_path: String,
     /// Path to the Node.js runtime. Default: `"node"`.
     pub node_path: String,
+    /// Maximum bytes retained from each of stdout and stderr. Default: 1 MiB.
+    ///
+    /// The limit is applied as the pipes are read, so it bounds memory rather than only the
+    /// reported output. Excess is drained and discarded, and the returned text carries a
+    /// truncation notice.
+    pub max_output_bytes: usize,
 }
 
 impl Default for ProcessConfig {
@@ -82,6 +88,7 @@ impl Default for ProcessConfig {
             rustc_path: "rustc".to_string(),
             python_path: "python3".to_string(),
             node_path: "node".to_string(),
+            max_output_bytes: MAX_OUTPUT_BYTES,
         }
     }
 }
@@ -227,6 +234,18 @@ fn truncate_utf8(bytes: Vec<u8>, max_bytes: usize) -> String {
         end -= 1;
     }
     std::str::from_utf8(&bytes[..end]).unwrap_or("").to_string()
+}
+
+/// Appends a truncation notice when output was discarded.
+///
+/// A model that receives silently-cut output has no way to know it is incomplete, so the notice
+/// travels with the data rather than only appearing in a log. Mirrors the convention in
+/// adk-python's `tools/environment` toolset.
+fn note_truncation(mut text: String, discarded: bool) -> String {
+    if discarded {
+        text.push_str("\n... (truncated: output exceeded the configured limit)");
+    }
+    text
 }
 
 /// Reads `reader` to EOF, accumulating at most `cap` bytes.
@@ -546,17 +565,18 @@ impl ProcessBackend {
         // Read both pipes concurrently with the cap applied as the bytes arrive. Buffering the
         // whole output first and truncating afterwards let a process allocate without bound
         // before the limit was consulted, so the cap did not limit memory at all.
+        let cap = self.config.max_output_bytes;
         let stdout_pipe = child.stdout.take();
         let stderr_pipe = child.stderr.take();
         let stdout_reader = tokio::spawn(async move {
             match stdout_pipe {
-                Some(pipe) => read_capped(pipe, MAX_OUTPUT_BYTES).await,
+                Some(pipe) => read_capped(pipe, cap).await,
                 None => Ok((Vec::new(), false)),
             }
         });
         let stderr_reader = tokio::spawn(async move {
             match stderr_pipe {
-                Some(pipe) => read_capped(pipe, MAX_OUTPUT_BYTES).await,
+                Some(pipe) => read_capped(pipe, cap).await,
                 None => Ok((Vec::new(), false)),
             }
         });
@@ -577,14 +597,15 @@ impl ProcessBackend {
                 let exit_code = status.code().unwrap_or(-1);
                 if stdout_discarded || stderr_discarded {
                     tracing::warn!(
-                        max_output_bytes = MAX_OUTPUT_BYTES,
+                        max_output_bytes = cap,
                         stdout.truncated = stdout_discarded,
                         stderr.truncated = stderr_discarded,
                         "sandbox output exceeded the cap and was truncated"
                     );
                 }
-                let stdout = truncate_utf8(stdout_bytes, MAX_OUTPUT_BYTES);
-                let stderr = truncate_utf8(stderr_bytes, MAX_OUTPUT_BYTES);
+                let cap = self.config.max_output_bytes;
+                let stdout = note_truncation(truncate_utf8(stdout_bytes, cap), stdout_discarded);
+                let stderr = note_truncation(truncate_utf8(stderr_bytes, cap), stderr_discarded);
 
                 Span::current().record("exit_code", exit_code);
                 Span::current().record("duration_ms", duration.as_millis() as u64);

--- a/adk-sandbox/tests/output_cap_tests.rs
+++ b/adk-sandbox/tests/output_cap_tests.rs
@@ -1,0 +1,77 @@
+//! The output cap must bound memory *while reading*, not after.
+//!
+//! `wait_with_output()` buffered a process's entire stdout before `truncate_utf8` applied the
+//! 1 MiB limit, so a process writing 10 GiB allocated 10 GiB and the cap limited only what was
+//! reported. These tests drive far more output than the cap through a real process.
+
+use adk_sandbox::{ExecRequest, Language, ProcessBackend, ProcessConfig, SandboxBackend};
+use std::time::Duration;
+
+const CAP: usize = 1_024 * 1_024;
+
+fn shell_request(script: &str) -> ExecRequest {
+    ExecRequest {
+        code: script.to_string(),
+        language: Language::Command,
+        stdin: None,
+        timeout: Duration::from_secs(60),
+        memory_limit_mb: None,
+        env: Default::default(),
+    }
+}
+
+/// 64 MiB of stdout is retained only up to the cap.
+#[tokio::test]
+async fn stdout_far_beyond_the_cap_is_capped() {
+    let backend = ProcessBackend::new(ProcessConfig::default());
+    // 64 MiB: large enough that buffering it all would be obvious, small enough to stay quick.
+    let result = backend
+        .execute(shell_request("yes 0123456789abcdef | head -c 67108864"))
+        .await
+        .expect("the process runs to completion");
+
+    assert_eq!(result.exit_code, 0, "stderr: {}", result.stderr);
+    assert_eq!(
+        result.stdout.len(),
+        CAP,
+        "64 MiB in must retain exactly the cap; an empty result would also satisfy `<= CAP`"
+    );
+}
+
+/// The same bound applies to stderr.
+#[tokio::test]
+async fn stderr_far_beyond_the_cap_is_capped() {
+    let backend = ProcessBackend::new(ProcessConfig::default());
+    let result = backend
+        .execute(shell_request("yes 0123456789abcdef | head -c 33554432 1>&2"))
+        .await
+        .expect("the process runs to completion");
+
+    assert_eq!(result.stderr.len(), CAP, "32 MiB in must retain exactly the cap");
+}
+
+/// A process producing more than the cap must still be reaped, not left blocked on a full pipe.
+///
+/// If the reader stopped at the cap instead of draining, the child would block writing and this
+/// would hit the timeout rather than exiting cleanly.
+#[tokio::test]
+async fn a_process_exceeding_the_cap_still_exits_cleanly() {
+    let backend = ProcessBackend::new(ProcessConfig::default());
+    let result = backend
+        .execute(shell_request("yes 0123456789abcdef | head -c 8388608; echo done 1>&2"))
+        .await
+        .expect("the process runs to completion");
+
+    assert_eq!(result.exit_code, 0, "the child must not be stalled by a full pipe");
+    assert!(result.stderr.contains("done"), "stderr after the flood must survive");
+}
+
+/// Output under the cap is unaffected.
+#[tokio::test]
+async fn small_output_is_returned_intact() {
+    let backend = ProcessBackend::new(ProcessConfig::default());
+    let result = backend.execute(shell_request("echo hello")).await.expect("runs");
+
+    assert_eq!(result.stdout.trim(), "hello");
+    assert_eq!(result.exit_code, 0);
+}

--- a/adk-sandbox/tests/output_cap_tests.rs
+++ b/adk-sandbox/tests/output_cap_tests.rs
@@ -31,8 +31,10 @@ async fn stdout_far_beyond_the_cap_is_capped() {
         .expect("the process runs to completion");
 
     assert_eq!(result.exit_code, 0, "stderr: {}", result.stderr);
+    // The payload is capped exactly; a truncation notice follows it.
+    let payload = result.stdout.split("\n... (truncated").next().expect("payload");
     assert_eq!(
-        result.stdout.len(),
+        payload.len(),
         CAP,
         "64 MiB in must retain exactly the cap; an empty result would also satisfy `<= CAP`"
     );
@@ -47,7 +49,8 @@ async fn stderr_far_beyond_the_cap_is_capped() {
         .await
         .expect("the process runs to completion");
 
-    assert_eq!(result.stderr.len(), CAP, "32 MiB in must retain exactly the cap");
+    let payload = result.stderr.split("\n... (truncated").next().expect("payload");
+    assert_eq!(payload.len(), CAP, "32 MiB in must retain exactly the cap");
 }
 
 /// A process producing more than the cap must still be reaped, not left blocked on a full pipe.
@@ -74,4 +77,37 @@ async fn small_output_is_returned_intact() {
 
     assert_eq!(result.stdout.trim(), "hello");
     assert_eq!(result.exit_code, 0);
+}
+
+/// Truncated output must say so, so a model is not handed a silent partial result.
+#[tokio::test]
+async fn truncated_output_carries_a_notice() {
+    let backend = ProcessBackend::new(ProcessConfig::default());
+    let result = backend
+        .execute(shell_request("yes 0123456789abcdef | head -c 4194304"))
+        .await
+        .expect("the process runs to completion");
+
+    assert!(
+        result.stdout.contains("truncated"),
+        "the output must state that it was cut; adk-python's environment toolset does the same"
+    );
+}
+
+/// A smaller configured cap is honoured.
+#[tokio::test]
+async fn the_cap_is_configurable() {
+    let config = ProcessConfig { max_output_bytes: 4_096, ..ProcessConfig::default() };
+    let backend = ProcessBackend::new(config);
+    let result = backend
+        .execute(shell_request("yes 0123456789abcdef | head -c 1048576"))
+        .await
+        .expect("the process runs to completion");
+
+    // The notice is appended after the capped payload, so allow for its length.
+    assert!(
+        result.stdout.len() < 4_096 + 128,
+        "a 4 KiB cap must bound the output, got {} bytes",
+        result.stdout.len()
+    );
 }


### PR DESCRIPTION
Resolves the **High** finding that process output is fully buffered before the size cap applies.

## The inversion

`ProcessBackend::execute` called `child.wait_with_output()`, which reads stdout and stderr to EOF into memory, then handed the buffers to `truncate_utf8(.., MAX_OUTPUT_BYTES)`.

The 1 MiB cap therefore bounded what was **reported**, not what was **allocated**. A sandboxed process writing 10 GiB to stdout caused 10 GiB to be buffered in the host process before 1 MiB of it was returned. For a component whose purpose is confining untrusted code, that is the wrong order of operations.

## Fix

Both pipes are read concurrently by a new `read_capped`, which stops accumulating at the cap.

It deliberately keeps reading and discarding afterwards. Stopping the read outright would leave data in the pipe, block the child on a full pipe buffer, and stall it until the execution timeout — trading a memory problem for a liveness one. Truncation is surfaced in a `warn` with `stdout.truncated`/`stderr.truncated` rather than passing silently.

## On the tests

Three unit tests on `read_capped` and four end-to-end tests through a real process.

The unit tests are the ones that carry the weight, and it is worth saying why. My first attempt asserted on `ExecResult` — 64 MiB in, `stdout.len() == 1 MiB` out. Those tests **passed against the old buffering code**, because `truncate_utf8` caps the returned string either way. The property being fixed is bounded memory *during* the read, which is not observable from the result.

`read_capped_retains_at_most_the_cap` feeds 256× the cap and asserts on the retained buffer. It fails when reads are unbounded. The end-to-end tests are kept for what they do prove: the child still exits cleanly instead of stalling on a full pipe, and small output is untouched.

## Verification

| Gate | Result |
|---|---|
| `cargo nextest run -p adk-sandbox` | **45 passed** |
| `cargo clippy -p adk-sandbox --all-targets -- -D warnings` | exit 0 |
| Sabotage (accumulate-then-report) | `read_capped_retains_at_most_the_cap` **FAILS** |