### PR TITLE
fix: unblock v2 stabilization baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 ![Rust](https://img.shields.io/badge/rust-1.94%2B-orange.svg)
 [![GitHub Discussions](https://img.shields.io/github/discussions/zavora-ai/adk-rust?style=flat&logo=github&color=5865F2)](https://github.com/zavora-ai/adk-rust/discussions)
 
-> **🚀 v2.0.0 Released!** 41 published crates. Official `rmcp 2.2` MCP SDK (protocol `2025-11-25`) with effective HTTP configuration, official `agent-client-protocol` 1.2 for ACP with exact capability publication, the new `adk-computer-use` governed desktop-automation layer, `adk-devtools` coding-agent tools, live async tool confirmation keyed by function-call ID, and resolved dependency advisories. See the [migration guide](docs/official_docs/migration/1.0-to-2.0.md) for the complete breaking-change list and [CHANGELOG](CHANGELOG.md) for full details.
+> **v2.0.0 release candidate — unpublished.** The 41-crate v2 workspace is being stabilized; v2 has not been published to crates.io. The candidate targets the official `rmcp 2.2` MCP SDK (protocol `2025-11-25`) with effective HTTP configuration, official `agent-client-protocol` 1.2 for ACP with exact capability publication, the new `adk-computer-use` governed desktop-automation layer, `adk-devtools` coding-agent tools, and live async tool confirmation keyed by function-call ID. See the [migration guide](docs/official_docs/migration/1.0-to-2.0.md) for the planned breaking changes and [CHANGELOG](CHANGELOG.md) for full details.
+>
+> **Release transition:** This banner changes to “Released” only after all 41 v2.0.0 crates are available on crates.io. The roadmap marker then changes from “release candidate” to “current.”
 >
 > **Contributors:** Many thanks to [@mikefaille](https://github.com/mikefaille) — AdkIdentity design, realtime audio, LiveKit bridge, skill system. [@rohan-panickar](https://github.com/rohan-panickar) — OpenAI-compatible providers, xAI, multimodal content. [@dhruv-pant](https://github.com/dhruv-pant) — Gemini service account auth. [@tomtom215](https://github.com/tomtom215) — A2A Protocol v1.0.0 types crate ([a2a-protocol-types](https://crates.io/crates/a2a-protocol-types)), Foundation-verified wire types powering our A2A v1 layer. [@danielsan](https://github.com/danielsan) — Google deps issue & PR (#181, #203), RAG crash report (#205). [@CodingFlow](https://github.com/CodingFlow) — Gemini 3 thinking level, global endpoint, citationSources (#177, #178, #179). [@ctylx](https://github.com/ctylx) — skill discovery fix (#204). [@poborin](https://github.com/poborin) — project config proposal (#176). [@chillin-capybara](https://github.com/chillin-capybara) — ACP integration, adk-acp crate. [@baotao2006](https://github.com/baotao2006) — UTF-8 boundary audit, CJK search/skill/eval fixes (#349, #357). [Get started →](https://github.com/zavora-ai/adk-rust/wiki/quickstart)
 >
@@ -1104,7 +1106,7 @@ Contributions welcome! Please open an issue or pull request on GitHub.
 
 ## Roadmap
 
-**v2.0.0** (current) — production agent framework:
+**v2.0.0** (release candidate) — production agent framework:
 - **Composable Template System** — 12 templates, 9 add-ons, 5 enterprise patterns via `cargo adk new --addon`.
 - **Cargo Adk Build** — compile-without-deploy subcommand for pre-deployment verification.
 - **A2A Simple Scaffolding** — `A2aServer::quick_start`, `A2aServer::builder`, and `cargo adk new --template a2a-server`.

--- a/adk-sandbox/src/process.rs
+++ b/adk-sandbox/src/process.rs
@@ -51,6 +51,26 @@ use crate::types::{ExecRequest, ExecResult, Language};
 /// Maximum output size in bytes (1 MB).
 const MAX_OUTPUT_BYTES: usize = 1_024 * 1_024;
 
+/// Host variables exposed only while compiling Rust on non-Windows platforms.
+const NON_WINDOWS_TOOLCHAIN_ENV_KEYS: &[&str] = &[
+    "PATH",
+    "DEVELOPER_DIR",
+    "SDKROOT",
+    "HOME",
+    "TMPDIR",
+    "RUSTUP_HOME",
+    "CARGO_HOME",
+    "RUSTUP_TOOLCHAIN",
+];
+
+/// Host variables exposed only while compiling Rust with the MSVC toolchain.
+///
+/// `LIB` is the linker's library search path. The remaining Windows-specific
+/// values support temporary files, system DLL discovery, and rustup's default
+/// toolchain location without copying the full developer-shell environment.
+const WINDOWS_TOOLCHAIN_ENV_KEYS: &[&str] =
+    &["PATH", "LIB", "SystemRoot", "TEMP", "TMP", "USERPROFILE", "RUSTUP_HOME", "RUSTUP_TOOLCHAIN"];
+
 /// Configuration for [`ProcessBackend`].
 ///
 /// Provides paths to language runtimes. Defaults use bare command names
@@ -442,9 +462,10 @@ impl ProcessBackend {
 
     /// Variables a compiler needs to find its own tools.
     ///
-    /// `rustc` shells out to a linker — `cc`, and `xcrun` on macOS — and resolves them
-    /// through the environment. With the environment cleared it cannot link at all, so
-    /// compilation gets these passed through from the caller when they are set.
+    /// `rustc` shells out to a platform linker and resolves it through the environment.
+    /// The MSVC linker also reads `LIB` to find the Windows and C runtime libraries.
+    /// With the environment cleared it cannot link at all, so compilation gets a small
+    /// platform-specific allowlist from the caller when those values are set.
     ///
     /// This widens what the compile phase can see compared with the run phase. An OS
     /// enforcer is what constrains it; see [`ProcessBackend::isolation`].
@@ -455,19 +476,12 @@ impl ProcessBackend {
         // caller intended, or — when the pinned one is not installed — tries to download it and
         // fails against the sandbox's network denial, reporting "syncing channel updates" from
         // what looks like a compile error.
-        [
-            "PATH",
-            "DEVELOPER_DIR",
-            "SDKROOT",
-            "HOME",
-            "TMPDIR",
-            "RUSTUP_HOME",
-            "CARGO_HOME",
-            "RUSTUP_TOOLCHAIN",
-        ]
-        .iter()
-        .filter_map(|key| std::env::var(key).ok().map(|value| ((*key).to_string(), value)))
-        .collect()
+        let keys =
+            if cfg!(windows) { WINDOWS_TOOLCHAIN_ENV_KEYS } else { NON_WINDOWS_TOOLCHAIN_ENV_KEYS };
+
+        keys.iter()
+            .filter_map(|key| std::env::var(key).ok().map(|value| ((*key).to_string(), value)))
+            .collect()
     }
 
     /// Shared execution logic, with `extra_env` applied below policy and request values.
@@ -877,5 +891,22 @@ mod tests {
         assert_eq!(config.rustc_path, "rustc");
         assert_eq!(config.python_path, "python3");
         assert_eq!(config.node_path, "node");
+    }
+
+    #[test]
+    fn windows_compiler_environment_is_a_minimal_allowlist() {
+        assert_eq!(
+            WINDOWS_TOOLCHAIN_ENV_KEYS,
+            &[
+                "PATH",
+                "LIB",
+                "SystemRoot",
+                "TEMP",
+                "TMP",
+                "USERPROFILE",
+                "RUSTUP_HOME",
+                "RUSTUP_TOOLCHAIN",
+            ]
+        );
     }
 }

--- a/adk-sandbox/tests/process_enforcement_tests.rs
+++ b/adk-sandbox/tests/process_enforcement_tests.rs
@@ -97,11 +97,19 @@ async fn a_compile_error_is_still_reported_as_a_failed_execution() {
 
 #[tokio::test]
 async fn a_working_program_still_runs() {
-    // Guards against the compile rerouting breaking ordinary execution.
+    // Guards against the compile rerouting breaking ordinary execution. The
+    // compiler receives a small toolchain allowlist, while the produced binary
+    // starts again from the cleared runtime environment.
     let backend = ProcessBackend::default();
     let result = backend
         .execute(rust_request(
-            r#"fn main() { println!("hello from rust"); }"#,
+            r#"
+fn main() {
+    println!("hello from rust");
+    println!("compile_lib={}", option_env!("LIB").is_some());
+    println!("runtime_lib={}", std::env::var_os("LIB").is_some());
+}
+"#,
             Duration::from_secs(120),
         ))
         .await
@@ -109,4 +117,15 @@ async fn a_working_program_still_runs() {
 
     assert_eq!(result.exit_code, 0, "stderr was: {}", result.stderr);
     assert!(result.stdout.contains("hello from rust"));
+    assert!(
+        result.stdout.contains("runtime_lib=false"),
+        "the MSVC library path leaked into the produced program: {}",
+        result.stdout
+    );
+    #[cfg(windows)]
+    assert!(
+        result.stdout.contains("compile_lib=true"),
+        "rustc did not receive the MSVC library path: {}",
+        result.stdout
+    );
 }

--- a/scripts/check-release-consistency.py
+++ b/scripts/check-release-consistency.py
@@ -1,18 +1,20 @@
 #!/usr/bin/env python3
-"""Check that every release statement agrees with the workspace version.
+"""Check that every release statement agrees with the workspace version and state.
 
 The workspace version in the root `Cargo.toml` is the single source. The changelog
-heading, the README release banner, and the README roadmap's "current" marker are
-checked against it, so a version bump cannot land with any of them stale.
+heading, README banner, and README roadmap marker are checked against it, so a
+version bump cannot land with any of them stale. The README may describe the
+workspace as an unpublished release candidate before publication or as released
+after publication, but the banner and roadmap must describe the same state.
 
 `scripts/check-doc-versions.py` covers dependency snippets and feature names; it
 explicitly skips `CHANGELOG.md` and does not look at the banner or the roadmap, which
 is how those three drifted apart.
 
 Release mode (`--release`) additionally requires an annotated `v<version>` tag so a
-published artifact can be attributed to an exact commit. Without it the run reports the
-missing tag and the commit that would be tagged, but does not fail — a tag is a release
-action, not a pull-request gate.
+published artifact can be attributed to an exact commit. The normal pull-request
+gate validates documentation state without requiring tags, because pull-request
+checkouts may be shallow.
 """
 
 from __future__ import annotations
@@ -25,6 +27,15 @@ import tomllib
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
+README_BANNER_PATTERN = re.compile(
+    r"\*\*(?:🚀\s*)?v(\d+\.\d+\.\d+)\s+"
+    r"(release candidate\s+—\s+unpublished\.|Released!)\*\*",
+    re.IGNORECASE,
+)
+README_ROADMAP_PATTERN = re.compile(
+    r"\*\*v(\d+\.\d+\.\d+)\*\*\s*\((release candidate|current)\)",
+    re.IGNORECASE,
+)
 
 
 def workspace_version() -> str:
@@ -44,18 +55,26 @@ def changelog_heading_version() -> tuple[str, str] | None:
     return None
 
 
-def readme_banner_version() -> str | None:
-    """The version announced by the README release banner."""
-    match = re.search(r"v(\d+\.\d+\.\d+) Released!", (ROOT / "README.md").read_text())
-    return match.group(1) if match else None
-
-
-def readme_roadmap_current_version() -> str | None:
-    """The version the README roadmap marks as current."""
-    match = re.search(
-        r"\*\*v(\d+\.\d+\.\d+)\*\*\s*\(current\)", (ROOT / "README.md").read_text()
+def readme_banner() -> tuple[str, str] | None:
+    """The version and publication state announced by the README banner."""
+    match = README_BANNER_PATTERN.search((ROOT / "README.md").read_text())
+    if not match:
+        return None
+    state = (
+        "candidate"
+        if match.group(2).lower().startswith("release candidate")
+        else "released"
     )
-    return match.group(1) if match else None
+    return match.group(1), state
+
+
+def readme_roadmap() -> tuple[str, str] | None:
+    """The version and publication state marked by the README roadmap."""
+    match = README_ROADMAP_PATTERN.search((ROOT / "README.md").read_text())
+    if not match:
+        return None
+    state = "candidate" if match.group(2).lower() == "release candidate" else "released"
+    return match.group(1), state
 
 
 def git(*args: str) -> str:
@@ -73,7 +92,7 @@ def main() -> None:
     parser.add_argument(
         "--release",
         action="store_true",
-        help="also require a v<version> tag, for use when cutting a release",
+        help="also require an annotated v<version> tag, for use when cutting a release",
     )
     args = parser.parse_args()
 
@@ -89,31 +108,52 @@ def main() -> None:
             f"but the workspace version is {version}"
         )
 
-    banner = readme_banner_version()
+    banner = readme_banner()
     if banner is None:
-        failures.append("README.md has no `vX.Y.Z Released!` banner")
-    elif banner != version:
         failures.append(
-            f"README.md's release banner announces v{banner}, "
+            "README.md has neither a `vX.Y.Z release candidate — unpublished.` "
+            "nor a `vX.Y.Z Released!` banner"
+        )
+    elif banner[0] != version:
+        failures.append(
+            f"README.md's release banner announces v{banner[0]}, "
             f"but the workspace version is {version}"
         )
 
-    roadmap = readme_roadmap_current_version()
+    roadmap = readme_roadmap()
     if roadmap is None:
-        failures.append("README.md's roadmap has no `**vX.Y.Z** (current)` marker")
-    elif roadmap != version:
         failures.append(
-            f"README.md's roadmap marks v{roadmap} as current, "
+            "README.md's roadmap has neither a `**vX.Y.Z** (release candidate)` "
+            "nor a `**vX.Y.Z** (current)` marker"
+        )
+    elif roadmap[0] != version:
+        failures.append(
+            f"README.md's roadmap marks v{roadmap[0]}, "
             f"but the workspace version is {version}"
+        )
+    if banner is not None and roadmap is not None and banner[1] != roadmap[1]:
+        failures.append(
+            f"README.md's banner is {banner[1]}, but its roadmap is {roadmap[1]}"
         )
 
     tag = f"v{version}"
+    tag_type = git("cat-file", "-t", tag)
     tag_commit = git("rev-list", "-n", "1", tag)
-    if tag_commit:
+    if tag_type == "tag" and tag_commit:
         print(f"release baseline: {tag} -> {tag_commit}")
+    elif tag_type:
+        if args.release:
+            failures.append(
+                f"{tag} is a {tag_type} object, not an annotated tag. Replace it with: "
+                f"git tag -a {tag} -m 'Release {version}'"
+            )
+        else:
+            print(
+                f"note: {tag} exists but is not annotated; release mode will reject it"
+            )
     elif args.release:
         failures.append(
-            f"no {tag} tag exists, so the release cannot be attributed to a commit. "
+            f"no annotated {tag} tag exists, so the release cannot be attributed to a commit. "
             f"Create it with: git tag -a {tag} -m 'Release {version}'"
         )
     else:
@@ -123,13 +163,27 @@ def main() -> None:
             f"Run with --release to make this a failure."
         )
 
+    if banner is not None and banner[1] == "candidate":
+        print(f"release state: v{version} is an unpublished release candidate")
+        if tag_type == "tag":
+            print(
+                "post-publication transition: after every workspace crate is available "
+                "on crates.io, change the README banner to `Released!` and the roadmap "
+                "marker to `(current)`"
+            )
+    elif banner is not None:
+        print(f"release state: v{version} is marked released")
+
     if failures:
-        print(f"\nrelease statements disagree with the workspace version ({version}):\n")
+        print(
+            f"\nrelease statements disagree with the workspace version or state "
+            f"({version}):\n"
+        )
         for failure in failures:
             print(f"  - {failure}")
         sys.exit(1)
 
-    print(f"release statements agree on {version}")
+    print(f"release statements agree on {version} and its publication state")
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_check_release_consistency.py
+++ b/scripts/tests/test_check_release_consistency.py
@@ -1,0 +1,52 @@
+"""Focused tests for the release-state markers parsed from README.md."""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "check-release-consistency.py"
+SPEC = importlib.util.spec_from_file_location("check_release_consistency", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+CHECKER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(CHECKER)
+
+
+class ReleaseStatePatternTests(unittest.TestCase):
+    """Covers the two supported README publication states."""
+
+    def test_candidate_markers_are_recognized(self) -> None:
+        banner = CHECKER.README_BANNER_PATTERN.search(
+            "> **v2.0.0 release candidate — unpublished.**"
+        )
+        roadmap = CHECKER.README_ROADMAP_PATTERN.search(
+            "**v2.0.0** (release candidate)"
+        )
+
+        self.assertEqual(
+            banner.groups(), ("2.0.0", "release candidate — unpublished.")
+        )
+        self.assertEqual(roadmap.groups(), ("2.0.0", "release candidate"))
+
+    def test_released_markers_are_recognized(self) -> None:
+        banner = CHECKER.README_BANNER_PATTERN.search(
+            "> **🚀 v2.0.0 Released!**"
+        )
+        roadmap = CHECKER.README_ROADMAP_PATTERN.search("**v2.0.0** (current)")
+
+        self.assertEqual(banner.groups(), ("2.0.0", "Released!"))
+        self.assertEqual(roadmap.groups(), ("2.0.0", "current"))
+
+    def test_ambiguous_markers_are_rejected(self) -> None:
+        self.assertIsNone(
+            CHECKER.README_BANNER_PATTERN.search("> **v2.0.0 available soon.**")
+        )
+        self.assertIsNone(
+            CHECKER.README_ROADMAP_PATTERN.search("**v2.0.0** (next)")
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

- passes the minimal MSVC toolchain environment to sandboxed Rust compilation on Windows
- verifies `LIB` is compile-only and does not leak into the produced program
- marks v2.0.0 as an unpublished release candidate
- validates candidate/released README state and requires an annotated tag in release mode

## Why

The current merge-tier Windows run fails because `link.exe` cannot locate MSVC system libraries after environment clearing. The README also states that v2.0.0 is released even though publication has not occurred.

## How

- Windows compiler allowlist: `PATH`, `LIB`, `SystemRoot`, `TEMP`, `TMP`, `USERPROFILE`, `RUSTUP_HOME`, `RUSTUP_TOOLCHAIN`
- runtime execution still starts from a cleared environment
- release consistency parser accepts only aligned candidate or released markers
- branch is rebased onto the bounded-output fix from #512

## Verification

- [x] `cargo nextest run -p adk-sandbox` — 48 passed after integrating #512
- [x] `cargo clippy -p adk-sandbox --all-targets -- -D warnings`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `python3 -m unittest scripts/tests/test_check_release_consistency.py` — 3 passed
- [x] `bash scripts/check-release-consistency.sh`
- [x] `cargo check --workspace` (pre-push hook)