### PR TITLE
ci: complete Rust 1.95 and example-gate transition

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,7 +27,7 @@ What actually happened. Include error messages, stack traces, or logs.
 ## Environment
 
 - OS: [e.g., macOS 15, Ubuntu 24.04]
-- Rust version: [e.g., 1.94.0]
+- Rust version: [e.g., 1.95.0]
 - ADK-Rust version/commit: [e.g., v0.3.0 or commit hash]
 - Affected crate(s): [e.g., adk-gemini, adk-realtime]
 

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -9,7 +9,7 @@ inputs:
   toolchain:
     description: 'Rust toolchain version to install.'
     required: false
-    default: '1.94.0'
+    default: '1.95.0'
   components:
     description: 'Comma-separated list of toolchain components (e.g. clippy,rustfmt).'
     required: false

--- a/.github/workflows/ci-merge.yml
+++ b/.github/workflows/ci-merge.yml
@@ -99,11 +99,11 @@ jobs:
   #     its pinned git dependency during quiet periods. It no longer carries a
   #     push-to-main trigger, so a Monty-touching merge is not built twice.
   #
-  # adk-codeact-monty is outside the root workspace: it needs rustc 1.95 (the
-  # workspace is pinned to 1.94) plus rustfmt + clippy. neutralize-wild is true
-  # because this is a plain Linux runner that does not provide the `wild` linker
-  # pinned in .cargo/config.toml. The cache is keyed on the Monty crate's own
-  # lockfile so a dependency change there is not masked by a stale workspace cache.
+  # adk-codeact-monty is outside the root workspace because it carries a Monty
+  # git dependency. neutralize-wild is true because this is a plain Linux runner
+  # that does not provide the `wild` linker pinned in .cargo/config.toml. The
+  # cache is keyed on the Monty crate's own lockfile so dependency changes are
+  # not masked by the workspace cache.
   out-of-workspace-monty:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -127,14 +127,13 @@ jobs:
         cache-key: features-${{ matrix.name }}
         neutralize-wild: ${{ matrix.neutralize-wild }}
 
-    # espeak-ng is required by `espeak-rs`, pulled in by adk-audio's `kokoro`
-    # backend (part of `all-onnx`). Installed unconditionally so adding a matrix
-    # entry stays a one-line change.
+    # espeak-ng is required by adk-audio's `kokoro` backend. glib is required by
+    # the WebRTC transport in adk-realtime's `full` feature.
     - name: Install system dependencies (Linux)
       if: runner.os == 'Linux'
       run: |
         sudo apt-get update
-        sudo apt-get install -y cmake protobuf-compiler libespeak-ng-dev
+        sudo apt-get install -y cmake protobuf-compiler libespeak-ng-dev libglib2.0-dev
 
     - name: Install system dependencies (macOS)
       if: runner.os == 'macOS'
@@ -187,45 +186,6 @@ jobs:
       if: always()
       shell: bash
       run: echo "### 🔐 supply-chain checks (cargo audit + cargo deny) completed" >> "$GITHUB_STEP_SUMMARY"
-
-  # ── Standalone examples: compile every examples/* crate ────────
-  # Each example under examples/ is its own workspace with its own Cargo.lock and
-  # path dependencies back into this repo. Nothing else in CI compiles them:
-  # `cargo check --workspace` cannot see them (they are in the root manifest's
-  # `exclude`/outside `members`), and scripts/check-doc-examples.sh only validates
-  # that documented commands resolve in cargo metadata. A public API change can
-  # therefore break the adoption surface silently.
-  #
-  # Nightly tier because this is ~96 separate crate graphs. Sharded so each job
-  # stays within a sensible runtime; the script shares one CARGO_TARGET_DIR per
-  # shard so the ADK crates compile once per shard rather than once per example.
-  examples-compile:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [0, 1, 2, 3]
-    steps:
-    - uses: actions/checkout@v7
-
-    - name: Setup Rust
-      uses: ./.github/actions/setup-rust
-      with:
-        cache-key: examples-compile-${{ matrix.shard }}
-        neutralize-wild: 'true'
-
-    - name: Install system dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y cmake protobuf-compiler
-
-    - name: Compile standalone examples (shard ${{ matrix.shard }} of 4)
-      run: bash scripts/check-examples-compile.sh ${{ matrix.shard }} 4
-
-    - name: Examples summary
-      if: always()
-      shell: bash
-      run: echo "### 📦 standalone example compile, shard ${{ matrix.shard }} of 4" >> "$GITHUB_STEP_SUMMARY"
 
   # ── Integration tests: #[ignore]d tests gated on secrets ───────
   # Requirement 2.3 (scheduled integration coverage). The workspace marks tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,6 +271,40 @@ jobs:
       if: always()
       run: echo "### 🧪 doctests (workspace + adk-rust --features full) completed" >> "$GITHUB_STEP_SUMMARY"
 
+  # ── Standalone examples: compile every examples/* crate ────────
+  # The standalone examples are separate workspaces, so the workspace build does
+  # not catch public-API breakage or stale example lockfiles. Run the four
+  # shards before merge; each shard shares one target directory across its
+  # examples to avoid rebuilding common ADK crates.
+  examples-compile:
+    name: examples-compile (${{ matrix.shard }}/4)
+    needs: fmt
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Setup Rust
+      uses: ./.github/actions/setup-rust
+      with:
+        cache-key: pr-examples-compile-${{ matrix.shard }}
+
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake protobuf-compiler libdbus-1-dev libasound2-dev libudev-dev
+
+    - name: Compile standalone examples (shard ${{ matrix.shard }} of 4)
+      run: bash scripts/check-examples-compile.sh ${{ matrix.shard }} 4
+
+    - name: Examples summary
+      if: always()
+      shell: bash
+      run: echo "### 📦 standalone example compile, shard ${{ matrix.shard }} of 4" >> "$GITHUB_STEP_SUMMARY"
+
   # ── Scaffolds: cargo-adk generated projects compile ────────────
   templates:
     needs: fmt

--- a/.github/workflows/codeact-monty.yml
+++ b/.github/workflows/codeact-monty.yml
@@ -1,10 +1,9 @@
 name: CodeAct Monty
 
-# `adk-codeact-monty` is intentionally OUTSIDE the main workspace: it depends on
-# the Monty interpreter via a git dependency (not yet on crates.io) and requires
-# rustc 1.95+, while the workspace is pinned to 1.94. The main CI workflow does
-# not build it, so this workflow exercises it (and the CodeAct feature in
-# adk-agent) separately.
+# `adk-codeact-monty` is intentionally OUTSIDE the main workspace because it
+# depends on the Monty interpreter through a git dependency that is not yet on
+# crates.io. The main CI workflow does not build it, so this workflow exercises
+# it (and the CodeAct feature in adk-agent) separately.
 #
 # Tiering (see ci-pipeline-restructure spec):
 #   • codeact-feature — the lightweight in-workspace CodeAct check — runs on PRs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Rust Agent Development Kit — a modular workspace of publishable crates for bui
 
 ## Dev environment
 
-- Rust 1.94.0+, edition 2024. Use `make setup` or `devenv shell` to bootstrap.
+- Rust 1.95.0+, edition 2024. Use `make setup` or `devenv shell` to bootstrap.
 - `sccache` is the compilation cache. Set `RUSTC_WRAPPER=sccache` in your shell profile.
 - On Linux, `wild` is the linker (configured in `.cargo/config.toml`). macOS uses the default linker.
 - Copy `.env.example` to `.env` for API keys. Never commit `.env` files or secrets.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,16 +32,16 @@ expensive axes move to a later tier.
   set: `fmt` (prerequisite gate), `clippy --workspace --all-targets -D warnings`,
   `nextest --workspace` (Linux, runs at most once), `feature-coverage` for
   feature-gated modules default builds skip (e.g. `adk-agent --features codeact`),
-  `docs` (`cargo doc --workspace --no-deps` plus doctests), `templates`,
-  compile-only `macos`/`windows` builds, and `semver` (stable strict, everything
-  else warn-only).
+  `docs` (`cargo doc --workspace --no-deps` plus doctests), standalone examples
+  (4 shards), `templates`, compile-only `macos`/`windows` builds, and `semver`
+  (stable strict, everything else warn-only).
 - **Merge tier** (`ci-merge.yml`, on `push: main`) — cross-platform
   `nextest --workspace` on macOS/Windows, the out-of-workspace Monty build, and
   doc-example compilation. Runs post-merge; not branch-protection-required.
 - **Nightly tier** (`ci-nightly.yml`, on `schedule`) — the feature-combination
   matrix (clippy with `-D warnings`), `cargo-audit`/`cargo-deny` supply-chain
-  checks, standalone `examples/*` compilation (4 shards), and `#[ignore]`
-  integration tests gated on available secrets. Not branch-protection-required.
+  checks, and `#[ignore]` integration tests gated on available secrets. Not
+  branch-protection-required.
 
 Only the PR tier gates merges. See CONTRIBUTING.md ("Branch Protection — Required
 Status Checks") for the authoritative required-check set.
@@ -458,7 +458,7 @@ cargo nextest run -p adk-realtime --features full            # with features
 ## Documentation
 
 - When making a change that adds or changes an API, ensure that `docs/official_docs/` is up to date.
-- Documented examples (Cargo snippets, feature names, and package/example references in `README.md` and `docs/official_docs/`) are validated in CI by `scripts/check-doc-examples.sh` against `cargo metadata`. Compile coverage comes from the workspace example crates and cargo-adk templates, so if you change a public API, keep those in sync.
+- Documented examples (Cargo snippets, feature names, and package/example references in `README.md` and `docs/official_docs/`) are validated in CI by `scripts/check-doc-examples.sh` against `cargo metadata`. The PR tier compiles the standalone example workspaces and cargo-adk templates, so if you change a public API, keep those in sync.
 - Update the crate's `README.md` if capabilities changed.
 - Update `CHANGELOG.md` for user-facing changes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -323,6 +323,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **OpenAI integrations now use `async-openai` 0.41.** Chat Completions,
   Responses, and Realtime integrations adopt the current 0.41 types and
   transport dependencies.
+- **Toolchain pinned to Rust 1.95.0.** `rust-toolchain.toml` is now the single source: rustup
+  reads it locally and devenv reads the same file through `languages.rust.toolchainFile`, so a
+  devenv shell and a plain `cargo` invocation cannot drift. The workspace resolver moves to `3`
+  and `rust-version` to `1.95`; `Cargo.lock` is unchanged by the resolver bump. Five new 1.95
+  clippy lints are fixed — three `collapsible_match`, one `iter_kv_map`, and one `sort_by_key`
+  that needed `Reverse` because the sort is descending. 1.95 also clears the AWS SDK MSRV floor,
+  so `cargo update` no longer breaks the `bedrock` feature.
+
 - **MCP now uses official `rmcp 2.2` and MCP `2025-11-25` protocol types.**
   ADK-Rust re-exports its aligned SDK for advanced transports and server
   authoring. Sampling remains an opt-in deprecated-compatibility feature under

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ cargo nextest run --workspace
 
 ### Prerequisites
 
-- Rust 1.94.0+ (edition 2024)
+- Rust 1.95.0+ (edition 2024)
 - For browser examples: Chrome/Chromium
 - For `openai-webrtc` feature: cmake (audiopus builds Opus from source)
 - For mistral.rs: see [adk-mistralrs section](#adk-mistralrs)
@@ -504,7 +504,7 @@ If your change is purely internal refactoring with no behavior change, existing 
 
 ### Rust Conventions
 
-- Edition 2024, MSRV 1.94.0
+- Edition 2024, MSRV 1.95.0
 - `thiserror` for library error types
 - `async-trait` for async trait methods
 - `Arc<T>` for shared ownership across async boundaries

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -292,7 +292,7 @@ expensive axes just move to a later tier.
 
 | Tier | Trigger | Checks | Blocks merge? |
 |------|---------|--------|---------------|
-| **PR** | pull request (`ci.yml` + `semver.yml`) | `fmt` (prerequisite gate), `clippy --workspace -D warnings`, `nextest --workspace` on Linux (at most once), `feature-coverage` (feature-gated modules like `adk-agent --features codeact`), `docs` (single `cargo doc --workspace --no-deps`), `templates`, compile-only `macos`/`windows` builds, `semver` (stable strict, beta warn-only) | Yes — this is the required-check set |
+| **PR** | pull request (`ci.yml` + `semver.yml`) | `fmt` (prerequisite gate), `clippy --workspace -D warnings`, `nextest --workspace` on Linux (at most once), `feature-coverage` (feature-gated modules like `adk-agent --features codeact`), docs and doctests, standalone examples (4 shards), `templates`, compile-only `macos`/`windows` builds, `semver` (stable strict, beta warn-only) | Yes — this is the required-check set |
 | **Merge** | `push: main` (`ci-merge.yml`) | cross-platform `nextest --workspace` on macOS/Windows, out-of-workspace Monty build, doc-example compilation | No — runs post-merge |
 | **Nightly** | `schedule` (`ci-nightly.yml`) | feature-combination matrix, `cargo-audit`/`cargo-deny` supply-chain, `#[ignore]` integration tests gated on secrets | No — runs on a schedule |
 
@@ -326,22 +326,30 @@ name is the job name (matrix jobs include the matrix value in parentheses):
 | `clippy` | `ci.yml` | `clippy` |
 | `test` | `ci.yml` | `test` |
 | `feature-coverage (adk-agent, codeact)` | `ci.yml` | `feature-coverage` (matrix) |
+| `feature-coverage (adk-agent, ambient)` | `ci.yml` | `feature-coverage` (matrix) |
 | `feature-coverage (adk-model, openrouter)` | `ci.yml` | `feature-coverage` (matrix) |
 | `feature-coverage (adk-sandbox, wasm)` | `ci.yml` | `feature-coverage` (matrix) |
+| `feature-coverage (adk-sandbox, sandbox-linux)` | `ci.yml` | `feature-coverage` (matrix) |
+| `feature-coverage (adk-realtime, integration)` | `ci.yml` | `feature-coverage` (matrix) |
+| `feature-coverage (adk-managed, memory)` | `ci.yml` | `feature-coverage` (matrix) |
 | `feature-coverage (adk-audio, fx)` | `ci.yml` | `feature-coverage` (matrix) |
 | `feature-coverage (adk-rag, lancedb)` | `ci.yml` | `feature-coverage` (matrix) |
+| `feature-coverage (adk-auth, sso)` | `ci.yml` | `feature-coverage` (matrix) |
+| `feature-coverage (adk-server, a2a-v1)` | `ci.yml` | `feature-coverage` (matrix) |
 | `docs` | `ci.yml` | `docs` |
+| `examples-compile (0/4)` | `ci.yml` | `examples-compile` (matrix) |
+| `examples-compile (1/4)` | `ci.yml` | `examples-compile` (matrix) |
+| `examples-compile (2/4)` | `ci.yml` | `examples-compile` (matrix) |
+| `examples-compile (3/4)` | `ci.yml` | `examples-compile` (matrix) |
 | `templates` | `ci.yml` | `templates` |
 | `macos` | `ci.yml` | `macos` (compile-only build) |
 | `windows` | `ci.yml` | `windows` (compile-only build) |
 | `semver` | `semver.yml` | `semver` (stable-tier strict; beta is warn-only within the same job) |
 
 Notes:
-- `feature-coverage` is a matrix job; its context includes the matrix value, so
-  add each entry that exists. Today the entries are `adk-agent, codeact`,
-  `adk-model, openrouter`, `adk-sandbox, wasm`, `adk-audio, fx`, and
-  `adk-rag, lancedb`. If you append matrix entries, add their contexts here and
-  to branch protection.
+- Matrix-job contexts include the matrix value. If you append a
+  `feature-coverage` entry or change the four `examples-compile` shards, update
+  both this table and branch protection.
 - `semver` is a single job that runs the strict stable-crate check (which can fail
   the job) and a warn-only beta/experimental check (which never fails). Requiring
   the `semver` job therefore requires only the stable-tier semver gate, keeping the
@@ -380,11 +388,21 @@ gh api -X PUT repos/zavora-ai/adk-rust/branches/main/protection \
       { "context": "clippy" },
       { "context": "test" },
       { "context": "feature-coverage (adk-agent, codeact)" },
+      { "context": "feature-coverage (adk-agent, ambient)" },
       { "context": "feature-coverage (adk-model, openrouter)" },
       { "context": "feature-coverage (adk-sandbox, wasm)" },
+      { "context": "feature-coverage (adk-sandbox, sandbox-linux)" },
+      { "context": "feature-coverage (adk-realtime, integration)" },
+      { "context": "feature-coverage (adk-managed, memory)" },
       { "context": "feature-coverage (adk-audio, fx)" },
       { "context": "feature-coverage (adk-rag, lancedb)" },
+      { "context": "feature-coverage (adk-auth, sso)" },
+      { "context": "feature-coverage (adk-server, a2a-v1)" },
       { "context": "docs" },
+      { "context": "examples-compile (0/4)" },
+      { "context": "examples-compile (1/4)" },
+      { "context": "examples-compile (2/4)" },
+      { "context": "examples-compile (3/4)" },
       { "context": "templates" },
       { "context": "macos" },
       { "context": "windows" },
@@ -484,7 +502,7 @@ cargo test --workspace --doc
 - Unit tests: `#[cfg(test)]` modules in source files
 - Integration tests: `tests/*.rs` in each crate
 - Property tests: `tests/*_property_tests.rs` using `proptest` (100+ iterations)
-- Doc examples: Cargo snippets, feature names, and package/example references in `README.md` and `docs/official_docs/` are validated against `cargo metadata` by `scripts/check-doc-examples.sh`. Compile coverage comes from the workspace example crates and cargo-adk templates.
+- Doc examples: Cargo snippets, feature names, and package/example references in `README.md` and `docs/official_docs/` are validated against `cargo metadata` by `scripts/check-doc-examples.sh`. The PR tier compiles the standalone example workspaces and cargo-adk templates.
 
 ### Writing Tests for New Code
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 members = [
     # Core packages (publishable to crates.io)
     "adk-core",
@@ -120,7 +120,7 @@ opt-level = 2
 [workspace.package]
 version = "2.0.0"
 edition = "2024"
-rust-version = "1.94.0"
+rust-version = "1.95"
 license = "Apache-2.0"
 authors = ["James Karanja Maina <james.karanja@zavora.ai>"]
 homepage = "https://www.zavora.ai"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![docs.rs](https://docs.rs/adk-rust/badge.svg)](https://docs.rs/adk-rust)
 [![Wiki](https://img.shields.io/badge/docs-Wiki-blue)](https://github.com/zavora-ai/adk-rust/wiki)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-![Rust](https://img.shields.io/badge/rust-1.94%2B-orange.svg)
+![Rust](https://img.shields.io/badge/rust-1.95%2B-orange.svg)
 [![GitHub Discussions](https://img.shields.io/github/discussions/zavora-ai/adk-rust?style=flat&logo=github&color=5865F2)](https://github.com/zavora-ai/adk-rust/discussions)
 
 > **v2.0.0 release candidate — unpublished.** The 41-crate v2 workspace is being stabilized; v2 has not been published to crates.io. The candidate targets the official `rmcp 2.2` MCP SDK (protocol `2025-11-25`) with effective HTTP configuration, official `agent-client-protocol` 1.2 for ACP with exact capability publication, the new `adk-computer-use` governed desktop-automation layer, `adk-devtools` coding-agent tools, and live async tool confirmation keyed by function-call ID. See the [migration guide](docs/official_docs/migration/1.0-to-2.0.md) for the planned breaking changes and [CHANGELOG](CHANGELOG.md) for full details.
@@ -275,7 +275,7 @@ Use `cargo adk build` to verify compilation without deploying.
 
 ### Manual installation
 
-Requires Rust 1.94 or later (Rust 2024 edition). Add to your `Cargo.toml`:
+Requires Rust 1.95 or later (Rust 2024 edition). Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]

--- a/adk-codeact-monty/rust-toolchain.toml
+++ b/adk-codeact-monty/rust-toolchain.toml
@@ -1,5 +1,4 @@
-# Monty (v0.0.18) requires rustc 1.95+, while the parent adk-rust workspace is
-# pinned to 1.94.0. This crate is its own workspace, so it overrides the
-# toolchain locally. Build from inside this directory (or with `cargo +1.95.0`).
+# This out-of-workspace crate keeps an explicit pin so its independent Monty
+# build uses the same supported toolchain as the root workspace.
 [toolchain]
 channel = "1.95.0"

--- a/adk-computer-use/src/eval.rs
+++ b/adk-computer-use/src/eval.rs
@@ -96,7 +96,7 @@ fn canonical_json(value: &serde_json::Value) -> String {
         }
         serde_json::Value::Object(values) => {
             let mut entries = values.iter().collect::<Vec<_>>();
-            entries.sort_by(|(left, _), (right, _)| left.cmp(right));
+            entries.sort_by_key(|(left, _)| *left);
             format!(
                 "{{{}}}",
                 entries

--- a/adk-enterprise/tests/integration_tests.rs
+++ b/adk-enterprise/tests/integration_tests.rs
@@ -200,16 +200,15 @@ async fn test_custom_tool_round_trip() {
 
                     tool_use_id = Some(custom_tool_use_id);
                 }
-                SessionEvent::Message { content, .. } => {
+                SessionEvent::Message { content, .. }
                     // 7. After tool result is sent, agent should produce a final message
-                    if tool_use_id.is_some() {
+                    if tool_use_id.is_some() => {
                         let has_text =
                             content.iter().any(|block| matches!(block, ContentBlock::Text { .. }));
                         if has_text {
                             final_message_received = true;
                         }
                     }
-                }
                 SessionEvent::StatusIdle { .. } => {
                     break;
                 }

--- a/adk-gemini/Cargo.toml
+++ b/adk-gemini/Cargo.toml
@@ -2,6 +2,7 @@
 edition = "2024"
 name = "adk-gemini"
 version.workspace = true
+rust-version.workspace = true
 build = false
 autolib = false
 autobins = false

--- a/adk-gemini/examples/image_editing.rs
+++ b/adk-gemini/examples/image_editing.rs
@@ -141,10 +141,8 @@ fn save_generated_images(
         if let Some(parts) = &candidate.content.parts {
             for part in parts.iter() {
                 match part {
-                    adk_gemini::Part::Text { text, .. } => {
-                        if !text.trim().is_empty() {
-                            info!(text = text.trim(), prefix = prefix, "model text response");
-                        }
+                    adk_gemini::Part::Text { text, .. } if !text.trim().is_empty() => {
+                        info!(text = text.trim(), prefix = prefix, "model text response");
                     }
                     adk_gemini::Part::InlineData { inline_data } => {
                         image_count += 1;

--- a/adk-gemini/examples/multi_speaker_tts.rs
+++ b/adk-gemini/examples/multi_speaker_tts.rs
@@ -77,46 +77,43 @@ Alice: I couldn't agree more. It's remarkable how far AI-generated speech has co
                     for (j, part) in parts.iter().enumerate() {
                         match part {
                             // Look for inline data with audio MIME type
-                            Part::InlineData { inline_data } => {
-                                if inline_data.mime_type.starts_with("audio/") {
-                                    info!("📄 Found audio data: {}", inline_data.mime_type);
+                            Part::InlineData { inline_data }
+                                if inline_data.mime_type.starts_with("audio/") =>
+                            {
+                                info!("📄 Found audio data: {}", inline_data.mime_type);
 
-                                    // Decode base64 audio data
-                                    match general_purpose::STANDARD.decode(&inline_data.data) {
-                                        Ok(audio_bytes) => {
-                                            let filename =
-                                                format!("multi_speaker_dialogue_{}_{}.pcm", i, j);
+                                // Decode base64 audio data
+                                match general_purpose::STANDARD.decode(&inline_data.data) {
+                                    Ok(audio_bytes) => {
+                                        let filename =
+                                            format!("multi_speaker_dialogue_{}_{}.pcm", i, j);
 
-                                            // Save audio to file
-                                            match File::create(&filename) {
-                                                Ok(mut file) => {
-                                                    if let Err(e) = file.write_all(&audio_bytes) {
-                                                        error!(
-                                                            "❌ Error writing audio file: {}",
-                                                            e
-                                                        );
-                                                    } else {
-                                                        info!(
-                                                            "💾 Multi-speaker audio saved as: {}",
-                                                            filename
-                                                        );
-                                                        info!(
-                                                            "🎧 Play with: aplay {} (Linux) or afplay {} (macOS)",
-                                                            filename, filename
-                                                        );
-                                                        info!(
-                                                            "👥 Features Alice (Puck voice) and Bob (Charon voice)"
-                                                        );
-                                                    }
-                                                }
-                                                Err(e) => {
-                                                    error!("❌ Error creating audio file: {}", e)
+                                        // Save audio to file
+                                        match File::create(&filename) {
+                                            Ok(mut file) => {
+                                                if let Err(e) = file.write_all(&audio_bytes) {
+                                                    error!("❌ Error writing audio file: {}", e);
+                                                } else {
+                                                    info!(
+                                                        "💾 Multi-speaker audio saved as: {}",
+                                                        filename
+                                                    );
+                                                    info!(
+                                                        "🎧 Play with: aplay {} (Linux) or afplay {} (macOS)",
+                                                        filename, filename
+                                                    );
+                                                    info!(
+                                                        "👥 Features Alice (Puck voice) and Bob (Charon voice)"
+                                                    );
                                                 }
                                             }
+                                            Err(e) => {
+                                                error!("❌ Error creating audio file: {}", e)
+                                            }
                                         }
-                                        Err(e) => {
-                                            error!("❌ Error decoding base64 audio: {}", e)
-                                        }
+                                    }
+                                    Err(e) => {
+                                        error!("❌ Error decoding base64 audio: {}", e)
                                     }
                                 }
                             }

--- a/adk-gemini/examples/simple_speech_generation.rs
+++ b/adk-gemini/examples/simple_speech_generation.rs
@@ -65,8 +65,8 @@ async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
                     for (j, part) in parts.iter().enumerate() {
                         match part {
                             // Look for inline data with audio MIME type
-                            Part::InlineData { inline_data } => {
-                                if inline_data.mime_type.starts_with("audio/") {
+                            Part::InlineData { inline_data }
+                                if inline_data.mime_type.starts_with("audio/") => {
                                     info!(mime_type = inline_data.mime_type, "found audio data");
 
                                     // Decode base64 audio data using the new API
@@ -89,8 +89,7 @@ async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
                                         },
                                         Err(e) => error!(error = %e, "error decoding base64 audio"),
                                     }
-                                }
-                            },
+                                },
                             // Display any text content
                             Part::Text { text, thought, thought_signature: _ } => {
                                 if thought.unwrap_or(false) {

--- a/adk-graph/src/graph.rs
+++ b/adk-graph/src/graph.rs
@@ -316,11 +316,9 @@ impl CompiledGraph {
         for edge in &self.edges {
             match edge {
                 Edge::Direct { source, target: EdgeTarget::Node(n) }
-                    if executed.contains(source) =>
+                    if executed.contains(source) && !next.contains(n) =>
                 {
-                    if !next.contains(n) {
-                        next.push(n.clone());
-                    }
+                    next.push(n.clone());
                 }
                 Edge::Conditional { source, router, targets } if executed.contains(source) => {
                     let route = router(state);
@@ -342,10 +340,8 @@ impl CompiledGraph {
     pub fn leads_to_end(&self, executed: &[String], state: &State) -> bool {
         for edge in &self.edges {
             match edge {
-                Edge::Direct { source, target } if executed.contains(source) => {
-                    if target.is_end() {
-                        return true;
-                    }
+                Edge::Direct { source, target } if executed.contains(source) && target.is_end() => {
+                    return true;
                 }
                 Edge::Conditional { source, router, targets } if executed.contains(source) => {
                     let route = router(state);

--- a/adk-memory/src/inmemory.rs
+++ b/adk-memory/src/inmemory.rs
@@ -182,7 +182,9 @@ impl MemoryService for InMemoryMemoryService {
                 sessions.values().flatten().map(|stored| stored.entry.clone()).collect()
             })
             .unwrap_or_default();
-        entries.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        // Newest first. `Reverse` keeps this a key-based sort, which clippy prefers, without
+        // flipping the comparison by hand.
+        entries.sort_by_key(|entry| std::cmp::Reverse(entry.timestamp));
         entries.truncate(limit);
         Ok(entries)
     }

--- a/adk-model/src/openrouter/adapter.rs
+++ b/adk-model/src/openrouter/adapter.rs
@@ -1028,8 +1028,8 @@ impl ChatStreamState {
 
     fn drain_chat_tool_calls(&mut self) -> Vec<Part> {
         self.pending_tool_calls
-            .iter()
-            .filter_map(|(_, pending)| {
+            .values()
+            .filter_map(|pending| {
                 let name = pending.name.clone()?;
                 let args = serde_json::from_str(&pending.arguments).ok()?;
                 Some(Part::FunctionCall {

--- a/adk-realtime/src/runner.rs
+++ b/adk-realtime/src/runner.rs
@@ -914,12 +914,12 @@ impl RealtimeRunner {
                 self.respond_after_tools().await?;
                 self.check_resumption_queue().await?;
             }
-            ServerEvent::FunctionCallDone { call_id, name, arguments, .. } => {
-                if self.runner_config.auto_execute_tools {
-                    // Returned rather than awaited: the run loop dispatches it so event
-                    // intake — audio deltas included — continues while the tool runs.
-                    return Ok(Some(PendingToolCall { call_id, name, arguments }));
-                }
+            ServerEvent::FunctionCallDone { call_id, name, arguments, .. }
+                if self.runner_config.auto_execute_tools =>
+            {
+                // Returned rather than awaited: the run loop dispatches it so event
+                // intake — audio deltas included — continues while the tool runs.
+                return Ok(Some(PendingToolCall { call_id, name, arguments }));
             }
             ServerEvent::SessionUpdated { session, .. } => {
                 // Check if the generic session update contains a resumption token

--- a/adk-server/src/a2a/v1/task_store.rs
+++ b/adk-server/src/a2a/v1/task_store.rs
@@ -243,7 +243,7 @@ impl TaskStore for InMemoryTaskStore {
             .collect();
 
         // Sort by created_at for deterministic pagination
-        results.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+        results.sort_by_key(|a| a.created_at);
 
         if let Some(page_size) = params.page_size {
             results.truncate(page_size as usize);

--- a/devenv.lock
+++ b/devenv.lock
@@ -127,11 +127,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774408260,
-        "narHash": "sha256-Jn9d9r85dmf3gTMnSRt6t+DP2nQ5uJns/MMXg2FpzfM=",
+        "lastModified": 1785131767,
+        "narHash": "sha256-VNbQv2P0zgaNh96mT4LrnX7hdXgiC5nBH+uvyrrVX7U=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "d6471ee5a8f470251e6e5b83a20a182eb6c46c9b",
+        "rev": "c67ce00525464a710971351c183ce67acb6ca827",
         "type": "github"
       },
       "original": {

--- a/devenv.nix
+++ b/devenv.nix
@@ -30,7 +30,9 @@
   # --------------------------------------------------------------------------
   languages.rust = {
     enable = true;
-    channel = "stable";
+    # Read the same file rustup reads, so a devenv shell and a plain `cargo`
+    # invocation always agree. `channel`/`version` cannot be combined with this.
+    toolchainFile = ./rust-toolchain.toml;
   };
 
   languages.javascript = {

--- a/docs/official_docs/a2a/getting-started.md
+++ b/docs/official_docs/a2a/getting-started.md
@@ -4,7 +4,7 @@ Create and run an A2A (Agent-to-Agent) protocol agent in under 5 minutes.
 
 ## Prerequisites
 
-- Rust 1.94.0 or later (`rustup update stable`)
+- Rust 1.95.0 or later (`rustup update stable`)
 - `cargo-adk` installed (`cargo install cargo-adk`)
 - A Google API key ([get one here](https://aistudio.google.com/app/apikey))
 

--- a/docs/official_docs/development/development-guidelines.md
+++ b/docs/official_docs/development/development-guidelines.md
@@ -18,7 +18,7 @@ This document provides comprehensive guidelines for developers contributing to A
 
 ### Prerequisites
 
-- **Rust**: 1.94.0 or higher (edition 2024, check with `rustc --version`)
+- **Rust**: 1.95.0 or higher (edition 2024, check with `rustc --version`)
 - **Cargo**: Latest stable
 - **Git**: For version control
 - **sccache** (recommended): Compilation cache that cuts rebuild times by ~70%

--- a/docs/official_docs/introduction.md
+++ b/docs/official_docs/introduction.md
@@ -2,7 +2,7 @@
 
 Agent Development Kit (ADK) is a flexible and modular framework for developing and deploying AI agents. While optimized for Gemini and the Google ecosystem, ADK is model-agnostic, deployment-agnostic, and built for compatibility with other frameworks. ADK was designed to make agent development feel more like software development, making it easier for developers to create, deploy, and orchestrate agentic architectures that range from simple tasks to complex workflows.
 
-> **Note:** ADK-Rust requires Rust 1.94.0 or higher.
+> **Note:** ADK-Rust requires Rust 1.95.0 or higher.
 
 ## Installation
 

--- a/docs/official_docs/quickstart.md
+++ b/docs/official_docs/quickstart.md
@@ -4,7 +4,7 @@ Create your first AI agent in under 5 minutes.
 
 ## Prerequisites
 
-- Rust 1.94.0 or later (`rustup update stable`)
+- Rust 1.95.0 or later (`rustup update stable`)
 - A Google API key ([get one here](https://aistudio.google.com/app/apikey))
 
 ## Step 1: Scaffold Your Project

--- a/docs/podcast/episode-2-slides.md
+++ b/docs/podcast/episode-2-slides.md
@@ -144,7 +144,7 @@ Faster than Python ADK
 
 - **Lock poison recovery** — one panicked task won't crash your service
 - **Security audit** — every advisory documented, `cargo audit` CI-integrated
-- **MSRV enforcement** — `rust-toolchain.toml` pins Rust 1.94
+- **MSRV enforcement** — `rust-toolchain.toml` pins Rust 1.95
 
 ---
 

--- a/examples/a2a_interceptors/README.md
+++ b/examples/a2a_interceptors/README.md
@@ -15,7 +15,7 @@ Demonstrates ADK-Rust's A2A (Agent-to-Agent) interceptor chain for request proce
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - **`GOOGLE_API_KEY`** environment variable set with a valid Gemini API key
 
 Set up your environment:

--- a/examples/a2a_quickstart/Cargo.lock
+++ b/examples/a2a_quickstart/Cargo.lock
@@ -99,6 +99,7 @@ dependencies = [
  "adk-graph",
  "adk-tool",
  "async-trait",
+ "chrono",
  "rmcp",
  "serde",
  "serde_json",

--- a/examples/agent_registry/README.md
+++ b/examples/agent_registry/README.md
@@ -14,7 +14,7 @@ Demonstrates the Agent Registry REST API from ADK-Rust v1.0 for registering, dis
 
 ## Prerequisites
 
-- Rust 1.94+
+- Rust 1.95+
 - No LLM provider or API keys required
 
 ## Environment Variables

--- a/examples/ambient_cron_agent/Cargo.lock
+++ b/examples/ambient_cron_agent/Cargo.lock
@@ -22,6 +22,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 

--- a/examples/ambient_cron_agent/README.md
+++ b/examples/ambient_cron_agent/README.md
@@ -10,7 +10,7 @@ Runs an ambient agent on a `CronTrigger`, wrapping a Gemini-powered quote genera
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - **`GOOGLE_API_KEY`** environment variable set
 
 ## Run

--- a/examples/anthropic_server_tools/Cargo.lock
+++ b/examples/anthropic_server_tools/Cargo.lock
@@ -89,6 +89,7 @@ dependencies = [
  "adk-graph",
  "adk-tool",
  "async-trait",
+ "chrono",
  "rmcp",
  "serde",
  "serde_json",

--- a/examples/background_runs/README.md
+++ b/examples/background_runs/README.md
@@ -10,7 +10,7 @@ Exercises the Background Runs REST API from `adk-server`: submit a run, poll its
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - Built with the adk-server `background` feature (already enabled in this example's manifest)
 
 ## Run

--- a/examples/bedrock_test/README.md
+++ b/examples/bedrock_test/README.md
@@ -10,7 +10,7 @@ Drives the Amazon Bedrock provider through the ADK stack, including prompt cachi
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - **`AWS_REGION (or AWS_DEFAULT_REGION)`** environment variable set
 
 Authentication uses the standard AWS credential chain — run `aws configure` first.

--- a/examples/bigquery_toolset/README.md
+++ b/examples/bigquery_toolset/README.md
@@ -14,7 +14,7 @@ lists datasets, inspects table schemas, and executes SQL queries via the BigQuer
 
 ## Prerequisites
 
-- Rust 1.94+
+- Rust 1.95+
 - `GOOGLE_API_KEY` for the Gemini LLM provider
 - (Optional) A Google Cloud project with BigQuery enabled for live mode
 - (Optional) Application Default Credentials configured via `gcloud auth application-default login`

--- a/examples/codeact_monty_agent/rust-toolchain.toml
+++ b/examples/codeact_monty_agent/rust-toolchain.toml
@@ -1,5 +1,4 @@
-# This example pulls in `monty` (via adk-codeact-monty), which requires rustc
-# 1.95+, while the parent adk-rust workspace is pinned to 1.94.0. As a standalone
-# workspace, it overrides the toolchain locally.
+# This standalone example keeps an explicit pin so its Monty dependency uses
+# the same supported toolchain as the root workspace.
 [toolchain]
 channel = "1.95.0"

--- a/examples/competitive_ergonomics/Cargo.lock
+++ b/examples/competitive_ergonomics/Cargo.lock
@@ -89,6 +89,7 @@ dependencies = [
  "adk-graph",
  "adk-tool",
  "async-trait",
+ "chrono",
  "rmcp",
  "serde",
  "serde_json",

--- a/examples/competitive_ergonomics/README.md
+++ b/examples/competitive_ergonomics/README.md
@@ -10,7 +10,7 @@ Validation example for the convenience APIs and encrypted session storage.
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - **`One of ANTHROPIC_API_KEY, OPENAI_API_KEY, or GOOGLE_API_KEY`** environment variable set
 
 ## Run

--- a/examples/competitive_graph_resume/README.md
+++ b/examples/competitive_graph_resume/README.md
@@ -10,7 +10,7 @@ Validation example for resume-from-checkpoint in `adk-graph`.
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - No API key required
 
 ## Run

--- a/examples/competitive_tool_search/README.md
+++ b/examples/competitive_tool_search/README.md
@@ -9,7 +9,7 @@ Validation example for `ToolSearchConfig` filtering and realtime interruption mo
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - No API key required
 
 ## Run

--- a/examples/context_compaction/README.md
+++ b/examples/context_compaction/README.md
@@ -12,7 +12,7 @@ Demonstrates ADK-Rust's automatic context window management, showing how to hand
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - **`GOOGLE_API_KEY`** environment variable set with a valid Gemini API key
 
 Set up your environment:

--- a/examples/crate_adoption_feedback/Cargo.lock
+++ b/examples/crate_adoption_feedback/Cargo.lock
@@ -90,6 +90,7 @@ dependencies = [
  "adk-graph",
  "adk-tool",
  "async-trait",
+ "chrono",
  "rmcp",
  "serde",
  "serde_json",

--- a/examples/cron_scheduling/README.md
+++ b/examples/cron_scheduling/README.md
@@ -10,7 +10,7 @@ Exercises the cron scheduling API from `adk-server`: create jobs, list them, and
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - Built with the adk-server `background` feature (already enabled in this example's manifest)
 
 ## Run

--- a/examples/customer_service/README.md
+++ b/examples/customer_service/README.md
@@ -51,7 +51,7 @@ Camera frames are sent via the realtime crate's `send_video_frame`:
 
 ## Prerequisites
 
-- Rust 1.94+
+- Rust 1.95+
 - `OPENAI_API_KEY` (OpenAI) and/or `GEMINI_API_KEY` / `GOOGLE_API_KEY` (Gemini)
 - A browser with WebSocket + Web Audio + mic/camera access
 

--- a/examples/delta_checkpoints/README.md
+++ b/examples/delta_checkpoints/README.md
@@ -13,7 +13,7 @@ Demonstrates ADK-Rust's delta checkpointing system that stores incremental state
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - **`GOOGLE_API_KEY`** environment variable set with a valid Gemini API key
 
 Set up your environment:

--- a/examples/desktop_agent/README.md
+++ b/examples/desktop_agent/README.md
@@ -11,7 +11,7 @@ Controls a macOS desktop with a Gemini-powered agent driving the
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - **`GOOGLE_API_KEY`** (or `GEMINI_API_KEY`) environment variable set
 - **`computer-use-mcp`** installed: `npm install -g @zavora-ai/computer-use-mcp`
 - **macOS**, with the accessibility and screen-recording permissions the MCP server requests

--- a/examples/desktop_audio/README.md
+++ b/examples/desktop_audio/README.md
@@ -4,7 +4,7 @@ Practical examples exercising the full `adk-audio` desktop audio pipeline: devic
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - **Audio hardware** — microphone and speakers (all examples except `config-validation`)
 - **GEMINI_API_KEY** — required for the `voice-agent` example ([get a key](https://aistudio.google.com/apikey))
 

--- a/examples/developer_ergonomics/Cargo.lock
+++ b/examples/developer_ergonomics/Cargo.lock
@@ -89,6 +89,7 @@ dependencies = [
  "adk-graph",
  "adk-tool",
  "async-trait",
+ "chrono",
  "rmcp",
  "serde",
  "serde_json",

--- a/examples/functional_workflow/README.md
+++ b/examples/functional_workflow/README.md
@@ -11,7 +11,7 @@ Demonstrates the Functional API from `adk-graph`: write a workflow as async func
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - Built with the adk-graph `functional` feature (already enabled in this example's manifest)
 
 ## Run

--- a/examples/gemini3_builtin_tools/Cargo.lock
+++ b/examples/gemini3_builtin_tools/Cargo.lock
@@ -89,6 +89,7 @@ dependencies = [
  "adk-graph",
  "adk-tool",
  "async-trait",
+ "chrono",
  "rmcp",
  "serde",
  "serde_json",

--- a/examples/gemini_audio/Cargo.lock
+++ b/examples/gemini_audio/Cargo.lock
@@ -110,6 +110,7 @@ dependencies = [
  "adk-graph",
  "adk-tool",
  "async-trait",
+ "chrono",
  "rmcp",
  "serde",
  "serde_json",

--- a/examples/gemini_managed_agents/README.md
+++ b/examples/gemini_managed_agents/README.md
@@ -14,7 +14,7 @@ Four focused agents that do real work, built on the official [Managed Agents Qui
 
 ## Prerequisites
 
-- Rust 1.94.0+
+- Rust 1.95.0+
 - A `GOOGLE_API_KEY` with [Interactions API (Beta)](https://ai.google.dev/gemini-api/docs/interactions) access
 
 ## Setup

--- a/examples/gemini_search_bug/README.md
+++ b/examples/gemini_search_bug/README.md
@@ -9,7 +9,7 @@ Reproduction for GitHub issue #224: a built-in Google Search tool and a function
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - **`GOOGLE_API_KEY`** environment variable set
 
 ## Run

--- a/examples/intra_compaction/README.md
+++ b/examples/intra_compaction/README.md
@@ -31,7 +31,7 @@ The low threshold in this example ensures compaction triggers quickly for demons
 
 ## Prerequisites
 
-- Rust 1.94+
+- Rust 1.95+
 - `GOOGLE_API_KEY` environment variable set
 
 ## Environment Variables

--- a/examples/live_translation/README.md
+++ b/examples/live_translation/README.md
@@ -63,7 +63,7 @@ lives entirely server-side.
 
 ## Prerequisites
 
-- Rust 1.94+
+- Rust 1.95+
 - `OPENAI_API_KEY` (for OpenAI) and/or `GEMINI_API_KEY` / `GOOGLE_API_KEY` (for Gemini)
 - A modern browser with WebSocket + Web Audio + microphone access
 

--- a/examples/managed_agents_custom_tools/README.md
+++ b/examples/managed_agents_custom_tools/README.md
@@ -4,7 +4,7 @@ Demonstrates defining a custom tool on a managed agent, handling `AgentCustomToo
 
 ## Prerequisites
 
-- Rust 1.94.0+
+- Rust 1.95.0+
 - An `ANTHROPIC_API_KEY` with Managed Agents beta access
 
 ## Setup

--- a/examples/managed_agents_files/README.md
+++ b/examples/managed_agents_files/README.md
@@ -4,7 +4,7 @@ Demonstrates uploading a file via the Anthropic Files API, mounting it in a mana
 
 ## Prerequisites
 
-- Rust 1.94.0+
+- Rust 1.95.0+
 - An `ANTHROPIC_API_KEY` with Managed Agents and Files API beta access
 
 ## Setup

--- a/examples/managed_agents_hello/README.md
+++ b/examples/managed_agents_hello/README.md
@@ -4,7 +4,7 @@ The simplest possible Anthropic Managed Agents session. Creates an agent, enviro
 
 ## Prerequisites
 
-- Rust 1.94.0+
+- Rust 1.95.0+
 - An `ANTHROPIC_API_KEY` with Managed Agents beta access
 
 ## Setup

--- a/examples/managed_agents_memory/README.md
+++ b/examples/managed_agents_memory/README.md
@@ -4,7 +4,7 @@ Demonstrates creating a memory store, seeding it with content, running a session
 
 ## Prerequisites
 
-- Rust 1.94.0+
+- Rust 1.95.0+
 - An `ANTHROPIC_API_KEY` with Managed Agents beta access
 
 ## Setup

--- a/examples/managed_agents_multiagent/README.md
+++ b/examples/managed_agents_multiagent/README.md
@@ -4,7 +4,7 @@ Demonstrates creating multiple specialized agents, configuring a coordinator age
 
 ## Prerequisites
 
-- Rust 1.94.0+
+- Rust 1.95.0+
 - An `ANTHROPIC_API_KEY` with Managed Agents beta access
 
 ## Setup

--- a/examples/managed_runtime_hello/README.md
+++ b/examples/managed_runtime_hello/README.md
@@ -10,7 +10,7 @@ End-to-end smoke test of the managed agent runtime against a scripted LLM, so it
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - Built with the adk-rust `managed-runtime` feature (already enabled in this example's manifest)
 
 ## Run

--- a/examples/managed_runtime_hello/src/main.rs
+++ b/examples/managed_runtime_hello/src/main.rs
@@ -19,7 +19,8 @@
 use std::sync::Arc;
 
 use adk_managed::{
-    DefaultManagedAgentRuntime, ManagedAgentRuntime, ModelResolver, ScriptedLlm, ScriptedTurn,
+    DefaultManagedAgentRuntime, ManagedAgentRuntime, ManagedOwner, ModelResolver, ScriptedLlm,
+    ScriptedTurn,
     resolver::ResolverResult,
     types::{ContentBlock, ManagedAgentDef, ModelRef, SessionEvent, UserEvent},
 };
@@ -54,7 +55,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // The ScriptedLlm returns pre-defined responses in FIFO order.
     // No API key, no network calls, fully deterministic.
     let scripted_turns = vec![ScriptedTurn {
-        text: Some("Hello! I'm a managed agent running on ADK-Rust. How can I help you today?".to_string()),
+        text: Some(
+            "Hello! I'm a managed agent running on ADK-Rust. How can I help you today?".to_string(),
+        ),
         tool_calls: vec![],
     }];
     let scripted_llm = Arc::new(ScriptedLlm::new("scripted-hello-model", scripted_turns));
@@ -65,10 +68,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let resolver = Arc::new(MockResolver { llm: scripted_llm });
     let session_service = Arc::new(InMemorySessionService::new());
 
-    let runtime = DefaultManagedAgentRuntime::new(
-        resolver,
-        session_service,
-    );
+    let runtime = DefaultManagedAgentRuntime::new(resolver, session_service);
 
     println!("✓ Created DefaultManagedAgentRuntime (InMemory sessions)");
 
@@ -84,7 +84,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("✓ Registered agent: {:?}", agent_handle);
 
     // ─── Step 4: Start a session ─────────────────────────────────────────
-    let session_handle = runtime.start_session(&agent_handle, None).await?;
+    let owner = ManagedOwner::new("managed-runtime-hello", "demo-user")?;
+    let session_handle = runtime.start_session(&agent_handle, &owner, None).await?;
     println!("✓ Started session: {:?}", session_handle);
 
     // Check initial status (should be Queued)
@@ -96,9 +97,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // ─── Step 6: Send a user message ─────────────────────────────────────
     let user_event = UserEvent::Message {
-        content: vec![ContentBlock::Text {
-            text: "Hello, agent!".to_string(),
-        }],
+        content: vec![ContentBlock::Text { text: "Hello, agent!".to_string() }],
     };
     runtime.send_event(&session_handle, user_event).await?;
     println!("✓ Sent user message: \"Hello, agent!\"");
@@ -159,11 +158,7 @@ fn print_event(index: usize, event: &SessionEvent) {
             let text: String = content
                 .iter()
                 .filter_map(|block| {
-                    if let ContentBlock::Text { text } = block {
-                        Some(text.as_str())
-                    } else {
-                        None
-                    }
+                    if let ContentBlock::Text { text } = block { Some(text.as_str()) } else { None }
                 })
                 .collect::<Vec<_>>()
                 .join("");

--- a/examples/mcp_elicitation/Cargo.lock
+++ b/examples/mcp_elicitation/Cargo.lock
@@ -122,6 +122,7 @@ dependencies = [
  "adk-graph",
  "adk-tool",
  "async-trait",
+ "chrono",
  "rmcp",
  "serde",
  "serde_json",

--- a/examples/mcp_resources/Cargo.lock
+++ b/examples/mcp_resources/Cargo.lock
@@ -122,6 +122,7 @@ dependencies = [
  "adk-graph",
  "adk-tool",
  "async-trait",
+ "chrono",
  "rmcp",
  "serde",
  "serde_json",

--- a/examples/mcp_sampling/Cargo.lock
+++ b/examples/mcp_sampling/Cargo.lock
@@ -122,6 +122,7 @@ dependencies = [
  "adk-graph",
  "adk-tool",
  "async-trait",
+ "chrono",
  "rmcp",
  "serde",
  "serde_json",

--- a/examples/mcp_sampling/README.md
+++ b/examples/mcp_sampling/README.md
@@ -52,7 +52,7 @@ let toolset = McpToolset::with_sampling_handler(transport, elicitation, sampling
 
 ## Prerequisites
 
-- Rust 1.94+
+- Rust 1.95+
 - `GOOGLE_API_KEY` environment variable set
 
 ## Environment Variables

--- a/examples/multi_perspective_analysis/Cargo.lock
+++ b/examples/multi_perspective_analysis/Cargo.lock
@@ -89,6 +89,7 @@ dependencies = [
  "adk-graph",
  "adk-tool",
  "async-trait",
+ "chrono",
  "rmcp",
  "serde",
  "serde_json",

--- a/examples/multi_perspective_analysis/README.md
+++ b/examples/multi_perspective_analysis/README.md
@@ -20,7 +20,7 @@ merges their event streams.
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - **`GOOGLE_API_KEY`** environment variable set with a valid Gemini API key
 
 ```bash

--- a/examples/multimodal_function_response/Cargo.lock
+++ b/examples/multimodal_function_response/Cargo.lock
@@ -89,6 +89,7 @@ dependencies = [
  "adk-graph",
  "adk-tool",
  "async-trait",
+ "chrono",
  "rmcp",
  "serde",
  "serde_json",

--- a/examples/node_caching/README.md
+++ b/examples/node_caching/README.md
@@ -12,7 +12,7 @@ Demonstrates ADK-Rust's blake3-keyed LRU caching of graph node results, showing 
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - **`GOOGLE_API_KEY`** environment variable set with a valid Gemini API key
 
 Set up your environment:

--- a/examples/node_timeouts/README.md
+++ b/examples/node_timeouts/README.md
@@ -15,7 +15,7 @@ The example builds a four-node graph where each node demonstrates a different ti
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - **`GOOGLE_API_KEY`** environment variable set with a valid Gemini API key
 
 Set the API key in your shell or create a `.env` file:

--- a/examples/ollama_qwen/Cargo.lock
+++ b/examples/ollama_qwen/Cargo.lock
@@ -89,6 +89,7 @@ dependencies = [
  "adk-graph",
  "adk-tool",
  "async-trait",
+ "chrono",
  "rmcp",
  "serde",
  "serde_json",

--- a/examples/openai_background/README.md
+++ b/examples/openai_background/README.md
@@ -6,7 +6,7 @@ This is useful for long-running requests where you don't want to hold open a str
 
 ## Prerequisites
 
-- Rust 1.94.0+
+- Rust 1.95.0+
 - `OPENAI_API_KEY` environment variable set with a valid OpenAI API key
 
 ## Running

--- a/examples/openai_builtin_tools/README.md
+++ b/examples/openai_builtin_tools/README.md
@@ -8,7 +8,7 @@ This example covers two built-in tools:
 
 ## Prerequisites
 
-- Rust 1.94.0+
+- Rust 1.95.0+
 - `OPENAI_API_KEY` environment variable set with a valid OpenAI API key
 
 ## Running

--- a/examples/openai_conversations/README.md
+++ b/examples/openai_conversations/README.md
@@ -4,7 +4,7 @@ Demonstrates the OpenAI Responses API **Conversations** lifecycle. The Conversat
 
 ## Prerequisites
 
-- Rust 1.94.0+
+- Rust 1.95.0+
 - `OPENAI_API_KEY` environment variable set with a valid OpenAI API key
 
 ## Running

--- a/examples/openai_deep_research/README.md
+++ b/examples/openai_deep_research/README.md
@@ -6,7 +6,7 @@ Deep research models are designed for complex research tasks that require synthe
 
 ## Prerequisites
 
-- Rust 1.94.0+
+- Rust 1.95.0+
 - `OPENAI_API_KEY` environment variable set with a valid OpenAI API key
 - Access to deep research models (may require specific API tier)
 

--- a/examples/openai_open_responses/README.md
+++ b/examples/openai_open_responses/README.md
@@ -4,7 +4,7 @@ Demonstrates the **Open Responses mode** for provider-agnostic usage of the Resp
 
 ## Prerequisites
 
-- Rust 1.94.0+
+- Rust 1.95.0+
 - One of the following:
   - `OPENAI_API_KEY` environment variable set (for OpenAI)
   - A running Open Responses-compatible local server (LM Studio, Ollama, vLLM)

--- a/examples/openai_responses/README.md
+++ b/examples/openai_responses/README.md
@@ -10,7 +10,7 @@ Drives `OpenAIResponsesClient` through the full ADK stack (Runner â†’ LlmAgent â
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - **`OPENAI_API_KEY`** environment variable set
 
 ## Run

--- a/examples/openai_ws_minimal/README.md
+++ b/examples/openai_ws_minimal/README.md
@@ -4,7 +4,7 @@ Demonstrates the lowest-level WebSocket transport for the OpenAI Responses API. 
 
 ## Prerequisites
 
-- Rust 1.94.0+
+- Rust 1.95.0+
 - `OPENAI_API_KEY` environment variable set
 - The `openai-ws` feature flag on `adk-model`
 

--- a/examples/openrouter/README.md
+++ b/examples/openrouter/README.md
@@ -10,7 +10,7 @@ Live integration example for the native OpenRouter provider and its discovery AP
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - **`OPENROUTER_API_KEY`** environment variable set
 - Built with the adk-model `openrouter` feature (already enabled in this example's manifest)
 

--- a/examples/output_schema_agent/README.md
+++ b/examples/output_schema_agent/README.md
@@ -10,7 +10,7 @@ Demonstrates structured-output enforcement on an `LlmAgent`.
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - **`GOOGLE_API_KEY`** environment variable set
 
 ## Run

--- a/examples/payments/Cargo.lock
+++ b/examples/payments/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "zeroize",
 ]
 
 [[package]]
@@ -1919,6 +1920,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/examples/plugin_system/README.md
+++ b/examples/plugin_system/README.md
@@ -43,7 +43,7 @@ Demonstrates the ADK-Rust Enhanced Plugin System (Sprint 1) with three custom pl
 
 ## Prerequisites
 
-- Rust 1.94+
+- Rust 1.95+
 - `GOOGLE_API_KEY` environment variable set
 
 ## Setup

--- a/examples/realtime_voice/README.md
+++ b/examples/realtime_voice/README.md
@@ -92,7 +92,7 @@ configures its capture/playback contexts accordingly.
 
 ## Prerequisites
 
-- Rust 1.94.0+
+- Rust 1.95.0+
 - `OPENAI_API_KEY` (for OpenAI) and/or `GEMINI_API_KEY` / `GOOGLE_API_KEY` (for Gemini)
 - A modern browser with WebSocket + Web Audio API support and microphone access
 

--- a/examples/retry_reflect/README.md
+++ b/examples/retry_reflect/README.md
@@ -62,7 +62,7 @@ This gives the agent context to self-correct on the next turn.
 
 ## Prerequisites
 
-- Rust 1.94+
+- Rust 1.95+
 - `GOOGLE_API_KEY` environment variable set
 
 ## Setup

--- a/examples/sandbox_agent/src/main.rs
+++ b/examples/sandbox_agent/src/main.rs
@@ -373,7 +373,8 @@ async fn main() -> anyhow::Result<()> {
 
     let caps = backend.capabilities();
     println!("  Backend capabilities:");
-    println!("    Filesystem isolation: {}", caps.enforced_limits.filesystem_isolation);
+    println!("    Filesystem writes:    {}", caps.enforced_limits.filesystem_write_isolation);
+    println!("    Filesystem reads:     {}", caps.enforced_limits.filesystem_read_isolation);
     println!("    Network isolation:    {}", caps.enforced_limits.network_isolation);
     println!("    Timeout enforcement:  {}", caps.enforced_limits.timeout);
 

--- a/examples/secret_provider/Cargo.lock
+++ b/examples/secret_provider/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "zeroize",
 ]
 
 [[package]]

--- a/examples/secret_provider/README.md
+++ b/examples/secret_provider/README.md
@@ -11,7 +11,7 @@ Demonstrates ADK-Rust's secret management — retrieving secrets from a provider
 
 ## Prerequisites
 
-- Rust 1.94+
+- Rust 1.95+
 - `GOOGLE_API_KEY` environment variable set
 
 ## Environment Variables

--- a/examples/server_builder/README.md
+++ b/examples/server_builder/README.md
@@ -85,7 +85,7 @@ Routes added via `add_api_routes()` additionally receive the auth middleware lay
 
 ## Prerequisites
 
-- Rust 1.94+
+- Rust 1.95+
 - No LLM provider or API keys required
 
 ## Environment Variables

--- a/examples/skill_memory_improvements/README.md
+++ b/examples/skill_memory_improvements/README.md
@@ -10,7 +10,7 @@ Validation example covering the skill-discovery and memory APIs added by the ski
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - No API key required
 
 ## Run

--- a/examples/skills_multilingual/README.md
+++ b/examples/skills_multilingual/README.md
@@ -6,7 +6,7 @@ Previously, non-ASCII characters in queries and skill metadata were silently dro
 
 ## Prerequisites
 
-- Rust 1.94+
+- Rust 1.95+
 - `GOOGLE_API_KEY` environment variable set (for Scenario 6 live demo)
 
 ## Running

--- a/examples/slack_toolset/README.md
+++ b/examples/slack_toolset/README.md
@@ -14,7 +14,7 @@ reads channels, sends messages, adds reactions, and lists threads via the Slack 
 
 ## Prerequisites
 
-- Rust 1.94+
+- Rust 1.95+
 - `GOOGLE_API_KEY` for the Gemini LLM provider
 - (Optional) A Slack Bot Token for live mode
 

--- a/examples/spanner_toolset/README.md
+++ b/examples/spanner_toolset/README.md
@@ -14,7 +14,7 @@ lists tables, inspects table schemas, and executes SQL queries via the Cloud Spa
 
 ## Prerequisites
 
-- Rust 1.94+
+- Rust 1.95+
 - `GOOGLE_API_KEY` for the Gemini LLM provider
 - (Optional) A Google Cloud project with Cloud Spanner enabled for live mode
 - (Optional) Application Default Credentials configured via `gcloud auth application-default login`

--- a/examples/streaming_bash/Cargo.lock
+++ b/examples/streaming_bash/Cargo.lock
@@ -54,6 +54,7 @@ dependencies = [
  "adk-core",
  "async-trait",
  "glob",
+ "libc",
  "regex",
  "serde",
  "serde_json",

--- a/examples/telemetry_sqlite_export/README.md
+++ b/examples/telemetry_sqlite_export/README.md
@@ -10,7 +10,7 @@ Traces an agent run end-to-end into a local SQLite file — no OTLP collector or
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - **`GOOGLE_API_KEY`** environment variable set
 - Built with the adk-telemetry `sqlite` feature (already enabled in this example's manifest)
 

--- a/examples/time_travel/README.md
+++ b/examples/time_travel/README.md
@@ -13,7 +13,7 @@ Demonstrates ADK-Rust's time-travel debugging capabilities for graph workflows, 
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - **`GOOGLE_API_KEY`** environment variable set with a valid Gemini API key
 
 Set up your environment:

--- a/examples/tool_concurrency/README.md
+++ b/examples/tool_concurrency/README.md
@@ -12,7 +12,7 @@ Demonstrates ADK-Rust's per-tool concurrency limits with backpressure policies, 
 
 ## Prerequisites
 
-- **Rust 1.94+** (edition 2024)
+- **Rust 1.95+** (edition 2024)
 - **`GOOGLE_API_KEY`** environment variable set with a valid Gemini API key
 
 Set up your environment:

--- a/examples/video_avatar/README.md
+++ b/examples/video_avatar/README.md
@@ -46,7 +46,7 @@ let builder = RealtimeAgentBuilder::new("my_agent")
 
 ## Prerequisites
 
-- Rust 1.94.0+
+- Rust 1.95.0+
 - No API keys or LLM provider required
 
 ## Environment Variables

--- a/examples/yaml_agent/README.md
+++ b/examples/yaml_agent/README.md
@@ -11,7 +11,7 @@ Demonstrates the YAML agent definition loading feature from ADK-Rust v1.0.
 
 ## Prerequisites
 
-- Rust 1.94+
+- Rust 1.95+
 - A Google API key for Gemini
 
 ## Environment Variables

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,11 @@
 [toolchain]
-channel = "1.94.0"
+# Single source of truth for the toolchain: rustup reads this locally, and
+# devenv reads the same file through `languages.rust.toolchainFile`, so CI and
+# local builds cannot drift.
+#
+# 1.95 rather than the newest stable: it is the lowest version that satisfies
+# every constraint — adk-codeact-monty needs 1.95, and a fresh resolution of the
+# aws-secrets dependencies needs 1.95.1 — while still leaving consumers on 1.95
+# able to build the published crates.
+channel = "1.95.0"
+components = ["rustc", "cargo", "clippy", "rustfmt", "rust-analyzer"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -4,8 +4,7 @@
 # local builds cannot drift.
 #
 # 1.95 rather than the newest stable: it is the lowest version that satisfies
-# every constraint — adk-codeact-monty needs 1.95, and a fresh resolution of the
-# aws-secrets dependencies needs 1.95.1 — while still leaving consumers on 1.95
-# able to build the published crates.
+# every constraint — adk-codeact-monty needs 1.95, and current AWS SDK releases
+# require a patch release newer than the previous 1.94.0 pin.
 channel = "1.95.0"
 components = ["rustc", "cargo", "clippy", "rustfmt", "rust-analyzer"]

--- a/scripts/check-examples-compile.sh
+++ b/scripts/check-examples-compile.sh
@@ -23,8 +23,8 @@ cd "$ROOT" || exit 1
 SHARD_INDEX="${1:-0}"
 SHARD_TOTAL="${2:-1}"
 
-# adk-codeact-monty requires rustc 1.95 (the workspace is pinned to 1.94), so
-# examples/codeact_monty_agent is built by its own workflow on that toolchain.
+# The Monty example pulls a large git dependency and belongs to the separately
+# cached out-of-workspace Monty build in ci-merge.yml/codeact-monty.yml.
 SKIP_EXAMPLES=("examples/codeact_monty_agent")
 
 export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$ROOT/target/examples-check}"


### PR DESCRIPTION
## What

- pins the workspace, devenv, local action, Monty crates, and active documentation to Rust 1.95
- makes all 41 publishable workspace crates inherit the Rust 1.95 workspace MSRV
- applies the Rust 1.95 clippy updates without behavior changes
- repairs 37 stale standalone-example lock entries introduced by current `main` dependency edges
- repairs the managed-runtime and sandbox examples against current public APIs
- moves the four-shard standalone-example compile gate from nightly to the PR tier
- installs the Linux packages required by the PR and nightly feature matrices

## Why

The existing #503 branch is stale and its merged-`main` CI fails all four example shards. The exact causes are missing lock entries for `zeroize`, `libc`, `tokio-util`, and the `adk-tool` `chrono` edge, plus two examples that no longer match current APIs. This rebased replacement fixes those failures and makes example regressions visible before merge.

## Verification

- `bash scripts/check-examples-compile.sh` — 97 checked, 1 intentional Monty skip, 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo metadata --no-deps --locked` — all 41 publishable crates report Rust 1.95
- `scripts/check-doc-versions.sh`
- `scripts/check-release-consistency.sh`
- `shellcheck` on changed scripts
- all changed workflow/action YAML parses
- repository pre-push workspace check passes

Supersedes #503.