### PR TITLE
fix(computer-use): enforce execution bindings and cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **adk-computer-use: the reference graph now enforces execution-time bindings and
+  deterministic reservation cleanup.** Generic `ComputerUseRuntime` implementations could
+  return a well-formed lease, reservation, or receipt without the graph applying the binding
+  validators used by the MCP adapter. The graph now validates each response before storing it
+  and revalidates the envelope, lease, reservation, approval route, action digest, and policy
+  digest immediately before the single mutation. Reservations bind the exact action intent,
+  active state, expiry, and app/window scope. Every post-reservation terminal path attempts
+  release; a primary failure remains primary, and a cleanup failure is reported alongside it.
+  The checkpointed preview is append-only, so resume input cannot replace it while supplying a
+  matching forged approval. Verification now reads the postcondition from the stored preview
+  envelope rather than a nonexistent `envelope` state channel. The MCP adapter also retains the
+  exact preview envelope and rejects direct execution if it changes.
+
 - **adk-sandbox: the process output cap now bounds memory instead of only the report.**
   `ProcessBackend::execute` called `child.wait_with_output()`, which buffers a process's entire
   stdout and stderr, and applied the 1 MiB `MAX_OUTPUT_BYTES` limit afterwards. A sandboxed

--- a/adk-computer-use/README.md
+++ b/adk-computer-use/README.md
@@ -27,6 +27,12 @@ by wrapping every action in the same fixed, predictable control flow:
 - **Approval is bound to the action.** When you resume after approval, the action
   is pinned to the exact action and policy digests it was approved for. An
   approval for one action cannot authorize a different action.
+- **Authority is rechecked at mutation time.** Envelope expiry, approval
+  authority, reservation scope, lease validity, and receipt identity are checked
+  again immediately around the single executor call.
+- **Reservations have deterministic cleanup.** Once acquired, a reservation is
+  released after verification and on every later error path. When the primary
+  operation and cleanup both fail, the returned error records both.
 - **Identity cannot be forged.** The principal and tenant come from `adk-auth`,
   not from model output or graph state, so a prompt cannot change who you are
   mid-run.
@@ -62,7 +68,8 @@ flowchart TD
 
 Read top to bottom: observe in parallel, join the results, preview, branch to
 approval when required, acquire the one-writer lease, perform the single mutation,
-then verify it happened.
+then verify it happened. The reservation is released after verification and on
+every error after it is acquired.
 
 ## What's included
 
@@ -85,8 +92,10 @@ whole graph with no server, no desktop, and no specific OS:
 cargo run -p adk-computer-use --example minimal_graph
 ```
 
-You'll see the observations join, the action take the "allowed" route, a committed
-receipt, and `verified: true`. In code:
+You'll see the observations join, the action take the "allowed" route, and a
+committed receipt. The example declares no postcondition, so it reports
+`committed: true` and `verified: false` rather than claiming an observation it
+did not make. In code:
 
 ```rust,no_run
 use std::sync::Arc;
@@ -104,7 +113,8 @@ let mut input = State::new();
 input.insert("proposed_action".into(), json!({ "tool": "write_clipboard" }));
 
 let result = graph.invoke(input, ExecutionConfig::new("demo")).await?;
-assert_eq!(result.get("verified"), Some(&json!(true)));
+assert_eq!(result.get("committed"), Some(&json!(true)));
+assert_eq!(result.get("verified"), Some(&json!(false)));
 # Ok(())
 # }
 ```

--- a/adk-computer-use/examples/minimal_graph.rs
+++ b/adk-computer-use/examples/minimal_graph.rs
@@ -47,6 +47,7 @@ impl ComputerUseRuntime for InProcessRuntime {
         &self,
         _proposed_action: Value,
     ) -> Result<ActionPreview, ComputerUseError> {
+        let proposed_at = chrono::Utc::now();
         Ok(ActionPreview {
             envelope: ActionEnvelope {
                 action_id: "action-1".into(),
@@ -66,8 +67,8 @@ impl ComputerUseRuntime for InProcessRuntime {
                 postcondition: None,
                 reversible: true,
                 external_side_effect: false,
-                proposed_at: "2026-07-13T10:00:00Z".into(),
-                expires_at: "2026-07-13T10:01:00Z".into(),
+                proposed_at: proposed_at.to_rfc3339(),
+                expires_at: (proposed_at + chrono::Duration::seconds(30)).to_rfc3339(),
                 args_digest: "digest-1".into(),
             },
             executable: true,
@@ -105,7 +106,7 @@ impl ComputerUseRuntime for InProcessRuntime {
             execution_mode: envelope.requested_mode,
             state: "active".into(),
             acquired_at: None,
-            expires_at: "2026-07-13T10:01:00Z".into(),
+            expires_at: (chrono::Utc::now() + chrono::Duration::seconds(30)).to_rfc3339(),
             action_budget: 1,
             actions_used: 0,
             boundaries: LeaseBoundaries::default(),

--- a/adk-computer-use/src/graph.rs
+++ b/adk-computer-use/src/graph.rs
@@ -1,17 +1,190 @@
+use crate::runtime::binding::{
+    validate_envelope_freshness, validate_lease, validate_receipt, validate_reservation,
+};
 use crate::{
-    ActionClass, ActionEnvelope, ActionPreview, ComputerUseAuthContext, ComputerUseRuntime,
-    ControlLease, ExecutionMode, ExecutionReceipt, ScopeAuthorizer, TargetReservation,
-    VerificationOutcome,
+    ActionClass, ActionPreview, ComputerUseAuthContext, ComputerUseRuntime, ControlLease,
+    ExecutionMode, ExecutionReceipt, ScopeAuthorizer, TargetReservation, VerificationOutcome,
 };
 use adk_graph::{
-    Checkpointer, CompiledGraph, DeferredNodeConfig, END, GraphError, MergeStrategy, NodeOutput,
-    START, StateGraph,
+    Channel, Checkpointer, CompiledGraph, DeferredNodeConfig, END, GraphError, MergeStrategy,
+    NodeOutput, START, StateGraph, StateSchema,
 };
 use serde_json::{Value, json};
 use std::sync::Arc;
 
 fn node_error(node: &str, message: impl Into<String>) -> GraphError {
     GraphError::NodeExecutionFailed { node: node.to_string(), message: message.into() }
+}
+
+fn preview_route(preview: &ActionPreview) -> &'static str {
+    if preview.executable {
+        "allowed"
+    } else if preview.blocker.as_deref() == Some("approval_required") {
+        "approval"
+    } else {
+        "blocked"
+    }
+}
+
+fn reservation_from_state(
+    value: Option<&Value>,
+    node: &str,
+) -> Result<Option<TargetReservation>, GraphError> {
+    match value {
+        None | Some(Value::Null) => Ok(None),
+        Some(value) => serde_json::from_value(value.clone())
+            .map(Some)
+            .map_err(|error| node_error(node, format!("invalid target reservation: {error}"))),
+    }
+}
+
+fn validate_preview_history(
+    preview: &ActionPreview,
+    history: Option<&Value>,
+    node: &str,
+) -> Result<(), GraphError> {
+    let history = history
+        .and_then(Value::as_array)
+        .ok_or_else(|| node_error(node, "missing append-only preview history"))?;
+    if history.len() != 1 {
+        return Err(node_error(
+            node,
+            format!(
+                "append-only preview history contains {} entries instead of exactly one; \
+                 resumed state may have attempted to replace the approved preview",
+                history.len()
+            ),
+        ));
+    }
+    let original: ActionPreview = serde_json::from_value(history[0].clone())
+        .map_err(|error| node_error(node, format!("invalid preview history: {error}")))?;
+    if original != *preview {
+        return Err(node_error(node, "preview changed after policy evaluation; refusing mutation"));
+    }
+    Ok(())
+}
+
+fn validate_execution_approval(
+    preview: &ActionPreview,
+    route: Option<&str>,
+    approval: Option<&Value>,
+    approval_grant_id: Option<&str>,
+    approved_action_digest: Option<&str>,
+    approved_policy_digest: Option<&str>,
+) -> Result<(), GraphError> {
+    let expected_route = preview_route(preview);
+    if route != Some(expected_route) {
+        return Err(node_error(
+            "execute",
+            "preview route changed after policy evaluation; refusing mutation",
+        ));
+    }
+
+    match expected_route {
+        "allowed" => {
+            if approval_grant_id.is_some()
+                || approved_action_digest.is_some()
+                || approved_policy_digest.is_some()
+            {
+                return Err(node_error(
+                    "execute",
+                    "an allowed preview carried stale approval authority",
+                ));
+            }
+        }
+        "approval" => {
+            let approval = approval.and_then(Value::as_object).ok_or_else(|| {
+                node_error("execute", "approval state is missing before mutation")
+            })?;
+            let action_digest = approval.get("actionDigest").and_then(Value::as_str);
+            let policy_digest = approval.get("policyDigest").and_then(Value::as_str);
+            if action_digest != Some(preview.envelope.args_digest.as_str())
+                || policy_digest != Some(preview.policy.policy_digest.as_str())
+                || approved_action_digest != action_digest
+                || approved_policy_digest != policy_digest
+            {
+                return Err(node_error(
+                    "execute",
+                    "approval no longer matches the exact preview action and policy digests",
+                ));
+            }
+
+            let supplied_grant = approval.get("grantId").and_then(Value::as_str);
+            let runtime_approved =
+                approval.get("runtimeApproved").and_then(Value::as_bool).unwrap_or(false);
+            let exact_grant = supplied_grant.is_some()
+                && supplied_grant == approval_grant_id
+                && !runtime_approved;
+            let runtime_holds_grant =
+                supplied_grant.is_none() && approval_grant_id.is_none() && runtime_approved;
+            if !exact_grant && !runtime_holds_grant {
+                return Err(node_error(
+                    "execute",
+                    "approval authority changed after the digest-bound approval step",
+                ));
+            }
+        }
+        _ => {
+            return Err(node_error("execute", "a blocked preview reached the mutation node"));
+        }
+    }
+
+    Ok(())
+}
+
+async fn release_on_error<T>(
+    runtime: &Arc<dyn ComputerUseRuntime>,
+    reservation: Option<&TargetReservation>,
+    node: &str,
+    result: Result<T, GraphError>,
+) -> Result<T, GraphError> {
+    let Err(primary) = result else {
+        return result;
+    };
+    let Some(reservation) = reservation else {
+        return Err(primary);
+    };
+    match runtime.release_target(reservation).await {
+        Ok(()) => Err(primary),
+        Err(cleanup) => Err(node_error(
+            node,
+            format!(
+                "primary failure: {primary}; target reservation cleanup also failed for {}: \
+                 {cleanup}",
+                reservation.reservation_id
+            ),
+        )),
+    }
+}
+
+async fn release_after_terminal<T>(
+    runtime: &Arc<dyn ComputerUseRuntime>,
+    reservation: Option<&TargetReservation>,
+    node: &str,
+    result: Result<T, GraphError>,
+) -> Result<T, GraphError> {
+    let Some(reservation) = reservation else {
+        return result;
+    };
+    match (result, runtime.release_target(reservation).await) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Ok(_), Err(cleanup)) => Err(node_error(
+            node,
+            format!(
+                "target reservation cleanup failed for {}: {cleanup}",
+                reservation.reservation_id
+            ),
+        )),
+        (Err(primary), Ok(())) => Err(primary),
+        (Err(primary), Err(cleanup)) => Err(node_error(
+            node,
+            format!(
+                "primary failure: {primary}; target reservation cleanup also failed for {}: \
+                 {cleanup}",
+                reservation.reservation_id
+            ),
+        )),
+    }
 }
 
 /// Build the flagship deterministic ADK graph.
@@ -41,22 +214,31 @@ pub fn build_reference_graph_with_checkpointer(
     let execute_runtime = runtime.clone();
     let verify_runtime = runtime;
 
-    StateGraph::with_channels(&[
-        "proposed_action",
-        "capabilities",
-        "visual_evidence",
-        "semantic_evidence",
-        "observations_joined",
-        "preview",
-        "route",
-        "approval",
-        "approval_grant_id",
-        "reservation",
-        "lease",
-        "receipt",
-        "verified",
-        "result",
-    ])
+    StateGraph::new({
+        let mut schema = StateSchema::simple(&[
+            "proposed_action",
+            "capabilities",
+            "visual_evidence",
+            "semantic_evidence",
+            "observations_joined",
+            "preview",
+            "route",
+            "approval",
+            "approval_grant_id",
+            "approved_action_digest",
+            "approved_policy_digest",
+            "reservation",
+            "lease",
+            "receipt",
+            "verified",
+            "result",
+        ]);
+        // A resumed caller cannot overwrite an append-only channel. Supplying another preview
+        // creates a second entry, and the approval/execute checks fail closed unless exactly
+        // the original runtime preview remains.
+        schema.channels.insert("preview_history".into(), Channel::list("preview_history"));
+        schema
+    })
     .add_node_fn("discover", move |_| {
         let runtime = capability_runtime.clone();
         async move {
@@ -121,15 +303,13 @@ pub fn build_reference_graph_with_checkpointer(
                 .preview_action(proposed)
                 .await
                 .map_err(|error| node_error("preview", error.to_string()))?;
-            let route = if preview.executable {
-                "allowed"
-            } else if preview.blocker.as_deref() == Some("approval_required") {
-                "approval"
-            } else {
-                "blocked"
-            };
+            validate_envelope_freshness(&preview.envelope)
+                .map_err(|error| node_error("preview", error.to_string()))?;
+            let route = preview_route(&preview);
+            let preview = serde_json::to_value(preview)?;
             Ok(NodeOutput::new()
-                .with_update("preview", serde_json::to_value(preview)?)
+                .with_update("preview", preview.clone())
+                .with_update("preview_history", preview)
                 .with_update("route", json!(route)))
         }
     })
@@ -139,6 +319,7 @@ pub fn build_reference_graph_with_checkpointer(
                 .cloned()
                 .ok_or_else(|| node_error("request_approval", "missing preview"))?,
         )?;
+        validate_preview_history(&preview, ctx.get("preview_history"), "request_approval")?;
         let approval = ctx.get("approval").and_then(Value::as_object);
         let approved_digest =
             approval.and_then(|value| value.get("actionDigest")).and_then(Value::as_str);
@@ -157,17 +338,22 @@ pub fn build_reference_graph_with_checkpointer(
                 "computer-use action requires scoped approval",
                 serde_json::to_value(&preview)?,
             )),
-            (Some(digest), Some(policy), Some(grant_id), _)
+            (Some(digest), Some(policy), Some(grant_id), false)
                 if digest == preview.envelope.args_digest
                     && policy == preview.policy.policy_digest =>
             {
-                Ok(NodeOutput::new().with_update("approval_grant_id", json!(grant_id)))
+                Ok(NodeOutput::new()
+                    .with_update("approval_grant_id", json!(grant_id))
+                    .with_update("approved_action_digest", json!(digest))
+                    .with_update("approved_policy_digest", json!(policy)))
             }
             (Some(digest), Some(policy), None, true)
                 if digest == preview.envelope.args_digest
                     && policy == preview.policy.policy_digest =>
             {
-                Ok(NodeOutput::new())
+                Ok(NodeOutput::new()
+                    .with_update("approved_action_digest", json!(digest))
+                    .with_update("approved_policy_digest", json!(policy)))
             }
             _ => Err(node_error(
                 "request_approval",
@@ -192,121 +378,165 @@ pub fn build_reference_graph_with_checkpointer(
                     .cloned()
                     .ok_or_else(|| node_error("reserve_target", "missing preview"))?,
             )?;
+            validate_preview_history(&preview, ctx.get("preview_history"), "reserve_target")?;
             let reservation = runtime
                 .reserve_target(&preview.envelope)
                 .await
                 .map_err(|error| node_error("reserve_target", error.to_string()))?;
-            Ok(NodeOutput::new().with_update("reservation", serde_json::to_value(reservation)?))
+            if let Some(reservation) = reservation.as_ref() {
+                let validation = validate_reservation(reservation, &preview.envelope)
+                    .map_err(|error| node_error("reserve_target", error.to_string()));
+                release_on_error(&runtime, Some(reservation), "reserve_target", validation).await?;
+            }
+            let serialized = serde_json::to_value(&reservation)
+                .map_err(|error| node_error("reserve_target", error.to_string()));
+            let serialized =
+                release_on_error(&runtime, reservation.as_ref(), "reserve_target", serialized)
+                    .await?;
+            Ok(NodeOutput::new().with_update("reservation", serialized))
         }
     })
     .add_node_fn("acquire_lease", move |ctx| {
         let runtime = lease_runtime.clone();
         async move {
-            let preview: ActionPreview = serde_json::from_value(
-                ctx.get("preview")
-                    .cloned()
-                    .ok_or_else(|| node_error("acquire_lease", "missing preview"))?,
-            )?;
-            let lease = runtime
-                .acquire_lease(&preview.envelope)
-                .await
+            let reservation = reservation_from_state(ctx.get("reservation"), "acquire_lease")?;
+            let result = async {
+                let preview: ActionPreview = serde_json::from_value(
+                    ctx.get("preview")
+                        .cloned()
+                        .ok_or_else(|| node_error("acquire_lease", "missing preview"))?,
+                )
                 .map_err(|error| node_error("acquire_lease", error.to_string()))?;
-            Ok(NodeOutput::new().with_update("lease", serde_json::to_value(lease)?))
+                let lease = runtime
+                    .acquire_lease(&preview.envelope)
+                    .await
+                    .map_err(|error| node_error("acquire_lease", error.to_string()))?;
+                validate_lease(&lease, &preview.envelope)
+                    .map_err(|error| node_error("acquire_lease", error.to_string()))?;
+                let lease = serde_json::to_value(lease)
+                    .map_err(|error| node_error("acquire_lease", error.to_string()))?;
+                Ok(NodeOutput::new().with_update("lease", lease))
+            }
+            .await;
+            release_on_error(&runtime, reservation.as_ref(), "acquire_lease", result).await
         }
     })
     .add_node_fn("execute", move |ctx| {
         let runtime = execute_runtime.clone();
         let authorizer = authorizer.clone();
         async move {
-            let preview: ActionPreview = serde_json::from_value(
-                ctx.get("preview")
-                    .cloned()
-                    .ok_or_else(|| node_error("execute", "missing preview"))?,
-            )?;
-            let lease: ControlLease = serde_json::from_value(
-                ctx.get("lease").cloned().ok_or_else(|| node_error("execute", "missing lease"))?,
-            )?;
-            let envelope = &preview.envelope;
-            let auth = ComputerUseAuthContext {
-                principal_id: envelope.principal_id.clone(),
-                tenant_id: authorizer.verified_tenant_id().map(str::to_owned),
-                session_id: envelope.session_id.clone(),
-                execution_group_id: envelope.execution_group_id.clone().unwrap_or_default(),
-                requested_mode: envelope.requested_mode,
-                action_class: envelope.action_class,
-                target_app: envelope.target.as_ref().map(|target| target.app_id.clone()),
-                target_window: envelope
-                    .target
-                    .as_ref()
-                    .and_then(|target| target.window_id.as_ref())
-                    .map(|value| match value {
-                        Value::String(value) => value.clone(),
-                        value => value.to_string(),
-                    }),
-                policy_digest: preview.policy.policy_digest.clone(),
-            };
-            authorizer
-                .authorize(&auth)
-                .map_err(|error| node_error("execute", error.to_string()))?;
-            let receipt = runtime
-                .execute_action(
-                    envelope,
-                    &lease,
-                    ctx.get("approval_grant_id").and_then(Value::as_str),
+            let reservation = reservation_from_state(ctx.get("reservation"), "execute")?;
+            let result = async {
+                let preview: ActionPreview = serde_json::from_value(
+                    ctx.get("preview")
+                        .cloned()
+                        .ok_or_else(|| node_error("execute", "missing preview"))?,
                 )
-                .await
                 .map_err(|error| node_error("execute", error.to_string()))?;
-            Ok(NodeOutput::new().with_update("receipt", serde_json::to_value(receipt)?))
+                let lease: ControlLease = serde_json::from_value(
+                    ctx.get("lease")
+                        .cloned()
+                        .ok_or_else(|| node_error("execute", "missing lease"))?,
+                )
+                .map_err(|error| node_error("execute", error.to_string()))?;
+                let envelope = &preview.envelope;
+                validate_preview_history(&preview, ctx.get("preview_history"), "execute")?;
+                validate_envelope_freshness(envelope)
+                    .map_err(|error| node_error("execute", error.to_string()))?;
+                validate_lease(&lease, envelope)
+                    .map_err(|error| node_error("execute", error.to_string()))?;
+                if let Some(reservation) = reservation.as_ref() {
+                    validate_reservation(reservation, envelope)
+                        .map_err(|error| node_error("execute", error.to_string()))?;
+                }
+                validate_execution_approval(
+                    &preview,
+                    ctx.get("route").and_then(Value::as_str),
+                    ctx.get("approval"),
+                    ctx.get("approval_grant_id").and_then(Value::as_str),
+                    ctx.get("approved_action_digest").and_then(Value::as_str),
+                    ctx.get("approved_policy_digest").and_then(Value::as_str),
+                )?;
+                let auth = ComputerUseAuthContext {
+                    principal_id: envelope.principal_id.clone(),
+                    tenant_id: authorizer.verified_tenant_id().map(str::to_owned),
+                    session_id: envelope.session_id.clone(),
+                    execution_group_id: envelope.execution_group_id.clone().unwrap_or_default(),
+                    requested_mode: envelope.requested_mode,
+                    action_class: envelope.action_class,
+                    target_app: envelope.target.as_ref().map(|target| target.app_id.clone()),
+                    target_window: envelope
+                        .target
+                        .as_ref()
+                        .and_then(|target| target.window_id.as_ref())
+                        .map(|value| match value {
+                            Value::String(value) => value.clone(),
+                            value => value.to_string(),
+                        }),
+                    policy_digest: preview.policy.policy_digest.clone(),
+                };
+                authorizer
+                    .authorize(&auth)
+                    .map_err(|error| node_error("execute", error.to_string()))?;
+                let receipt = runtime
+                    .execute_action(
+                        envelope,
+                        &lease,
+                        ctx.get("approval_grant_id").and_then(Value::as_str),
+                    )
+                    .await
+                    .map_err(|error| node_error("execute", error.to_string()))?;
+                validate_receipt(&receipt, envelope, &envelope.args_digest)
+                    .map_err(|error| node_error("execute", error.to_string()))?;
+                let receipt = serde_json::to_value(receipt)
+                    .map_err(|error| node_error("execute", error.to_string()))?;
+                Ok(NodeOutput::new().with_update("receipt", receipt))
+            }
+            .await;
+            release_on_error(&runtime, reservation.as_ref(), "execute", result).await
         }
     })
     .add_node_fn("verify", move |ctx| {
         let runtime = verify_runtime.clone();
         async move {
-            let receipt: ExecutionReceipt = serde_json::from_value(
-                ctx.get("receipt")
-                    .cloned()
-                    .ok_or_else(|| node_error("verify", "missing receipt"))?,
-            )?;
-            // The postcondition comes from the envelope the action was approved against, so
-            // verification is evaluated against what was promised rather than against nothing.
-            let postcondition = ctx
-                .get("envelope")
-                .and_then(|value| serde_json::from_value::<ActionEnvelope>(value.clone()).ok())
-                .and_then(|envelope| envelope.postcondition);
-
-            let outcome = runtime
-                .verify(&receipt, postcondition.as_ref())
-                .await
+            let reservation = reservation_from_state(ctx.get("reservation"), "verify")?;
+            let result = async {
+                let receipt: ExecutionReceipt = serde_json::from_value(
+                    ctx.get("receipt")
+                        .cloned()
+                        .ok_or_else(|| node_error("verify", "missing receipt"))?,
+                )
                 .map_err(|error| node_error("verify", error.to_string()))?;
-            if let Some(reservation) = ctx.get("reservation")
-                && !reservation.is_null()
-            {
-                let reservation: TargetReservation = serde_json::from_value(reservation.clone())?;
-                runtime
-                    .release_target(&reservation)
+                let preview: ActionPreview = serde_json::from_value(
+                    ctx.get("preview")
+                        .cloned()
+                        .ok_or_else(|| node_error("verify", "missing preview"))?,
+                )
+                .map_err(|error| node_error("verify", error.to_string()))?;
+                let outcome = runtime
+                    .verify(&receipt, preview.envelope.postcondition.as_ref())
                     .await
                     .map_err(|error| node_error("verify", error.to_string()))?;
-            }
-            // `verified` is true only when the postcondition was observed. A committed action
-            // with no evidence reports `committed_unverified` and carries the reason, instead
-            // of being labelled completed.
-            let detail = match &outcome {
-                VerificationOutcome::Verified => None,
-                VerificationOutcome::CommittedUnverified { reason }
-                | VerificationOutcome::Failed { reason } => Some(reason.clone()),
-            };
+                let detail = match &outcome {
+                    VerificationOutcome::Verified => None,
+                    VerificationOutcome::CommittedUnverified { reason }
+                    | VerificationOutcome::Failed { reason } => Some(reason.clone()),
+                };
 
-            Ok(NodeOutput::new()
-                .with_update("verified", json!(outcome.is_verified()))
-                .with_update("committed", json!(outcome.is_committed()))
-                .with_update(
-                    "result",
-                    json!({
-                        "status": outcome.status(),
-                        "receiptId": receipt.receipt_id,
-                        "verificationDetail": detail,
-                    }),
-                ))
+                Ok(NodeOutput::new()
+                    .with_update("verified", json!(outcome.is_verified()))
+                    .with_update("committed", json!(outcome.is_committed()))
+                    .with_update(
+                        "result",
+                        json!({
+                            "status": outcome.status(),
+                            "receiptId": receipt.receipt_id,
+                            "verificationDetail": detail,
+                        }),
+                    ))
+            }
+            .await;
+            release_after_terminal(&runtime, reservation.as_ref(), "verify", result).await
         }
     })
     .add_edge(START, "discover")

--- a/adk-computer-use/src/runtime/binding.rs
+++ b/adk-computer-use/src/runtime/binding.rs
@@ -12,6 +12,50 @@
 use crate::contracts::{ActionEnvelope, ControlLease, ExecutionReceipt, TargetReservation};
 use crate::error::ComputerUseError;
 
+/// Verifies that an action envelope is inside its runtime-declared validity window.
+///
+/// The runtime owns the validity duration. ADK only enforces that both timestamps are
+/// readable, that the interval is ordered, and that execution happens before `expires_at`.
+/// This check belongs immediately before mutation because an approval interrupt or lease
+/// acquisition can consume the rest of an otherwise-valid preview window.
+///
+/// # Errors
+///
+/// Returns [`ComputerUseError::IdentityMismatch`] when either timestamp is unreadable,
+/// `expires_at` is not later than `proposed_at`, or the envelope has expired.
+pub fn validate_envelope_freshness(envelope: &ActionEnvelope) -> Result<(), ComputerUseError> {
+    let proposed_at =
+        chrono::DateTime::parse_from_rfc3339(&envelope.proposed_at).map_err(|error| {
+            ComputerUseError::IdentityMismatch(format!(
+                "action envelope {} has an unreadable proposed_at {:?}: {error}",
+                envelope.action_id, envelope.proposed_at
+            ))
+        })?;
+    let expires_at =
+        chrono::DateTime::parse_from_rfc3339(&envelope.expires_at).map_err(|error| {
+            ComputerUseError::IdentityMismatch(format!(
+                "action envelope {} has an unreadable expires_at {:?}: {error}",
+                envelope.action_id, envelope.expires_at
+            ))
+        })?;
+
+    if expires_at <= proposed_at {
+        return Err(ComputerUseError::IdentityMismatch(format!(
+            "action envelope {} has a non-positive validity window: proposed_at is {} and \
+             expires_at is {}",
+            envelope.action_id, envelope.proposed_at, envelope.expires_at
+        )));
+    }
+    if expires_at <= chrono::Utc::now() {
+        return Err(ComputerUseError::IdentityMismatch(format!(
+            "action envelope {} expired at {}",
+            envelope.action_id, envelope.expires_at
+        )));
+    }
+
+    Ok(())
+}
+
 /// Reports a mismatch between what was requested and what came back.
 fn mismatch(object: &str, field: &str, expected: &str, actual: &str) -> ComputerUseError {
     ComputerUseError::IdentityMismatch(format!(
@@ -153,12 +197,13 @@ pub fn validate_lease(
     Ok(())
 }
 
-/// Verifies a reservation belongs to this session, principal, agent, and action.
+/// Verifies a reservation belongs to this action and is active, current, and target-bound.
 ///
 /// # Errors
 ///
 /// Returns [`ComputerUseError::IdentityMismatch`] when any bound field disagrees with
-/// `envelope`.
+/// `envelope`, the reservation is not active, its expiry cannot be established, or it has
+/// expired.
 pub fn validate_reservation(
     reservation: &TargetReservation,
     envelope: &ActionEnvelope,
@@ -188,6 +233,50 @@ pub fn validate_reservation(
         envelope.execution_group_id.as_deref(),
         reservation.execution_group_id.as_deref(),
     )?;
+
+    if reservation.intent_id != envelope.action_id {
+        return Err(mismatch(OBJECT, "intent_id", &envelope.action_id, &reservation.intent_id));
+    }
+    if !reservation.state.eq_ignore_ascii_case("active") {
+        return Err(ComputerUseError::IdentityMismatch(format!(
+            "target reservation {} is in state {:?}, not active",
+            reservation.reservation_id, reservation.state
+        )));
+    }
+    match chrono::DateTime::parse_from_rfc3339(&reservation.expires_at) {
+        Ok(expires_at) => {
+            if expires_at <= chrono::Utc::now() {
+                return Err(ComputerUseError::IdentityMismatch(format!(
+                    "target reservation {} expired at {}",
+                    reservation.reservation_id, reservation.expires_at
+                )));
+            }
+        }
+        Err(error) => {
+            return Err(ComputerUseError::IdentityMismatch(format!(
+                "target reservation {} has an unreadable expiry {:?}: {error}",
+                reservation.reservation_id, reservation.expires_at
+            )));
+        }
+    }
+
+    let target = envelope.target.as_ref().ok_or_else(|| {
+        ComputerUseError::IdentityMismatch(format!(
+            "target reservation {} was returned for action {} without target evidence",
+            reservation.reservation_id, envelope.action_id
+        ))
+    })?;
+    if reservation.scope.app_id != target.app_id {
+        return Err(mismatch(OBJECT, "scope.app_id", &target.app_id, &reservation.scope.app_id));
+    }
+    if reservation.scope.window_id != target.window_id {
+        return Err(mismatch(
+            OBJECT,
+            "scope.window_id",
+            &format!("{:?}", target.window_id),
+            &format!("{:?}", reservation.scope.window_id),
+        ));
+    }
 
     Ok(())
 }

--- a/adk-computer-use/src/runtime/mcp.rs
+++ b/adk-computer-use/src/runtime/mcp.rs
@@ -1,5 +1,7 @@
 use crate::runtime::VerificationOutcome;
-use crate::runtime::binding::{validate_lease, validate_receipt, validate_reservation};
+use crate::runtime::binding::{
+    validate_envelope_freshness, validate_lease, validate_receipt, validate_reservation,
+};
 use crate::{
     ActionEnvelope, ActionPreview, ComputerUseError, ComputerUseRuntime, ControlLease,
     ExecutionReceipt, SessionDeletionResult, SessionFollowUp, SessionFollowUpPage,
@@ -63,7 +65,13 @@ where
 {
     toolset: Arc<McpToolset<S>>,
     config: ComputerUseMcpConfig,
-    proposed: Mutex<HashMap<String, Map<String, Value>>>,
+    proposed: Mutex<HashMap<String, ProposedAction>>,
+}
+
+#[derive(Clone)]
+struct ProposedAction {
+    arguments: Map<String, Value>,
+    preview: ActionPreview,
 }
 
 impl<S> ComputerUseMcpRuntime<S>
@@ -389,7 +397,10 @@ where
                 "preview principal does not match authenticated ADK identity".into(),
             ));
         }
-        self.proposed.lock().await.insert(preview.envelope.action_id.clone(), args);
+        self.proposed.lock().await.insert(
+            preview.envelope.action_id.clone(),
+            ProposedAction { arguments: args, preview: preview.clone() },
+        );
         Ok(preview)
     }
 
@@ -475,10 +486,19 @@ where
         lease: &ControlLease,
         approval_grant_id: Option<&str>,
     ) -> Result<ExecutionReceipt, ComputerUseError> {
-        let mut args =
+        validate_envelope_freshness(envelope)?;
+        validate_lease(lease, envelope)?;
+        let proposed =
             self.proposed.lock().await.get(&envelope.action_id).cloned().ok_or_else(|| {
                 ComputerUseError::Runtime("missing exact proposed action for execution".into())
             })?;
+        if proposed.preview.envelope != *envelope {
+            return Err(ComputerUseError::IdentityMismatch(format!(
+                "action envelope {} changed after preview; exact preview binding is required",
+                envelope.action_id
+            )));
+        }
+        let mut args = proposed.arguments;
         args.insert("action_id".into(), json!(envelope.action_id));
         args.insert("lease_id".into(), json!(lease.lease_id));
         if let Some(grant) = approval_grant_id {

--- a/adk-computer-use/src/runtime/mod.rs
+++ b/adk-computer-use/src/runtime/mod.rs
@@ -79,8 +79,14 @@ impl VerificationOutcome {
 /// exactly one [`execute_action`](Self::execute_action),
 /// [`verify`](Self::verify), and [`release_target`](Self::release_target).
 ///
+/// The reference graph validates leases, reservations, receipts, envelope expiry, and
+/// approval bindings independently of the implementation. After a reservation is accepted,
+/// it calls [`release_target`](Self::release_target) on every later success or error path.
+///
 /// Implementations must treat the runtime (not graph or model state) as
-/// authoritative for policy, identity, lease ownership, and idempotency.
+/// authoritative for policy, identity, lease ownership, exact preview binding, and
+/// idempotency. Implementations that expose these methods outside the reference graph must
+/// enforce the same invariants at that direct-call boundary.
 ///
 /// # Errors
 ///
@@ -112,6 +118,9 @@ pub trait ComputerUseRuntime: Send + Sync {
         Ok(None)
     }
     /// Release a previously acquired [`TargetReservation`].
+    ///
+    /// The graph reports cleanup failures, including when another operation already failed,
+    /// so implementations should return an error instead of hiding an uncertain release.
     async fn release_target(
         &self,
         _reservation: &TargetReservation,

--- a/adk-computer-use/tests/reference_graph.rs
+++ b/adk-computer-use/tests/reference_graph.rs
@@ -2,8 +2,8 @@ use adk_computer_use::{
     ActionClass, ActionEnvelope, ActionPostcondition, ActionPreview, CancellationBridge,
     ComputerUseError, ComputerUseRuntime, ControlLease, ExecutionCapability, ExecutionMode,
     ExecutionReceipt, LeaseBoundaries, PolicyDecision, ReceiptStatus, ScopeAuthorizer,
-    TargetReservation, TargetReservationScope, VerificationOutcome, build_reference_graph,
-    build_reference_graph_with_checkpointer,
+    TargetEvidence, TargetReservation, TargetReservationScope, VerificationOutcome,
+    build_reference_graph, build_reference_graph_with_checkpointer,
 };
 use adk_graph::{ExecutionConfig, GraphError, MemoryCheckpointer, State};
 use async_trait::async_trait;
@@ -21,6 +21,15 @@ struct FakeRuntime {
     max_observation_concurrency: AtomicUsize,
     fail_after_first_commit: AtomicBool,
     fail_before_first_effect: AtomicBool,
+    fail_acquire: AtomicBool,
+    fail_verify: AtomicBool,
+    fail_release: AtomicBool,
+    expired_envelope: AtomicBool,
+    expire_during_acquire: AtomicBool,
+    wrong_lease_session: AtomicBool,
+    wrong_receipt_digest: AtomicBool,
+    wrong_reservation_intent: AtomicBool,
+    declared_postcondition: Option<ActionPostcondition>,
     receipts: Mutex<HashMap<String, ExecutionReceipt>>,
     last_approval_grant: Mutex<Option<String>>,
     cancellation_log: Mutex<Vec<String>>,
@@ -37,12 +46,26 @@ impl FakeRuntime {
             max_observation_concurrency: AtomicUsize::new(0),
             fail_after_first_commit: AtomicBool::new(false),
             fail_before_first_effect: AtomicBool::new(false),
+            fail_acquire: AtomicBool::new(false),
+            fail_verify: AtomicBool::new(false),
+            fail_release: AtomicBool::new(false),
+            expired_envelope: AtomicBool::new(false),
+            expire_during_acquire: AtomicBool::new(false),
+            wrong_lease_session: AtomicBool::new(false),
+            wrong_receipt_digest: AtomicBool::new(false),
+            wrong_reservation_intent: AtomicBool::new(false),
+            declared_postcondition: None,
             receipts: Mutex::new(HashMap::new()),
             last_approval_grant: Mutex::new(None),
             cancellation_log: Mutex::new(Vec::new()),
             reservations: AtomicUsize::new(0),
             releases: AtomicUsize::new(0),
         }
+    }
+
+    fn with_postcondition(mut self, postcondition: ActionPostcondition) -> Self {
+        self.declared_postcondition = Some(postcondition);
+        self
     }
 
     async fn observe(&self, kind: &str) -> Value {
@@ -54,6 +77,18 @@ impl FakeRuntime {
     }
 
     fn preview(&self) -> ActionPreview {
+        let proposed_at = if self.expired_envelope.load(Ordering::SeqCst) {
+            "2019-01-01T00:00:00Z".into()
+        } else {
+            "2026-07-13T10:00:00Z".into()
+        };
+        let expires_at = if self.expired_envelope.load(Ordering::SeqCst) {
+            "2020-01-01T00:01:00Z".into()
+        } else if self.expire_during_acquire.load(Ordering::SeqCst) {
+            (chrono::Utc::now() + chrono::Duration::milliseconds(100)).to_rfc3339()
+        } else {
+            "2099-01-01T00:01:00Z".into()
+        };
         ActionPreview {
             envelope: ActionEnvelope {
                 action_id: "action-1".into(),
@@ -65,16 +100,31 @@ impl FakeRuntime {
                 operation: "write_clipboard".into(),
                 action_class: ActionClass::EditReversible,
                 requested_mode: ExecutionMode::Background,
-                target: None,
+                target: Some(TargetEvidence {
+                    platform: "test".into(),
+                    app_id: "app.reference".into(),
+                    pid: None,
+                    window_id: None,
+                    window_title_digest: None,
+                    display_id: None,
+                    role: None,
+                    label_digest: None,
+                    bounds: None,
+                    observation_id: "observation-1".into(),
+                    screenshot_hash: None,
+                    ui_tree_revision: None,
+                    confidence: 1.0,
+                    captured_at: "2026-07-13T10:00:00Z".into(),
+                }),
                 target_sensitivity: None,
                 resource: None,
                 provenance: None,
                 data_labels: vec!["private".into()],
-                postcondition: None,
+                postcondition: self.declared_postcondition.clone(),
                 reversible: true,
                 external_side_effect: false,
-                proposed_at: "2026-07-13T10:00:00Z".into(),
-                expires_at: "2026-07-13T10:01:00Z".into(),
+                proposed_at,
+                expires_at,
                 args_digest: "digest-1".into(),
             },
             executable: self.blocker.is_none(),
@@ -128,17 +178,27 @@ impl ComputerUseRuntime for FakeRuntime {
         &self,
         envelope: &ActionEnvelope,
     ) -> Result<ControlLease, ComputerUseError> {
+        if self.fail_acquire.swap(false, Ordering::SeqCst) {
+            return Err(ComputerUseError::Runtime("injected lease failure".into()));
+        }
+        if self.expire_during_acquire.load(Ordering::SeqCst) {
+            sleep(Duration::from_millis(200)).await;
+        }
         Ok(ControlLease {
             lease_id: "lease-1".into(),
             revision: 1,
-            session_id: envelope.session_id.clone(),
+            session_id: if self.wrong_lease_session.load(Ordering::SeqCst) {
+                "another-session".into()
+            } else {
+                envelope.session_id.clone()
+            },
             principal_id: envelope.principal_id.clone(),
             agent_id: envelope.agent_id.clone(),
             kind: "cooperative".into(),
             execution_mode: envelope.requested_mode,
             state: "active".into(),
             acquired_at: None,
-            expires_at: "2026-07-13T10:01:00Z".into(),
+            expires_at: "2099-01-01T00:01:00Z".into(),
             action_budget: 1,
             actions_used: 0,
             boundaries: LeaseBoundaries::default(),
@@ -153,15 +213,22 @@ impl ComputerUseRuntime for FakeRuntime {
         Ok(Some(TargetReservation {
             reservation_id: "reservation-1".into(),
             revision: 1,
-            intent_id: envelope.action_id.clone(),
+            intent_id: if self.wrong_reservation_intent.load(Ordering::SeqCst) {
+                "another-action".into()
+            } else {
+                envelope.action_id.clone()
+            },
             session_id: envelope.session_id.clone(),
             principal_id: envelope.principal_id.clone(),
             execution_group_id: envelope.execution_group_id.clone(),
             agent_id: envelope.agent_id.clone(),
-            scope: TargetReservationScope { app_id: "app.reference".into(), window_id: None },
+            scope: TargetReservationScope {
+                app_id: envelope.target.as_ref().unwrap().app_id.clone(),
+                window_id: envelope.target.as_ref().unwrap().window_id.clone(),
+            },
             state: "active".into(),
             acquired_at: "2026-07-13T10:00:00Z".into(),
-            expires_at: "2026-07-13T10:01:00Z".into(),
+            expires_at: "2099-01-01T00:01:00Z".into(),
             terminal_reason: None,
         }))
     }
@@ -171,6 +238,9 @@ impl ComputerUseRuntime for FakeRuntime {
         _reservation: &TargetReservation,
     ) -> Result<(), ComputerUseError> {
         self.releases.fetch_add(1, Ordering::SeqCst);
+        if self.fail_release.load(Ordering::SeqCst) {
+            return Err(ComputerUseError::Runtime("injected reservation cleanup failure".into()));
+        }
         Ok(())
     }
 
@@ -193,7 +263,11 @@ impl ComputerUseRuntime for FakeRuntime {
             receipt_id: "receipt-1".into(),
             session_id: envelope.session_id.clone(),
             action_id: envelope.action_id.clone(),
-            action_digest: envelope.args_digest.clone(),
+            action_digest: if self.wrong_receipt_digest.load(Ordering::SeqCst) {
+                "wrong-digest".into()
+            } else {
+                envelope.args_digest.clone()
+            },
             attempt: 1,
             status: ReceiptStatus::Committed,
             created_at: None,
@@ -213,6 +287,9 @@ impl ComputerUseRuntime for FakeRuntime {
         receipt: &ExecutionReceipt,
         postcondition: Option<&ActionPostcondition>,
     ) -> Result<VerificationOutcome, ComputerUseError> {
+        if self.fail_verify.swap(false, Ordering::SeqCst) {
+            return Err(ComputerUseError::Runtime("injected verification failure".into()));
+        }
         if receipt.status != ReceiptStatus::Committed {
             return Ok(VerificationOutcome::Failed {
                 reason: format!("receipt status is {:?}", receipt.status),
@@ -425,6 +502,246 @@ async fn approval_resume_rejects_a_changed_policy_digest_before_mutation() {
 }
 
 #[tokio::test]
+async fn approval_resume_rejects_ambiguous_runtime_and_grant_authority() {
+    let runtime = Arc::new(FakeRuntime::new(Some("approval_required")));
+    let graph = build_reference_graph_with_checkpointer(
+        runtime.clone(),
+        authorizer(),
+        Some(Arc::new(MemoryCheckpointer::new())),
+    )
+    .unwrap();
+    let checkpoint_id = match graph
+        .invoke(input(), ExecutionConfig::new("thread-ambiguous-approval"))
+        .await
+        .unwrap_err()
+    {
+        GraphError::Interrupted(value) => value.checkpoint_id,
+        other => panic!("expected interrupt, got {other:?}"),
+    };
+    let mut resumed_input = State::new();
+    resumed_input.insert(
+        "approval".into(),
+        json!({
+            "actionDigest": "digest-1",
+            "policyDigest": "policy-1",
+            "grantId": "grant-exact",
+            "runtimeApproved": true
+        }),
+    );
+
+    let error = graph
+        .invoke(
+            resumed_input,
+            ExecutionConfig::new("thread-ambiguous-approval").with_resume_from(&checkpoint_id),
+        )
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("does not match"), "{error}");
+    assert_eq!(runtime.reservations.load(Ordering::SeqCst), 0);
+    assert_eq!(runtime.physical_mutations.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn approval_resume_cannot_replace_the_checkpointed_preview() {
+    let runtime = Arc::new(FakeRuntime::new(Some("approval_required")));
+    let graph = build_reference_graph_with_checkpointer(
+        runtime.clone(),
+        authorizer(),
+        Some(Arc::new(MemoryCheckpointer::new())),
+    )
+    .unwrap();
+    let checkpoint_id = match graph
+        .invoke(input(), ExecutionConfig::new("thread-preview-replacement"))
+        .await
+        .unwrap_err()
+    {
+        GraphError::Interrupted(value) => value.checkpoint_id,
+        other => panic!("expected interrupt, got {other:?}"),
+    };
+
+    let mut changed_preview = runtime.preview();
+    changed_preview.envelope.action_id = "action-2".into();
+    changed_preview.envelope.args_digest = "digest-2".into();
+    changed_preview.policy.policy_digest = "policy-2".into();
+    let changed_preview = serde_json::to_value(changed_preview).unwrap();
+    let mut resumed_input = State::new();
+    resumed_input.insert("preview".into(), changed_preview.clone());
+    resumed_input.insert("preview_history".into(), json!([changed_preview]));
+    resumed_input.insert(
+        "approval".into(),
+        json!({
+            "actionDigest": "digest-2",
+            "policyDigest": "policy-2",
+            "grantId": "grant-replacement"
+        }),
+    );
+
+    let error = graph
+        .invoke(
+            resumed_input,
+            ExecutionConfig::new("thread-preview-replacement").with_resume_from(&checkpoint_id),
+        )
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("preview history"), "{error}");
+    assert_eq!(runtime.reservations.load(Ordering::SeqCst), 0);
+    assert_eq!(runtime.physical_mutations.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn graph_rejects_an_expired_preview_before_reservation_or_mutation() {
+    let runtime = Arc::new(FakeRuntime::new(None));
+    runtime.expired_envelope.store(true, Ordering::SeqCst);
+    let graph = build_reference_graph(runtime.clone(), authorizer()).unwrap();
+
+    let error =
+        graph.invoke(input(), ExecutionConfig::new("thread-expired-envelope")).await.unwrap_err();
+
+    assert!(error.to_string().contains("expired"), "{error}");
+    assert_eq!(runtime.reservations.load(Ordering::SeqCst), 0);
+    assert_eq!(runtime.physical_mutations.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn graph_rechecks_envelope_expiry_immediately_before_mutation() {
+    let runtime = Arc::new(FakeRuntime::new(None));
+    runtime.expire_during_acquire.store(true, Ordering::SeqCst);
+    let graph = build_reference_graph(runtime.clone(), authorizer()).unwrap();
+
+    let error =
+        graph.invoke(input(), ExecutionConfig::new("thread-expired-at-execute")).await.unwrap_err();
+
+    assert!(error.to_string().contains("expired"), "{error}");
+    assert_eq!(runtime.reservations.load(Ordering::SeqCst), 1);
+    assert_eq!(runtime.releases.load(Ordering::SeqCst), 1);
+    assert_eq!(runtime.physical_mutations.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn graph_rejects_a_mismatched_generic_runtime_reservation_and_releases_it() {
+    let runtime = Arc::new(FakeRuntime::new(None));
+    runtime.wrong_reservation_intent.store(true, Ordering::SeqCst);
+    let graph = build_reference_graph(runtime.clone(), authorizer()).unwrap();
+
+    let error =
+        graph.invoke(input(), ExecutionConfig::new("thread-wrong-reservation")).await.unwrap_err();
+
+    assert!(error.to_string().contains("intent_id"), "{error}");
+    assert_eq!(runtime.reservations.load(Ordering::SeqCst), 1);
+    assert_eq!(runtime.releases.load(Ordering::SeqCst), 1);
+    assert_eq!(runtime.physical_mutations.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn graph_rejects_a_mismatched_generic_runtime_lease_and_releases_reservation() {
+    let runtime = Arc::new(FakeRuntime::new(None));
+    runtime.wrong_lease_session.store(true, Ordering::SeqCst);
+    let graph = build_reference_graph(runtime.clone(), authorizer()).unwrap();
+
+    let error =
+        graph.invoke(input(), ExecutionConfig::new("thread-wrong-lease")).await.unwrap_err();
+
+    assert!(error.to_string().contains("session_id"), "{error}");
+    assert_eq!(runtime.releases.load(Ordering::SeqCst), 1);
+    assert_eq!(runtime.physical_mutations.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn graph_rejects_a_mismatched_generic_runtime_receipt_and_releases_reservation() {
+    let runtime = Arc::new(FakeRuntime::new(None));
+    runtime.wrong_receipt_digest.store(true, Ordering::SeqCst);
+    let graph = build_reference_graph(runtime.clone(), authorizer()).unwrap();
+
+    let error =
+        graph.invoke(input(), ExecutionConfig::new("thread-wrong-receipt")).await.unwrap_err();
+
+    assert!(error.to_string().contains("action_digest"), "{error}");
+    assert_eq!(runtime.physical_mutations.load(Ordering::SeqCst), 1);
+    assert_eq!(runtime.releases.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn graph_verifies_the_postcondition_from_the_preview_envelope() {
+    let runtime =
+        Arc::new(FakeRuntime::new(None).with_postcondition(ActionPostcondition::Filesystem {
+            path: "/tmp/report.txt".into(),
+            exists: true,
+            content_digest: Some("expected-digest".into()),
+        }));
+    let graph = build_reference_graph(runtime, authorizer()).unwrap();
+
+    let output = graph.invoke(input(), ExecutionConfig::new("thread-postcondition")).await.unwrap();
+
+    assert_eq!(output.get("verified"), Some(&json!(true)));
+    assert_eq!(output.get("committed"), Some(&json!(true)));
+}
+
+#[tokio::test]
+async fn graph_releases_reservation_when_lease_acquisition_fails() {
+    let runtime = Arc::new(FakeRuntime::new(None));
+    runtime.fail_acquire.store(true, Ordering::SeqCst);
+    let graph = build_reference_graph(runtime.clone(), authorizer()).unwrap();
+
+    let error =
+        graph.invoke(input(), ExecutionConfig::new("thread-lease-failure")).await.unwrap_err();
+
+    assert!(error.to_string().contains("injected lease failure"), "{error}");
+    assert_eq!(runtime.releases.load(Ordering::SeqCst), 1);
+    assert_eq!(runtime.physical_mutations.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn graph_releases_reservation_when_verification_fails() {
+    let runtime = Arc::new(FakeRuntime::new(None));
+    runtime.fail_verify.store(true, Ordering::SeqCst);
+    let graph = build_reference_graph(runtime.clone(), authorizer()).unwrap();
+
+    let error =
+        graph.invoke(input(), ExecutionConfig::new("thread-verify-failure")).await.unwrap_err();
+
+    assert!(error.to_string().contains("injected verification failure"), "{error}");
+    assert_eq!(runtime.physical_mutations.load(Ordering::SeqCst), 1);
+    assert_eq!(runtime.releases.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn graph_reports_primary_and_cleanup_failures_deterministically() {
+    let runtime = Arc::new(FakeRuntime::new(None));
+    runtime.fail_acquire.store(true, Ordering::SeqCst);
+    runtime.fail_release.store(true, Ordering::SeqCst);
+    let graph = build_reference_graph(runtime.clone(), authorizer()).unwrap();
+
+    let error =
+        graph.invoke(input(), ExecutionConfig::new("thread-double-failure")).await.unwrap_err();
+    let message = error.to_string();
+
+    assert!(message.contains("primary failure"), "{message}");
+    assert!(message.contains("injected lease failure"), "{message}");
+    assert!(message.contains("cleanup also failed"), "{message}");
+    assert!(message.contains("injected reservation cleanup failure"), "{message}");
+    assert_eq!(runtime.releases.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn graph_reports_cleanup_failure_after_successful_verification() {
+    let runtime = Arc::new(FakeRuntime::new(None));
+    runtime.fail_release.store(true, Ordering::SeqCst);
+    let graph = build_reference_graph(runtime.clone(), authorizer()).unwrap();
+
+    let error =
+        graph.invoke(input(), ExecutionConfig::new("thread-cleanup-failure")).await.unwrap_err();
+    let message = error.to_string();
+
+    assert!(message.contains("target reservation cleanup failed"), "{message}");
+    assert!(message.contains("injected reservation cleanup failure"), "{message}");
+    assert!(!message.contains("primary failure"), "{message}");
+    assert_eq!(runtime.physical_mutations.load(Ordering::SeqCst), 1);
+    assert_eq!(runtime.releases.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
 async fn cancellation_bridge_revokes_runtime_before_interrupting_adk() {
     let runtime = Arc::new(FakeRuntime::new(None));
     let runtime_for_interrupt = runtime.clone();
@@ -457,6 +774,7 @@ async fn graph_retry_after_post_commit_crash_does_not_duplicate_mutation() {
     assert_eq!(output.get("committed"), Some(&json!(true)));
     assert_eq!(output.get("verified"), Some(&json!(false)));
     assert_eq!(runtime.physical_mutations.load(Ordering::SeqCst), 1);
+    assert_eq!(runtime.releases.load(Ordering::SeqCst), 2);
 }
 
 #[tokio::test]
@@ -475,4 +793,5 @@ async fn graph_retry_after_pre_effect_crash_executes_exactly_once() {
     assert_eq!(output.get("committed"), Some(&json!(true)));
     assert_eq!(output.get("verified"), Some(&json!(false)));
     assert_eq!(runtime.physical_mutations.load(Ordering::SeqCst), 1);
+    assert_eq!(runtime.releases.load(Ordering::SeqCst), 2);
 }

--- a/adk-computer-use/tests/response_binding_tests.rs
+++ b/adk-computer-use/tests/response_binding_tests.rs
@@ -12,7 +12,9 @@
 //! occurred — so a committed action whose effect did not happen was reported as completed,
 //! from a node the reference graph labels "verify".
 
-use adk_computer_use::runtime::binding::{validate_lease, validate_receipt, validate_reservation};
+use adk_computer_use::runtime::binding::{
+    validate_envelope_freshness, validate_lease, validate_receipt, validate_reservation,
+};
 use adk_computer_use::{
     ActionClass, ActionEnvelope, ActionPostcondition, ControlLease, ExecutionMode,
     ExecutionReceipt, LeaseBoundaries, ReceiptStatus, TargetReservation, TargetReservationScope,
@@ -30,7 +32,7 @@ fn envelope() -> ActionEnvelope {
         operation: "click".into(),
         action_class: ActionClass::EditReversible,
         requested_mode: ExecutionMode::Foreground,
-        target: None,
+        target: Some(target_for("app-1")),
         target_sensitivity: None,
         postcondition: None,
         reversible: true,
@@ -72,7 +74,7 @@ fn reservation() -> TargetReservation {
     TargetReservation {
         reservation_id: "res-1".into(),
         revision: 1,
-        intent_id: "intent-1".into(),
+        intent_id: "action-1".into(),
         session_id: "session-1".into(),
         principal_id: "principal-1".into(),
         execution_group_id: Some("group-1".into()),
@@ -178,6 +180,59 @@ fn a_reservation_for_another_session_or_principal_or_group_is_rejected() {
 }
 
 #[test]
+fn a_reservation_for_another_intent_is_rejected() {
+    let mut reservation = reservation();
+    reservation.intent_id = "action-2".into();
+
+    let error = validate_reservation(&reservation, &envelope()).expect_err("must reject");
+    assert!(error.to_string().contains("intent_id"), "{error}");
+}
+
+#[test]
+fn an_inactive_or_expired_reservation_is_rejected() {
+    let mut inactive = reservation();
+    inactive.state = "released".into();
+    let error = validate_reservation(&inactive, &envelope()).expect_err("must reject");
+    assert!(error.to_string().contains("not active"), "{error}");
+
+    let mut expired = reservation();
+    expired.expires_at = "2020-01-01T00:00:00Z".into();
+    let error = validate_reservation(&expired, &envelope()).expect_err("must reject");
+    assert!(error.to_string().contains("expired"), "{error}");
+}
+
+#[test]
+fn a_reservation_with_an_unreadable_expiry_is_rejected() {
+    let mut reservation = reservation();
+    reservation.expires_at = "later".into();
+
+    let error = validate_reservation(&reservation, &envelope()).expect_err("must reject");
+    assert!(error.to_string().contains("unreadable expiry"), "{error}");
+}
+
+#[test]
+fn a_reservation_for_another_target_scope_is_rejected() {
+    let mut wrong_app = reservation();
+    wrong_app.scope.app_id = "app-2".into();
+    let error = validate_reservation(&wrong_app, &envelope()).expect_err("must reject");
+    assert!(error.to_string().contains("scope.app_id"), "{error}");
+
+    let mut envelope = envelope();
+    envelope.target.as_mut().unwrap().window_id = Some(serde_json::json!(42));
+    let error = validate_reservation(&reservation(), &envelope).expect_err("must reject");
+    assert!(error.to_string().contains("scope.window_id"), "{error}");
+}
+
+#[test]
+fn a_reservation_without_target_evidence_is_rejected() {
+    let mut envelope = envelope();
+    envelope.target = None;
+
+    let error = validate_reservation(&reservation(), &envelope).expect_err("must reject");
+    assert!(error.to_string().contains("without target evidence"), "{error}");
+}
+
+#[test]
 fn a_correctly_bound_receipt_is_accepted() {
     let envelope = envelope();
     assert!(validate_receipt(&receipt(), &envelope, &envelope.args_digest).is_ok());
@@ -211,6 +266,35 @@ fn a_receipt_for_another_session_is_rejected() {
     let mut receipt = receipt();
     receipt.session_id = "session-2".into();
     assert!(validate_receipt(&receipt, &envelope, &envelope.args_digest).is_err());
+}
+
+#[test]
+fn a_current_action_envelope_is_accepted() {
+    assert!(validate_envelope_freshness(&envelope()).is_ok());
+}
+
+#[test]
+fn an_expired_or_malformed_action_envelope_is_rejected() {
+    let mut expired = envelope();
+    expired.proposed_at = "2019-01-01T00:00:00Z".into();
+    expired.expires_at = "2020-01-01T00:00:00Z".into();
+    let error = validate_envelope_freshness(&expired).expect_err("must reject");
+    assert!(error.to_string().contains("expired"), "{error}");
+
+    let mut malformed = envelope();
+    malformed.proposed_at = "eventually".into();
+    let error = validate_envelope_freshness(&malformed).expect_err("must reject");
+    assert!(error.to_string().contains("unreadable proposed_at"), "{error}");
+}
+
+#[test]
+fn a_non_positive_action_validity_window_is_rejected() {
+    let mut envelope = envelope();
+    envelope.proposed_at = "2099-01-01T00:00:01Z".into();
+    envelope.expires_at = "2099-01-01T00:00:00Z".into();
+
+    let error = validate_envelope_freshness(&envelope).expect_err("must reject");
+    assert!(error.to_string().contains("non-positive validity window"), "{error}");
 }
 
 // ── CU-02: committed is not verified ──────────────────────────────────

--- a/docs/official_docs/computer-use/index.md
+++ b/docs/official_docs/computer-use/index.md
@@ -7,16 +7,18 @@ verification as a deterministic graph, and checks what the external runtime retu
 ## Response binding
 
 The external runtime is authoritative, but its responses are checked locally before entering
-graph state. Typed deserialization proves shape, not provenance — `ControlLease`,
-`TargetReservation`, and `ExecutionReceipt` have no invariant-enforcing constructor, so a
-well-formed object belonging to a different session parses cleanly.
+graph state. The checks run in the reference graph for every `ComputerUseRuntime`
+implementation, and the MCP adapter repeats them at its direct-call boundary. Typed
+deserialization proves shape, not provenance — `ControlLease`, `TargetReservation`, and
+`ExecutionReceipt` have no invariant-enforcing constructor, so a well-formed object belonging
+to a different session parses cleanly.
 
 Each response is bound back to the request that produced it:
 
 | Response | Checked against the envelope |
 |----------|------------------------------|
 | `ControlLease` | `session_id`, `principal_id`, `agent_id`, `execution_mode`, active state, **unexpired** `expires_at`, **remaining** budget (`actions_used < action_budget`), and target within `boundaries` |
-| `TargetReservation` | `session_id`, `principal_id`, `agent_id`, `execution_group_id` |
+| `TargetReservation` | `session_id`, `principal_id`, `agent_id`, `execution_group_id`, `intent_id == action_id`, active state, unexpired `expires_at`, and exact app/window target scope |
 | `ExecutionReceipt` | `session_id`, `action_id`, and `action_digest` against the envelope's `args_digest` |
 
 A mismatch produces `ComputerUseError::IdentityMismatch` naming the field, and the response is
@@ -35,6 +37,43 @@ validate_lease(&lease, &envelope)?;
 
 An optional field that comes back absent is treated as under-specification, not contradiction;
 a field that is present and different is a mismatch.
+
+## Execution-time revalidation
+
+Preview is not mutation authority. The reference graph revalidates all mutation inputs in the
+`execute` node immediately before calling `execute_action`:
+
+| Input | Immediate check |
+|-------|-----------------|
+| `ActionEnvelope` | RFC 3339 timestamps, positive validity window, and `now < expires_at` |
+| `ControlLease` | identity, mode, active state, remaining budget, expiry, and target boundaries |
+| `TargetReservation` | identity, action intent, active state, expiry, and exact target scope |
+| Approval | route, action digest, policy digest, and exactly one authority source (`grantId` or runtime-held approval) |
+
+The envelope check also runs when preview returns, so an already-expired preview never reaches
+reservation or approval. It runs again at execution because an approval interrupt, target
+reservation, or lease acquisition can consume the remaining validity window.
+
+`ComputerUseMcpRuntime` retains the exact envelope returned by `preview_action`. A direct
+`execute_action` call is rejected if any envelope field changes after preview, even when the
+action ID still matches.
+
+For checkpoint resume, the graph stores the runtime preview in an append-only state channel.
+Approval and execution require that channel to contain exactly one preview matching the active
+preview. Resume input can add state but cannot replace the checkpointed value: an attempted
+replacement creates a second entry and fails before reservation or mutation.
+
+## Reservation cleanup
+
+Once a reservation is accepted, every terminal path attempts to release it:
+
+- lease acquisition, authorization, validation, execution, receipt, and verification failures;
+- successful verification; and
+- reservation validation or serialization failures when the runtime returned a reservation.
+
+The primary failure stays primary when cleanup succeeds. If cleanup also fails, the graph
+returns one deterministic error containing both failures. A cleanup failure after otherwise
+successful verification is returned as an error rather than hidden.
 
 ## Verification is not commitment
 


### PR DESCRIPTION
## What

- Apply lease, reservation, and receipt binding validation in the reference graph for every `ComputerUseRuntime`, including non-MCP implementations.
- Bind target reservations to the exact action intent, active state, unexpired lifetime, and exact app/window scope.
- Revalidate the action envelope, lease, reservation, approval route, action digest, policy digest, and authority source immediately before the single executor call.
- Preserve the checkpointed runtime preview in an append-only channel so resume input cannot replace the approved preview.
- Retain the exact preview envelope in `ComputerUseMcpRuntime` and reject changed envelopes at its direct execution boundary.
- Release accepted reservations after successful verification and on every later validation, acquisition, authorization, execution, receipt, or verification failure.
- Read verification postconditions from `preview.envelope` instead of the nonexistent `envelope` state channel.

## Why

Typed deserialization proves payload shape, not provenance. The MCP adapter validated runtime responses, but the reference graph accepted equivalent values from generic runtimes without those checks. Approval and lease latency could also outlive a preview without an execution-time expiry check, checkpoint resume input could replace preview state, and reservations were released only after successful verification.

These gaps allowed stale or mismatched authority to reach the mutation boundary and left reservations behind on error paths.

## How

- Add `validate_envelope_freshness` and strengthen `validate_reservation`.
- Add append-only preview history and exact approval-authority checks in the graph.
- Revalidate all mutation inputs directly around `execute_action` while preserving exactly one executor node.
- Combine primary and cleanup failures deterministically without hiding either result.
- Add adversarial regressions for preview replacement, expiry during lease acquisition, mismatched generic runtime values, postcondition propagation, and cleanup failures.
- Update the portable example, crate README, official documentation, and changelog.

## Verification

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p adk-computer-use --all-targets -- -D warnings`
- [x] `cargo nextest run -p adk-computer-use --no-fail-fast` — 66 passed
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc -p adk-computer-use --no-deps`
- [x] `RUSTDOCFLAGS='-D warnings' cargo test -p adk-computer-use --doc` — 3 passed
- [x] Pre-commit hook: full-workspace clippy and formatting passed
- [x] Pre-push hook: workspace `cargo check` passed
