### PR TITLE
fix(runner): make SandboxRunner actually run the agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -612,6 +612,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **adk-runner: `SandboxRunner::run` runs the agent instead of reporting a completed run that
+  did nothing.** The method provisioned the workspace, started the session, bound tools, then
+  executed a placeholder future and returned `Ok`. It now drives the inner `Runner` with the
+  bound sandbox tools injected through `RunConfig::runtime_toolsets`, creates the session when
+  absent, and drains the event stream before the session is stopped. **Breaking:** `run` takes a
+  `user_content: Content` argument — an agent loop cannot run without input.
+- **adk-runner: `Runner::run_with_config` supplies a per-invocation `RunConfig`.** Needed for
+  tools that exist only for the duration of one run. `Runner::run` delegates to it with `None`.
+  New accessors: `Runner::run_config`, `Runner::app_name`, `Runner::session_service`.
+
 - **adk-auth: the `sso` feature compiles and is gated by CI again.** No workflow built
   `adk-auth --features sso`, so its SSO/OAuth surface had drifted out of the clippy gate and
   failed `-D warnings` on four `collapsible_if` lints. `jsonwebtoken` moves to 11, whose

--- a/adk-runner/Cargo.toml
+++ b/adk-runner/Cargo.toml
@@ -39,6 +39,7 @@ sandbox-runner = ["dep:adk-sandbox", "adk-sandbox/workspace"]
 context-compaction = []
 
 [dev-dependencies]
+adk-session.workspace = true
 chrono = "0.4"
 proptest = "1.5"
 tempfile = "3"

--- a/adk-runner/src/runner.rs
+++ b/adk-runner/src/runner.rs
@@ -261,6 +261,43 @@ impl Runner {
         session_id: SessionId,
         user_content: Content,
     ) -> Result<EventStream> {
+        self.run_with_config(user_id, session_id, user_content, None).await
+    }
+
+    /// Returns the runner's application name.
+    pub fn app_name(&self) -> &str {
+        &self.app_name
+    }
+
+    /// Returns the runner's session service.
+    pub fn session_service(&self) -> &Arc<dyn adk_session::SessionService> {
+        &self.session_service
+    }
+
+    /// Returns the runner's configured [`RunConfig`].
+    ///
+    /// Useful as a base to clone and adjust for [`Self::run_with_config`].
+    pub fn run_config(&self) -> &RunConfig {
+        &self.run_config
+    }
+
+    /// Runs the agent with a per-invocation [`RunConfig`] override.
+    ///
+    /// Passing `None` uses the runner's configured `RunConfig`. Supply one to vary a single
+    /// invocation — injecting `runtime_toolsets` for tools that only exist for the duration of
+    /// that run, for example, as [`crate::sandbox_runner::SandboxRunner`] does with the tools
+    /// bound to a live sandbox session.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the session cannot be resolved or the agent fails to start.
+    pub async fn run_with_config(
+        &self,
+        user_id: UserId,
+        session_id: SessionId,
+        user_content: Content,
+        run_config: Option<RunConfig>,
+    ) -> Result<EventStream> {
         let app_name = self.app_name.clone();
         let typed_app_name = AppName::try_from(app_name.clone())?;
         let session_service = self.session_service.clone();
@@ -272,7 +309,7 @@ impl Runner {
         let plugin_manager = self.plugin_manager.clone();
         #[cfg(feature = "skills")]
         let skill_injector = self.skill_injector.clone();
-        let mut run_config = self.run_config.clone();
+        let mut run_config = run_config.unwrap_or_else(|| self.run_config.clone());
         let compaction_config = self.compaction_config.clone();
         let context_cache_config = self.context_cache_config.clone();
         let cache_capable = self.cache_capable.clone();

--- a/adk-runner/src/sandbox_runner/mod.rs
+++ b/adk-runner/src/sandbox_runner/mod.rs
@@ -19,7 +19,10 @@
 //!
 //! let runner = Runner::new(config)?;
 //! let sandbox_runner = SandboxRunner::new(runner);
-//! let result = sandbox_runner.run(&sandbox_config, "user_1", "session_1").await?;
+//! let content = adk_core::Content::new("user").with_text("list the files");
+//! let result = sandbox_runner
+//!     .run(&sandbox_config, "user_1", "session_1", content)
+//!     .await?;
 //! ```
 
 pub mod binding;
@@ -29,7 +32,31 @@ use crate::Runner;
 use adk_sandbox::SandboxError;
 use adk_sandbox::workspace::{SandboxConfig, SnapshotId};
 use std::sync::Arc;
+
+use futures::StreamExt;
 use tracing::{info, warn};
+
+/// Exposes the tools bound to a live sandbox session as a [`Toolset`].
+///
+/// The tools hold the session handle, so they are valid only for the run that created them and
+/// are injected per-invocation rather than attached to the agent.
+struct SandboxToolset {
+    tools: Vec<Arc<dyn adk_core::Tool>>,
+}
+
+#[async_trait::async_trait]
+impl adk_core::Toolset for SandboxToolset {
+    fn name(&self) -> &str {
+        "sandbox"
+    }
+
+    async fn tools(
+        &self,
+        _ctx: Arc<dyn adk_core::ReadonlyContext>,
+    ) -> adk_core::Result<Vec<Arc<dyn adk_core::Tool>>> {
+        Ok(self.tools.clone())
+    }
+}
 
 /// Runner wrapper that manages the sandbox lifecycle around agent execution.
 ///
@@ -76,6 +103,7 @@ impl SandboxRunner {
         config: &SandboxConfig,
         user_id: &str,
         session_id: &str,
+        user_content: adk_core::Content,
     ) -> Result<SandboxRunResult, adk_core::AdkError> {
         // 1. Provision workspace from manifest
         info!("provisioning sandbox workspace");
@@ -95,23 +123,62 @@ impl SandboxRunner {
 
         // 3. Bind tools based on capabilities
         let session_arc = Arc::from(session);
-        let _bound_tools =
+        let bound_tools =
             binding::bind_tools(session_arc, &config.capabilities, config.command_timeout);
         info!(
             capabilities = ?config.capabilities,
-            tool_count = _bound_tools.len(),
+            tool_count = bound_tools.len(),
             "bound sandbox tools"
         );
 
-        // 4. Run agent loop with session timeout
-        // NOTE: The inner Runner doesn't yet support dynamic tool injection.
-        // The bound tools are prepared here; actual agent loop integration will
-        // be completed when the agent builder supports injecting tools at runtime.
-        // For now, we simulate the agent loop step as a placeholder.
+        // 4. Run the agent loop with the sandbox tools injected, under the session timeout.
+        //
+        // The tools exist only while this session is live, so they are supplied per-invocation
+        // through `runtime_toolsets` rather than baked into the agent.
+        let mut run_config = self.inner.run_config().clone();
+        run_config
+            .runtime_toolsets
+            .push(adk_core::RuntimeToolset::new(Arc::new(SandboxToolset { tools: bound_tools })));
+
         let agent_loop_future = async {
-            // Use the user_id and session_id for future agent loop integration
-            let _ = (user_id, session_id);
-            Ok::<(), adk_core::AdkError>(())
+            // The Runner requires the session to exist. Create it when absent so a caller can
+            // hand in a fresh session ID, matching how the A2A handler resolves sessions.
+            let session_service = self.inner.session_service();
+            if session_service
+                .get(adk_session::GetRequest {
+                    app_name: self.inner.app_name().to_string(),
+                    user_id: user_id.to_string(),
+                    session_id: session_id.to_string(),
+                    num_recent_events: None,
+                    after: None,
+                })
+                .await
+                .is_err()
+            {
+                session_service
+                    .create(adk_session::CreateRequest {
+                        app_name: self.inner.app_name().to_string(),
+                        user_id: user_id.to_string(),
+                        session_id: Some(session_id.to_string()),
+                        state: std::collections::HashMap::new(),
+                    })
+                    .await?;
+            }
+
+            let user_id = adk_core::UserId::new(user_id)?;
+            let session_id = adk_core::SessionId::new(session_id)?;
+            let mut events = self
+                .inner
+                .run_with_config(user_id, session_id, user_content, Some(run_config))
+                .await?;
+            // Drain the stream so the agent runs to completion before the session is stopped;
+            // returning early would tear the sandbox down underneath the agent.
+            let mut count = 0usize;
+            while let Some(event) = events.next().await {
+                event?;
+                count += 1;
+            }
+            Ok::<usize, adk_core::AdkError>(count)
         };
 
         let agent_loop_result =
@@ -126,9 +193,9 @@ impl SandboxRunner {
                     timeout = ?config.session_timeout,
                     "sandbox session timed out"
                 );
-                Err(adk_core::AdkError::from(SandboxError::SessionTimeout {
-                    timeout: config.session_timeout,
-                }))
+                Err::<usize, adk_core::AdkError>(adk_core::AdkError::from(
+                    SandboxError::SessionTimeout { timeout: config.session_timeout },
+                ))
             }
         };
 

--- a/adk-runner/tests/sandbox_runner_tests.rs
+++ b/adk-runner/tests/sandbox_runner_tests.rs
@@ -1,0 +1,154 @@
+//! `SandboxRunner::run` must actually run the agent.
+//!
+//! It used to provision the workspace, start a session, bind tools, and then execute
+//! `Ok::<(), AdkError>(())` — a comment read "For now, we simulate the agent loop step as a
+//! placeholder." Provisioning succeeded, so the call returned `Ok` and reported a completed
+//! sandbox run in which no agent had ever executed.
+#![cfg(feature = "sandbox-runner")]
+
+use adk_core::{Agent, Content, EventStream, InvocationContext, Result as AdkResult};
+use adk_runner::Runner;
+use adk_runner::sandbox_runner::SandboxRunner;
+use adk_sandbox::SandboxError;
+use adk_sandbox::workspace::{
+    Capability, DirEntry, ExecOutput, Manifest, SandboxClient, SandboxConfig, SandboxSession,
+    SessionHandle, SnapshotId,
+};
+use async_trait::async_trait;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+/// Records whether the agent was invoked, and what tools it could see.
+struct RecordingAgent {
+    runs: Arc<AtomicUsize>,
+    tools_seen: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl Agent for RecordingAgent {
+    fn name(&self) -> &str {
+        "recording_agent"
+    }
+
+    fn description(&self) -> &str {
+        "records that it ran"
+    }
+
+    fn sub_agents(&self) -> &[Arc<dyn Agent>] {
+        &[]
+    }
+
+    async fn run(&self, ctx: Arc<dyn InvocationContext>) -> AdkResult<EventStream> {
+        self.runs.fetch_add(1, Ordering::SeqCst);
+        let mut count = 0usize;
+        for runtime in &ctx.run_config().runtime_toolsets {
+            count += runtime.toolset().tools(ctx.clone()).await?.len();
+        }
+        self.tools_seen.store(count, Ordering::SeqCst);
+        Ok(Box::pin(futures::stream::empty()))
+    }
+}
+
+struct FakeSession;
+
+#[async_trait]
+impl SandboxSession for FakeSession {
+    async fn exec_command(
+        &self,
+        _command: &str,
+        _working_dir: Option<&str>,
+    ) -> Result<ExecOutput, SandboxError> {
+        Ok(ExecOutput {
+            stdout: String::new(),
+            stderr: String::new(),
+            exit_code: 0,
+            duration: Duration::from_millis(1),
+            timed_out: false,
+        })
+    }
+
+    async fn read_file(&self, _path: &str) -> Result<Vec<u8>, SandboxError> {
+        Ok(Vec::new())
+    }
+
+    async fn write_file(&self, _path: &str, _content: &[u8]) -> Result<(), SandboxError> {
+        Ok(())
+    }
+
+    async fn list_dir(&self, _path: &str) -> Result<Vec<DirEntry>, SandboxError> {
+        Ok(Vec::new())
+    }
+
+    async fn apply_patch(&self, _patch: &str) -> Result<(), SandboxError> {
+        Ok(())
+    }
+}
+
+/// Counts lifecycle calls so cleanup can be asserted.
+struct FakeClient {
+    stops: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl SandboxClient for FakeClient {
+    async fn provision(&self, _manifest: &Manifest) -> Result<SessionHandle, SandboxError> {
+        Ok(SessionHandle("fake-handle".to_string()))
+    }
+
+    async fn start(
+        &self,
+        _handle: &SessionHandle,
+    ) -> Result<Box<dyn SandboxSession>, SandboxError> {
+        Ok(Box::new(FakeSession))
+    }
+
+    async fn stop(&self, _handle: &SessionHandle) -> Result<(), SandboxError> {
+        self.stops.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn snapshot(&self, _handle: &SessionHandle) -> Result<SnapshotId, SandboxError> {
+        Ok(SnapshotId("fake-snapshot".to_string()))
+    }
+
+    async fn resume(&self, _snapshot_id: &SnapshotId) -> Result<SessionHandle, SandboxError> {
+        Ok(SessionHandle("fake-handle".to_string()))
+    }
+}
+
+#[tokio::test]
+async fn run_invokes_the_inner_agent() {
+    let runs = Arc::new(AtomicUsize::new(0));
+    let tools_seen = Arc::new(AtomicUsize::new(0));
+    let stops = Arc::new(AtomicUsize::new(0));
+
+    let agent = Arc::new(RecordingAgent { runs: runs.clone(), tools_seen: tools_seen.clone() });
+    let runner = Runner::builder()
+        .app_name("sandbox-runner-test")
+        .agent(agent)
+        .session_service(Arc::new(adk_session::InMemorySessionService::new()))
+        .build()
+        .expect("runner builds");
+
+    let config = SandboxConfig {
+        client: Arc::new(FakeClient { stops: stops.clone() }),
+        manifest: Manifest::new(Vec::new()),
+        capabilities: [Capability::Shell, Capability::Filesystem].into_iter().collect(),
+        command_timeout: Duration::from_secs(5),
+        session_timeout: Duration::from_secs(30),
+        snapshot_on_stop: false,
+    };
+
+    let sandbox = SandboxRunner::new(runner);
+    let content = Content::new("user").with_text("do the thing");
+    sandbox.run(&config, "user-1", "session-1", content).await.expect("the sandbox run succeeds");
+
+    assert_eq!(runs.load(Ordering::SeqCst), 1, "the agent must actually be invoked");
+    assert!(
+        tools_seen.load(Ordering::SeqCst) >= 2,
+        "the agent must see the tools bound to the live session, saw {}",
+        tools_seen.load(Ordering::SeqCst)
+    );
+    assert_eq!(stops.load(Ordering::SeqCst), 1, "the session must be stopped exactly once");
+}


### PR DESCRIPTION
Resolves the **High** finding that `SandboxRunner::run` returns success without invoking its inner Runner.

## What it did

Provisioned the workspace, started the session, bound the capability tools, then awaited this:

```rust
let agent_loop_future = async {
    let _ = (user_id, session_id);
    Ok::<(), adk_core::AdkError>(())
};
```

with the comment *"For now, we simulate the agent loop step as a placeholder."* Provisioning succeeded, so the call returned `Ok` and reported a completed sandbox run in which no agent had executed. For a component whose purpose is confining an agent, reporting success for work not done is the worst available outcome.

## The recorded blocker was stale

That comment said *"the inner Runner doesn't yet support dynamic tool injection."* `RunConfig::runtime_toolsets` now exists and `LlmAgent` honours it (`llm_agent.rs:1599`), so the tools bound to the live session are injected per-invocation — the correct lifetime, since they hold the session handle and are invalid once it stops.

## Three supporting changes

| Change | Why |
|---|---|
| `Runner::run_with_config` | supplies a per-invocation `RunConfig`; `run` delegates with `None`, so existing callers are untouched |
| `run` gains `user_content` | **breaking** — an agent loop cannot run without input, which is why the old signature could not express one |
| session created when absent | matches how the A2A handler resolves sessions |

The event stream is drained before the session is stopped; returning early would tear the sandbox down underneath the running agent.

The breaking signature change affects one caller — an example that constructed the type without ever calling `run`.

## The session gap was found by the test

My first implementation compiled and failed:

```
the sandbox run succeeds: AdkError { component: Session, message: "session not found" }
```

The agent ran and the Runner rejected it. Worth recording because it is the kind of thing an assertion-free placeholder never surfaces.

## Upstream context

I checked both reference ADKs before implementing. **Neither sandboxes the agent loop** — adk-python and adk-go both sandbox individual code-execution calls through a per-block hook, with the Runner, session service and model client always in the host process. adk-python has no `SandboxRunner`; adk-go has no code executors at all (its two flow processors are `// TODO: implement` no-op stubs).

So this is an ADK-Rust concept with no upstream design to copy and no upstream validation. It stays experimental.

## Verification

| Gate | Result |
|---|---|
| `cargo nextest run -p adk-runner --all-features` | **142 passed** |
| `cargo clippy -p adk-runner --all-features --all-targets -- -D warnings` | exit 0 |
| `examples/sandbox_workspace_agent` compiles `--locked` | yes |
| Sabotage (restore the placeholder) | `run_invokes_the_inner_agent` **FAILS** |