### PR TITLE
fix(runner): complete sandbox lifecycle contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -626,6 +626,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **adk-runner: `SandboxRunner::run` runs the agent instead of reporting a completed run that
+  did nothing.** The method provisioned the workspace, started a session, bound tools, then
+  executed a placeholder future and returned `Ok`. It now drives the inner `Runner` with the
+  bound sandbox tools injected through `RunConfig::runtime_toolsets`, returns the buffered events,
+  snapshots the live workspace when configured, and always stops the sandbox before returning.
+  Identity validation happens before side effects; session creation occurs only for a structured
+  not-found result; and execution, snapshot, and stop failures follow deterministic precedence
+  with later cleanup failures retained as error metadata. **Breaking:** `SandboxRunner::run` takes
+  a `user_content: Content` argument — an agent loop cannot run without input — and
+  `SandboxRunResult` now includes the emitted events.
+- **adk-runner: `Runner::run_with_config` supplies a per-invocation `RunConfig`.** Needed for
+  tools that exist only for the duration of one run. `Runner::run` delegates to it with `None`.
+  New accessors expose the runner's application name, session service, and base run config.
+- **adk-session: missing sessions have one structured contract across every backend.**
+  `SessionService::get` returns `session.not_found` with the `NotFound` category only when a
+  valid `(app_name, user_id, session_id)` identity has no matching record. SQLite and PostgreSQL
+  use `fetch_optional`, so query failures are no longer misreported as missing sessions. The
+  Firestore backend also verifies the stored user before returning a session.
 - **adk-server: `message/stream` drives the agent instead of emitting synthetic events.**
   The handler created a task, transitioned `Working` then `Completed`, and never invoked the
   Runner, so a streaming client received a task that reported success and produced no output.

--- a/adk-runner/src/runner.rs
+++ b/adk-runner/src/runner.rs
@@ -253,13 +253,50 @@ impl Runner {
 
     /// Execute the root agent for the given user and session, returning an event stream.
     ///
-    /// Retrieves (or creates) the session, resolves the target agent, runs
-    /// plugins/skills, and streams events as the agent executes.
+    /// Retrieves the existing session, resolves the target agent, runs plugins and skills, and
+    /// streams events as the agent executes.
     pub async fn run(
         &self,
         user_id: UserId,
         session_id: SessionId,
         user_content: Content,
+    ) -> Result<EventStream> {
+        self.run_with_config(user_id, session_id, user_content, None).await
+    }
+
+    /// Returns the runner's application name.
+    pub fn app_name(&self) -> &str {
+        &self.app_name
+    }
+
+    /// Returns the runner's session service.
+    pub fn session_service(&self) -> &Arc<dyn adk_session::SessionService> {
+        &self.session_service
+    }
+
+    /// Returns the runner's configured [`RunConfig`].
+    ///
+    /// Useful as a base to clone and adjust for [`Self::run_with_config`].
+    pub fn run_config(&self) -> &RunConfig {
+        &self.run_config
+    }
+
+    /// Runs the agent with a per-invocation [`RunConfig`] override.
+    ///
+    /// Passing `None` uses the runner's configured `RunConfig`. Supply one to vary a single
+    /// invocation — injecting `runtime_toolsets` for tools that only exist for the duration of
+    /// that run, for example, as `SandboxRunner` does with tools bound to a live sandbox session.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if invocation setup fails before the stream is created. Session lookup
+    /// and agent execution failures are yielded by the returned stream.
+    pub async fn run_with_config(
+        &self,
+        user_id: UserId,
+        session_id: SessionId,
+        user_content: Content,
+        run_config: Option<RunConfig>,
     ) -> Result<EventStream> {
         let app_name = self.app_name.clone();
         let typed_app_name = AppName::try_from(app_name.clone())?;
@@ -272,7 +309,7 @@ impl Runner {
         let plugin_manager = self.plugin_manager.clone();
         #[cfg(feature = "skills")]
         let skill_injector = self.skill_injector.clone();
-        let mut run_config = self.run_config.clone();
+        let mut run_config = run_config.unwrap_or_else(|| self.run_config.clone());
         let compaction_config = self.compaction_config.clone();
         let context_cache_config = self.context_cache_config.clone();
         let cache_capable = self.cache_capable.clone();
@@ -335,7 +372,7 @@ impl Runner {
 
             // Use the effective token (combines global + per-session)
             let cancellation_token = effective_token;
-            // Get or create session
+            // Resolve the existing session.
             let session = match session_service
                 .get(adk_session::GetRequest {
                     app_name: app_name.clone(),

--- a/adk-runner/src/sandbox_runner/binding.rs
+++ b/adk-runner/src/sandbox_runner/binding.rs
@@ -1,18 +1,14 @@
 //! Tool binding logic per sandbox capability.
 //!
 //! This module provides the [`bind_tools`] function that creates the appropriate
-//! set of tools based on the enabled [`Capability`](adk_sandbox::workspace::Capability)
+//! set of tools based on the enabled [`Capability`]
 //! set from the agent's [`SandboxConfig`](adk_sandbox::workspace::SandboxConfig).
 //!
 //! # Binding Rules
 //!
-//! - [`Capability::Shell`](adk_sandbox::workspace::Capability::Shell) →
-//!   binds [`ExecCommandTool`](super::tools::ExecCommandTool)
-//! - [`Capability::Filesystem`](adk_sandbox::workspace::Capability::Filesystem) →
-//!   binds [`ReadFileTool`](super::tools::ReadFileTool),
-//!   [`WriteFileTool`](super::tools::WriteFileTool),
-//!   [`ListDirTool`](super::tools::ListDirTool),
-//!   [`ApplyPatchTool`](super::tools::ApplyPatchTool)
+//! - [`Capability::Shell`] → binds [`ExecCommandTool`]
+//! - [`Capability::Filesystem`] → binds [`ReadFileTool`], [`WriteFileTool`], [`ListDirTool`],
+//!   [`ApplyPatchTool`]
 
 use super::tools::{ApplyPatchTool, ExecCommandTool, ListDirTool, ReadFileTool, WriteFileTool};
 use adk_sandbox::workspace::{Capability, SandboxSession};

--- a/adk-runner/src/sandbox_runner/mod.rs
+++ b/adk-runner/src/sandbox_runner/mod.rs
@@ -1,11 +1,11 @@
 //! Sandbox runner lifecycle management.
 //!
-//! This module provides [`SandboxRunner`], a wrapper around the standard [`Runner`](crate::Runner)
-//! that manages the full sandbox lifecycle: provision → start → bind tools → run → stop → snapshot.
+//! This module provides [`SandboxRunner`], a wrapper around the standard [`Runner`]
+//! that manages the full sandbox lifecycle: provision → start → bind tools → run → snapshot → stop.
 //!
 //! # Overview
 //!
-//! The `SandboxRunner` extracts a [`SandboxConfig`](adk_sandbox::workspace::SandboxConfig) from
+//! The `SandboxRunner` extracts a [`SandboxConfig`] from
 //! the agent, provisions a workspace, binds shell and filesystem tools based on enabled
 //! capabilities, delegates execution to the inner runner, and guarantees cleanup (stop) even
 //! on failure.
@@ -19,22 +19,71 @@
 //!
 //! let runner = Runner::new(config)?;
 //! let sandbox_runner = SandboxRunner::new(runner);
-//! let result = sandbox_runner.run(&sandbox_config, "user_1", "session_1").await?;
+//! let content = adk_core::Content::new("user").with_text("list the files");
+//! let result = sandbox_runner
+//!     .run(&sandbox_config, "user_1", "session_1", content)
+//!     .await?;
 //! ```
 
 pub mod binding;
 pub mod tools;
 
 use crate::Runner;
+use adk_core::{AdkError, AppName, Event, SessionId, UserId};
 use adk_sandbox::SandboxError;
 use adk_sandbox::workspace::{SandboxConfig, SnapshotId};
+use serde_json::{Value, json};
 use std::sync::Arc;
+
+use futures::StreamExt;
 use tracing::{info, warn};
+
+/// Exposes the tools bound to a live sandbox session as a [`Toolset`].
+///
+/// The tools hold the session handle, so they are valid only for the run that created them and
+/// are injected per-invocation rather than attached to the agent.
+struct SandboxToolset {
+    tools: Vec<Arc<dyn adk_core::Tool>>,
+}
+
+#[async_trait::async_trait]
+impl adk_core::Toolset for SandboxToolset {
+    fn name(&self) -> &str {
+        "sandbox"
+    }
+
+    async fn tools(
+        &self,
+        _ctx: Arc<dyn adk_core::ReadonlyContext>,
+    ) -> adk_core::Result<Vec<Arc<dyn adk_core::Tool>>> {
+        Ok(self.tools.clone())
+    }
+}
+
+fn attach_cleanup_failure(primary: &mut AdkError, stage: &'static str, cleanup: &AdkError) {
+    let failure = json!({
+        "stage": stage,
+        "component": cleanup.component.to_string(),
+        "category": cleanup.category.to_string(),
+        "code": cleanup.code,
+        "message": cleanup.message,
+    });
+    let entry = primary
+        .details
+        .metadata
+        .entry("sandbox.cleanupErrors".to_string())
+        .or_insert_with(|| Value::Array(Vec::new()));
+    if let Value::Array(failures) = entry {
+        failures.push(failure);
+    } else {
+        *entry = Value::Array(vec![failure]);
+    }
+}
 
 /// Runner wrapper that manages the sandbox lifecycle around agent execution.
 ///
-/// Provisions the workspace, binds tools, delegates to the inner Runner,
-/// and cleans up (stop + optional snapshot) on completion or failure.
+/// Provisions the workspace, binds tools, delegates to the inner Runner, snapshots when
+/// configured, and stops the sandbox on completion or failure.
 pub struct SandboxRunner {
     inner: Runner,
 }
@@ -57,26 +106,49 @@ impl SandboxRunner {
     /// 2. Starts the sandbox session
     /// 3. Binds tools based on enabled capabilities
     /// 4. Runs the agent loop via the inner Runner
-    /// 5. Stops the session (always, even on failure)
-    /// 6. Optionally snapshots the workspace
+    /// 5. Optionally snapshots the workspace while the session is live
+    /// 6. Stops the session (always after a handle has been provisioned)
     ///
     /// # Stop Guarantee
     ///
-    /// The `stop` method is **always** called on the sandbox client, regardless
-    /// of whether the agent loop succeeds or fails. This ensures resources are
-    /// cleaned up even in error scenarios.
+    /// The `stop` method is called on the sandbox client after every successful provision,
+    /// regardless of whether start, execution, or snapshotting succeeds. This ensures resources
+    /// are cleaned up in error scenarios.
+    ///
+    /// Error precedence follows lifecycle order: an execution error takes precedence over a
+    /// snapshot error, which takes precedence over a stop error. Later cleanup failures are
+    /// retained in the returned error's `sandbox.cleanupErrors` metadata.
     ///
     /// # Errors
     ///
-    /// Returns an error if provisioning or starting the session fails (without
-    /// entering the agent loop), or if the agent loop itself fails (after
-    /// cleanup has been performed).
+    /// Returns an error if identity validation, session lookup or creation, provisioning,
+    /// starting, agent execution, snapshotting, or stopping fails. Cleanup completes before an
+    /// execution error is returned.
     pub async fn run(
         &self,
         config: &SandboxConfig,
         user_id: &str,
         session_id: &str,
+        user_content: adk_core::Content,
     ) -> Result<SandboxRunResult, adk_core::AdkError> {
+        // Validate caller-controlled identity before any session or sandbox side effect.
+        let app_name = AppName::try_from(self.inner.app_name())?;
+        let user_id = UserId::try_from(user_id)?;
+        let session_id = SessionId::try_from(session_id)?;
+
+        let get_request = adk_session::GetRequest {
+            app_name: app_name.to_string(),
+            user_id: user_id.to_string(),
+            session_id: session_id.to_string(),
+            num_recent_events: None,
+            after: None,
+        };
+        let create_session = match self.inner.session_service().get(get_request).await {
+            Ok(_) => false,
+            Err(error) if error.is_not_found() => true,
+            Err(error) => return Err(error),
+        };
+
         // 1. Provision workspace from manifest
         info!("provisioning sandbox workspace");
         let handle =
@@ -87,31 +159,62 @@ impl SandboxRunner {
         let session = match config.client.start(&handle).await {
             Ok(s) => s,
             Err(e) => {
-                // If start fails, attempt to stop/cleanup the provisioned session
-                let _ = config.client.stop(&handle).await;
-                return Err(adk_core::AdkError::from(e));
+                let mut primary = AdkError::from(e);
+                if let Err(cleanup) = config.client.stop(&handle).await {
+                    warn!(
+                        session_handle = %handle.0,
+                        error = %cleanup,
+                        "failed to stop sandbox after start failure"
+                    );
+                    attach_cleanup_failure(&mut primary, "stop", &AdkError::from(cleanup));
+                }
+                return Err(primary);
             }
         };
 
         // 3. Bind tools based on capabilities
         let session_arc = Arc::from(session);
-        let _bound_tools =
+        let bound_tools =
             binding::bind_tools(session_arc, &config.capabilities, config.command_timeout);
         info!(
             capabilities = ?config.capabilities,
-            tool_count = _bound_tools.len(),
+            tool_count = bound_tools.len(),
             "bound sandbox tools"
         );
 
-        // 4. Run agent loop with session timeout
-        // NOTE: The inner Runner doesn't yet support dynamic tool injection.
-        // The bound tools are prepared here; actual agent loop integration will
-        // be completed when the agent builder supports injecting tools at runtime.
-        // For now, we simulate the agent loop step as a placeholder.
+        // 4. Run the agent loop with the sandbox tools injected, under the session timeout.
+        //
+        // The tools exist only while this session is live, so they are supplied per-invocation
+        // through `runtime_toolsets` rather than baked into the agent.
+        let mut run_config = self.inner.run_config().clone();
+        run_config
+            .runtime_toolsets
+            .push(adk_core::RuntimeToolset::new(Arc::new(SandboxToolset { tools: bound_tools })));
+
         let agent_loop_future = async {
-            // Use the user_id and session_id for future agent loop integration
-            let _ = (user_id, session_id);
-            Ok::<(), adk_core::AdkError>(())
+            if create_session {
+                self.inner
+                    .session_service()
+                    .create(adk_session::CreateRequest {
+                        app_name: app_name.to_string(),
+                        user_id: user_id.to_string(),
+                        session_id: Some(session_id.to_string()),
+                        state: std::collections::HashMap::new(),
+                    })
+                    .await?;
+            }
+
+            let mut events = self
+                .inner
+                .run_with_config(user_id, session_id, user_content, Some(run_config))
+                .await?;
+            // Drain the stream so the agent runs to completion before the session is stopped;
+            // returning early would tear the sandbox down underneath the agent.
+            let mut buffered_events = Vec::new();
+            while let Some(event) = events.next().await {
+                buffered_events.push(event?);
+            }
+            Ok::<Vec<Event>, adk_core::AdkError>(buffered_events)
         };
 
         let agent_loop_result =
@@ -126,47 +229,66 @@ impl SandboxRunner {
                     timeout = ?config.session_timeout,
                     "sandbox session timed out"
                 );
-                Err(adk_core::AdkError::from(SandboxError::SessionTimeout {
-                    timeout: config.session_timeout,
-                }))
+                Err::<Vec<Event>, adk_core::AdkError>(adk_core::AdkError::from(
+                    SandboxError::SessionTimeout { timeout: config.session_timeout },
+                ))
             }
         };
 
-        // 5. Stop session — ALWAYS called, regardless of agent loop outcome
-        info!(session_handle = %handle.0, "stopping sandbox session");
-        if let Err(e) = config.client.stop(&handle).await {
-            warn!(
-                session_handle = %handle.0,
-                error = %e,
-                "failed to stop sandbox session during cleanup"
-            );
-        }
-
-        // 6. Handle agent loop result — propagate error after cleanup
-        agent_loop_result?;
-
-        // 7. Optionally snapshot
-        let snapshot_id = if config.snapshot_on_stop {
+        // 5. Snapshot while the live session still owns the workspace.
+        let (snapshot_id, snapshot_error) = if config.snapshot_on_stop {
             info!(session_handle = %handle.0, "snapshotting sandbox workspace");
             match config.client.snapshot(&handle).await {
                 Ok(id) => {
                     info!(snapshot_id = %id.0, "sandbox snapshot created");
-                    Some(id)
+                    (Some(id), None)
                 }
-                Err(e) => {
+                Err(error) => {
                     warn!(
                         session_handle = %handle.0,
-                        error = %e,
-                        "sandbox snapshot failed, continuing without snapshot"
+                        error = %error,
+                        "failed to snapshot sandbox during cleanup"
                     );
-                    None
+                    (None, Some(AdkError::from(error)))
                 }
             }
         } else {
-            None
+            (None, None)
         };
 
-        Ok(SandboxRunResult { snapshot_id })
+        // 6. Stop session — always called, regardless of agent or snapshot outcome.
+        info!(session_handle = %handle.0, "stopping sandbox session");
+        let stop_error = match config.client.stop(&handle).await {
+            Ok(()) => None,
+            Err(error) => {
+                warn!(
+                    session_handle = %handle.0,
+                    error = %error,
+                    "failed to stop sandbox session during cleanup"
+                );
+                Some(AdkError::from(error))
+            }
+        };
+
+        match (agent_loop_result, snapshot_error, stop_error) {
+            (Err(mut primary), snapshot_error, stop_error) => {
+                if let Some(error) = snapshot_error.as_ref() {
+                    attach_cleanup_failure(&mut primary, "snapshot", error);
+                }
+                if let Some(error) = stop_error.as_ref() {
+                    attach_cleanup_failure(&mut primary, "stop", error);
+                }
+                Err(primary)
+            }
+            (Ok(_), Some(mut primary), stop_error) => {
+                if let Some(error) = stop_error.as_ref() {
+                    attach_cleanup_failure(&mut primary, "stop", error);
+                }
+                Err(primary)
+            }
+            (Ok(_), None, Some(primary)) => Err(primary),
+            (Ok(events), None, None) => Ok(SandboxRunResult { snapshot_id, events }),
+        }
     }
 }
 
@@ -175,4 +297,9 @@ impl SandboxRunner {
 pub struct SandboxRunResult {
     /// The snapshot ID if snapshot-on-stop was enabled.
     pub snapshot_id: Option<SnapshotId>,
+    /// Agent events in the order they were emitted.
+    ///
+    /// Events are buffered because the sandbox is stopped before this result is returned. This
+    /// keeps tool-bearing event streams from outliving the sandbox session they depend on.
+    pub events: Vec<Event>,
 }

--- a/adk-runner/tests/sandbox_runner_tests.rs
+++ b/adk-runner/tests/sandbox_runner_tests.rs
@@ -1,0 +1,473 @@
+//! Lifecycle contract tests for `SandboxRunner`.
+#![cfg(feature = "sandbox-runner")]
+
+use adk_core::{
+    AdkError, Agent, Content, ErrorCategory, Event, EventStream, InvocationContext,
+    Result as AdkResult,
+};
+use adk_runner::Runner;
+use adk_runner::sandbox_runner::SandboxRunner;
+use adk_sandbox::SandboxError;
+use adk_sandbox::workspace::{
+    Capability, DirEntry, ExecOutput, Manifest, SandboxClient, SandboxConfig, SandboxSession,
+    SessionHandle, SnapshotId,
+};
+use adk_session::{
+    CreateRequest, DeleteRequest, Event as SessionEvent, GetRequest, InMemorySessionService,
+    ListRequest, Session, SessionService,
+};
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+#[derive(Clone, Copy)]
+enum AgentBehavior {
+    Events(usize),
+    Fail,
+    Delay(Duration),
+}
+
+struct TestAgent {
+    behavior: AgentBehavior,
+    calls: Arc<Mutex<Vec<&'static str>>>,
+    tools_seen: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl Agent for TestAgent {
+    fn name(&self) -> &str {
+        "sandbox_test_agent"
+    }
+
+    fn description(&self) -> &str {
+        "exercises the sandbox runner lifecycle"
+    }
+
+    fn sub_agents(&self) -> &[Arc<dyn Agent>] {
+        &[]
+    }
+
+    async fn run(&self, ctx: Arc<dyn InvocationContext>) -> AdkResult<EventStream> {
+        self.calls.lock().unwrap_or_else(|error| error.into_inner()).push("run");
+
+        let mut tool_count = 0;
+        for runtime in &ctx.run_config().runtime_toolsets {
+            tool_count += runtime.toolset().tools(ctx.clone()).await?.len();
+        }
+        self.tools_seen.store(tool_count, Ordering::SeqCst);
+
+        match self.behavior {
+            AgentBehavior::Events(count) => {
+                let events = (0..count)
+                    .map(|index| {
+                        let mut event =
+                            Event::with_id(format!("event-{index}"), "agent-invocation");
+                        event.author = self.name().to_string();
+                        Ok(event)
+                    })
+                    .collect::<Vec<AdkResult<Event>>>();
+                Ok(Box::pin(futures::stream::iter(events)))
+            }
+            AgentBehavior::Fail => Err(AdkError::agent("agent execution failed")),
+            AgentBehavior::Delay(duration) => {
+                tokio::time::sleep(duration).await;
+                Ok(Box::pin(futures::stream::empty()))
+            }
+        }
+    }
+}
+
+struct FakeSession;
+
+#[async_trait]
+impl SandboxSession for FakeSession {
+    async fn exec_command(
+        &self,
+        _command: &str,
+        _working_dir: Option<&str>,
+    ) -> Result<ExecOutput, SandboxError> {
+        Ok(ExecOutput {
+            stdout: String::new(),
+            stderr: String::new(),
+            exit_code: 0,
+            duration: Duration::from_millis(1),
+            timed_out: false,
+        })
+    }
+
+    async fn read_file(&self, _path: &str) -> Result<Vec<u8>, SandboxError> {
+        Ok(Vec::new())
+    }
+
+    async fn write_file(&self, _path: &str, _content: &[u8]) -> Result<(), SandboxError> {
+        Ok(())
+    }
+
+    async fn list_dir(&self, _path: &str) -> Result<Vec<DirEntry>, SandboxError> {
+        Ok(Vec::new())
+    }
+
+    async fn apply_patch(&self, _patch: &str) -> Result<(), SandboxError> {
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Default)]
+struct ClientFailures {
+    provision: bool,
+    start: bool,
+    snapshot: bool,
+    stop: bool,
+}
+
+struct FakeClient {
+    calls: Arc<Mutex<Vec<&'static str>>>,
+    failures: ClientFailures,
+}
+
+impl FakeClient {
+    fn fail(stage: &str) -> SandboxError {
+        SandboxError::ExecutionFailed(format!("{stage} failed"))
+    }
+
+    fn record(&self, stage: &'static str) {
+        self.calls.lock().unwrap_or_else(|error| error.into_inner()).push(stage);
+    }
+}
+
+#[async_trait]
+impl SandboxClient for FakeClient {
+    async fn provision(&self, _manifest: &Manifest) -> Result<SessionHandle, SandboxError> {
+        self.record("provision");
+        if self.failures.provision {
+            return Err(Self::fail("provision"));
+        }
+        Ok(SessionHandle("fake-handle".to_string()))
+    }
+
+    async fn start(
+        &self,
+        _handle: &SessionHandle,
+    ) -> Result<Box<dyn SandboxSession>, SandboxError> {
+        self.record("start");
+        if self.failures.start {
+            return Err(Self::fail("start"));
+        }
+        Ok(Box::new(FakeSession))
+    }
+
+    async fn stop(&self, _handle: &SessionHandle) -> Result<(), SandboxError> {
+        self.record("stop");
+        if self.failures.stop {
+            return Err(Self::fail("stop"));
+        }
+        Ok(())
+    }
+
+    async fn snapshot(&self, _handle: &SessionHandle) -> Result<SnapshotId, SandboxError> {
+        self.record("snapshot");
+        if self.failures.snapshot {
+            return Err(Self::fail("snapshot"));
+        }
+        Ok(SnapshotId("fake-snapshot".to_string()))
+    }
+
+    async fn resume(&self, _snapshot_id: &SnapshotId) -> Result<SessionHandle, SandboxError> {
+        Ok(SessionHandle("resumed-handle".to_string()))
+    }
+}
+
+struct CountingSessionService {
+    inner: InMemorySessionService,
+    creates: AtomicUsize,
+    fail_get: bool,
+}
+
+impl CountingSessionService {
+    fn new(fail_get: bool) -> Self {
+        Self { inner: InMemorySessionService::new(), creates: AtomicUsize::new(0), fail_get }
+    }
+
+    fn create_count(&self) -> usize {
+        self.creates.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl SessionService for CountingSessionService {
+    async fn create(&self, req: CreateRequest) -> AdkResult<Box<dyn Session>> {
+        self.creates.fetch_add(1, Ordering::SeqCst);
+        self.inner.create(req).await
+    }
+
+    async fn get(&self, req: GetRequest) -> AdkResult<Box<dyn Session>> {
+        if self.fail_get {
+            return Err(AdkError::session("session backend unavailable"));
+        }
+        self.inner.get(req).await
+    }
+
+    async fn list(&self, req: ListRequest) -> AdkResult<Vec<Box<dyn Session>>> {
+        self.inner.list(req).await
+    }
+
+    async fn delete(&self, req: DeleteRequest) -> AdkResult<()> {
+        self.inner.delete(req).await
+    }
+
+    async fn append_event(&self, session_id: &str, event: SessionEvent) -> AdkResult<()> {
+        self.inner.append_event(session_id, event).await
+    }
+}
+
+fn build_harness(
+    behavior: AgentBehavior,
+    failures: ClientFailures,
+    snapshot_on_stop: bool,
+    session_timeout: Duration,
+    session_service: Arc<CountingSessionService>,
+) -> (SandboxRunner, SandboxConfig, Arc<Mutex<Vec<&'static str>>>, Arc<AtomicUsize>) {
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let tools_seen = Arc::new(AtomicUsize::new(0));
+    let agent =
+        Arc::new(TestAgent { behavior, calls: calls.clone(), tools_seen: tools_seen.clone() });
+    let runner = Runner::builder()
+        .app_name("sandbox-runner-test")
+        .agent(agent)
+        .session_service(session_service)
+        .build()
+        .expect("runner builds");
+    let config = SandboxConfig {
+        client: Arc::new(FakeClient { calls: calls.clone(), failures }),
+        manifest: Manifest::new(Vec::new()),
+        capabilities: [Capability::Shell, Capability::Filesystem].into_iter().collect(),
+        command_timeout: Duration::from_secs(5),
+        session_timeout,
+        snapshot_on_stop,
+    };
+
+    (SandboxRunner::new(runner), config, calls, tools_seen)
+}
+
+fn content() -> Content {
+    Content::new("user").with_text("do the thing")
+}
+
+fn recorded(calls: &Arc<Mutex<Vec<&'static str>>>) -> Vec<&'static str> {
+    calls.lock().unwrap_or_else(|error| error.into_inner()).clone()
+}
+
+fn cleanup_stages(error: &AdkError) -> Vec<String> {
+    error
+        .details
+        .metadata
+        .get("sandbox.cleanupErrors")
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|failure| failure.get("stage").and_then(serde_json::Value::as_str))
+        .map(str::to_string)
+        .collect()
+}
+
+#[tokio::test]
+async fn invalid_identity_has_no_side_effects() {
+    let sessions = Arc::new(CountingSessionService::new(false));
+    let (runner, config, calls, _) = build_harness(
+        AgentBehavior::Events(0),
+        ClientFailures::default(),
+        false,
+        Duration::from_secs(1),
+        sessions.clone(),
+    );
+
+    let error = runner.run(&config, "", "session-1", content()).await.expect_err("ID is invalid");
+
+    assert_eq!(error.category, ErrorCategory::InvalidInput);
+    assert!(recorded(&calls).is_empty());
+    assert_eq!(sessions.create_count(), 0);
+}
+
+#[tokio::test]
+async fn session_lookup_failure_does_not_create_or_provision() {
+    let sessions = Arc::new(CountingSessionService::new(true));
+    let (runner, config, calls, _) = build_harness(
+        AgentBehavior::Events(0),
+        ClientFailures::default(),
+        false,
+        Duration::from_secs(1),
+        sessions.clone(),
+    );
+
+    let error = runner
+        .run(&config, "user-1", "session-1", content())
+        .await
+        .expect_err("lookup failure is preserved");
+
+    assert_eq!(error.message, "session backend unavailable");
+    assert!(recorded(&calls).is_empty());
+    assert_eq!(sessions.create_count(), 0);
+}
+
+#[tokio::test]
+async fn provision_failure_does_not_create_or_stop() {
+    let sessions = Arc::new(CountingSessionService::new(false));
+    let (runner, config, calls, _) = build_harness(
+        AgentBehavior::Events(0),
+        ClientFailures { provision: true, ..ClientFailures::default() },
+        false,
+        Duration::from_secs(1),
+        sessions.clone(),
+    );
+
+    let error =
+        runner.run(&config, "user-1", "session-1", content()).await.expect_err("provision fails");
+
+    assert!(error.message.contains("provision failed"));
+    assert_eq!(recorded(&calls), vec!["provision"]);
+    assert_eq!(sessions.create_count(), 0);
+}
+
+#[tokio::test]
+async fn start_error_precedes_stop_cleanup_error() {
+    let sessions = Arc::new(CountingSessionService::new(false));
+    let (runner, config, calls, _) = build_harness(
+        AgentBehavior::Events(0),
+        ClientFailures { start: true, stop: true, ..ClientFailures::default() },
+        true,
+        Duration::from_secs(1),
+        sessions.clone(),
+    );
+
+    let error =
+        runner.run(&config, "user-1", "session-1", content()).await.expect_err("start fails");
+
+    assert!(error.message.contains("start failed"));
+    assert_eq!(cleanup_stages(&error), vec!["stop"]);
+    assert_eq!(recorded(&calls), vec!["provision", "start", "stop"]);
+    assert_eq!(sessions.create_count(), 0);
+}
+
+#[tokio::test]
+async fn successful_run_buffers_events_and_orders_snapshot_before_stop() {
+    let sessions = Arc::new(CountingSessionService::new(false));
+    let (runner, config, calls, tools_seen) = build_harness(
+        AgentBehavior::Events(2),
+        ClientFailures::default(),
+        true,
+        Duration::from_secs(1),
+        sessions.clone(),
+    );
+
+    let result = runner.run(&config, "user-1", "session-1", content()).await.expect("run succeeds");
+
+    assert_eq!(result.events.len(), 2);
+    assert_eq!(result.events[0].id, "event-0");
+    assert_eq!(result.events[1].id, "event-1");
+    assert_eq!(result.snapshot_id, Some(SnapshotId("fake-snapshot".to_string())));
+    assert!(tools_seen.load(Ordering::SeqCst) >= 2);
+    assert_eq!(recorded(&calls), vec!["provision", "start", "run", "snapshot", "stop"]);
+    assert_eq!(sessions.create_count(), 1);
+}
+
+#[tokio::test]
+async fn existing_session_is_not_created_again() {
+    let sessions = Arc::new(CountingSessionService::new(false));
+    sessions
+        .create(CreateRequest {
+            app_name: "sandbox-runner-test".to_string(),
+            user_id: "user-1".to_string(),
+            session_id: Some("session-1".to_string()),
+            state: HashMap::new(),
+        })
+        .await
+        .expect("session is seeded");
+    let (runner, config, calls, _) = build_harness(
+        AgentBehavior::Events(0),
+        ClientFailures::default(),
+        false,
+        Duration::from_secs(1),
+        sessions.clone(),
+    );
+
+    runner.run(&config, "user-1", "session-1", content()).await.expect("run succeeds");
+
+    assert_eq!(sessions.create_count(), 1);
+    assert_eq!(recorded(&calls), vec!["provision", "start", "run", "stop"]);
+}
+
+#[tokio::test]
+async fn execution_error_precedes_snapshot_and_stop_errors() {
+    let sessions = Arc::new(CountingSessionService::new(false));
+    let (runner, config, calls, _) = build_harness(
+        AgentBehavior::Fail,
+        ClientFailures { snapshot: true, stop: true, ..ClientFailures::default() },
+        true,
+        Duration::from_secs(1),
+        sessions,
+    );
+
+    let error =
+        runner.run(&config, "user-1", "session-1", content()).await.expect_err("agent fails");
+
+    assert_eq!(error.message, "agent execution failed");
+    assert_eq!(cleanup_stages(&error), vec!["snapshot", "stop"]);
+    assert_eq!(recorded(&calls), vec!["provision", "start", "run", "snapshot", "stop"]);
+}
+
+#[tokio::test]
+async fn snapshot_error_is_returned_and_stop_still_runs() {
+    let sessions = Arc::new(CountingSessionService::new(false));
+    let (runner, config, calls, _) = build_harness(
+        AgentBehavior::Events(0),
+        ClientFailures { snapshot: true, ..ClientFailures::default() },
+        true,
+        Duration::from_secs(1),
+        sessions,
+    );
+
+    let error =
+        runner.run(&config, "user-1", "session-1", content()).await.expect_err("snapshot fails");
+
+    assert!(error.message.contains("snapshot failed"));
+    assert!(cleanup_stages(&error).is_empty());
+    assert_eq!(recorded(&calls), vec!["provision", "start", "run", "snapshot", "stop"]);
+}
+
+#[tokio::test]
+async fn stop_error_is_returned_after_successful_execution() {
+    let sessions = Arc::new(CountingSessionService::new(false));
+    let (runner, config, calls, _) = build_harness(
+        AgentBehavior::Events(0),
+        ClientFailures { stop: true, ..ClientFailures::default() },
+        false,
+        Duration::from_secs(1),
+        sessions,
+    );
+
+    let error =
+        runner.run(&config, "user-1", "session-1", content()).await.expect_err("stop fails");
+
+    assert!(error.message.contains("stop failed"));
+    assert_eq!(recorded(&calls), vec!["provision", "start", "run", "stop"]);
+}
+
+#[tokio::test]
+async fn timeout_still_snapshots_and_stops() {
+    let sessions = Arc::new(CountingSessionService::new(false));
+    let (runner, config, calls, _) = build_harness(
+        AgentBehavior::Delay(Duration::from_millis(200)),
+        ClientFailures::default(),
+        true,
+        Duration::from_millis(20),
+        sessions,
+    );
+
+    let error =
+        runner.run(&config, "user-1", "session-1", content()).await.expect_err("agent times out");
+
+    assert!(error.is_timeout());
+    assert_eq!(recorded(&calls), vec!["provision", "start", "run", "snapshot", "stop"]);
+}

--- a/adk-sandbox/src/workspace/client.rs
+++ b/adk-sandbox/src/workspace/client.rs
@@ -11,8 +11,8 @@
 //! provision(manifest) → SessionHandle
 //!     start(handle) → Box<dyn SandboxSession>
 //!         ... operations ...
+//!         snapshot(handle) → SnapshotId
 //!     stop(handle)
-//!     snapshot(handle) → SnapshotId
 //! resume(snapshot_id) → SessionHandle
 //! ```
 

--- a/adk-session/src/firestore.rs
+++ b/adk-session/src/firestore.rs
@@ -405,6 +405,7 @@ impl SessionService for FirestoreSessionService {
     }
 
     async fn get(&self, req: GetRequest) -> Result<Box<dyn Session>> {
+        req.try_identity()?;
         let sessions_parent = self.sessions_parent(&req.app_name)?;
 
         // Read session document
@@ -418,7 +419,13 @@ impl SessionService for FirestoreSessionService {
             .one(&req.session_id)
             .await
             .map_err(|e| adk_core::AdkError::session(format!("query failed: {e}")))?
-            .ok_or_else(|| adk_core::AdkError::session("session not found"))?;
+            .ok_or_else(|| crate::service::session_not_found(&req))?;
+        if session_doc.app_name != req.app_name
+            || session_doc.user_id != req.user_id
+            || session_doc.session_id != req.session_id
+        {
+            return Err(crate::service::session_not_found(&req));
+        }
 
         // Read events subcollection ordered by timestamp
         let events_parent = self.events_parent(&req.app_name, &req.session_id)?;

--- a/adk-session/src/inmemory.rs
+++ b/adk-session/src/inmemory.rs
@@ -48,16 +48,12 @@ impl InMemorySessionService {
         state_utils::merge_states(app, user, session)
     }
 
-    /// Build an [`AdkIdentity`] from raw string fields, returning a session
-    /// error if any field fails validation.
+    /// Builds an [`AdkIdentity`] from raw string fields.
     fn make_identity(app_name: &str, user_id: &str, session_id: &str) -> Result<AdkIdentity> {
         Ok(AdkIdentity::new(
-            AppName::try_from(app_name)
-                .map_err(|e| adk_core::AdkError::session(format!("invalid app_name: {e}")))?,
-            UserId::try_from(user_id)
-                .map_err(|e| adk_core::AdkError::session(format!("invalid user_id: {e}")))?,
-            SessionId::try_from(session_id)
-                .map_err(|e| adk_core::AdkError::session(format!("invalid session_id: {e}")))?,
+            AppName::try_from(app_name)?,
+            UserId::try_from(user_id)?,
+            SessionId::try_from(session_id)?,
         ))
     }
 
@@ -155,9 +151,8 @@ impl SessionService for InMemorySessionService {
         let identity = Self::make_identity(&req.app_name, &req.user_id, &req.session_id)?;
 
         let sessions = self.sessions.read().unwrap_or_else(|e| e.into_inner());
-        let data = sessions
-            .get(&identity)
-            .ok_or_else(|| adk_core::AdkError::session("session not found"))?;
+        let data =
+            sessions.get(&identity).ok_or_else(|| crate::service::session_not_found(&req))?;
 
         let app_state_lock = self.app_state.read().unwrap_or_else(|e| e.into_inner());
         let app_state = app_state_lock.get(&req.app_name).cloned().unwrap_or_default();

--- a/adk-session/src/mongodb.rs
+++ b/adk-session/src/mongodb.rs
@@ -111,11 +111,11 @@ impl MongoSessionService {
 
         if max_applied == 0 {
             let existing = self.detect_existing_tables().await?;
-            if existing {
-                if let Some(&(version, description)) = Self::MONGO_SESSION_MIGRATIONS.first() {
-                    self.record_migration(version, description).await?;
-                    max_applied = version;
-                }
+            if existing
+                && let Some(&(version, description)) = Self::MONGO_SESSION_MIGRATIONS.first()
+            {
+                self.record_migration(version, description).await?;
+                max_applied = version;
             }
         }
 
@@ -417,11 +417,12 @@ impl SessionService for MongoSessionService {
 
     #[instrument(skip_all, fields(app_name = %req.app_name, user_id = %req.user_id, session_id = %req.session_id))]
     async fn get(&self, req: GetRequest) -> Result<Box<dyn Session>> {
+        req.try_identity()?;
         let sess_coll = self.db.collection::<Document>("sessions");
         let session_doc = sess_coll
             .find_one(doc! { "app_name": &req.app_name, "user_id": &req.user_id, "session_id": &req.session_id })
             .await.map_err(|e| adk_core::AdkError::session(format!("query failed: {e}")))?
-            .ok_or_else(|| adk_core::AdkError::session("session not found"))?;
+            .ok_or_else(|| crate::service::session_not_found(&req))?;
 
         let state = session_doc.get_document("state").map(bson_to_state).unwrap_or_default();
         let updated_at = session_doc

--- a/adk-session/src/neo4j.rs
+++ b/adk-session/src/neo4j.rs
@@ -123,11 +123,11 @@ impl Neo4jSessionService {
         // constraint already exists, record v1 as applied.
         if max_applied == 0 {
             let existing = self.detect_existing_tables().await?;
-            if existing {
-                if let Some(&(version, description, _)) = Self::NEO4J_SESSION_MIGRATIONS.first() {
-                    self.record_migration(version, description).await?;
-                    max_applied = version;
-                }
+            if existing
+                && let Some(&(version, description, _)) = Self::NEO4J_SESSION_MIGRATIONS.first()
+            {
+                self.record_migration(version, description).await?;
+                max_applied = version;
             }
         }
 
@@ -325,10 +325,9 @@ impl SessionService for Neo4jSessionService {
             .next(&mut txn)
             .await
             .map_err(|e| adk_core::AdkError::session(format!("query failed: {e}")))?
+            && let Ok(state_str) = row.get::<String>("state")
         {
-            if let Ok(state_str) = row.get::<String>("state") {
-                app_state = json_string_to_state(&state_str)?;
-            }
+            app_state = json_string_to_state(&state_str)?;
         }
         app_state.extend(app_delta);
         let app_state_json = state_to_json_string(&app_state)?;
@@ -364,10 +363,9 @@ impl SessionService for Neo4jSessionService {
             .next(&mut txn)
             .await
             .map_err(|e| adk_core::AdkError::session(format!("query failed: {e}")))?
+            && let Ok(state_str) = row.get::<String>("state")
         {
-            if let Ok(state_str) = row.get::<String>("state") {
-                user_state = json_string_to_state(&state_str)?;
-            }
+            user_state = json_string_to_state(&state_str)?;
         }
         user_state.extend(user_delta);
         let user_state_json = state_to_json_string(&user_state)?;
@@ -442,6 +440,7 @@ impl SessionService for Neo4jSessionService {
 
     #[instrument(skip_all, fields(app_name = %req.app_name, user_id = %req.user_id, session_id = %req.session_id))]
     async fn get(&self, req: GetRequest) -> Result<Box<dyn Session>> {
+        req.try_identity()?;
         let mut row_stream = self
             .graph
             .execute(
@@ -463,7 +462,7 @@ impl SessionService for Neo4jSessionService {
             .next()
             .await
             .map_err(|e| adk_core::AdkError::session(format!("query failed: {e}")))?
-            .ok_or_else(|| adk_core::AdkError::session("session not found"))?;
+            .ok_or_else(|| crate::service::session_not_found(&req))?;
 
         let state_str = row.get::<String>("state").unwrap_or_default();
         let updated_at_str = row.get::<String>("updated_at").unwrap_or_default();
@@ -653,10 +652,9 @@ impl SessionService for Neo4jSessionService {
             .next(&mut txn)
             .await
             .map_err(|e| adk_core::AdkError::session(format!("query failed: {e}")))?
+            && let Ok(state_str) = row.get::<String>("state")
         {
-            if let Ok(state_str) = row.get::<String>("state") {
-                app_state = json_string_to_state(&state_str)?;
-            }
+            app_state = json_string_to_state(&state_str)?;
         }
 
         // Load current user state
@@ -677,10 +675,9 @@ impl SessionService for Neo4jSessionService {
             .next(&mut txn)
             .await
             .map_err(|e| adk_core::AdkError::session(format!("query failed: {e}")))?
+            && let Ok(state_str) = row.get::<String>("state")
         {
-            if let Ok(state_str) = row.get::<String>("state") {
-                user_state = json_string_to_state(&state_str)?;
-            }
+            user_state = json_string_to_state(&state_str)?;
         }
 
         let (app_delta, user_delta, session_delta) =
@@ -848,10 +845,9 @@ impl SessionService for Neo4jSessionService {
             .next(&mut txn)
             .await
             .map_err(|e| adk_core::AdkError::session(format!("query failed: {e}")))?
+            && let Ok(state_str) = row.get::<String>("state")
         {
-            if let Ok(state_str) = row.get::<String>("state") {
-                app_state = json_string_to_state(&state_str)?;
-            }
+            app_state = json_string_to_state(&state_str)?;
         }
 
         // Load current user state
@@ -872,10 +868,9 @@ impl SessionService for Neo4jSessionService {
             .next(&mut txn)
             .await
             .map_err(|e| adk_core::AdkError::session(format!("query failed: {e}")))?
+            && let Ok(state_str) = row.get::<String>("state")
         {
-            if let Ok(state_str) = row.get::<String>("state") {
-                user_state = json_string_to_state(&state_str)?;
-            }
+            user_state = json_string_to_state(&state_str)?;
         }
 
         let (app_delta, user_delta, session_delta) =

--- a/adk-session/src/postgres.rs
+++ b/adk-session/src/postgres.rs
@@ -309,15 +309,17 @@ impl SessionService for PostgresSessionService {
 
     #[instrument(skip_all, fields(app_name = %req.app_name, user_id = %req.user_id, session_id = %req.session_id))]
     async fn get(&self, req: GetRequest) -> Result<Box<dyn Session>> {
+        req.try_identity()?;
         let row = sqlx::query(
             "SELECT state, updated_at FROM sessions WHERE app_name = $1 AND user_id = $2 AND session_id = $3",
         )
         .bind(&req.app_name)
         .bind(&req.user_id)
         .bind(&req.session_id)
-        .fetch_one(&self.pool)
+        .fetch_optional(&self.pool)
         .await
-        .map_err(|_| adk_core::AdkError::session("session not found"))?;
+        .map_err(|e| adk_core::AdkError::session(format!("query failed: {e}")))?
+        .ok_or_else(|| crate::service::session_not_found(&req))?;
 
         let state: HashMap<String, Value> = row
             .get::<Value, _>("state")

--- a/adk-session/src/redis.rs
+++ b/adk-session/src/redis.rs
@@ -270,6 +270,7 @@ impl SessionService for RedisSessionService {
 
     #[instrument(skip_all, fields(app_name = %req.app_name, user_id = %req.user_id, session_id = %req.session_id))]
     async fn get(&self, req: GetRequest) -> Result<Box<dyn Session>> {
+        req.try_identity()?;
         let session_k = session_key(&req.app_name, &req.user_id, &req.session_id);
 
         let exists: bool = self
@@ -278,7 +279,7 @@ impl SessionService for RedisSessionService {
             .await
             .map_err(|e| adk_core::AdkError::session(format!("redis exists failed: {e}")))?;
         if !exists {
-            return Err(adk_core::AdkError::session("session not found"));
+            return Err(crate::service::session_not_found(&req));
         }
 
         let raw: HashMap<String, String> = self

--- a/adk-session/src/service.rs
+++ b/adk-session/src/service.rs
@@ -1,6 +1,6 @@
 use crate::{Event, Session};
-use adk_core::Result;
 use adk_core::identity::{AdkIdentity, AppName, SessionId, UserId};
+use adk_core::{AdkError, ErrorComponent, Result};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde_json::Value;
@@ -106,6 +106,18 @@ impl GetRequest {
     }
 }
 
+/// Builds the canonical error returned when a session identity has no matching record.
+pub(crate) fn session_not_found(req: &GetRequest) -> AdkError {
+    AdkError::not_found(
+        ErrorComponent::Session,
+        "session.not_found",
+        format!(
+            "session '{}' was not found for app '{}' and user '{}'",
+            req.session_id, req.app_name, req.user_id
+        ),
+    )
+}
+
 /// Request to list sessions for a given app and user.
 #[derive(Debug, Clone)]
 pub struct ListRequest {
@@ -206,7 +218,18 @@ impl DeleteRequest {
 pub trait SessionService: Send + Sync {
     /// Create a new session and return it.
     async fn create(&self, req: CreateRequest) -> Result<Box<dyn Session>>;
-    /// Retrieve an existing session by its identifiers.
+    /// Retrieves an existing session by its complete identity.
+    ///
+    /// Implementations address sessions by the full `(app_name, user_id, session_id)` tuple.
+    /// When that valid identity has no matching record, implementations return an
+    /// [`AdkError`] with code `session.not_found` and a
+    /// [`NotFound`](adk_core::ErrorCategory::NotFound) category. Backend and transport failures
+    /// must not be reported as not-found errors.
+    ///
+    /// # Errors
+    ///
+    /// Returns an invalid-input error when an identifier fails validation, `session.not_found`
+    /// when no matching session exists, or a backend-specific error when retrieval fails.
     async fn get(&self, req: GetRequest) -> Result<Box<dyn Session>>;
     /// List sessions for a given app and user.
     async fn list(&self, req: ListRequest) -> Result<Vec<Box<dyn Session>>>;

--- a/adk-session/src/sqlite.rs
+++ b/adk-session/src/sqlite.rs
@@ -232,13 +232,15 @@ impl SessionService for SqliteSessionService {
     }
 
     async fn get(&self, req: GetRequest) -> Result<Box<dyn Session>> {
+        req.try_identity()?;
         let row = sqlx::query("SELECT state, updated_at FROM sessions WHERE app_name = ? AND user_id = ? AND session_id = ?")
             .bind(&req.app_name)
             .bind(&req.user_id)
             .bind(&req.session_id)
-            .fetch_one(&self.pool)
+            .fetch_optional(&self.pool)
             .await
-            .map_err(|_| adk_core::AdkError::session("session not found"))?;
+            .map_err(|e| adk_core::AdkError::session(format!("query failed: {e}")))?
+            .ok_or_else(|| crate::service::session_not_found(&req))?;
 
         let state: HashMap<String, Value> = serde_json::from_str(row.get("state"))
             .map_err(|e| adk_core::AdkError::session(format!("deserialize failed: {}", e)))?;

--- a/adk-session/src/vertex.rs
+++ b/adk-session/src/vertex.rs
@@ -411,27 +411,16 @@ impl SessionService for VertexAiSessionService {
     }
 
     async fn get(&self, req: GetRequest) -> Result<Box<dyn Session>> {
-        if req.app_name.trim().is_empty()
-            || req.user_id.trim().is_empty()
-            || req.session_id.trim().is_empty()
-        {
-            return Err(Self::session_error(format!(
-                "app_name, user_id, and session_id are required, got app_name: '{}' user_id: '{}' session_id: '{}'",
-                req.app_name, req.user_id, req.session_id,
-            )));
-        }
+        req.try_identity()?;
 
         let session_name = self.session_name_from_app(&req.app_name, &req.session_id)?;
         let payload = self
             .fetch_session(&session_name)
             .await?
-            .ok_or_else(|| Self::session_error("session not found"))?;
+            .ok_or_else(|| crate::service::session_not_found(&req))?;
 
         if payload.user_id != req.user_id {
-            return Err(Self::session_error(format!(
-                "session '{}' does not belong to user '{}'",
-                req.session_id, req.user_id,
-            )));
+            return Err(crate::service::session_not_found(&req));
         }
 
         self.remember_session_scope(&req.session_id, &req.app_name, &req.user_id);

--- a/adk-session/tests/common/session_contract.rs
+++ b/adk-session/tests/common/session_contract.rs
@@ -21,6 +21,33 @@ pub async fn assert_session_contract_with_users(
     user_1: &str,
     user_2: &str,
 ) {
+    let missing = service
+        .get(GetRequest {
+            app_name: app_name.to_string(),
+            user_id: user_1.to_string(),
+            session_id: "contract-missing".to_string(),
+            num_recent_events: None,
+            after: None,
+        })
+        .await
+        .err()
+        .expect("a missing session must return an error");
+    assert!(missing.is_not_found());
+    assert_eq!(missing.code, "session.not_found");
+
+    let invalid = service
+        .get(GetRequest {
+            app_name: app_name.to_string(),
+            user_id: String::new(),
+            session_id: "contract-invalid".to_string(),
+            num_recent_events: None,
+            after: None,
+        })
+        .await
+        .err()
+        .expect("an invalid session identity must return an error");
+    assert_eq!(invalid.category, adk_core::ErrorCategory::InvalidInput);
+
     let mut initial_state = HashMap::new();
     initial_state.insert("app:locale".to_string(), json!("en-US"));
     initial_state.insert("user:name".to_string(), json!("alice"));
@@ -151,8 +178,11 @@ pub async fn assert_session_contract_with_users(
             num_recent_events: None,
             after: None,
         })
-        .await;
-    assert!(wrong_user_get.is_err());
+        .await
+        .err()
+        .expect("a session owned by another user must not be returned");
+    assert!(wrong_user_get.is_not_found());
+    assert_eq!(wrong_user_get.code, "session.not_found");
 
     let sessions_user2 = service
         .list(ListRequest {
@@ -239,6 +269,9 @@ pub async fn assert_session_contract_with_users(
             num_recent_events: None,
             after: None,
         })
-        .await;
-    assert!(deleted_get.is_err());
+        .await
+        .err()
+        .expect("a deleted session must return an error");
+    assert!(deleted_get.is_not_found());
+    assert_eq!(deleted_get.code, "session.not_found");
 }

--- a/adk-session/tests/session_contract_sqlite.rs
+++ b/adk-session/tests/session_contract_sqlite.rs
@@ -1,0 +1,14 @@
+#![cfg(feature = "sqlite")]
+
+mod common;
+
+use adk_session::SqliteSessionService;
+
+#[tokio::test]
+async fn test_sqlite_service_contract() {
+    let service = SqliteSessionService::new(":memory:").await.expect("SQLite service starts");
+    service.migrate().await.expect("SQLite schema migrates");
+
+    common::session_contract::assert_session_contract(&service, "contract_app", "contract_app_2")
+        .await;
+}

--- a/adk-session/tests/session_contract_vertex.rs
+++ b/adk-session/tests/session_contract_vertex.rs
@@ -262,14 +262,13 @@ async fn append_event(
         .and_then(Value::as_object)
         .and_then(|actions| actions.get("stateDelta"))
         .and_then(Value::as_object)
+        && let Some(session) = db.sessions.get_mut(&name)
     {
-        if let Some(session) = db.sessions.get_mut(&name) {
-            for (key, value) in actions {
-                session.state.insert(key.clone(), value.clone());
-            }
-            if let Some(timestamp) = event_map.get("timestamp").and_then(Value::as_str) {
-                session.update_time = timestamp.to_string();
-            }
+        for (key, value) in actions {
+            session.state.insert(key.clone(), value.clone());
+        }
+        if let Some(timestamp) = event_map.get("timestamp").and_then(Value::as_str) {
+            session.update_time = timestamp.to_string();
         }
     }
 

--- a/examples/sandbox_workspace_agent/Cargo.lock
+++ b/examples/sandbox_workspace_agent/Cargo.lock
@@ -1910,8 +1910,6 @@ dependencies = [
  "anyhow",
  "clap",
  "dotenvy",
- "futures",
- "serde",
  "serde_json",
  "tokio",
  "tracing",

--- a/examples/sandbox_workspace_agent/Cargo.toml
+++ b/examples/sandbox_workspace_agent/Cargo.toml
@@ -19,10 +19,8 @@ anyhow = "1.0"
 dotenvy = "0.15"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 clap = { version = "4", features = ["derive"] }
-futures = "0.3"
 
 [features]
 default = []

--- a/examples/sandbox_workspace_agent/README.md
+++ b/examples/sandbox_workspace_agent/README.md
@@ -8,7 +8,8 @@ Demonstrates the full sandbox-agent-harness lifecycle — Manifest definition, w
 - **SandboxConfig construction** — capabilities, timeouts, and snapshot settings
 - **LocalUnixClient** — default backend using local filesystem and child processes
 - **DockerClient** — optional Docker-based isolation via `--docker` flag
-- **Tool binding** — automatic binding of `exec_command`, `write_file`, and `list_dir` tools
+- **Tool binding** — `SandboxRunner` injects `exec_command`, `write_file`, and `list_dir` only
+  while the sandbox session is live
 - **LLM agent loop** — Gemini-powered agent that creates, compiles, and runs a Rust project
 - **Snapshot/resume** — optional workspace persistence and verification via `--snapshot` flag
 - **Lifecycle observability** — structured output with section banners and phase tracking
@@ -133,14 +134,16 @@ The example prints structured output with section banners for each lifecycle pha
   Snapshot on stop: false
 
 ════════════════════════════════════════════════════════════
-  Phase 3: Provisioning Workspace
+  Phase 3: Agent and Runner Construction
 ════════════════════════════════════════════════════════════
-  ...
+  Building LlmAgent with Gemini model...
+  ✅ Agent built: sandbox-workspace-agent
+  ✅ Runner and SandboxRunner constructed
 
 ════════════════════════════════════════════════════════════
-  Phase 4: Agent Execution
+  Phase 4: Managed Sandbox Execution
 ════════════════════════════════════════════════════════════
-  Running agent loop...
+  Provisioning, running, snapshotting, and cleaning up...
 
   🔧 Tool call: list_dir
   🔧 Tool call: write_file
@@ -159,16 +162,18 @@ The example prints structured output with section banners for each lifecycle pha
   Phase 5: Results
 ════════════════════════════════════════════════════════════
   ✅ Agent execution completed successfully
+  ✅ Sandbox session stopped
+  Snapshot disabled
 
 ════════════════════════════════════════════════════════════
   Summary
 ════════════════════════════════════════════════════════════
   ✓ Manifest definition
   ✓ SandboxConfig construction
-  ✓ Provisioning
-  ✓ Agent execution
+  ✓ Runner construction
+  ✓ Managed sandbox execution
   ✓ Stop/cleanup
-  ✗ Snapshot
+  ✓ Snapshot
 ```
 
 When `--snapshot` is enabled, an additional phase appears:
@@ -204,7 +209,7 @@ When `--snapshot` is enabled, an additional phase appears:
 ┌─────────────────────────────────────────────┐
 │  SandboxRunner                              │
 │  Lifecycle: provision → start → bind →      │
-│             agent loop → stop → snapshot    │
+│             agent loop → snapshot → stop    │
 └──────────────┬──────────────────────────────┘
                │
        ┌───────┴───────┐

--- a/examples/sandbox_workspace_agent/src/main.rs
+++ b/examples/sandbox_workspace_agent/src/main.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use adk_agent::LlmAgentBuilder;
@@ -6,10 +5,9 @@ use adk_core::{Agent, Content};
 use adk_model::gemini::GeminiModel;
 use adk_runner::Runner;
 use adk_runner::sandbox_runner::SandboxRunner;
-use adk_sandbox::workspace::{ManifestEntry, SandboxSession};
-use adk_session::{CreateRequest, InMemorySessionService, SessionService};
+use adk_sandbox::workspace::ManifestEntry;
+use adk_session::InMemorySessionService;
 use clap::Parser;
-use futures::StreamExt;
 use tracing_subscriber::EnvFilter;
 
 mod config;
@@ -91,9 +89,6 @@ async fn main() -> anyhow::Result<()> {
             ManifestEntry::GitRepo { url, path, .. } => {
                 println!("    🔗 {path} (from {url})");
             }
-            _ => {
-                println!("    ❓ (unknown entry type)");
-            }
         }
     }
 
@@ -105,140 +100,56 @@ async fn main() -> anyhow::Result<()> {
     println!("  Command timeout: {:?}", sandbox_config.command_timeout);
     println!("  Snapshot on stop: {}", sandbox_config.snapshot_on_stop);
 
-    // ─── Phase 3: Provisioning Workspace ────────────────────────────────────────
-    banner("Phase 3: Provisioning Workspace");
-    println!("  Provisioning workspace from manifest...");
-
-    let handle = sandbox_config
-        .client
-        .provision(&sandbox_config.manifest)
-        .await
-        .map_err(|e| anyhow::anyhow!("Provisioning failed: {e}"))?;
-
-    println!("  ✅ SessionHandle: {}", handle.0);
-
-    // Start the session
-    println!("  Starting sandbox session...");
-    let session: Box<dyn SandboxSession> = sandbox_config
-        .client
-        .start(&handle)
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to start session: {e}"))?;
-
-    // Bind tools based on capabilities
-    let session_arc: Arc<dyn SandboxSession> = Arc::from(session);
-    let bound_tools = adk_runner::sandbox_runner::binding::bind_tools(
-        Arc::clone(&session_arc),
-        &sandbox_config.capabilities,
-        sandbox_config.command_timeout,
-    );
-
-    println!("  ✅ Bound {} tool(s):", bound_tools.len());
-    for tool in &bound_tools {
-        println!("    🔧 {}", tool.name());
-    }
-
-    // ─── Phase 4: Agent Execution ───────────────────────────────────────────────
-    banner("Phase 4: Agent Execution");
+    // ─── Phase 3: Agent and Runner Construction ─────────────────────────────────
+    banner("Phase 3: Agent and Runner Construction");
     println!("  Building LlmAgent with Gemini model...");
 
     let model = GeminiModel::new(&api_key, "gemini-2.5-flash")
         .map_err(|e| anyhow::anyhow!("Failed to create Gemini model: {e}"))?;
 
-    let mut agent_builder = LlmAgentBuilder::new("sandbox-workspace-agent")
+    let agent = LlmAgentBuilder::new("sandbox-workspace-agent")
         .model(Arc::new(model))
-        .instruction(AGENT_INSTRUCTIONS);
-
-    for t in bound_tools {
-        agent_builder = agent_builder.tool(t);
-    }
-
-    let agent = agent_builder.build().map_err(|e| anyhow::anyhow!("Failed to build agent: {e}"))?;
+        .instruction(AGENT_INSTRUCTIONS)
+        .build()
+        .map_err(|e| anyhow::anyhow!("Failed to build agent: {e}"))?;
 
     println!("  ✅ Agent built: {}", agent.name());
 
-    // Create session service and session
-    let session_service: Arc<dyn SessionService> = Arc::new(InMemorySessionService::new());
-    session_service
-        .create(CreateRequest {
-            app_name: "sandbox-workspace-agent".to_string(),
-            user_id: "demo-user".to_string(),
-            session_id: Some("session-1".to_string()),
-            state: HashMap::new(),
-        })
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to create session: {e}"))?;
-
-    // Build the Runner
     let runner = Runner::builder()
         .app_name("sandbox-workspace-agent")
         .agent(Arc::new(agent))
-        .session_service(session_service)
+        .session_service(Arc::new(InMemorySessionService::new()))
         .build()
         .map_err(|e| anyhow::anyhow!("Failed to build runner: {e}"))?;
 
-    // Create SandboxRunner wrapping the Runner (demonstrates the intended API)
     let sandbox_runner = SandboxRunner::new(runner);
-
     println!("  ✅ Runner and SandboxRunner constructed");
-    println!("  Running agent loop...\n");
 
-    // Run the agent via the inner runner with a user message
+    // ─── Phase 4: Managed Sandbox Execution ─────────────────────────────────────
+    banner("Phase 4: Managed Sandbox Execution");
+    println!("  Provisioning, running, snapshotting, and cleaning up...\n");
     let user_content =
         Content::new("user").with_text("Create the Rust hello-world project as instructed.");
+    let result = sandbox_runner
+        .run(&sandbox_config, "demo-user", "session-1", user_content)
+        .await
+        .map_err(|error| anyhow::anyhow!("Sandbox run failed after lifecycle cleanup: {error}"))?;
 
-    let run_result = sandbox_runner.inner().run_str("demo-user", "session-1", user_content).await;
-
-    // Process events from the agent loop
-    let agent_succeeded = match run_result {
-        Ok(mut event_stream) => {
-            let mut success = true;
-            while let Some(event_result) = event_stream.next().await {
-                match event_result {
-                    Ok(event) => print_event(&event),
-                    Err(e) => {
-                        println!("  ❌ Event error: {e}");
-                        success = false;
-                    }
-                }
-            }
-            success
-        }
-        Err(e) => {
-            println!("  ❌ Agent execution failed: {e}");
-            false
-        }
-    };
-
-    // ─── Always stop the session (cleanup guarantee) ────────────────────────────
-    println!("\n  Stopping sandbox session...");
-    if let Err(e) = sandbox_config.client.stop(&handle).await {
-        println!("  ⚠️  Stop failed (non-fatal): {e}");
-    } else {
-        println!("  ✅ Session stopped");
+    for event in &result.events {
+        print_event(event);
     }
+    let snapshot_id = result.snapshot_id;
 
     // ─── Phase 5: Results ───────────────────────────────────────────────────────
     banner("Phase 5: Results");
-    if agent_succeeded {
-        println!("  ✅ Agent execution completed successfully");
+    println!("  ✅ Agent execution completed successfully");
+    println!("  ✅ Sandbox session stopped");
+    if let Some(id) = snapshot_id.as_ref() {
+        println!("  ✅ SnapshotId: {}", id.0);
+    } else if sandbox_config.snapshot_on_stop {
+        println!("  ❌ Snapshot was requested but not returned");
     } else {
-        println!("  ❌ Agent execution failed");
-    }
-
-    // Snapshot if enabled
-    let mut snapshot_id = None;
-    if sandbox_config.snapshot_on_stop {
-        println!("  📸 Creating snapshot...");
-        match sandbox_config.client.snapshot(&handle).await {
-            Ok(id) => {
-                println!("  ✅ SnapshotId: {}", id.0);
-                snapshot_id = Some(id);
-            }
-            Err(e) => {
-                println!("  ⚠️  Snapshot failed: {e}");
-            }
-        }
+        println!("  Snapshot disabled");
     }
 
     // ─── Phase 6: Snapshot/Resume Verification (optional) ───────────────────────
@@ -261,8 +172,11 @@ async fn main() -> anyhow::Result<()> {
                                 }
                                 Err(e) => println!("  ⚠️  list_dir failed: {e}"),
                             }
-                            // Stop the resumed session
-                            let _ = sandbox_config.client.stop(&resumed_handle).await;
+                            if let Err(error) =
+                                sandbox_config.client.stop(&resumed_handle).await
+                            {
+                                println!("  ⚠️  Failed to stop resumed session: {error}");
+                            }
                         }
                         Err(e) => println!("  ❌ Failed to start resumed session: {e}"),
                     }
@@ -278,8 +192,8 @@ async fn main() -> anyhow::Result<()> {
     let phases: Vec<(&str, bool)> = vec![
         ("Manifest definition", true),
         ("SandboxConfig construction", true),
-        ("Provisioning", true),
-        ("Agent execution", agent_succeeded),
+        ("Runner construction", true),
+        ("Managed sandbox execution", true),
         ("Stop/cleanup", true),
         ("Snapshot", !args.snapshot || snapshot_id.is_some()),
     ];


### PR DESCRIPTION
## What

- replaces the sandbox runner placeholder with the managed provision → start → bind → run → snapshot → stop lifecycle
- injects live sandbox tools per invocation and buffers emitted events until cleanup completes
- validates caller identities before side effects
- creates a session only for a structured `session.not_found` result
- standardizes that not-found contract across every session backend while preserving backend failures
- preserves execution-error precedence and records later cleanup failures in `sandbox.cleanupErrors`
- repairs the sandbox workspace example to use the real lifecycle

## Why

The existing #515 implementation did not run the agent or expose the bound tools, attempted snapshotting after teardown, conflated database errors with missing sessions, and could create state after arbitrary lookup failures. Those are release blockers.

## Verification

- `cargo nextest run -p adk-runner --features sandbox-runner` — 131 passed
- `cargo nextest run -p adk-session --all-features` — 50 passed, 1 live-secret test skipped
- runner and session clippy with `-D warnings`
- warning-free rustdoc with and without `sandbox-runner`
- sandbox example clippy with `-D warnings`
- publish-order check — 41 crates, 8 tiers
- repository pre-commit workspace clippy/format hooks pass
- repository pre-push workspace check passes

Supersedes #515.