### PR TITLE
feat(server): stream real agent events from A2A message/stream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,9 @@ jobs:
           # feature flags never compiled it. It had drifted out of the clippy gate, and a
           # jsonwebtoken major bump broke it while every required check stayed green.
           - { package: adk-auth, features: sso }
+          # adk-server's A2A v1 surface: gated behind `a2a-v1`, so `--workspace` without feature
+          # flags never compiled it. 11 clippy failures had accumulated unseen.
+          - { package: adk-server, features: a2a-v1 }
     steps:
     - uses: actions/checkout@v7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -612,6 +612,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **adk-server: `message/stream` drives the agent instead of emitting synthetic events.**
+  The handler created a task, transitioned `Working` then `Completed`, and never invoked the
+  Runner, so a streaming client received a task that reported success and produced no output.
+  It now streams `TaskArtifactUpdateEvent`s as the agent produces them, keyed to one artifact ID
+  with `append`/`lastChunk` derived from each event's `partial` flag, and reports `Failed` when
+  the agent errors. The joined text is persisted so a later `tasks/get` returns what was
+  streamed. `tasks/resubscribe` is documented as the snapshot it is rather than implying a live
+  re-attach.
+- **adk-server: `--features a2a-v1` passes clippy and is gated by CI.** No workflow built the
+  feature, so 11 `collapsible_if` failures had accumulated in the A2A v1 surface unseen.
+  `adk-server --features a2a-v1` joins the feature-coverage matrix.
+
 - **adk-auth: the `sso` feature compiles and is gated by CI again.** No workflow built
   `adk-auth --features sso`, so its SSO/OAuth surface had drifted out of the clippy gate and
   failed `-D warnings` on four `collapsible_if` lints. `jsonwebtoken` moves to 11, whose

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ is running. See the [MCP guide](docs/official_docs/tools/mcp-tools.md).
 | `adk-acp` | Agent Client Protocol integration | Official stable v1 client and server, one-shot and persistent sessions, streaming, cancellation, async permissions, client files and terminals, per-session MCP, and editor-facing ADK agents |
 | `adk-rag` | RAG pipeline | Document chunking, embeddings, vector search, reranking, 6 backends |
 | `adk-runner` | Agent execution runtime | Context management, event streaming, session lifecycle, callbacks |
-| `adk-server` | Production API servers | REST API, A2A v1.0.0 protocol (all 11 operations), middleware, health checks |
+| `adk-server` | Production API servers | REST API, A2A v1.0.0 protocol (11 JSON-RPC operations; `tasks/resubscribe` returns a snapshot, not a live re-attach), middleware, health checks |
 | `adk-cli` | Command-line interface | Interactive REPL, session management, MCP server integration |
 | `adk-realtime` | Real-time voice & multimodal agents | OpenAI Realtime + Gemini Live, bidirectional audio, video frames, VAD, affective dialogue, server-side tools via `IntegratedRealtimeRunner` |
 | `adk-graph` | Graph-based workflows | LangGraph-style orchestration, state management, checkpointing, human-in-the-loop |

--- a/adk-server/src/a2a/client.rs
+++ b/adk-server/src/a2a/client.rs
@@ -649,10 +649,10 @@ pub mod v1_client {
             // Try to extract supported versions from ErrorInfo metadata
             if let Some(data_arr) = data.and_then(|d| d.as_array()) {
                 for info in data_arr {
-                    if let Some(meta) = info.get("metadata") {
-                        if let Some(versions) = meta.get("supported").and_then(|v| v.as_str()) {
-                            supported = versions.split(", ").map(String::from).collect();
-                        }
+                    if let Some(meta) = info.get("metadata")
+                        && let Some(versions) = meta.get("supported").and_then(|v| v.as_str())
+                    {
+                        supported = versions.split(", ").map(String::from).collect();
                     }
                 }
             }

--- a/adk-server/src/a2a/executor.rs
+++ b/adk-server/src/a2a/executor.rs
@@ -231,15 +231,15 @@ impl Executor {
 
         // --- Interceptor: after delegation ---
         #[cfg(feature = "a2a-interceptors")]
-        if let Some(chain) = &self.config.interceptor_chain {
-            if let Some(ctx) = &interceptor_ctx {
-                let mut response_value =
-                    serde_json::to_value(&results).unwrap_or(serde_json::Value::Null);
-                chain
-                    .run_after(ctx, &mut response_value)
-                    .await
-                    .map_err(|e| adk_core::AdkError::agent(e.to_string()))?;
-            }
+        if let Some(chain) = &self.config.interceptor_chain
+            && let Some(ctx) = &interceptor_ctx
+        {
+            let mut response_value =
+                serde_json::to_value(&results).unwrap_or(serde_json::Value::Null);
+            chain
+                .run_after(ctx, &mut response_value)
+                .await
+                .map_err(|e| adk_core::AdkError::agent(e.to_string()))?;
         }
 
         Ok(results)

--- a/adk-server/src/a2a/remote_agent.rs
+++ b/adk-server/src/a2a/remote_agent.rs
@@ -718,10 +718,10 @@ pub mod v1_remote {
 
         // Try JSON-RPC wrapped response
         if let Ok(rpc_value) = serde_json::from_str::<serde_json::Value>(data) {
-            if let Some(result) = rpc_value.get("result") {
-                if let Ok(stream_resp) = serde_json::from_value::<StreamResponse>(result.clone()) {
-                    return convert_stream_response(&stream_resp, invocation_id, agent_name);
-                }
+            if let Some(result) = rpc_value.get("result")
+                && let Ok(stream_resp) = serde_json::from_value::<StreamResponse>(result.clone())
+            {
+                return convert_stream_response(&stream_resp, invocation_id, agent_name);
             }
             // Check for JSON-RPC error
             if let Some(error) = rpc_value.get("error") {

--- a/adk-server/src/a2a/v1/convert.rs
+++ b/adk-server/src/a2a/v1/convert.rs
@@ -262,17 +262,17 @@ pub fn adk_message_to_wire(
     if let Some(ref meta) = msg.metadata {
         let mut clean_meta = meta.clone();
 
-        if let Some(ext_val) = clean_meta.remove("_a2a_extensions") {
-            if let Ok(exts) = serde_json::from_value::<Vec<String>>(ext_val) {
-                extensions = Some(exts);
-            }
+        if let Some(ext_val) = clean_meta.remove("_a2a_extensions")
+            && let Ok(exts) = serde_json::from_value::<Vec<String>>(ext_val)
+        {
+            extensions = Some(exts);
         }
 
-        if let Some(ref_val) = clean_meta.remove("_a2a_reference_task_ids") {
-            if let Ok(ids) = serde_json::from_value::<Vec<String>>(ref_val) {
-                reference_task_ids =
-                    Some(ids.into_iter().map(a2a_protocol_types::TaskId::new).collect());
-            }
+        if let Some(ref_val) = clean_meta.remove("_a2a_reference_task_ids")
+            && let Ok(ids) = serde_json::from_value::<Vec<String>>(ref_val)
+        {
+            reference_task_ids =
+                Some(ids.into_iter().map(a2a_protocol_types::TaskId::new).collect());
         }
 
         if !clean_meta.is_empty() {

--- a/adk-server/src/a2a/v1/push.rs
+++ b/adk-server/src/a2a/v1/push.rs
@@ -198,24 +198,23 @@ pub fn validate_webhook_url(url: &str) -> Result<(), A2aError> {
     }
 
     // Check if host is an IP address
-    if let Ok(ip) = host.parse::<IpAddr>() {
-        if is_private_or_loopback(&ip) {
-            return Err(A2aError::InvalidParams {
-                message: format!("webhook URL must not target private/loopback address: {ip}"),
-            });
-        }
+    if let Ok(ip) = host.parse::<IpAddr>()
+        && is_private_or_loopback(&ip)
+    {
+        return Err(A2aError::InvalidParams {
+            message: format!("webhook URL must not target private/loopback address: {ip}"),
+        });
     }
 
     // Also check bracketed IPv6 (e.g., [::1])
     let trimmed = host.trim_start_matches('[').trim_end_matches(']');
-    if trimmed != host {
-        if let Ok(ip) = trimmed.parse::<IpAddr>() {
-            if is_private_or_loopback(&ip) {
-                return Err(A2aError::InvalidParams {
-                    message: format!("webhook URL must not target private/loopback address: {ip}"),
-                });
-            }
-        }
+    if trimmed != host
+        && let Ok(ip) = trimmed.parse::<IpAddr>()
+        && is_private_or_loopback(&ip)
+    {
+        return Err(A2aError::InvalidParams {
+            message: format!("webhook URL must not target private/loopback address: {ip}"),
+        });
     }
 
     Ok(())

--- a/adk-server/src/a2a/v1/request_handler.rs
+++ b/adk-server/src/a2a/v1/request_handler.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use a2a_protocol_types::artifact::{Artifact, ArtifactId};
-use a2a_protocol_types::events::{StreamResponse, TaskStatusUpdateEvent};
+use a2a_protocol_types::events::{StreamResponse, TaskArtifactUpdateEvent, TaskStatusUpdateEvent};
 use a2a_protocol_types::task::{Task, TaskState};
 use a2a_protocol_types::{AgentCard, Message, TaskPushNotificationConfig};
 use futures::StreamExt;
@@ -25,6 +25,7 @@ use super::convert::internal_task_to_wire;
 use super::error::A2aError;
 use super::executor::V1Executor;
 use super::push::PushNotificationSender;
+use super::stream::wrap_artifact_event;
 use super::task_store::{ListTasksParams, TaskStore};
 
 /// Validates an ID string (messageId or taskId).
@@ -151,51 +152,46 @@ impl RequestHandler {
         }
 
         // Multi-turn resume: check if contextId matches an existing INPUT_REQUIRED task
-        if let Some(ref ctx_id) = msg.context_id {
-            if let Some(existing) = self.task_store.find_task_by_context(&ctx_id.0).await? {
-                if existing.status.state == TaskState::InputRequired {
-                    // Resume the existing task
-                    let task_id = existing.id.clone();
-                    let context_id = existing.context_id.clone();
+        if let Some(ref ctx_id) = msg.context_id
+            && let Some(existing) = self.task_store.find_task_by_context(&ctx_id.0).await?
+            && existing.status.state == TaskState::InputRequired
+        {
+            // Resume the existing task
+            let task_id = existing.id.clone();
+            let context_id = existing.context_id.clone();
 
-                    // Transition from INPUT_REQUIRED to Working
-                    self.executor
-                        .transition_state(&task_id, &context_id, TaskState::Working, None)
-                        .await?;
+            // Transition from INPUT_REQUIRED to Working
+            self.executor.transition_state(&task_id, &context_id, TaskState::Working, None).await?;
 
-                    // Append the new message to history
-                    self.task_store.add_history_message(&task_id, msg.clone()).await?;
+            // Append the new message to history
+            self.task_store.add_history_message(&task_id, msg.clone()).await?;
 
-                    // Run the agent if a runner config is available
-                    if let Some(runner_config) = &self.runner_config {
-                        match self.run_agent(runner_config, &task_id, &context_id, &msg).await {
-                            Ok(()) => {}
-                            Err(e) => {
-                                let _ = self
-                                    .executor
-                                    .fail_task(&task_id, &context_id, &e.to_string())
-                                    .await;
-                                let entry = self.task_store.get_task(&task_id).await?;
-                                return internal_task_to_wire(&entry);
-                            }
-                        }
+            // Run the agent if a runner config is available
+            if let Some(runner_config) = &self.runner_config {
+                match self.run_agent(runner_config, &task_id, &context_id, &msg).await {
+                    Ok(()) => {}
+                    Err(e) => {
+                        let _ =
+                            self.executor.fail_task(&task_id, &context_id, &e.to_string()).await;
+                        let entry = self.task_store.get_task(&task_id).await?;
+                        return internal_task_to_wire(&entry);
                     }
-
-                    // Transition to COMPLETED
-                    self.executor
-                        .transition_state(&task_id, &context_id, TaskState::Completed, None)
-                        .await?;
-
-                    // Record idempotency mapping
-                    self.idempotency_map.write().await.insert(message_id, task_id.clone());
-
-                    let entry = self.task_store.get_task(&task_id).await?;
-                    return internal_task_to_wire(&entry);
                 }
-                // If task is in a terminal state or other non-INPUT_REQUIRED state,
-                // fall through to create a new task (existing behavior)
             }
+
+            // Transition to COMPLETED
+            self.executor
+                .transition_state(&task_id, &context_id, TaskState::Completed, None)
+                .await?;
+
+            // Record idempotency mapping
+            self.idempotency_map.write().await.insert(message_id, task_id.clone());
+
+            let entry = self.task_store.get_task(&task_id).await?;
+            return internal_task_to_wire(&entry);
         }
+        // If task is in a terminal state or other non-INPUT_REQUIRED state,
+        // fall through to create a new task (existing behavior)
 
         let task_id = uuid::Uuid::new_v4().to_string();
         let context_id = msg
@@ -238,13 +234,15 @@ impl RequestHandler {
     }
 
     /// Runs the agent through the ADK Runner and records the response as an artifact.
-    async fn run_agent(
-        &self,
+    /// Builds the session, converts the inbound message, and starts the agent.
+    ///
+    /// Both the buffered (`message/send`) and streaming (`message/stream`) paths use this, so
+    /// they cannot drift: streaming yields from the same stream the buffered path drains.
+    async fn start_agent(
         runner_config: &Arc<adk_runner::RunnerConfig>,
-        task_id: &str,
         context_id: &str,
         msg: &Message,
-    ) -> Result<(), A2aError> {
+    ) -> Result<adk_core::EventStream, A2aError> {
         use adk_core::{SessionId, UserId};
         use adk_session::{CreateRequest, GetRequest};
 
@@ -328,7 +326,7 @@ impl RequestHandler {
             .build()
             .map_err(|e| A2aError::Internal { message: format!("runner create: {e}") })?;
 
-        let mut event_stream = runner
+        runner
             .run(
                 UserId::new(&user_id).map_err(|e| A2aError::Internal { message: e.to_string() })?,
                 SessionId::new(&session_id)
@@ -336,9 +334,19 @@ impl RequestHandler {
                 content,
             )
             .await
-            .map_err(|e| A2aError::Internal { message: format!("runner run: {e}") })?;
+            .map_err(|e| A2aError::Internal { message: format!("runner run: {e}") })
+    }
 
-        // Collect LLM response text from events
+    /// Runs the agent to completion and records its output as a single artifact.
+    async fn run_agent(
+        &self,
+        runner_config: &Arc<adk_runner::RunnerConfig>,
+        task_id: &str,
+        context_id: &str,
+        msg: &Message,
+    ) -> Result<(), A2aError> {
+        let mut event_stream = Self::start_agent(runner_config, context_id, msg).await?;
+
         let mut response_text = String::new();
         while let Some(result) = event_stream.next().await {
             match result {
@@ -357,7 +365,6 @@ impl RequestHandler {
             }
         }
 
-        // Record the response as an artifact if we got any text
         if !response_text.is_empty() {
             let artifact = Artifact::new(
                 ArtifactId::new(uuid::Uuid::new_v4().to_string()),
@@ -371,12 +378,26 @@ impl RequestHandler {
 
     /// Sends a streaming message, returning a stream of SSE events.
     ///
-    /// Creates a task, yields status update events as the task progresses.
-    /// This is a placeholder — actual Runner streaming integration comes later.
+    /// Drives the agent and translates its events as they arrive:
+    ///
+    /// | Agent event | A2A event |
+    /// |-------------|-----------|
+    /// | first, before any output | `Task`, then `TaskStatusUpdateEvent` — `Working` |
+    /// | content with `partial = true` | `TaskArtifactUpdateEvent` — `append`, not last chunk |
+    /// | content with `partial = false` | `TaskArtifactUpdateEvent` — final chunk |
+    /// | stream ends | `TaskStatusUpdateEvent` — `Completed` |
+    /// | stream errors | `TaskStatusUpdateEvent` — `Failed` |
+    ///
+    /// Chunks of one response share an artifact ID so a client can reassemble them, which is the
+    /// same contract adk-python and adk-go implement over their A2A SDKs.
+    ///
+    /// With no runner configured the task is created and completed without agent output, which
+    /// keeps discovery-only deployments working.
     ///
     /// # Errors
     ///
-    /// Returns an error if task creation fails.
+    /// Returns an error if task creation fails. Failures once streaming has begun are reported
+    /// as a `Failed` status event, since the response has already started.
     pub async fn message_stream(
         &self,
         msg: Message,
@@ -415,6 +436,9 @@ impl RequestHandler {
         // Create task
         self.executor.create_task(&task_id, &context_id).await?;
 
+        // Keep a copy for the agent: `add_history_message` takes ownership.
+        let msg_for_agent = msg.clone();
+
         // Add the incoming message to history
         self.task_store.add_history_message(&task_id, msg).await?;
 
@@ -428,12 +452,12 @@ impl RequestHandler {
         let executor = self.executor.clone();
         let tid = task_id.clone();
         let cid = context_id.clone();
+        let runner_config = self.runner_config.clone();
+        let stream_msg = msg_for_agent;
 
         let stream = async_stream::stream! {
-            // Emit Task as first SSE event
             yield Ok(StreamResponse::Task(first_task));
 
-            // Transition to WORKING
             match executor.transition_state(&tid, &cid, TaskState::Working, None).await {
                 Ok(event) => yield Ok(StreamResponse::StatusUpdate(event)),
                 Err(e) => {
@@ -442,7 +466,84 @@ impl RequestHandler {
                 }
             }
 
-            // Transition to COMPLETED (placeholder — Runner integration later)
+            if let Some(config) = runner_config {
+                let started = Self::start_agent(&config, &cid, &stream_msg).await;
+                let mut event_stream = match started {
+                    Ok(stream) => stream,
+                    Err(e) => {
+                        // The agent never started, so nothing partial was emitted. Report the
+                        // task as failed rather than completing a task that did no work.
+                        if let Ok(event) = executor
+                            .transition_state(&tid, &cid, TaskState::Failed, None)
+                            .await
+                        {
+                            yield Ok(StreamResponse::StatusUpdate(event));
+                        }
+                        yield Err(e);
+                        return;
+                    }
+                };
+
+                // One artifact ID for the whole response so a client can join the chunks.
+                let artifact_id = uuid::Uuid::new_v4().to_string();
+                let mut chunks_sent = false;
+                let mut full_text = String::new();
+
+                while let Some(result) = event_stream.next().await {
+                    match result {
+                        Ok(event) => {
+                            let Some(content) = &event.llm_response.content else { continue };
+                            let text: String =
+                                content.parts.iter().filter_map(|p| p.text()).collect();
+                            if text.is_empty() {
+                                continue;
+                            }
+                            full_text.push_str(&text);
+
+                            let partial = event.llm_response.partial;
+                            let artifact = Artifact::new(
+                                ArtifactId::new(artifact_id.clone()),
+                                vec![a2a_protocol_types::Part::text(&text)],
+                            );
+                            yield Ok(wrap_artifact_event(TaskArtifactUpdateEvent {
+                                task_id: a2a_protocol_types::TaskId::new(tid.clone()),
+                                context_id: a2a_protocol_types::ContextId::new(cid.clone()),
+                                artifact,
+                                append: Some(chunks_sent),
+                                last_chunk: Some(!partial),
+                                metadata: None,
+                            }));
+                            chunks_sent = true;
+                        }
+                        Err(e) => {
+                            if let Ok(event) = executor
+                                .transition_state(&tid, &cid, TaskState::Failed, None)
+                                .await
+                            {
+                                yield Ok(StreamResponse::StatusUpdate(event));
+                            }
+                            yield Err(A2aError::Internal {
+                                message: format!("agent error: {e}"),
+                            });
+                            return;
+                        }
+                    }
+                }
+
+                // Persist the joined text so `tasks/get` returns the same artifact a
+                // non-streaming caller would have received.
+                if !full_text.is_empty() {
+                    let artifact = Artifact::new(
+                        ArtifactId::new(artifact_id),
+                        vec![a2a_protocol_types::Part::text(&full_text)],
+                    );
+                    if let Err(e) = executor.record_artifact(&tid, &cid, artifact).await {
+                        yield Err(e);
+                        return;
+                    }
+                }
+            }
+
             match executor.transition_state(&tid, &cid, TaskState::Completed, None).await {
                 Ok(event) => yield Ok(StreamResponse::StatusUpdate(event)),
                 Err(e) => yield Err(e),
@@ -518,14 +619,20 @@ impl RequestHandler {
         entries.iter().map(internal_task_to_wire).collect()
     }
 
-    /// Subscribes to task updates via SSE.
+    /// Returns the current state of a task as a short stream, then closes.
     ///
-    /// Placeholder — returns a stream that yields the current task status.
-    /// Full SSE subscription will be implemented in a later task.
+    /// > **Important:** this is a point-in-time snapshot, not a live subscription. It emits the
+    /// > task and its current status and then ends; it does not deliver subsequent updates. A
+    /// > client that needs live updates should use `message/stream`, which streams the agent's
+    /// > events as they are produced.
+    ///
+    /// A real re-attach would require a per-task event queue that outlives the request, which
+    /// the A2A SDKs in adk-python and adk-go provide and this hand-rolled server does not yet.
     ///
     /// # Errors
     ///
-    /// Returns [`A2aError::TaskNotFound`] if the task does not exist.
+    /// Returns [`A2aError::TaskNotFound`] if the task does not exist, or
+    /// [`A2aError::TaskNotCancelable`] if the task already reached a terminal state.
     pub async fn tasks_subscribe(
         &self,
         task_id: &str,
@@ -684,6 +791,202 @@ mod tests {
         AgentCapabilities, AgentCard, AgentInterface, AgentSkill, MessageId, MessageRole, Part,
         TaskPushNotificationConfig,
     };
+
+    // ── message/stream must carry real agent output ────────────────────────
+    //
+    // The handler used to create a task and transition Working -> Completed without invoking the
+    // Runner, so a client saw a task reporting success that produced nothing. Both reference ADK
+    // implementations drive the runner and translate its events; these assert that contract.
+
+    /// Reads the text out of an A2A part, or `None` for non-text content.
+    fn part_text(part: &a2a_protocol_types::Part) -> Option<&str> {
+        match &part.content {
+            a2a_protocol_types::PartContent::Text(text) => Some(text.as_str()),
+            _ => None,
+        }
+    }
+
+    /// Emits `chunks` as partial events then a final one, the shape a streaming model produces.
+    struct ChunkingAgent {
+        chunks: Vec<String>,
+    }
+
+    #[async_trait::async_trait]
+    impl adk_core::Agent for ChunkingAgent {
+        fn name(&self) -> &str {
+            "chunking_agent"
+        }
+
+        fn description(&self) -> &str {
+            "emits partial text chunks"
+        }
+
+        fn sub_agents(&self) -> &[Arc<dyn adk_core::Agent>] {
+            &[]
+        }
+
+        async fn run(
+            &self,
+            _ctx: Arc<dyn adk_core::InvocationContext>,
+        ) -> adk_core::Result<adk_core::EventStream> {
+            let chunks = self.chunks.clone();
+            let last = chunks.len().saturating_sub(1);
+            let events: Vec<adk_core::Result<adk_core::Event>> = chunks
+                .into_iter()
+                .enumerate()
+                .map(|(i, text)| {
+                    let mut event = adk_core::Event::new("chunking_agent");
+                    event.llm_response.content =
+                        Some(adk_core::Content::new("model").with_text(&text));
+                    event.llm_response.partial = i < last;
+                    Ok(event)
+                })
+                .collect();
+            Ok(Box::pin(futures::stream::iter(events)))
+        }
+    }
+
+    /// Fails immediately, to check the terminal state is not reported as success.
+    struct FailingAgent;
+
+    #[async_trait::async_trait]
+    impl adk_core::Agent for FailingAgent {
+        fn name(&self) -> &str {
+            "failing_agent"
+        }
+
+        fn description(&self) -> &str {
+            "fails immediately"
+        }
+
+        fn sub_agents(&self) -> &[Arc<dyn adk_core::Agent>] {
+            &[]
+        }
+
+        async fn run(
+            &self,
+            _ctx: Arc<dyn adk_core::InvocationContext>,
+        ) -> adk_core::Result<adk_core::EventStream> {
+            Ok(Box::pin(futures::stream::iter(vec![Err(adk_core::AdkError::model(
+                "upstream exploded",
+            ))])))
+        }
+    }
+
+    fn handler_with_agent(agent: Arc<dyn adk_core::Agent>) -> (RequestHandler, Arc<dyn TaskStore>) {
+        let store: Arc<dyn TaskStore> = Arc::new(InMemoryTaskStore::new());
+        let executor = Arc::new(V1Executor::new(store.clone()));
+        let cached = Arc::new(RwLock::new(CachedAgentCard::new(make_test_agent_card())));
+        let runner_config = Arc::new(
+            adk_runner::Runner::builder()
+                .app_name("a2a-stream-test")
+                .agent(agent)
+                .session_service(Arc::new(adk_session::InMemorySessionService::new()))
+                .build_config(),
+        );
+        let handler = RequestHandler::with_runner(
+            executor,
+            store.clone(),
+            Arc::new(NoOpPushNotificationSender),
+            cached,
+            runner_config,
+        );
+        (handler, store)
+    }
+
+    #[tokio::test]
+    async fn stream_delivers_agent_text_as_artifact_chunks() {
+        let (handler, _store) = handler_with_agent(Arc::new(ChunkingAgent {
+            chunks: vec!["Hel".into(), "lo ".into(), "world".into()],
+        }));
+
+        let mut stream = handler.message_stream(make_test_message()).await.expect("stream starts");
+        let mut artifacts = Vec::new();
+        let mut states = Vec::new();
+        while let Some(item) = stream.next().await {
+            match item.expect("no stream error") {
+                StreamResponse::ArtifactUpdate(e) => artifacts.push(e),
+                StreamResponse::StatusUpdate(e) => states.push(e.status.state),
+                _ => {}
+            }
+        }
+
+        assert_eq!(artifacts.len(), 3, "one artifact event per agent chunk");
+        let joined: String =
+            artifacts.iter().flat_map(|e| e.artifact.parts.iter().filter_map(part_text)).collect();
+        assert_eq!(joined, "Hello world", "the agent's text must reach the client");
+        assert_eq!(states, vec![TaskState::Working, TaskState::Completed]);
+    }
+
+    #[tokio::test]
+    async fn stream_chunks_share_one_artifact_id_and_mark_the_last() {
+        let (handler, _store) =
+            handler_with_agent(Arc::new(ChunkingAgent { chunks: vec!["a".into(), "b".into()] }));
+
+        let mut stream = handler.message_stream(make_test_message()).await.expect("stream starts");
+        let mut artifacts = Vec::new();
+        while let Some(item) = stream.next().await {
+            if let StreamResponse::ArtifactUpdate(e) = item.expect("no error") {
+                artifacts.push(e);
+            }
+        }
+
+        assert_eq!(artifacts.len(), 2);
+        assert_eq!(
+            artifacts[0].artifact.id, artifacts[1].artifact.id,
+            "a client joins chunks by artifact ID, so they must match"
+        );
+        assert_eq!(artifacts[0].append, Some(false), "the first chunk starts the artifact");
+        assert_eq!(artifacts[1].append, Some(true), "later chunks append");
+        assert_eq!(artifacts[0].last_chunk, Some(false));
+        assert_eq!(artifacts[1].last_chunk, Some(true), "the final chunk must be marked");
+    }
+
+    #[tokio::test]
+    async fn stream_failure_does_not_report_a_completed_task() {
+        let (handler, _store) = handler_with_agent(Arc::new(FailingAgent));
+
+        let mut stream = handler.message_stream(make_test_message()).await.expect("stream starts");
+        let mut states = Vec::new();
+        let mut saw_error = false;
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(StreamResponse::StatusUpdate(e)) => states.push(e.status.state),
+                Ok(_) => {}
+                Err(_) => saw_error = true,
+            }
+        }
+
+        assert!(saw_error, "the agent error must surface to the caller");
+        assert!(
+            states.contains(&TaskState::Failed),
+            "terminal state must be Failed, got {states:?}"
+        );
+        assert!(
+            !states.contains(&TaskState::Completed),
+            "a failed run must never report Completed: {states:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn streamed_text_is_persisted_for_tasks_get() {
+        let (handler, store) = handler_with_agent(Arc::new(ChunkingAgent {
+            chunks: vec!["one ".into(), "two".into()],
+        }));
+
+        let mut stream = handler.message_stream(make_test_message()).await.expect("stream starts");
+        let mut task_id = None;
+        while let Some(item) = stream.next().await {
+            if let Ok(StreamResponse::Task(t)) = item {
+                task_id = Some(t.id.0.clone());
+            }
+        }
+
+        let entry = store.get_task(&task_id.expect("task event")).await.expect("task exists");
+        let text: String =
+            entry.artifacts.iter().flat_map(|a| a.parts.iter().filter_map(part_text)).collect();
+        assert_eq!(text, "one two", "a later tasks/get must see what was streamed");
+    }
 
     fn make_handler() -> RequestHandler {
         let store = Arc::new(InMemoryTaskStore::new());

--- a/adk-server/src/a2a/v1/task_store.rs
+++ b/adk-server/src/a2a/v1/task_store.rs
@@ -227,15 +227,15 @@ impl TaskStore for InMemoryTaskStore {
         let mut results: Vec<TaskStoreEntry> = tasks
             .values()
             .filter(|entry| {
-                if let Some(ref ctx) = params.context_id {
-                    if entry.context_id != *ctx {
-                        return false;
-                    }
+                if let Some(ref ctx) = params.context_id
+                    && entry.context_id != *ctx
+                {
+                    return false;
                 }
-                if let Some(ref state) = params.state {
-                    if entry.status.state != *state {
-                        return false;
-                    }
+                if let Some(ref state) = params.state
+                    && entry.status.state != *state
+                {
+                    return false;
                 }
                 true
             })

--- a/adk-server/src/registry/store.rs
+++ b/adk-server/src/registry/store.rs
@@ -136,16 +136,16 @@ impl AgentRegistryStore for InMemoryAgentRegistryStore {
 
 /// Check whether an agent card matches the given filter criteria.
 fn matches_filter(card: &AgentCard, filter: &AgentFilter) -> bool {
-    if let Some(prefix) = &filter.name_prefix {
-        if !card.name.starts_with(prefix.as_str()) {
-            return false;
-        }
+    if let Some(prefix) = &filter.name_prefix
+        && !card.name.starts_with(prefix.as_str())
+    {
+        return false;
     }
 
-    if let Some(tag) = &filter.tag {
-        if !card.tags.contains(tag) {
-            return false;
-        }
+    if let Some(tag) = &filter.tag
+        && !card.tags.contains(tag)
+    {
+        return false;
     }
 
     // version_range is reserved for future use — currently a no-op

--- a/adk-server/src/yaml_agent/interpolator.rs
+++ b/adk-server/src/yaml_agent/interpolator.rs
@@ -199,10 +199,10 @@ fn interpolate_option_field(
     path: &str,
     errors: &mut Vec<InterpolationError>,
 ) {
-    if let Some(value) = field {
-        if value.contains("${") {
-            *value = resolve_placeholders(value, path, errors);
-        }
+    if let Some(value) = field
+        && value.contains("${")
+    {
+        *value = resolve_placeholders(value, path, errors);
     }
 }
 

--- a/adk-server/src/yaml_agent/loader.rs
+++ b/adk-server/src/yaml_agent/loader.rs
@@ -280,12 +280,12 @@ impl AgentConfigLoader {
         }
 
         // Validate temperature range if provided
-        if let Some(temp) = def.model.temperature {
-            if !(0.0..=2.0).contains(&temp) {
-                return Err(adk_core::AdkError::config(format!(
-                    "field 'model.temperature' must be between 0.0 and 2.0, got {temp} in '{path_display}'"
-                )));
-            }
+        if let Some(temp) = def.model.temperature
+            && !(0.0..=2.0).contains(&temp)
+        {
+            return Err(adk_core::AdkError::config(format!(
+                "field 'model.temperature' must be between 0.0 and 2.0, got {temp} in '{path_display}'"
+            )));
         }
 
         Ok(())
@@ -407,12 +407,12 @@ fn collect_yaml_files(dir: &Path) -> adk_core::Result<Vec<PathBuf>> {
             ))
         })?;
         let path = entry.path();
-        if path.is_file() {
-            if let Some(ext) = path.extension() {
-                let ext = ext.to_string_lossy().to_lowercase();
-                if ext == "yaml" || ext == "yml" {
-                    files.push(path);
-                }
+        if path.is_file()
+            && let Some(ext) = path.extension()
+        {
+            let ext = ext.to_string_lossy().to_lowercase();
+            if ext == "yaml" || ext == "yml" {
+                files.push(path);
             }
         }
     }

--- a/adk-server/tests/registry_property_tests.rs
+++ b/adk-server/tests/registry_property_tests.rs
@@ -100,15 +100,15 @@ fn arb_agent_filter() -> impl Strategy<Value = AgentFilter> {
 
 /// Reference implementation of filter matching (mirrors store.rs logic).
 fn card_matches_filter(card: &AgentCard, filter: &AgentFilter) -> bool {
-    if let Some(prefix) = &filter.name_prefix {
-        if !card.name.starts_with(prefix.as_str()) {
-            return false;
-        }
+    if let Some(prefix) = &filter.name_prefix
+        && !card.name.starts_with(prefix.as_str())
+    {
+        return false;
     }
-    if let Some(tag) = &filter.tag {
-        if !card.tags.contains(tag) {
-            return false;
-        }
+    if let Some(tag) = &filter.tag
+        && !card.tags.contains(tag)
+    {
+        return false;
     }
     true
 }

--- a/docs/official_docs/deployment/a2a.md
+++ b/docs/official_docs/deployment/a2a.md
@@ -1,6 +1,6 @@
 # Agent-to-Agent (A2A) Protocol
 
-ADK-Rust implements the [A2A Protocol v1.0.0](https://google.github.io/A2A/) for cross-network agent communication. The implementation lives in `adk-server` behind the `a2a-v1` feature flag and covers all 11 JSON-RPC operations, REST bindings, agent card discovery, and version negotiation. Wire types are provided by [`a2a-protocol-types`](https://crates.io/crates/a2a-protocol-types) — the Foundation-verified Rust A2A SDK by [@tomtom215](https://github.com/tomtom215) ([a2a-rust](https://github.com/tomtom215/a2a-rust)).
+ADK-Rust implements the [A2A Protocol v1.0.0](https://google.github.io/A2A/) for cross-network agent communication. The implementation lives in `adk-server` behind the `a2a-v1` feature flag and covers all 11 JSON-RPC operations, REST bindings, agent card discovery, and version negotiation. See [Operation coverage](#operation-coverage) for the one operation whose semantics are narrower than the specification allows. Wire types are provided by [`a2a-protocol-types`](https://crates.io/crates/a2a-protocol-types) — the Foundation-verified Rust A2A SDK by [@tomtom215](https://github.com/tomtom215) ([a2a-rust](https://github.com/tomtom215/a2a-rust)).
 
 ## Overview
 
@@ -147,7 +147,7 @@ axum::serve(listener, app).await?;
 
 This exposes:
 - `GET /.well-known/agent-card.json` — Agent card with ETag caching
-- `POST /jsonrpc` — JSON-RPC endpoint (all 11 v1 operations)
+- `POST /jsonrpc` — JSON-RPC endpoint (all 11 v1 operations; see [Operation coverage](#operation-coverage))
 - REST routes for all operations
 - `A2A-Version` header negotiation on all routes
 
@@ -340,3 +340,46 @@ The client validates: agent card discovery, SendMessage (both agents with real L
 ---
 
 **Previous**: [← Server](server.md) | **Next**: [Evaluation →](../evaluation/evaluation.md)
+
+## Operation coverage
+
+All 11 v1 JSON-RPC operations are dispatched and implemented.
+
+| Operation | Status |
+|-----------|--------|
+| `SendMessage` | Drives the agent, records its output as an artifact |
+| `SendStreamingMessage` | Drives the agent, streams artifact chunks as they are produced |
+| `GetTask`, `ListTasks` | Full |
+| `CancelTask` | Full |
+| `SubscribeToTask` (`tasks/resubscribe`) | **Snapshot only** — see below |
+| `CreateTaskPushNotificationConfig`, `GetTaskPushNotificationConfig`, `ListTaskPushNotificationConfigs`, `DeleteTaskPushNotificationConfig` | Full |
+| `GetExtendedAgentCard` | Full |
+
+### `SubscribeToTask` is a snapshot
+
+The operation returns the task and its current status, then closes the stream. It does **not**
+deliver subsequent updates, so a client must not wait on it for progress.
+
+A live re-attach requires a per-task event queue that outlives the originating request. The
+reference implementations get this from their A2A SDKs — adk-python and adk-go both delegate
+`tasks/resubscribe` entirely to the SDK's queue manager, and neither implements it in ADK code.
+This server is hand-rolled on `a2a-protocol-types`, which provides wire types rather than a
+server runtime, so the queue does not exist yet.
+
+Use `SendStreamingMessage` when live updates are required.
+
+### Streaming event contract
+
+`SendStreamingMessage` translates agent events as they arrive:
+
+| Agent event | A2A event |
+|-------------|-----------|
+| first, before output | `Task`, then `TaskStatusUpdateEvent` — `Working` |
+| content, `partial = true` | `TaskArtifactUpdateEvent` — `append`, not last chunk |
+| content, `partial = false` | `TaskArtifactUpdateEvent` — final chunk |
+| stream ends | `TaskStatusUpdateEvent` — `Completed` |
+| stream errors | `TaskStatusUpdateEvent` — `Failed` |
+
+All chunks of one response share an artifact ID so a client can reassemble them. The joined text
+is persisted, so a later `GetTask` returns what was streamed. This matches the contract
+adk-python and adk-go implement over their SDKs.


### PR DESCRIPTION
Resolves the **High** finding that the advertised A2A v1 implementation is unfinished. Implemented rather than relabelled, because both reference ADKs gave a clear blueprint.

## The defect

`message_stream` created a task, transitioned `Working` then `Completed`, and returned — never calling the Runner. Its own doc said so: *"This is a placeholder — actual Runner streaming integration comes later."* A client streaming from an A2A agent received a task that reported success and carried no output.

## What the references do

Checked both before writing anything. Neither hand-rolls the A2A server — adk-python uses `a2a-sdk`, adk-go uses `a2a-go` — but both bridge the runner identically:

```python
# adk-python, a2a_agent_executor_impl.py:189
async for adk_event in runner.run_async(...): enqueue(convert(adk_event))
```
```go
// adk-go, v2/executor.go:342
for adkEvent := range r.Run(...) { yield(processor.process(adkEvent)) }
```

## Approach

Runner setup is extracted into `start_agent`, shared with the buffered `message/send` path, so the two cannot drift — streaming yields from the same stream the buffered path drains.

Translation keys off `llm_response.partial`, matching both references:

| Agent event | A2A event |
|---|---|
| first, before output | `Task`, then `TaskStatusUpdateEvent` — `Working` |
| content, `partial = true` | `TaskArtifactUpdateEvent` — `append`, not last chunk |
| content, `partial = false` | `TaskArtifactUpdateEvent` — final chunk |
| stream ends | `Completed` |
| stream errors | `Failed` |

All chunks share one artifact ID so a client can rejoin them, and the joined text is persisted so a later `tasks/get` returns what was streamed.

## `tasks/resubscribe` — documented, not implemented

Left as a snapshot, now documented as one instead of implying a live re-attach. A real re-attach needs a per-task event queue that outlives the request. **Neither reference implements this in ADK code** — both delegate it wholly to their A2A SDK's queue manager. We build on `a2a-protocol-types`, which is wire types rather than a server runtime, so the queue does not exist yet. `docs/official_docs/deployment/a2a.md` now has an Operation coverage section stating this plainly.

Worth noting: all 11 operations really are dispatched here, which is more than either reference manages — adk-python `raise NotImplementedError` for `tasks/cancel`, adk-go returns `ErrPushNotificationNotSupported` for push config.

## The CI hole behind this

`grep -rn a2a-v1 .github/workflows/` returned **nothing**. The A2A v1 surface — the thing flagged as advertised-but-unfinished — had never been clippy- or test-gated. 11 `collapsible_if` failures had accumulated; I confirmed all 11 on `origin/main` in a clean worktree. Fixed, and `adk-server --features a2a-v1` joins the feature-coverage matrix.

Third instance of this pattern after standalone examples (#503) and `sso` (#510).

## Verification

| Gate | Result |
|---|---|
| `cargo nextest run -p adk-server --features a2a-v1` | **355 passed** |
| `cargo clippy -p adk-server --features a2a-v1 --all-targets -- -D warnings` | exit 0 |
| `cargo clippy -p adk-server --all-features --all-targets -- -D warnings` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| Sabotage (bypass the runner) | **4 of 4 new tests FAIL** |