### PR TITLE
fix(awp): enforce production request boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,11 +31,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   forge signed webhook deliveries. The field is now `skip_serializing`, and a hand-written
   `Debug` redacts it so capturing a subscription in a `tracing` call cannot write a live
   credential to the logs. The secret remains available in-process for signing.
-- **adk-awp: management routes are separated from the public ones.** `awp_routes` mounted
-  discovery, manifest, health, A2A, and subscription CRUD as one unauthenticated router. The new
-  `awp_public_routes` and `awp_management_routes` let an auth layer be applied to the half that
-  creates, enumerates, and deletes webhook destinations. `awp_routes` still returns everything
-  for local development, and its rustdoc says why that is not a production shape.
+- **adk-awp: public execution and management boundaries now fail closed.** `/awp/a2a` returned
+  `200 acknowledged` without dispatching a message, so callers were told work succeeded when no
+  agent ran. `AwpA2aHandler` now supplies application dispatch; the unconfigured endpoint returns
+  `503`, message IDs and bodies are bounded, and public routes apply the configured rate limiter.
+  `DefaultTrustAssigner` no longer treats an unverified authorization header as known identity.
+  `awp_routes` now returns only public routes; subscription CRUD requires the explicit
+  `awp_management_routes` router and an application auth layer. Malformed version headers return
+  `400` instead of silently becoming the current version. Subscription configuration now requires
+  bounded fields, HTTPS callback URLs, and signing secrets of at least 32 bytes. The no-op
+  `webhook-delivery` feature is removed; the in-memory service signs and logs deliveries, while
+  production HTTP delivery stays behind the `EventSubscriptionService` interface.
 - **adk-server: A2A JSON-RPC routes now sit behind the configured authentication layer.**
   `/a2a` and `/a2a/stream` were merged at the router root, outside the layer applied to `/api`,
   in both `create_app_with_a2a` and `ServerBuilder::build`. A deployment that authenticated every

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,7 +248,6 @@ dependencies = [
  "hmac 0.12.1",
  "http 1.4.1",
  "proptest",
- "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/README.md
+++ b/README.md
@@ -674,28 +674,63 @@ cargo run --manifest-path examples/realtime_tools/Cargo.toml -- probe openai
 Make any website or service natively accessible to AI agents using the `awp-types` and `adk-awp` crates:
 
 ```rust
-use adk_awp::{AwpState, BusinessContextLoader, awp_routes};
+use std::sync::Arc;
+
+use adk_awp::{AwpA2aHandler, AwpState, BusinessContextLoader, awp_routes};
+use async_trait::async_trait;
+use awp_types::AwpError;
+use axum::http::{HeaderMap, header};
+use serde_json::{Value, json};
+
+struct ApplicationA2a {
+    bearer_token: Arc<str>,
+}
+
+#[async_trait]
+impl AwpA2aHandler for ApplicationA2a {
+    async fn handle(&self, headers: HeaderMap, message: Value) -> Result<Value, AwpError> {
+        let expected = format!("Bearer {}", self.bearer_token);
+        if !headers
+            .get(header::AUTHORIZATION)
+            .and_then(|value| value.to_str().ok())
+            .is_some_and(|value| value == expected)
+        {
+            return Err(AwpError::Unauthorized("invalid A2A credential".to_string()));
+        }
+        Ok(json!({ "status": "processed", "messageId": message["id"] }))
+    }
+}
 
 // Load business context from TOML
 let loader = BusinessContextLoader::from_file("business.toml".as_ref())?;
 
-// Build AWP state with sensible defaults (rate limiting, consent, health, events)
-let state = AwpState::builder(loader.context_ref()).build();
+// Install application-specific, authenticated A2A dispatch.
+let a2a_token: Arc<str> = std::env::var("AWP_A2A_TOKEN")?.into();
+let state = AwpState::builder(loader.context_ref())
+    .a2a_handler(Arc::new(ApplicationA2a { bearer_token: a2a_token }))
+    .build();
 
-// Merge AWP routes into your Axum app — 7 endpoints, version negotiation included
+// The safe default router excludes privileged subscription management.
 let app = axum::Router::new()
     .merge(awp_routes(state))
     .merge(your_custom_routes);
+
+let listener = tokio::net::TcpListener::bind("127.0.0.1:3456").await?;
+axum::serve(
+    listener,
+    app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+)
+.await?;
 ```
 
 **AWP Endpoints**:
 - `GET /.well-known/awp.json` — Discovery document (entry point for agents)
 - `GET /awp/manifest` — JSON-LD capability manifest
 - `GET /awp/health` — Health state (Healthy/Degrading/Degraded)
-- `POST /awp/events/subscribe` — Webhook subscriptions with HMAC-SHA256 signing
-- `POST /awp/a2a` — Agent-to-agent message handling
+- `POST /awp/a2a` — Application-provided agent-to-agent dispatch
+- `awp_management_routes()` — Explicit subscription CRUD; apply application auth before merging
 
-**Features**: Trust levels (Anonymous/Known/Partner/Internal), per-trust-level rate limiting, consent management (in-memory or file-backed), health state machine with event emission, version negotiation, business context hot-reload.
+**Features**: Fail-closed trust defaults, per-trust-level rate limiting, bounded A2A requests, consent storage, HMAC signing, health state transitions, version negotiation, and business context hot-reload.
 
 **Run the AWP example**:
 ```bash

--- a/adk-awp/Cargo.toml
+++ b/adk-awp/Cargo.toml
@@ -27,7 +27,6 @@ arc-swap = "1"
 hmac = "0.12"
 sha2 = { workspace = true }
 hex = { workspace = true }
-reqwest = { workspace = true, optional = true }
 dashmap = "6"
 tracing = { workspace = true }
 thiserror = { workspace = true }
@@ -44,4 +43,3 @@ tempfile = "3"
 
 [features]
 default = []
-webhook-delivery = ["dep:reqwest"]

--- a/adk-awp/README.md
+++ b/adk-awp/README.md
@@ -6,10 +6,10 @@ Agentic Web Protocol (AWP) implementation for [ADK-Rust](https://github.com/zavo
 [![docs.rs](https://docs.rs/adk-awp/badge.svg)](https://docs.rs/adk-awp)
 [![AWP](https://img.shields.io/badge/AWP-agenticwebprotocol.com-0F8A8A)](https://agenticwebprotocol.com)
 
-`adk-awp` provides the full AWP protocol implementation — route registration,
-middleware, rate limiting, consent, events, health monitoring, and business
-context management. Plug `awp_routes()` into any Axum app to make it
-AWP-compliant.
+`adk-awp` provides AWP protocol types, route registration, middleware, rate
+limiting, consent, events, health monitoring, and business context management.
+Applications provide the agent-specific A2A dispatcher and protect management
+routes with their authentication layer.
 
 ## Overview
 
@@ -17,7 +17,7 @@ Use `adk-awp` when you need to:
 
 - serve AWP discovery documents and capability manifests from a `business.toml`
 - apply per-trust-level rate limiting (Anonymous: 30/min, Known: 120/min, Partner: 600/min)
-- manage consent records with durable file-backed storage (GDPR/KPA compliance)
+- manage consent records with in-memory or local file-backed storage
 - subscribe agents to events with HMAC-SHA256 webhook signing
 - monitor service health with a validated state machine (Healthy → Degrading → Degraded)
 - detect whether requests come from humans or AI agents
@@ -52,39 +52,85 @@ policy_type = "privacy"
 ### 2. Serve AWP routes
 
 ```rust
-use adk_awp::{AwpState, BusinessContextLoader, awp_routes};
+use std::sync::Arc;
+
+use adk_awp::{AwpA2aHandler, AwpState, BusinessContextLoader, awp_routes};
+use async_trait::async_trait;
+use awp_types::AwpError;
+use axum::http::{HeaderMap, header};
+use serde_json::{Value, json};
+
+struct ApplicationA2a {
+    bearer_token: Arc<str>,
+}
+
+#[async_trait]
+impl AwpA2aHandler for ApplicationA2a {
+    async fn handle(&self, headers: HeaderMap, message: Value) -> Result<Value, AwpError> {
+        let expected = format!("Bearer {}", self.bearer_token);
+        if !headers
+            .get(header::AUTHORIZATION)
+            .and_then(|value| value.to_str().ok())
+            .is_some_and(|value| value == expected)
+        {
+            return Err(AwpError::Unauthorized("invalid A2A credential".to_string()));
+        }
+        // Authorize the requested capability and dispatch to the application agent.
+        Ok(json!({ "status": "processed", "messageId": message["id"] }))
+    }
+}
 
 let loader = BusinessContextLoader::from_file("business.toml".as_ref())?;
-let state = AwpState::builder(loader.context_ref()).build();
+let a2a_token: Arc<str> = std::env::var("AWP_A2A_TOKEN")?.into();
+let state = AwpState::builder(loader.context_ref())
+    .a2a_handler(Arc::new(ApplicationA2a { bearer_token: a2a_token }))
+    .build();
 
 let app = axum::Router::new()
     .merge(awp_routes(state))
     .merge(your_custom_routes);
 
-let listener = tokio::net::TcpListener::bind("0.0.0.0:3456").await?;
-axum::serve(listener, app).await?;
+let listener = tokio::net::TcpListener::bind("127.0.0.1:3456").await?;
+axum::serve(
+    listener,
+    app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+)
+.await?;
 ```
 
-This registers all 7 AWP endpoints with version negotiation middleware.
+This registers the four public endpoints with version negotiation and rate
+limiting. `POST /awp/a2a` returns `503` until an `AwpA2aHandler` is installed.
+Subscription management is registered separately behind application auth.
+`ConnectInfo` supplies the peer address used to isolate anonymous rate-limit
+buckets.
 
-## Endpoints
+## Public endpoints
 
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/.well-known/awp.json` | Discovery document |
 | GET | `/awp/manifest` | JSON-LD capability manifest |
 | GET | `/awp/health` | Health state |
+| POST | `/awp/a2a` | Application-provided A2A dispatch |
+
+## Authenticated management endpoints
+
+`awp_management_routes()` returns these routes without an auth layer so the
+application can apply its own:
+
+| Method | Path | Description |
+|--------|------|-------------|
 | POST | `/awp/events/subscribe` | Create webhook subscription |
 | GET | `/awp/events/subscriptions` | List subscriptions |
 | DELETE | `/awp/events/subscriptions/{id}` | Delete subscription |
-| POST | `/awp/a2a` | A2A message handler |
 
 ## Components
 
 ### AwpStateBuilder
 
-Build `AwpState` with sensible defaults — all services default to in-memory,
-health state machine auto-wired to event service:
+Build `AwpState` with fail-closed defaults. Services default to in-memory and
+the health state machine is wired to the event service. A2A dispatch returns
+`503` until the application installs a handler:
 
 ```rust
 use adk_awp::{AwpState, FileConsentService};
@@ -123,19 +169,23 @@ Per-trust-level sliding window with configurable limits:
 use adk_awp::{InMemoryRateLimiter, RateLimitConfig};
 use awp_types::TrustLevel;
 use std::collections::HashMap;
-use std::time::Duration;
 
 let mut limits = HashMap::new();
 limits.insert(TrustLevel::Anonymous, RateLimitConfig { max_requests: 10, window_secs: 60 });
-let limiter = InMemoryRateLimiter::with_config(limits, Duration::from_secs(60));
+let limiter = InMemoryRateLimiter::with_config(limits);
 ```
+
+`DefaultTrustAssigner` classifies every request as anonymous. An authorization
+header is not proof that a credential is valid. Install a verifier-backed
+`TrustLevelAssigner` before assigning higher trust levels.
 
 ### Consent Service
 
 Two implementations:
 
 - **`InMemoryConsentService`** — ephemeral, for development
-- **`FileConsentService`** — JSON file-backed, for production (GDPR/KPA)
+- **`FileConsentService`** — durable local JSON; the application controls file
+  permissions, encryption, retention, and regulatory policy
 
 ```rust
 use adk_awp::FileConsentService;
@@ -181,18 +231,15 @@ let requester = detect_requester_type(&headers);
 // RequesterType::Agent
 ```
 
-## Feature Flags
-
-```toml
-[features]
-default = []
-webhook-delivery = ["dep:reqwest"]  # Enable real HTTP webhook delivery
-```
+`InMemoryEventSubscriptionService` signs and logs matching deliveries without
+performing network I/O. Implement `EventSubscriptionService` for production
+HTTP delivery so destination policy, retries, and durable storage remain under
+application control.
 
 ## Testing
 
 ```bash
-cargo test -p adk-awp                    # 124 tests
+cargo nextest run -p adk-awp             # protocol and boundary tests
 cargo clippy -p adk-awp -- -D warnings  # zero warnings
 ```
 
@@ -204,8 +251,8 @@ cp .env.example .env   # add your GOOGLE_API_KEY
 cargo run
 ```
 
-The example loads `business.toml`, creates an LLM agent with business context
-instructions, serves all AWP endpoints, and exercises each one.
+The example loads `business.toml`, installs authenticated A2A dispatch to a real
+LLM agent, protects management routes separately, and exercises each endpoint.
 
 ## Documentation
 

--- a/adk-awp/src/a2a.rs
+++ b/adk-awp/src/a2a.rs
@@ -1,0 +1,41 @@
+//! Application-provided A2A message dispatch for AWP.
+
+use async_trait::async_trait;
+use awp_types::AwpError;
+use axum::http::HeaderMap;
+use serde_json::Value;
+
+/// Handles an A2A message received through the AWP public endpoint.
+///
+/// `adk-awp` owns discovery, protocol middleware, and the HTTP boundary, but it
+/// cannot choose which agent or application operation should receive a message.
+/// Applications install an implementation through
+/// [`crate::AwpStateBuilder::a2a_handler`].
+///
+/// Implementations must authenticate and authorize any application-specific
+/// operation represented by the message. The request headers are supplied so a
+/// handler can use the same credentials as the surrounding Axum application.
+#[async_trait]
+pub trait AwpA2aHandler: Send + Sync {
+    /// Dispatches one validated JSON object and returns the protocol response.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AwpError`] when authentication, validation, dispatch, or
+    /// downstream execution fails.
+    async fn handle(&self, headers: HeaderMap, message: Value) -> Result<Value, AwpError>;
+}
+
+/// Fail-closed handler used until an application installs real A2A dispatch.
+pub(crate) struct UnconfiguredA2aHandler;
+
+#[async_trait]
+impl AwpA2aHandler for UnconfiguredA2aHandler {
+    async fn handle(&self, _headers: HeaderMap, _message: Value) -> Result<Value, AwpError> {
+        Err(AwpError::ServiceUnavailable(
+            "AWP A2A dispatch is not configured; install an AwpA2aHandler before serving \
+             /awp/a2a"
+                .to_string(),
+        ))
+    }
+}

--- a/adk-awp/src/consent.rs
+++ b/adk-awp/src/consent.rs
@@ -2,7 +2,7 @@
 //!
 //! Provides two implementations:
 //! - [`InMemoryConsentService`] — ephemeral, for development and testing
-//! - [`FileConsentService`] — JSON file-backed, for production (GDPR/KPA compliance)
+//! - [`FileConsentService`] — durable local JSON storage
 
 use std::path::{Path, PathBuf};
 

--- a/adk-awp/src/events.rs
+++ b/adk-awp/src/events.rs
@@ -66,6 +66,60 @@ impl std::fmt::Debug for EventSubscription {
     }
 }
 
+impl EventSubscription {
+    /// Validates the bounded subscription fields accepted by the built-in service.
+    ///
+    /// Callback URLs require HTTPS. The in-memory implementation does not
+    /// perform HTTP delivery, but enforcing the boundary here prevents an
+    /// invalid or insecure destination from becoming durable configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AwpError::InvalidRequest`] when a field is missing, oversized,
+    /// insecure, or malformed.
+    pub fn validate(&self) -> Result<(), AwpError> {
+        if self.subscriber.trim().is_empty() || self.subscriber.len() > 256 {
+            return Err(AwpError::InvalidRequest(
+                "subscriber must contain 1 to 256 bytes".to_string(),
+            ));
+        }
+        if self.callback_url.len() > 2_048 {
+            return Err(AwpError::InvalidRequest(
+                "callbackUrl must not exceed 2048 bytes".to_string(),
+            ));
+        }
+        let callback = self.callback_url.parse::<http::Uri>().map_err(|_| {
+            AwpError::InvalidRequest("callbackUrl must be a valid absolute HTTPS URL".to_string())
+        })?;
+        if callback.scheme_str() != Some("https") || callback.authority().is_none() {
+            return Err(AwpError::InvalidRequest(
+                "callbackUrl must be a valid absolute HTTPS URL".to_string(),
+            ));
+        }
+        if self.event_types.len() > 64 {
+            return Err(AwpError::InvalidRequest(
+                "eventTypes must not contain more than 64 entries".to_string(),
+            ));
+        }
+        if self
+            .event_types
+            .iter()
+            .any(|event_type| event_type.trim().is_empty() || event_type.len() > 128)
+        {
+            return Err(AwpError::InvalidRequest(
+                "each eventTypes entry must contain 1 to 128 bytes".to_string(),
+            ));
+        }
+        if self.secret.len() < 32 || self.secret.len() > 4_096 {
+            return Err(AwpError::InvalidRequest(
+                "secret must contain 32 to 4096 bytes".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+}
+
 /// Trait for managing event subscriptions and delivering events.
 #[async_trait]
 pub trait EventSubscriptionService: Send + Sync {
@@ -87,8 +141,9 @@ pub trait EventSubscriptionService: Send + Sync {
 
 /// In-memory event subscription service backed by [`DashMap`].
 ///
-/// Webhook delivery is logged but not actually performed (no HTTP client).
-/// Enable the `webhook-delivery` feature for real HTTP delivery.
+/// Delivery is logged but not sent over the network. Production applications
+/// implement [`EventSubscriptionService`] with their HTTP client, destination
+/// policy, retry queue, and durable subscription store.
 pub struct InMemoryEventSubscriptionService {
     subscriptions: DashMap<Uuid, EventSubscription>,
 }
@@ -109,6 +164,7 @@ impl Default for InMemoryEventSubscriptionService {
 #[async_trait]
 impl EventSubscriptionService for InMemoryEventSubscriptionService {
     async fn create(&self, subscription: EventSubscription) -> Result<Uuid, AwpError> {
+        subscription.validate()?;
         let id = subscription.id;
         self.subscriptions.insert(id, subscription);
         Ok(id)
@@ -192,7 +248,7 @@ mod tests {
             subscriber: "test-subscriber".to_string(),
             callback_url: "https://example.com/webhook".to_string(),
             event_types,
-            secret: "test-secret-key".to_string(),
+            secret: "test-secret-key-32-bytes-minimum!!".to_string(),
         }
     }
 
@@ -203,6 +259,25 @@ mod tests {
             timestamp: Utc::now(),
             payload: serde_json::json!({"state": "degrading"}),
         }
+    }
+
+    #[test]
+    fn test_subscription_validation_accepts_bounded_https_destination() {
+        assert!(sample_subscription(vec!["health.changed".to_string()]).validate().is_ok());
+    }
+
+    #[test]
+    fn test_subscription_validation_rejects_insecure_destination() {
+        let mut subscription = sample_subscription(vec![]);
+        subscription.callback_url = "http://example.com/webhook".to_string();
+        assert!(subscription.validate().is_err());
+    }
+
+    #[test]
+    fn test_subscription_validation_rejects_short_signing_secret() {
+        let mut subscription = sample_subscription(vec![]);
+        subscription.secret = "short".to_string();
+        assert!(subscription.validate().is_err());
     }
 
     #[tokio::test]

--- a/adk-awp/src/handlers.rs
+++ b/adk-awp/src/handlers.rs
@@ -2,6 +2,7 @@
 
 use axum::Json;
 use axum::extract::{Path, State};
+use axum::http::HeaderMap;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use uuid::Uuid;
@@ -15,7 +16,8 @@ use crate::state::AwpState;
 /// GET `/.well-known/awp.json` — serve the AWP discovery document.
 pub async fn discovery(State(state): State<AwpState>) -> impl IntoResponse {
     let ctx = state.business_context.load();
-    let doc = generate_discovery_document(&ctx);
+    let mut doc = generate_discovery_document(&ctx);
+    doc.supported_trust_levels = state.supported_trust_levels.clone();
     Json(doc)
 }
 
@@ -55,6 +57,10 @@ pub async fn subscribe(
         secret: body.secret,
     };
 
+    if let Err(error) = subscription.validate() {
+        return AwpErrorResponse(error).into_response();
+    }
+
     match state.event_service.create(subscription.clone()).await {
         Ok(id) => (StatusCode::CREATED, Json(serde_json::json!({ "id": id }))).into_response(),
         Err(e) => AwpErrorResponse(e).into_response(),
@@ -77,21 +83,33 @@ pub async fn delete_subscription(State(state): State<AwpState>, Path(id): Path<U
     }
 }
 
-/// POST `/awp/a2a` — handle an A2A message.
-///
-/// Currently returns a placeholder acknowledgment. Full A2A routing will be
-/// integrated with `adk-server`'s A2A handler in a future task.
+/// POST `/awp/a2a` — dispatch an A2A message through the configured handler.
 pub async fn a2a_message(
-    State(_state): State<AwpState>,
+    State(state): State<AwpState>,
+    headers: HeaderMap,
     Json(body): Json<serde_json::Value>,
 ) -> Response {
-    let id = body.get("id").and_then(|v| v.as_str()).unwrap_or("unknown");
-    (
-        StatusCode::OK,
-        Json(serde_json::json!({
-            "status": "acknowledged",
-            "messageId": id,
-        })),
-    )
-        .into_response()
+    let Some(object) = body.as_object() else {
+        return AwpErrorResponse(awp_types::AwpError::InvalidRequest(
+            "A2A message body must be a JSON object".to_string(),
+        ))
+        .into_response();
+    };
+    let Some(message_id) = object.get("id").and_then(serde_json::Value::as_str) else {
+        return AwpErrorResponse(awp_types::AwpError::InvalidRequest(
+            "A2A message id must be a string".to_string(),
+        ))
+        .into_response();
+    };
+    if message_id.trim().is_empty() || message_id.len() > 256 {
+        return AwpErrorResponse(awp_types::AwpError::InvalidRequest(
+            "A2A message id must contain 1 to 256 bytes".to_string(),
+        ))
+        .into_response();
+    }
+
+    match state.a2a_handler.handle(headers, body).await {
+        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Err(error) => AwpErrorResponse(error).into_response(),
+    }
 }

--- a/adk-awp/src/lib.rs
+++ b/adk-awp/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! Agentic Web Protocol (AWP) implementation for ADK-Rust.
 //!
-//! This crate provides the full AWP protocol implementation including:
+//! This crate provides AWP protocol infrastructure including:
 //!
 //! - **Configuration**: TOML-based business context loading with hot-reload
 //! - **Discovery**: Auto-generated discovery documents from business context
@@ -14,7 +14,8 @@
 //! - **Events**: Event subscription system with HMAC-SHA256 webhook signing
 //! - **Health**: Health state machine (Healthy/Degrading/Degraded)
 //! - **Middleware**: AWP version negotiation
-//! - **Router**: Axum route registration for all AWP endpoints
+//! - **Router**: Safe public routes and separately composable management routes
+//! - **A2A dispatch**: Application-provided handling with a fail-closed default
 //!
 //! ## Quick Start
 //!
@@ -27,6 +28,7 @@
 //! let manifest = build_manifest(&ctx);
 //! ```
 
+pub mod a2a;
 pub mod config;
 pub mod consent;
 pub mod detect;
@@ -43,6 +45,7 @@ pub mod router;
 pub mod state;
 pub mod trust;
 
+pub use a2a::AwpA2aHandler;
 pub use config::{AwpConfigError, business_context_to_toml};
 pub use consent::{ConsentService, FileConsentService, InMemoryConsentService};
 pub use detect::detect_requester_type;

--- a/adk-awp/src/middleware.rs
+++ b/adk-awp/src/middleware.rs
@@ -1,24 +1,33 @@
-//! AWP middleware for version negotiation.
+//! AWP middleware for version negotiation and request throttling.
 
 use awp_types::{AwpError, AwpVersion, CURRENT_VERSION};
-use axum::extract::Request;
+use axum::extract::{ConnectInfo, Request, State};
 use axum::middleware::Next;
 use axum::response::Response;
+use sha2::{Digest, Sha256};
+use std::net::SocketAddr;
 
 use crate::error_response::awp_error_response;
+use crate::state::AwpState;
 
 /// Axum middleware that performs AWP version negotiation.
 ///
 /// - Parses the `AWP-Version` request header (defaults to [`CURRENT_VERSION`] if absent)
+/// - Rejects malformed versions with [`AwpError::InvalidRequest`]
 /// - Returns a [`VersionMismatch`](AwpError::VersionMismatch) error if the major version differs
 /// - Sets the `AWP-Version` response header to [`CURRENT_VERSION`] on success
 pub async fn version_negotiation(request: Request, next: Next) -> Response {
-    let version = request
-        .headers()
-        .get("AWP-Version")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|s| s.parse::<AwpVersion>().ok())
-        .unwrap_or(CURRENT_VERSION);
+    let version = match request.headers().get("AWP-Version") {
+        None => CURRENT_VERSION,
+        Some(value) => match value.to_str().ok().and_then(|raw| raw.parse::<AwpVersion>().ok()) {
+            Some(version) => version,
+            None => {
+                return awp_error_response(AwpError::InvalidRequest(
+                    "AWP-Version must be a valid major.minor version".to_string(),
+                ));
+            }
+        },
+    };
 
     if !CURRENT_VERSION.is_compatible(&version) {
         return awp_error_response(AwpError::VersionMismatch {
@@ -32,6 +41,39 @@ pub async fn version_negotiation(request: Request, next: Next) -> Response {
         response.headers_mut().insert("AWP-Version", val);
     }
     response
+}
+
+/// Applies the configured per-trust-level rate limit.
+///
+/// Authenticated identities are keyed by a one-way digest of their credential.
+/// Anonymous callers use the peer IP supplied by Axum's `ConnectInfo`; when a
+/// server does not provide it, all unknown anonymous callers share one
+/// fail-closed bucket rather than trusting spoofable forwarding headers.
+pub async fn enforce_rate_limit(
+    State(state): State<AwpState>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let trust_level = state.trust_assigner.assign(request.headers()).await;
+    let key = rate_limit_key(&request, trust_level);
+
+    match state.rate_limiter.check(&key, trust_level).await {
+        Ok(()) => next.run(request).await,
+        Err(retry_after_secs) => awp_error_response(AwpError::RateLimited { retry_after_secs }),
+    }
+}
+
+fn rate_limit_key(request: &Request, trust_level: awp_types::TrustLevel) -> String {
+    if trust_level != awp_types::TrustLevel::Anonymous
+        && let Some(credential) = request.headers().get(axum::http::header::AUTHORIZATION)
+    {
+        return format!("credential:{:x}", Sha256::digest(credential.as_bytes()));
+    }
+
+    request
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map_or_else(|| "anonymous:unknown".to_string(), |peer| format!("ip:{}", peer.ip()))
 }
 
 #[cfg(test)]
@@ -90,7 +132,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_invalid_version_header_defaults() {
+    async fn test_invalid_version_header_is_rejected() {
         let app = test_app();
         let request = HttpRequest::builder()
             .uri("/test")
@@ -99,7 +141,6 @@ mod tests {
             .unwrap();
 
         let response = app.oneshot(request).await.unwrap();
-        // Invalid version string can't be parsed, defaults to CURRENT_VERSION
-        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 }

--- a/adk-awp/src/rate_limit.rs
+++ b/adk-awp/src/rate_limit.rs
@@ -1,11 +1,12 @@
 //! Per-trust-level sliding window rate limiter.
 
 use std::collections::{HashMap, VecDeque};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use async_trait::async_trait;
 use awp_types::TrustLevel;
 use dashmap::DashMap;
+use tokio::time::Instant;
 
 /// Trait for checking whether a request should be rate-limited.
 #[async_trait]
@@ -39,7 +40,6 @@ pub struct RateLimitConfig {
 pub struct InMemoryRateLimiter {
     windows: DashMap<String, VecDeque<Instant>>,
     limits: HashMap<TrustLevel, RateLimitConfig>,
-    window_size: Duration,
 }
 
 impl InMemoryRateLimiter {
@@ -51,15 +51,12 @@ impl InMemoryRateLimiter {
         limits.insert(TrustLevel::Partner, RateLimitConfig { max_requests: 600, window_secs: 60 });
         // Internal is unlimited — no entry in the map
 
-        Self { windows: DashMap::new(), limits, window_size: Duration::from_secs(60) }
+        Self { windows: DashMap::new(), limits }
     }
 
-    /// Create a rate limiter with custom limits and window size.
-    pub fn with_config(
-        limits: HashMap<TrustLevel, RateLimitConfig>,
-        window_size: Duration,
-    ) -> Self {
-        Self { windows: DashMap::new(), limits, window_size }
+    /// Create a rate limiter with custom per-trust-level limits.
+    pub fn with_config(limits: HashMap<TrustLevel, RateLimitConfig>) -> Self {
+        Self { windows: DashMap::new(), limits }
     }
 }
 
@@ -80,7 +77,8 @@ impl RateLimiter for InMemoryRateLimiter {
 
         let composite_key = format!("{trust_level}:{key}");
         let now = Instant::now();
-        let window_start = now - self.window_size;
+        let window_size = Duration::from_secs(config.window_secs.max(1));
+        let window_start = now - window_size;
 
         let mut entry = self.windows.entry(composite_key).or_default();
         let deque = entry.value_mut();
@@ -93,7 +91,7 @@ impl RateLimiter for InMemoryRateLimiter {
         if deque.len() as u64 >= config.max_requests {
             // Calculate retry-after from the oldest entry in the window
             let oldest = deque.front().copied().unwrap_or(now);
-            let expires_at = oldest + self.window_size;
+            let expires_at = oldest + window_size;
             let retry_after = expires_at.duration_since(now).as_secs().max(1);
             return Err(retry_after);
         }
@@ -159,11 +157,25 @@ mod tests {
     async fn test_custom_config() {
         let mut limits = HashMap::new();
         limits.insert(TrustLevel::Anonymous, RateLimitConfig { max_requests: 2, window_secs: 1 });
-        let limiter = InMemoryRateLimiter::with_config(limits, Duration::from_secs(1));
+        let limiter = InMemoryRateLimiter::with_config(limits);
 
         assert!(limiter.check("c", TrustLevel::Anonymous).await.is_ok());
         assert!(limiter.check("c", TrustLevel::Anonymous).await.is_ok());
         assert!(limiter.check("c", TrustLevel::Anonymous).await.is_err());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_each_limit_uses_its_configured_window() {
+        let limits = HashMap::from([(
+            TrustLevel::Anonymous,
+            RateLimitConfig { max_requests: 1, window_secs: 2 },
+        )]);
+        let limiter = InMemoryRateLimiter::with_config(limits);
+
+        limiter.check("c", TrustLevel::Anonymous).await.unwrap();
+        assert!(limiter.check("c", TrustLevel::Anonymous).await.is_err());
+        tokio::time::advance(Duration::from_secs(3)).await;
+        assert!(limiter.check("c", TrustLevel::Anonymous).await.is_ok());
     }
 
     #[tokio::test]

--- a/adk-awp/src/router.rs
+++ b/adk-awp/src/router.rs
@@ -1,11 +1,12 @@
 //! AWP route registration for Axum.
 
 use axum::Router;
-use axum::middleware::from_fn;
+use axum::extract::DefaultBodyLimit;
+use axum::middleware::{from_fn, from_fn_with_state};
 use axum::routing::{delete, get, post};
 
 use crate::handlers;
-use crate::middleware::version_negotiation;
+use crate::middleware::{enforce_rate_limit, version_negotiation};
 use crate::state::AwpState;
 
 /// Build an Axum [`Router`] with the publicly reachable AWP endpoints.
@@ -15,8 +16,9 @@ use crate::state::AwpState;
 /// - `GET  /awp/health` — health state
 /// - `POST /awp/a2a` — A2A message handler
 ///
-/// These are safe to expose: discovery, manifest, and health are read-only descriptions of the
-/// service, and agents fetch them before they hold any credential.
+/// Discovery, manifest, and health are read-only descriptions of the service.
+/// The configured [`crate::AwpA2aHandler`] remains responsible for
+/// application authentication and capability authorization.
 ///
 /// Subscription management is **not** included — see [`awp_management_routes`].
 pub fn awp_public_routes(state: AwpState) -> Router {
@@ -24,7 +26,8 @@ pub fn awp_public_routes(state: AwpState) -> Router {
         .route("/.well-known/awp.json", get(handlers::discovery))
         .route("/awp/manifest", get(handlers::manifest))
         .route("/awp/health", get(handlers::health))
-        .route("/awp/a2a", post(handlers::a2a_message))
+        .route("/awp/a2a", post(handlers::a2a_message).layer(DefaultBodyLimit::max(64 * 1024)))
+        .layer(from_fn_with_state(state.clone(), enforce_rate_limit))
         .layer(from_fn(version_negotiation))
         .with_state(state)
 }
@@ -52,20 +55,22 @@ pub fn awp_public_routes(state: AwpState) -> Router {
 /// alongside it.
 pub fn awp_management_routes(state: AwpState) -> Router {
     Router::new()
-        .route("/awp/events/subscribe", post(handlers::subscribe))
+        .route(
+            "/awp/events/subscribe",
+            post(handlers::subscribe).layer(DefaultBodyLimit::max(64 * 1024)),
+        )
         .route("/awp/events/subscriptions", get(handlers::list_subscriptions))
         .route("/awp/events/subscriptions/{id}", delete(handlers::delete_subscription))
+        .layer(from_fn_with_state(state.clone(), enforce_rate_limit))
         .layer(from_fn(version_negotiation))
         .with_state(state)
 }
 
-/// Build an Axum [`Router`] with every AWP endpoint, management included.
+/// Build the safe default AWP [`Router`].
 ///
-/// # Authentication
-///
-/// The management routes carry no authentication. Prefer composing
-/// [`awp_public_routes`] with [`awp_management_routes`] so an auth layer can be applied to the
-/// half that needs it; this function exists for local development and tests.
+/// This is an alias for [`awp_public_routes`]. Subscription management is
+/// excluded because it requires an application authentication layer. Merge
+/// [`awp_management_routes`] explicitly after applying that layer.
 pub fn awp_routes(state: AwpState) -> Router {
-    Router::new().merge(awp_public_routes(state.clone())).merge(awp_management_routes(state))
+    awp_public_routes(state)
 }

--- a/adk-awp/src/state.rs
+++ b/adk-awp/src/state.rs
@@ -3,8 +3,9 @@
 use std::sync::Arc;
 
 use arc_swap::ArcSwap;
-use awp_types::BusinessContext;
+use awp_types::{BusinessContext, TrustLevel};
 
+use crate::a2a::{AwpA2aHandler, UnconfiguredA2aHandler};
 use crate::consent::{ConsentService, InMemoryConsentService};
 use crate::events::{EventSubscriptionService, InMemoryEventSubscriptionService};
 use crate::health::HealthStateMachine;
@@ -26,13 +27,17 @@ pub struct AwpState {
     pub health: Arc<HealthStateMachine>,
     /// Trust level assigner.
     pub trust_assigner: Arc<dyn TrustLevelAssigner>,
+    /// Trust levels this deployment advertises in discovery.
+    pub supported_trust_levels: Vec<TrustLevel>,
+    /// Application-provided A2A message dispatcher.
+    pub a2a_handler: Arc<dyn AwpA2aHandler>,
 }
 
-/// Builder for [`AwpState`] with sensible defaults.
+/// Builder for [`AwpState`] with fail-closed defaults.
 ///
-/// Only `business_context` is required. All services default to their
-/// in-memory implementations. The builder wires `HealthStateMachine` to
-/// the event service automatically.
+/// Only `business_context` is required. Services default to their in-memory
+/// implementations, the builder wires `HealthStateMachine` to the event
+/// service automatically, and A2A dispatch rejects requests until configured.
 ///
 /// # Example
 ///
@@ -49,6 +54,8 @@ pub struct AwpStateBuilder {
     consent_service: Option<Arc<dyn ConsentService>>,
     event_service: Option<Arc<dyn EventSubscriptionService>>,
     trust_assigner: Option<Arc<dyn TrustLevelAssigner>>,
+    supported_trust_levels: Option<Vec<TrustLevel>>,
+    a2a_handler: Option<Arc<dyn AwpA2aHandler>>,
 }
 
 impl AwpStateBuilder {
@@ -60,6 +67,8 @@ impl AwpStateBuilder {
             consent_service: None,
             event_service: None,
             trust_assigner: None,
+            supported_trust_levels: None,
+            a2a_handler: None,
         }
     }
 
@@ -89,6 +98,25 @@ impl AwpStateBuilder {
         self
     }
 
+    /// Set the trust levels advertised by the discovery document.
+    ///
+    /// The fail-closed default advertises only [`TrustLevel::Anonymous`].
+    /// Include higher levels only when the configured
+    /// [`TrustLevelAssigner`] verifies them.
+    pub fn supported_trust_levels(mut self, levels: impl IntoIterator<Item = TrustLevel>) -> Self {
+        self.supported_trust_levels = Some(levels.into_iter().collect());
+        self
+    }
+
+    /// Set the application dispatcher for `POST /awp/a2a`.
+    ///
+    /// Without a handler, the endpoint fails closed with `503 Service
+    /// Unavailable`; it never acknowledges work that was not dispatched.
+    pub fn a2a_handler(mut self, handler: Arc<dyn AwpA2aHandler>) -> Self {
+        self.a2a_handler = Some(handler);
+        self
+    }
+
     /// Build the [`AwpState`], wiring the health state machine to the event service.
     pub fn build(self) -> AwpState {
         let event_service =
@@ -103,6 +131,11 @@ impl AwpStateBuilder {
             health: Arc::new(HealthStateMachine::new(event_service.clone())),
             event_service,
             trust_assigner: self.trust_assigner.unwrap_or_else(|| Arc::new(DefaultTrustAssigner)),
+            supported_trust_levels: self
+                .supported_trust_levels
+                .filter(|levels| !levels.is_empty())
+                .unwrap_or_else(|| vec![TrustLevel::Anonymous]),
+            a2a_handler: self.a2a_handler.unwrap_or_else(|| Arc::new(UnconfiguredA2aHandler)),
         }
     }
 }
@@ -138,6 +171,7 @@ mod tests {
     fn test_builder_defaults() {
         let state = AwpState::builder(test_context()).build();
         assert_eq!(state.business_context.load().site_name, "Test");
+        assert_eq!(state.supported_trust_levels, vec![TrustLevel::Anonymous]);
     }
 
     #[test]
@@ -183,7 +217,9 @@ mod tests {
             .consent_service(Arc::new(InMemoryConsentService::new()))
             .event_service(Arc::new(InMemoryEventSubscriptionService::new()))
             .trust_assigner(Arc::new(DefaultTrustAssigner))
+            .supported_trust_levels([TrustLevel::Anonymous, TrustLevel::Known])
             .build();
         assert_eq!(state.business_context.load().site_name, "Test");
+        assert_eq!(state.supported_trust_levels, vec![TrustLevel::Anonymous, TrustLevel::Known]);
     }
 }

--- a/adk-awp/src/trust.rs
+++ b/adk-awp/src/trust.rs
@@ -14,24 +14,17 @@ pub trait TrustLevelAssigner: Send + Sync {
     async fn assign(&self, headers: &HeaderMap) -> TrustLevel;
 }
 
-/// Default trust assigner that checks for `Authorization` headers.
+/// Fail-closed default trust assigner.
 ///
-/// - No credentials → [`TrustLevel::Anonymous`]
-/// - `Bearer` or `ApiKey` token present → [`TrustLevel::Known`]
-///
-/// Replace with `adk-auth` integration for full JWT scope extraction
-/// (Partner/Internal levels) when available.
+/// Every request is anonymous because the presence of an `Authorization`
+/// header does not prove that its credential is valid. Install a custom
+/// implementation backed by `adk-auth` or another verifier before assigning
+/// `Known`, `Partner`, or `Internal` trust.
 pub struct DefaultTrustAssigner;
 
 #[async_trait]
 impl TrustLevelAssigner for DefaultTrustAssigner {
-    async fn assign(&self, headers: &HeaderMap) -> TrustLevel {
-        if let Some(auth) = headers.get("Authorization")
-            && let Ok(val) = auth.to_str()
-            && (val.starts_with("Bearer ") || val.starts_with("ApiKey "))
-        {
-            return TrustLevel::Known;
-        }
+    async fn assign(&self, _headers: &HeaderMap) -> TrustLevel {
         TrustLevel::Anonymous
     }
 }
@@ -48,19 +41,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_bearer_token_is_known() {
+    async fn test_unverified_bearer_token_is_anonymous() {
         let assigner = DefaultTrustAssigner;
         let mut headers = HeaderMap::new();
         headers.insert("Authorization", "Bearer some-token-here".parse().unwrap());
-        assert_eq!(assigner.assign(&headers).await, TrustLevel::Known);
+        assert_eq!(assigner.assign(&headers).await, TrustLevel::Anonymous);
     }
 
     #[tokio::test]
-    async fn test_api_key_is_known() {
+    async fn test_unverified_api_key_is_anonymous() {
         let assigner = DefaultTrustAssigner;
         let mut headers = HeaderMap::new();
         headers.insert("Authorization", "ApiKey my-api-key".parse().unwrap());
-        assert_eq!(assigner.assign(&headers).await, TrustLevel::Known);
+        assert_eq!(assigner.assign(&headers).await, TrustLevel::Anonymous);
     }
 
     #[tokio::test]

--- a/adk-awp/tests/conformance_tests.rs
+++ b/adk-awp/tests/conformance_tests.rs
@@ -3,18 +3,20 @@
 //! These tests spin up an in-process Axum server with all AWP routes and
 //! verify protocol compliance against the endpoints.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use adk_awp::{
-    AwpState, BusinessContextLoader, DefaultTrustAssigner, HealthStateMachine,
-    InMemoryConsentService, InMemoryEventSubscriptionService, InMemoryRateLimiter, awp_routes,
+    AwpA2aHandler, AwpState, BusinessContextLoader, InMemoryEventSubscriptionService,
+    InMemoryRateLimiter, RateLimitConfig, awp_management_routes, awp_routes,
 };
 use arc_swap::ArcSwap;
 use awp_types::{
-    AwpDiscoveryDocument, BusinessCapability, BusinessContext, BusinessPolicy, CURRENT_VERSION,
-    CapabilityManifest, TrustLevel,
+    AwpDiscoveryDocument, AwpError, BusinessCapability, BusinessContext, BusinessPolicy,
+    CURRENT_VERSION, CapabilityManifest, TrustLevel,
 };
 use axum::body::Body;
+use axum::http::HeaderMap;
 use axum::http::{Request, StatusCode};
 use tower::util::ServiceExt;
 
@@ -49,20 +51,35 @@ fn sample_context() -> BusinessContext {
     ctx
 }
 
-fn build_state(ctx: BusinessContext) -> AwpState {
-    let event_service = Arc::new(InMemoryEventSubscriptionService::new());
-    AwpState {
-        business_context: Arc::new(ArcSwap::from_pointee(ctx)),
-        rate_limiter: Arc::new(InMemoryRateLimiter::new()),
-        consent_service: Arc::new(InMemoryConsentService::new()),
-        event_service: event_service.clone(),
-        health: Arc::new(HealthStateMachine::new(event_service)),
-        trust_assigner: Arc::new(DefaultTrustAssigner),
+struct TestA2aHandler;
+
+#[async_trait::async_trait]
+impl AwpA2aHandler for TestA2aHandler {
+    async fn handle(
+        &self,
+        _headers: HeaderMap,
+        message: serde_json::Value,
+    ) -> Result<serde_json::Value, AwpError> {
+        Ok(serde_json::json!({
+            "status": "processed",
+            "messageId": message["id"],
+        }))
     }
 }
 
+fn build_state(ctx: BusinessContext) -> AwpState {
+    AwpState::builder(Arc::new(ArcSwap::from_pointee(ctx)))
+        .event_service(Arc::new(InMemoryEventSubscriptionService::new()))
+        .a2a_handler(Arc::new(TestA2aHandler))
+        .build()
+}
+
 fn app() -> axum::Router {
-    awp_routes(build_state(sample_context()))
+    let state = build_state(sample_context());
+    axum::Router::new()
+        .merge(awp_routes(state.clone()))
+        // Test-only composition: production callers apply authentication here.
+        .merge(awp_management_routes(state))
 }
 
 // --- 1. Discovery document ---
@@ -90,6 +107,7 @@ async fn test_discovery_document_contains_version_and_urls() {
     assert!(doc.a2a_endpoint_url.contains("/awp/a2a"));
     assert!(doc.events_endpoint_url.contains("/awp/events"));
     assert!(doc.health_endpoint_url.contains("/awp/health"));
+    assert_eq!(doc.supported_trust_levels, vec![TrustLevel::Anonymous]);
 }
 
 // --- 2. Capability manifest ---
@@ -184,7 +202,7 @@ async fn test_event_subscription_create() {
         "subscriber": "test",
         "callbackUrl": "https://example.com/webhook",
         "eventTypes": ["health.changed"],
-        "secret": "test-secret"
+        "secret": "test-secret-at-least-32-bytes-long"
     });
     let response = app()
         .oneshot(
@@ -203,6 +221,35 @@ async fn test_event_subscription_create() {
 }
 
 #[tokio::test]
+async fn test_event_subscription_rejects_insecure_or_weak_configuration() {
+    for body in [
+        serde_json::json!({
+            "subscriber": "test",
+            "callbackUrl": "http://example.com/webhook",
+            "eventTypes": ["health.changed"],
+            "secret": "test-secret-at-least-32-bytes-long"
+        }),
+        serde_json::json!({
+            "subscriber": "test",
+            "callbackUrl": "https://example.com/webhook",
+            "eventTypes": ["health.changed"],
+            "secret": "short"
+        }),
+    ] {
+        let response = app()
+            .oneshot(
+                Request::post("/awp/events/subscribe")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+}
+
+#[tokio::test]
 async fn test_event_subscription_list() {
     let response = app()
         .oneshot(Request::get("/awp/events/subscriptions").body(Body::empty()).unwrap())
@@ -218,7 +265,7 @@ async fn test_event_subscription_list() {
 // --- 7. A2A message handler ---
 
 #[tokio::test]
-async fn test_a2a_message_acknowledged() {
+async fn test_a2a_message_is_dispatched() {
     let body = serde_json::json!({
         "id": "msg-123",
         "sender": "agent-a",
@@ -240,7 +287,99 @@ async fn test_a2a_message_acknowledged() {
 
     let resp_body = axum::body::to_bytes(response.into_body(), 8192).await.unwrap();
     let json: serde_json::Value = serde_json::from_slice(&resp_body).unwrap();
-    assert_eq!(json["status"], "acknowledged");
+    assert_eq!(json["status"], "processed");
+    assert_eq!(json["messageId"], "msg-123");
+}
+
+#[tokio::test]
+async fn test_unconfigured_a2a_handler_fails_closed() {
+    let state = AwpState::builder(Arc::new(ArcSwap::from_pointee(sample_context()))).build();
+    let body = serde_json::json!({ "id": "msg-123" });
+    let response = awp_routes(state)
+        .oneshot(
+            Request::post("/awp/a2a")
+                .header("Content-Type", "application/json")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+async fn test_a2a_requires_a_bounded_message_id() {
+    for body in [
+        serde_json::json!({ "payload": {} }),
+        serde_json::json!({ "id": " ".repeat(4), "payload": {} }),
+        serde_json::json!({ "id": "x".repeat(257), "payload": {} }),
+    ] {
+        let response = awp_routes(build_state(sample_context()))
+            .oneshot(
+                Request::post("/awp/a2a")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+}
+
+#[tokio::test]
+async fn test_a2a_body_is_limited_to_64_kib() {
+    let body = serde_json::json!({
+        "id": "msg-large",
+        "payload": "x".repeat(70 * 1024),
+    });
+    let response = awp_routes(build_state(sample_context()))
+        .oneshot(
+            Request::post("/awp/a2a")
+                .header("Content-Type", "application/json")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+}
+
+#[tokio::test]
+async fn test_public_routes_apply_the_configured_rate_limit() {
+    let limits = HashMap::from([(
+        TrustLevel::Anonymous,
+        RateLimitConfig { max_requests: 1, window_secs: 60 },
+    )]);
+    let state = AwpState::builder(Arc::new(ArcSwap::from_pointee(sample_context())))
+        .rate_limiter(Arc::new(InMemoryRateLimiter::with_config(limits)))
+        .a2a_handler(Arc::new(TestA2aHandler))
+        .build();
+    let app = awp_routes(state);
+
+    let first = app
+        .clone()
+        .oneshot(Request::get("/awp/health").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let second =
+        app.oneshot(Request::get("/awp/health").body(Body::empty()).unwrap()).await.unwrap();
+
+    assert_eq!(first.status(), StatusCode::OK);
+    assert_eq!(second.status(), StatusCode::TOO_MANY_REQUESTS);
+    assert!(second.headers().contains_key("Retry-After"));
+}
+
+#[tokio::test]
+async fn test_safe_default_router_excludes_management_routes() {
+    let response = awp_routes(build_state(sample_context()))
+        .oneshot(Request::get("/awp/events/subscriptions").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 // --- 8. HMAC signing ---

--- a/adk-awp/tests/subscription_secret_tests.rs
+++ b/adk-awp/tests/subscription_secret_tests.rs
@@ -16,7 +16,7 @@ fn subscription() -> EventSubscription {
         subscriber: "partner".to_string(),
         callback_url: "https://partner.test/hook".to_string(),
         event_types: vec!["order.created".to_string()],
-        secret: "super-secret-hmac-key".to_string(),
+        secret: "super-secret-hmac-key-32-bytes!!".to_string(),
     }
 }
 
@@ -70,7 +70,7 @@ async fn the_secret_is_still_usable_in_process_for_signing() {
     let found = listed.iter().find(|s| s.id == id).expect("subscription must be stored");
 
     assert_eq!(
-        found.secret, "super-secret-hmac-key",
+        found.secret, created.secret,
         "the secret must remain available in-process for HMAC signing"
     );
 }

--- a/docs/official_docs/deployment/awp.md
+++ b/docs/official_docs/deployment/awp.md
@@ -1,16 +1,16 @@
 # Agentic Web Protocol (AWP)
 
-ADK-Rust implements the [Agentic Web Protocol (AWP)](https://agenticwebprotocol.com) — a protocol for making websites and services natively accessible to AI agents. The implementation spans two crates: `awp-types` (pure protocol types) and `adk-awp` (full protocol implementation with Axum routes).
+ADK-Rust provides [Agentic Web Protocol (AWP)](https://agenticwebprotocol.com) types and Axum integration for making websites and services accessible to AI agents. The implementation spans two crates: `awp-types` (pure protocol types) and `adk-awp` (routes, middleware, and service interfaces). Applications supply agent dispatch, authentication, authorization, and durable webhook delivery.
 
 ## Overview
 
-AWP enables any website to declare its capabilities, policies, and business context in a machine-readable format. AI agents can discover these capabilities, negotiate protocol versions, subscribe to events, and interact through typed A2A messages — all while respecting trust levels and rate limits.
+AWP enables any website to declare its capabilities, policies, and business context in a machine-readable format. AI agents can discover these capabilities, negotiate protocol versions, subscribe to events, and interact through typed A2A messages. `adk-awp` enforces body and rate limits at its HTTP boundary; application handlers enforce identity and capability authorization.
 
 Use AWP when:
 - You want AI agents to discover and interact with your service programmatically
-- You need trust-level-based access control (Anonymous, Known, Partner, Internal)
+- You need trust-level metadata and a hook for application-enforced access control
 - You want to serve both human visitors and AI agents from the same endpoints
-- You need event-driven webhooks with HMAC-SHA256 signing
+- You need event subscriptions and HMAC-SHA256 signing primitives
 - You want a health state machine for service monitoring
 
 ## Architecture
@@ -40,7 +40,7 @@ sequenceDiagram
     
     ExtAgent->>Events: POST /awp/events/subscribe
     Events-->>ExtAgent: {subscription_id, webhook_url}
-    Note over Events,ExtAgent: Future events delivered via<br/>HMAC-SHA256 signed webhooks
+    Note over Events,ExtAgent: The application delivery service sends<br/>HMAC-SHA256 signed webhooks
 ```
 
 ### Application Layout
@@ -54,8 +54,8 @@ sequenceDiagram
 │  │  (adk-agent) │  │  ├ /.well-known/awp.json │ │
 │  │              │  │  ├ /awp/manifest          │ │
 │  │  Instructions│  │  ├ /awp/health            │ │
-│  │  derived from│  │  ├ /awp/events/*          │ │
-│  │  business.   │  │  └ /awp/a2a              │ │
+│  │  derived from│  │  └ /awp/a2a              │ │
+│  │  business.   │  │  auth + management routes│ │
 │  │  toml        │  │                           │ │
 │  └──────────────┘  └──────────────────────────┘ │
 │         ▲                      ▲                 │
@@ -72,7 +72,7 @@ sequenceDiagram
 | Crate | Purpose | Dependencies |
 |-------|---------|-------------|
 | `awp-types` | Protocol types (enums, structs, errors) | Zero `adk-*` deps — `serde`, `uuid`, `chrono`, `thiserror` only |
-| `adk-awp` | Full implementation (routes, middleware, services) | `awp-types`, `adk-core`, `axum` 0.8, `tokio`, `dashmap` |
+| `adk-awp` | Routes, middleware, service interfaces, and in-memory implementations | `awp-types`, `adk-core`, `axum` 0.8, `tokio`, `dashmap` |
 
 The split means any Rust project can depend on `awp-types` without pulling in the ADK tree.
 
@@ -134,50 +134,77 @@ hours = "Mon-Fri 9-5 EST"
 
 ```rust
 use std::sync::Arc;
-use adk_awp::{
-    AwpState, BusinessContextLoader, DefaultTrustAssigner,
-    HealthStateMachine, InMemoryConsentService,
-    InMemoryEventSubscriptionService, InMemoryRateLimiter,
-    awp_routes,
-};
 
-// Load business context
+use adk_awp::{AwpA2aHandler, AwpState, BusinessContextLoader, awp_routes};
+use async_trait::async_trait;
+use awp_types::AwpError;
+use axum::http::{HeaderMap, header};
+use serde_json::{Value, json};
+
+struct ApplicationA2a {
+    bearer_token: Arc<str>,
+}
+
+#[async_trait]
+impl AwpA2aHandler for ApplicationA2a {
+    async fn handle(&self, headers: HeaderMap, message: Value) -> Result<Value, AwpError> {
+        let expected = format!("Bearer {}", self.bearer_token);
+        let authorized = headers
+            .get(header::AUTHORIZATION)
+            .and_then(|value| value.to_str().ok())
+            .is_some_and(|value| value == expected);
+        if !authorized {
+            return Err(AwpError::Unauthorized("invalid A2A credential".to_string()));
+        }
+        // Authorize the requested capability and dispatch to the application agent.
+        Ok(json!({ "status": "processed", "messageId": message["id"] }))
+    }
+}
+
 let loader = BusinessContextLoader::from_file("business.toml".as_ref())?;
+let a2a_token: Arc<str> = std::env::var("AWP_A2A_TOKEN")?.into();
+let state = AwpState::builder(loader.context_ref())
+    .a2a_handler(Arc::new(ApplicationA2a { bearer_token: a2a_token }))
+    .build();
 
-// Build AWP state with all protocol services
-let event_service = Arc::new(InMemoryEventSubscriptionService::new());
-let state = AwpState {
-    business_context: loader.context_ref(),
-    rate_limiter: Arc::new(InMemoryRateLimiter::new()),
-    consent_service: Arc::new(InMemoryConsentService::new()),
-    event_service: event_service.clone(),
-    health: Arc::new(HealthStateMachine::new(event_service)),
-    trust_assigner: Arc::new(DefaultTrustAssigner),
-};
-
-// Merge AWP routes into your Axum app
 let app = axum::Router::new()
     .merge(awp_routes(state))
     .merge(your_custom_routes);
 
-// Serve
-let listener = tokio::net::TcpListener::bind("0.0.0.0:3456").await?;
-axum::serve(listener, app).await?;
+let listener = tokio::net::TcpListener::bind("127.0.0.1:3456").await?;
+axum::serve(
+    listener,
+    app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+)
+.await?;
 ```
 
-This registers all AWP endpoints with version negotiation middleware applied automatically.
+This registers the four public AWP endpoints with version negotiation, rate
+limiting, and a 64 KiB A2A body limit. Without an `AwpA2aHandler`,
+`POST /awp/a2a` returns `503` and never acknowledges work that was not
+dispatched. `ConnectInfo` supplies the peer address used to isolate anonymous
+rate-limit buckets; without it, unknown callers intentionally share one bucket.
 
-## AWP Endpoints
+## Public AWP endpoints
 
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/.well-known/awp.json` | Discovery document — entry point for agents |
 | GET | `/awp/manifest` | JSON-LD capability manifest |
 | GET | `/awp/health` | Health state (Healthy/Degrading/Degraded) |
+| POST | `/awp/a2a` | Application-provided A2A dispatch |
+
+## Authenticated management endpoints
+
+`awp_management_routes()` returns subscription management separately and
+without an authentication layer. Apply the application's auth middleware
+before merging it:
+
+| Method | Path | Description |
+|--------|------|-------------|
 | POST | `/awp/events/subscribe` | Create a webhook subscription |
 | GET | `/awp/events/subscriptions` | List all subscriptions |
 | DELETE | `/awp/events/subscriptions/{id}` | Delete a subscription |
-| POST | `/awp/a2a` | Agent-to-agent message handler |
 
 ## Discovery Document
 
@@ -192,7 +219,7 @@ The discovery document at `/.well-known/awp.json` is auto-generated from your `b
   "a2aEndpointUrl": "https://myshop.example.com/awp/a2a",
   "eventsEndpointUrl": "https://myshop.example.com/awp/events/subscribe",
   "healthEndpointUrl": "https://myshop.example.com/awp/health",
-  "supportedTrustLevels": ["anonymous", "known", "partner", "internal"]
+  "supportedTrustLevels": ["anonymous"]
 }
 ```
 
@@ -230,26 +257,48 @@ AWP uses four trust levels with increasing access:
 
 Trust levels are ordered: `Anonymous < Known < Partner < Internal`. Each capability in `business.toml` declares its minimum `access_level`.
 
+`DefaultTrustAssigner` classifies every request as `Anonymous`. A bearer or API
+key header is not trusted until an application verifier validates it. Higher
+trust levels therefore require a custom assigner.
+
+Configure `.supported_trust_levels(...)` alongside that assigner so discovery
+advertises only levels the deployment can verify.
+
 ### Custom Trust Assignment
 
 Implement the `TrustLevelAssigner` trait for custom logic:
 
 ```rust
+use std::sync::Arc;
+
+use adk_awp::TrustLevelAssigner;
 use async_trait::async_trait;
 use awp_types::TrustLevel;
-use axum::http::HeaderMap;
-use adk_awp::TrustLevelAssigner;
+use axum::http::{HeaderMap, header};
 
-struct MyTrustAssigner;
+struct MyTrustAssigner {
+    bearer_token: Arc<str>,
+}
 
 #[async_trait]
 impl TrustLevelAssigner for MyTrustAssigner {
     async fn assign(&self, headers: &HeaderMap) -> TrustLevel {
-        // Your JWT validation, allowlist checks, etc.
-        TrustLevel::Known
+        let expected = format!("Bearer {}", self.bearer_token);
+        if headers
+            .get(header::AUTHORIZATION)
+            .and_then(|value| value.to_str().ok())
+            .is_some_and(|value| value == expected)
+        {
+            TrustLevel::Known
+        } else {
+            TrustLevel::Anonymous
+        }
     }
 }
 ```
+
+Use the same verified identity and scope source as the rest of the application
+when assigning `Partner` or `Internal`.
 
 ## Rate Limiting
 
@@ -268,7 +317,6 @@ Rejected requests receive HTTP 429 with a `Retry-After` header.
 
 ```rust
 use std::collections::HashMap;
-use std::time::Duration;
 use awp_types::TrustLevel;
 use adk_awp::{InMemoryRateLimiter, RateLimitConfig};
 
@@ -282,7 +330,7 @@ limits.insert(TrustLevel::Known, RateLimitConfig {
     window_secs: 60,
 });
 
-let limiter = InMemoryRateLimiter::with_config(limits, Duration::from_secs(60));
+let limiter = InMemoryRateLimiter::with_config(limits);
 ```
 
 ## Version Negotiation
@@ -292,28 +340,40 @@ All AWP routes include version negotiation middleware:
 - Clients send `AWP-Version: 1.1` header (optional — defaults to current version)
 - Server checks major version compatibility
 - Compatible requests proceed; incompatible requests get HTTP 406
+- Malformed version values get HTTP 400
 - Response includes `AWP-Version: 1.0` header
 
 ## Event Subscriptions
 
-Agents can subscribe to AWP events via webhooks:
+Subscription management is a privileged surface. Mount
+`awp_management_routes()` behind authentication before accepting these
+requests. Callback URLs must be absolute HTTPS URLs and signing secrets must
+contain at least 32 bytes:
 
 ```bash
 # Subscribe
 curl -X POST http://localhost:3456/awp/events/subscribe \
+  -H "Authorization: Bearer $AWP_ADMIN_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
     "subscriber": "my-agent",
     "callbackUrl": "https://my-agent.example/webhook",
     "eventTypes": ["health.changed"],
-    "secret": "my-webhook-secret"
+    "secret": "replace-with-at-least-32-random-bytes"
   }'
 
 # List subscriptions
-curl http://localhost:3456/awp/events/subscriptions
+curl -H "Authorization: Bearer $AWP_ADMIN_TOKEN" \
+  http://localhost:3456/awp/events/subscriptions
 ```
 
-Webhook deliveries include an `X-AWP-Signature` header with HMAC-SHA256 signature:
+`InMemoryEventSubscriptionService` signs and logs matching deliveries but
+performs no network I/O. Production applications implement
+`EventSubscriptionService` with destination validation, a durable queue,
+bounded retries, and their HTTP client.
+
+An HTTP delivery implementation can carry an `X-AWP-Signature` header with the
+HMAC-SHA256 signature:
 
 ```
 X-AWP-Signature: sha256=<hex_digest>
@@ -349,9 +409,12 @@ health.report_healthy().await?;
 
 Invalid transitions (e.g., Healthy → Degraded) return an error.
 
-## Consent Framework
+## Consent Storage
 
-AWP includes a consent service for GDPR/privacy compliance:
+AWP includes a consent storage interface. Regulatory compliance also requires
+application-specific notice, lawful basis, retention, access controls, and
+deletion policy; selecting a storage implementation does not establish
+compliance:
 
 ```rust
 use adk_awp::InMemoryConsentService;
@@ -485,17 +548,20 @@ cargo run
 The example:
 1. Loads `business.toml` with products, policies, and brand voice
 2. Creates an LLM agent with instructions derived from the business context
-3. Serves all AWP endpoints + a `/ask` endpoint for the agent
-4. Exercises every endpoint and prints compliance verification
+3. Installs authenticated A2A dispatch to that agent
+4. Mounts management routes behind a separate demo credential
+5. Exercises every endpoint and prints protocol verification
 
 ## Best Practices
 
 1. **Start with a minimal `business.toml`** — only `site_name`, `site_description`, `domain`, capabilities, and policies are required
-2. **Use trust levels** — set `access_level` on capabilities to control who can access what
+2. **Enforce capability authorization** — `access_level` is manifest metadata; the application handler must enforce it
 3. **Enable hot-reload** in production — call `loader.watch()` for zero-downtime config updates
-4. **Implement custom `TrustLevelAssigner`** — the default only distinguishes Anonymous vs Known
-5. **Subscribe to health events** — monitor service state transitions via webhooks
-6. **Verify webhook signatures** — always validate `X-AWP-Signature` on incoming webhooks
+4. **Implement custom `TrustLevelAssigner`** — the default intentionally assigns only `Anonymous`
+5. **Authenticate management routes** — never expose subscription CRUD from an unprotected router
+6. **Install real A2A dispatch** — the fail-closed default returns `503`
+7. **Use durable event delivery** — implement destination policy, queueing, and bounded retries
+8. **Verify webhook signatures** — validate `X-AWP-Signature` on incoming webhooks
 
 ## Related
 

--- a/examples/awp_agent/Cargo.lock
+++ b/examples/awp_agent/Cargo.lock
@@ -289,6 +289,7 @@ dependencies = [
  "adk-session",
  "anyhow",
  "arc-swap",
+ "async-trait",
  "awp-types",
  "axum",
  "dotenvy",

--- a/examples/awp_agent/Cargo.toml
+++ b/examples/awp_agent/Cargo.toml
@@ -26,3 +26,4 @@ serde_json = "1.0"
 reqwest = { version = "0.12", features = ["json"] }
 uuid = { version = "1", features = ["v4"] }
 futures = "0.3"
+async-trait = "0.1"

--- a/examples/awp_agent/README.md
+++ b/examples/awp_agent/README.md
@@ -5,7 +5,9 @@ An AWP-compliant agent server that demonstrates the full Agentic Web Protocol in
 ## What This Shows
 
 - Loading a `business.toml` with the full AWP schema (business identity, brand voice, products, channels, payments, support, outreach)
-- Serving all 7 AWP protocol endpoints with version negotiation middleware
+- Serving public AWP routes with version negotiation and rate limiting
+- Installing authenticated A2A dispatch to the LLM agent
+- Protecting subscription management with a separate credential
 - Running an LLM agent whose instructions are derived from the business context
 - Exercising every endpoint with an HTTP client to verify compliance
 
@@ -45,8 +47,9 @@ cargo run
 1. **business.toml** defines the site: name, products, policies, brand voice, payment config
 2. **BusinessContextLoader** parses and validates the TOML file
 3. **LLM agent** receives the business context as system instructions
-4. **awp_routes()** registers all AWP protocol endpoints with version negotiation
-5. The example exercises every endpoint and prints the results
+4. **awp_routes()** registers the safe public protocol boundary
+5. **awp_management_routes()** is mounted behind demo authentication
+6. The example exercises every endpoint and prints the results
 
 ## AWP Compliance Verified
 
@@ -55,5 +58,6 @@ cargo run
 - ✓ Version negotiation (accept compatible, reject incompatible)
 - ✓ Health state machine (Healthy/Degrading/Degraded)
 - ✓ Event subscription CRUD with HMAC-SHA256 signing
-- ✓ A2A message handling
+- ✓ Authenticated A2A message dispatch to the LLM agent
+- ✓ Authenticated subscription management boundary
 - ✓ LLM agent with business context instructions

--- a/examples/awp_agent/src/main.rs
+++ b/examples/awp_agent/src/main.rs
@@ -3,10 +3,10 @@
 //! Demonstrates an AWP-compliant agent server that:
 //!
 //! 1. Loads a `business.toml` configuration file (full AWP schema)
-//! 2. Serves all AWP protocol endpoints (discovery, manifest, health, events, A2A)
+//! 2. Serves public AWP endpoints and separately authenticated management routes
 //! 3. Runs an LLM agent whose instructions are derived from the business context
 //! 4. Applies version negotiation middleware on all routes
-//! 5. Exercises every endpoint with an HTTP client to verify compliance
+//! 5. Exercises every endpoint with an HTTP client to verify the boundaries
 //!
 //! ## AWP Endpoints Served
 //!
@@ -34,16 +34,17 @@ use std::sync::Arc;
 
 use adk_agent::LlmAgentBuilder;
 use adk_awp::{
-    AwpState, BusinessContextLoader, DefaultTrustAssigner, HealthStateMachine,
-    InMemoryConsentService, InMemoryEventSubscriptionService, InMemoryRateLimiter, awp_routes,
+    AwpA2aHandler, AwpState, BusinessContextLoader, InMemoryEventSubscriptionService,
+    awp_management_routes, awp_routes,
 };
 use adk_core::Content;
 use adk_model::GeminiModel;
 use adk_runner::Runner;
 use adk_session::InMemorySessionService;
 use axum::Json;
-use axum::extract::State;
-use axum::http::StatusCode;
+use axum::extract::{Request, State};
+use axum::http::{HeaderMap, StatusCode, header};
+use axum::middleware::{Next, from_fn_with_state};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use serde::Deserialize;
@@ -59,6 +60,45 @@ struct AppState {
     session_service: Arc<InMemorySessionService>,
 }
 
+async fn run_question(state: &AppState, question: &str) -> Result<String, String> {
+    use adk_session::{CreateRequest, SessionService};
+    use futures::StreamExt;
+
+    let user_content = Content::new("user").with_text(question);
+    let session_id = format!("session-{}", uuid::Uuid::new_v4());
+
+    state
+        .session_service
+        .create(CreateRequest {
+            app_name: "awp-agent".into(),
+            user_id: "visitor".into(),
+            session_id: Some(session_id.clone()),
+            state: Default::default(),
+        })
+        .await
+        .map_err(|error| format!("session create error: {error}"))?;
+
+    let mut event_stream = state
+        .runner
+        .run_str("visitor", &session_id, user_content)
+        .await
+        .map_err(|error| format!("runner error: {error}"))?;
+
+    let mut response_text = String::new();
+    while let Some(event) = event_stream.next().await {
+        let event = event.map_err(|error| format!("stream error: {error}"))?;
+        if let Some(content) = event.content() {
+            for part in &content.parts {
+                if let adk_core::Part::Text { text, .. } = part {
+                    response_text.push_str(text);
+                }
+            }
+        }
+    }
+
+    Ok(response_text)
+}
+
 // ---------------------------------------------------------------------------
 // Custom route: POST /ask — send a question to the LLM agent
 // ---------------------------------------------------------------------------
@@ -69,67 +109,77 @@ struct AskRequest {
 }
 
 async fn ask_agent(State(state): State<AppState>, Json(body): Json<AskRequest>) -> Response {
-    use adk_session::{CreateRequest, SessionService};
-    use futures::StreamExt;
-
-    let user_content = Content::new("user").with_text(&body.question);
-    let session_id_str = format!("session-{}", uuid::Uuid::new_v4());
-
-    // Create the session first — the runner requires it to exist
-    if let Err(e) = state
-        .session_service
-        .create(CreateRequest {
-            app_name: "awp-agent".into(),
-            user_id: "visitor".into(),
-            session_id: Some(session_id_str.clone()),
-            state: Default::default(),
-        })
-        .await
-    {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({"error": format!("session create error: {e}")})),
-        )
-            .into_response();
-    }
-
-    // Run the agent
-    let mut event_stream =
-        match state.runner.run_str("visitor", &session_id_str, user_content).await {
-            Ok(s) => s,
-            Err(e) => {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({"error": format!("runner error: {e}")})),
-                )
-                    .into_response();
-            }
-        };
-
-    // Collect the final agent response
-    let mut response_text = String::new();
-    while let Some(event) = event_stream.next().await {
-        match event {
-            Ok(ev) => {
-                if let Some(content) = ev.content() {
-                    for part in &content.parts {
-                        if let adk_core::Part::Text { text, .. } = part {
-                            response_text.push_str(text);
-                        }
-                    }
-                }
-            }
-            Err(e) => {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({"error": format!("stream error: {e}")})),
-                )
-                    .into_response();
-            }
+    match run_question(&state, &body.question).await {
+        Ok(answer) => Json(serde_json::json!({ "answer": answer })).into_response(),
+        Err(error) => {
+            (StatusCode::INTERNAL_SERVER_ERROR, Json(serde_json::json!({ "error": error })))
+                .into_response()
         }
     }
+}
 
-    Json(serde_json::json!({ "answer": response_text })).into_response()
+#[derive(Clone)]
+struct AgentA2aHandler {
+    state: AppState,
+    bearer_token: Arc<str>,
+}
+
+#[async_trait::async_trait]
+impl AwpA2aHandler for AgentA2aHandler {
+    async fn handle(
+        &self,
+        headers: HeaderMap,
+        message: serde_json::Value,
+    ) -> Result<serde_json::Value, awp_types::AwpError> {
+        let expected = format!("Bearer {}", self.bearer_token);
+        let authorized = headers
+            .get(header::AUTHORIZATION)
+            .and_then(|value| value.to_str().ok())
+            .is_some_and(|value| value == expected);
+        if !authorized {
+            return Err(awp_types::AwpError::Unauthorized(
+                "a valid application A2A credential is required".to_string(),
+            ));
+        }
+
+        let question = message
+            .pointer("/payload/query")
+            .and_then(serde_json::Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+            .ok_or_else(|| {
+                awp_types::AwpError::InvalidRequest(
+                    "payload.query must be a non-empty string".to_string(),
+                )
+            })?;
+        let answer = run_question(&self.state, question)
+            .await
+            .map_err(awp_types::AwpError::InternalError)?;
+
+        Ok(serde_json::json!({
+            "status": "processed",
+            "messageId": message["id"],
+            "answer": answer,
+        }))
+    }
+}
+
+async fn require_management_auth(
+    State(token): State<Arc<str>>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let expected = format!("Bearer {token}");
+    let authorized = request
+        .headers()
+        .get(header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value == expected);
+
+    if authorized {
+        next.run(request).await
+    } else {
+        StatusCode::UNAUTHORIZED.into_response()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -236,16 +286,16 @@ async fn main() -> anyhow::Result<()> {
 
     let app_state = AppState { runner, session_service };
 
-    // --- Step 4: Build AWP state with all protocol services ---
-    let event_service = Arc::new(InMemoryEventSubscriptionService::new());
-    let awp_state = AwpState {
-        business_context: loader.context_ref(),
-        rate_limiter: Arc::new(InMemoryRateLimiter::new()),
-        consent_service: Arc::new(InMemoryConsentService::new()),
-        event_service: event_service.clone(),
-        health: Arc::new(HealthStateMachine::new(event_service)),
-        trust_assigner: Arc::new(DefaultTrustAssigner),
-    };
+    // --- Step 4: Build AWP state with real, authenticated A2A dispatch ---
+    let a2a_token: Arc<str> = uuid::Uuid::new_v4().to_string().into();
+    let management_token: Arc<str> = uuid::Uuid::new_v4().to_string().into();
+    let awp_state = AwpState::builder(loader.context_ref())
+        .event_service(Arc::new(InMemoryEventSubscriptionService::new()))
+        .a2a_handler(Arc::new(AgentA2aHandler {
+            state: app_state.clone(),
+            bearer_token: a2a_token.clone(),
+        }))
+        .build();
 
     // --- Step 5: Build the Axum router ---
     // AWP routes carry their own AwpState. Custom routes use AppState.
@@ -256,7 +306,14 @@ async fn main() -> anyhow::Result<()> {
         .route("/api/products", get(list_products))
         .with_state(app_state);
 
-    let app = axum::Router::new().merge(awp_routes(awp_state)).merge(custom_routes);
+    let management_routes = awp_management_routes(awp_state.clone()).layer(from_fn_with_state(
+        management_token.clone(),
+        require_management_auth,
+    ));
+    let app = axum::Router::new()
+        .merge(awp_routes(awp_state))
+        .merge(management_routes)
+        .merge(custom_routes);
 
     // --- Step 6: Start the server ---
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
@@ -264,7 +321,12 @@ async fn main() -> anyhow::Result<()> {
     println!("🚀 AWP server listening on http://{addr}\n");
 
     let server = tokio::spawn(async move {
-        axum::serve(listener, app).await.ok();
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .await
+        .ok();
     });
 
     // --- Step 7: Exercise all AWP endpoints ---
@@ -321,14 +383,23 @@ async fn main() -> anyhow::Result<()> {
         "subscriber": "test-client",
         "callbackUrl": "https://example.com/webhook",
         "eventTypes": ["health.changed"],
-        "secret": "test-secret-key"
+        "secret": "test-secret-key-at-least-32-bytes"
     });
-    let resp = client.post(format!("{base}/awp/events/subscribe")).json(&sub_body).send().await?;
+    let resp = client
+        .post(format!("{base}/awp/events/subscribe"))
+        .bearer_auth(&*management_token)
+        .json(&sub_body)
+        .send()
+        .await?;
     println!("POST /awp/events/subscribe → {}", resp.status());
     let sub_resp: serde_json::Value = resp.json().await?;
     println!("  subscription id: {}", sub_resp["id"]);
 
-    let resp = client.get(format!("{base}/awp/events/subscriptions")).send().await?;
+    let resp = client
+        .get(format!("{base}/awp/events/subscriptions"))
+        .bearer_auth(&*management_token)
+        .send()
+        .await?;
     println!("GET /awp/events/subscriptions → {}", resp.status());
     let subs: serde_json::Value = resp.json().await?;
     println!("  count: {}\n", subs.as_array().map(|a| a.len()).unwrap_or(0));
@@ -342,10 +413,16 @@ async fn main() -> anyhow::Result<()> {
         "messageType": "request",
         "payload": {"query": "What products do you sell?"}
     });
-    let resp = client.post(format!("{base}/awp/a2a")).json(&a2a_body).send().await?;
+    let resp = client
+        .post(format!("{base}/awp/a2a"))
+        .bearer_auth(&*a2a_token)
+        .json(&a2a_body)
+        .send()
+        .await?;
     println!("POST /awp/a2a → {}", resp.status());
     let a2a_resp: serde_json::Value = resp.json().await?;
-    println!("  status: {}\n", a2a_resp["status"]);
+    println!("  status: {}", a2a_resp["status"]);
+    println!("  answer: {}\n", a2a_resp["answer"]);
 
     // 7g. Product catalog
     println!("── Business API ───────────────────────────────");


### PR DESCRIPTION
## What

- replaces the placeholder `/awp/a2a` acknowledgement with application-provided dispatch and a fail-closed `503` default
- separates subscription CRUD from the safe public router and applies configured rate limiting to both route groups
- validates A2A IDs, body sizes, webhook destinations, event filters, and signing-secret bounds
- stops treating unverified authorization headers as trusted identities
- advertises only configured trust levels and rejects malformed protocol-version headers
- removes the no-op `webhook-delivery` feature and documents the production delivery interface honestly
- updates the AWP example to dispatch through a real authenticated agent path and protect management routes separately

## Why

The v2 AWP boundary acknowledged work it never executed, exposed privileged route composition by default, bypassed its configured rate limiter, and inferred trust from unverified header presence. These behaviors are release blockers.

## How

- adds `AwpA2aHandler` to the state builder
- makes `awp_routes` the public-only safe default
- keeps management routes explicit for application authentication
- keys anonymous throttling by Axum peer `ConnectInfo` and authenticated throttling by credential digest
- validates subscriptions at both HTTP and service boundaries

## Verification

- `cargo nextest run -p adk-awp` — 135 passed
- `cargo clippy -p adk-awp --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p adk-awp --no-deps`
- `cargo test -p adk-awp --doc`
- `cargo check --manifest-path examples/awp_agent/Cargo.toml --locked`
- `bash scripts/check-doc-examples.sh` — 96 Markdown files
- repository pre-commit workspace clippy and format hooks pass
- repository pre-push workspace check hook passes