### PR TITLE
fix(sandbox): close Windows and audit release gates

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -18,6 +18,12 @@ ignore = [
     "RUSTSEC-2026-0195",
     "RUSTSEC-2026-0194",
 
+    # pyo3 0.28: iterator out-of-bounds read and missing Sync bound. The crate
+    # appears only as jiter 0.15's disabled `python` feature in monty 0.0.19;
+    # no workspace feature enables it. See the security advisory review.
+    "RUSTSEC-2026-0176",
+    "RUSTSEC-2026-0177",
+
     # rsa: Marvin timing side-channel (no upstream fix, accepted risk)
     "RUSTSEC-2023-0071",
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **adk-sandbox now preserves Windows shell quoting and selects the intended Rust
+  linker.** Raw command text reaches `cmd.exe` without `CommandLineToArgvW`
+  escaping, so quoted executable and script paths work. Direct sandboxed Rust
+  compilation uses the toolchain's `rust-lld` instead of accidentally resolving
+  Git's unrelated GNU `link.exe` from `PATH` on hosted Windows runners.
+
+### Security
+
+- **Wasmtime is updated to 46.0.2.** This resolves RUSTSEC-2026-0222 and
+  RUSTSEC-2026-0223. The PyO3 0.28 advisories are documented as unreachable:
+  PyO3 exists only in the lockfile through jiter's disabled `python` feature,
+  and no workspace feature compiles it. The supply-chain license policy now
+  recognizes Monty's OSI-approved Unicode-DFS-2016 data license.
+
 ### Changed
 
 - **adk-codeact-monty joined the root workspace.** Monty is on crates.io since

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1330,7 +1330,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1341,7 +1341,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3831,7 +3831,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3860,7 +3860,7 @@ dependencies = [
  "maybe-owned",
  "rustix 1.1.4",
  "rustix-linux-procfs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
  "winx",
 ]
 
@@ -4514,27 +4514,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e06aeba2c965fc446d13c56a6ccb2631b78445d7544543dd9a25289977630914"
+checksum = "47ca6361f42d0c945fadc1103501e1c07438e034fd5a86896a3074eff3e860bd"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2d2dde4ec1352715595b5cfa6fe2e5b8ebb9da3457b3ee8db0aa2808c069aa"
+checksum = "2c1dbc96db7cebf747bd5722d482338a5acff91d6be43b6bec145f9471327ffa"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b4982ef9fa54ec9eee841e891e7ddc5434be1250e88de31572e000c888f30b"
+checksum = "353b309eef494e4adb4c6cca76f30ef27daa907534db7d05b5986500f51aa4e1"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -4542,9 +4542,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "529143118c4eeb58c39ecb02319557d512be6c61348486422974ab8e3906b8a8"
+checksum = "e3cafe127a4c5d9765b1df54052245d2cbaca7238782805bb5ac94986ccdb591"
 dependencies = [
  "serde",
  "serde_derive",
@@ -4553,9 +4553,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7780677247ad3577e3a6a3ebf43f39b325a11d6393db72b2c9968a910d4d13d"
+checksum = "3964f31c6dc9d21e926ef884d3eec2f1ca83266a233521da4a737143262ceb84"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -4584,9 +4584,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9645250416cbf92454fe61160e17e026e0ce405906a54500b114f923ddffc9"
+checksum = "b2f8b35746603b792e4ae34499a39251f310a06c98d4bc2ca02cf4bd29ce3c84"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -4597,24 +4597,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20ee8d222ff0fd3681791979afbf88586ac9f49010d3db96b3cbe4c96759aee3"
+checksum = "584bd91987927dfe35e79c5d6dd52a117cb64c4fce26df881d02dcc17bd59a8f"
 
 [[package]]
 name = "cranelift-control"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "591abe6f5312bd2c4220f1b3bead56c2ad00257c52668015ba013b85dcf2a17a"
+checksum = "af277352af76db01bb42fa4978b672a44406715798edb693cc02e363e12dc505"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5300c49cf940526fe771517b3b3eabd5d0ff164ee61698579cf403fe8d3af3c"
+checksum = "42ad4f0c556d3d57580d07477be9e665f4d2a826971a5ab4642ead20a19df443"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -4624,9 +4624,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da4adbf760207fdbbe130f1191cce01cdef66831a9f648b1f39ff2800d126d45"
+checksum = "29d69a6b7d8412c716e8599c7330dfbd122c1bc145f3bda05a9e237fba20419d"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.17.1",
@@ -4637,15 +4637,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8315b21ff018226a42a60a4702c2dd75f6447cac26e9bca622e14c22088c2ff5"
+checksum = "52fcdcd4a5c7fa8bfea35e72c0979ad5a699c836364870f0a84169d02a085a88"
 
 [[package]]
 name = "cranelift-native"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d506ef23a60715bde451b06620b14402166ded3b648454fccbf04f3e46a4aa70"
+checksum = "0fee933cf8ec90e58e68163a02bdb0e4d29f2260a7592b3f09cbba52fcd34d12"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -4654,9 +4654,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ed47e602652e3410f9387fc0db70fefadcee4d78a78881421aabcab4e26b89"
+checksum = "6bd75e1e2719808c80af27ebe168d2220ec10e519e1d5a52bdbed9bd5cac1a32"
 
 [[package]]
 name = "crc"
@@ -6389,7 +6389,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6776,7 +6776,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7351,7 +7351,7 @@ checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7906,8 +7906,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -9215,7 +9215,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -9302,7 +9302,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -9813,7 +9813,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
 dependencies = [
  "io-lifetimes",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9875,7 +9875,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12616,7 +12616,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -14271,7 +14271,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -14291,8 +14291,8 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -14326,7 +14326,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -14339,7 +14339,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -14440,9 +14440,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b92604caae1a1899b6a5b54967289dd538177c626004c91accf9d0ec7e4a12"
+checksum = "3683e69168d2e2374cea51a79fce2e9870e7c622366b8bf7af87fb5c2428a2a9"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -14452,9 +14452,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a7ac85c0bb3fb351f10d531230aaa5e366b46d7c4e5328e5f02801d6dac1165"
+checksum = "8ebbd6dada1e3df36ea4a4b8feca2ed230aa92d59e55bf5714eb4286cdd632b0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14663,7 +14663,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.40",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -14702,7 +14702,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -16016,7 +16016,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -16029,7 +16029,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -16141,7 +16141,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -16522,7 +16522,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -16587,7 +16587,7 @@ checksum = "4db5a4a562bcc0017c34cd0efbabf447be783f00576a2a516947f884e6a7ed57"
 dependencies = [
  "ahash 0.8.12",
  "annotate-snippets",
- "base64 0.22.1",
+ "base64 0.21.7",
  "encoding_rs_io",
  "nohash-hasher",
  "num-traits",
@@ -17023,7 +17023,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -17035,7 +17035,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f103c50866b8743da9429b8a581d81a27c2d3a9c4ac7df8f8571c1dd7896eda"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -17058,7 +17058,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -18376,7 +18376,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -18416,7 +18416,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -19517,7 +19517,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -20224,9 +20224,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4213d2f019a5e44aa8a61d8826dd33a505bff79f749b14a8bafd67321cb9351"
+checksum = "ed27b4a4a5271d2608406a99c8d1cf8aea1e894fe4ec361d470063bcf342f1d7"
 dependencies = [
  "addr2line 0.26.1",
  "async-trait",
@@ -20277,9 +20277,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45863de41977ec6453e859cf843d456fa3fcb45a659b66d16e794f90ec4f5b7"
+checksum = "7712f99b0920d4638023405eb9723ef200efd6d39bfc7466c92e926ca5d130f0"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -20308,9 +20308,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "438bc7dc45fb75297d75f79a9a0ce852345d13ebc6a6863f6f688f013836a9dd"
+checksum = "bb07d96412d6958817749712969cfd6416cbce11639c3f3431dc659816d84ace"
 dependencies = [
  "base64 0.22.1",
  "directories-next",
@@ -20328,9 +20328,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1e48f8d4966d62a10b6d70722bc432c1e163890be2801d3b5784589ad36ffc3"
+checksum = "f60f3492a55dbd4eb2e4f1f33ed0626d141f5f4cf4c0194168a4c5006f6601b0"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -20343,15 +20343,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819ad5abd5822a22dbf4014475cdfd1fe790707761cd732d74aaa3ba4d5ba489"
+checksum = "c777c83bb4c3414b23fe84fecd47a46016a0a0b0a39aa786cad0a701fe3cbc7f"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fc28372e36eaf8cf70faa83b5779137f7e99c8d18569a125d1580e735cc9e4d"
+checksum = "ffb54b5de8723a9acf2c0bc531df8e773462796a5f87e8f49a3d5ea5c3b32ef7"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
@@ -20361,9 +20361,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a433efc6e35112a5457e1dc8bc4d8d39820ac7722267e89bc04e5df641f32124"
+checksum = "9c60bb70116a88791ccceef605b31010c4888a7305e450f01dc7d4f430ad25f0"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -20388,9 +20388,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a1d3a39d0d210f6b8574ee96a4315e0a14c67f3a1fc3cd5372cb10d2fb4422"
+checksum = "24bdf54907e0bad31ad6676d03ed1008fa21489725635136f9c38979c39a98ed"
 dependencies = [
  "cc",
  "cfg-if",
@@ -20403,9 +20403,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f667288cb4dfa68a4639ffac4d5628535dda64ebdc2b990526efb12b30ba803"
+checksum = "ef4edaf07e20511f3ca070a4a0f026c407969f09e536075729872f548ca6f8d4"
 dependencies = [
  "cc",
  "object 0.39.1",
@@ -20415,9 +20415,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba651d44ab0faad4c58106b3adb45068189fb65ef50f0c404b6d9e3bf81a357"
+checksum = "f96a6d7eb246d1306b7db8915a169cd8628a9e6b8299d1d1f8ab109801ef0a66"
 dependencies = [
  "cfg-if",
  "libc",
@@ -20427,9 +20427,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ecc52563b0558af2a7487eb710de07cc4532564b55528876129238e83118cb1"
+checksum = "39472572ea3eb11b7cc7fe7bd6df0005cef87b580eb06a3378d103ac99d45bc3"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -20440,9 +20440,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e747f4a074699ba1b4e4d841fb263f9b7df5bd1555181c4752bf5990d21ba676"
+checksum = "7bf2eff1c108b01566a7c8870de34821e7bda7d327e86e12a548c026e1e3677d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -20451,9 +20451,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80009f46991622814196d96fac6fc0a938f46b5cba737a8f4e21e24e5a03856f"
+checksum = "d1d9d3ffd05d6e864adc35cff702f56307c454caec3b1d2d89dd6c843219b663"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -20464,9 +20464,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f65ef30a2c5478873cdb619085a7a649d3ce41cc3eaf298a7ce3dee96a8e11"
+checksum = "b88f243a21e600902fd03bd970df7e4671d760d724c9fad202166fd98c842548"
 dependencies = [
  "async-trait",
  "bitflags 2.13.0",
@@ -20493,9 +20493,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee57d5fef4976b1ab542615f4cef2c43278eb549d8078939668ea0f13d5c696"
+checksum = "0373c9dc92c9373aa9cee05963ea438bc318bf07bb284bede77a9ce24b39f682"
 dependencies = [
  "async-trait",
  "bytes",
@@ -20710,9 +20710,9 @@ checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "wiggle"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e03df88bf1a6068b02851aa3ef9427d285118f5c1c153b068a8995c69dd9562a"
+checksum = "9914a7e8ac8cb37be90753103e2aa96959e9e5d2f549a2d081bcfeb8fa97e08d"
 dependencies = [
  "bitflags 2.13.0",
  "thiserror 2.0.18",
@@ -20724,9 +20724,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e014aec8661b613154377e4b49dbbb0dfc4f424efcee749782054576c00537d9"
+checksum = "789b4c6d82c1ae0f5003eb6c5b9d3c9fb80112c4be50ad2690eb7347f0edd852"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -20738,9 +20738,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f67310a8ae5190b7f3dcacf8697f2890701a3a8427b3e77ed91d3632dcedaceb"
+checksum = "c5be72b12200c1270ee5cc9c6c30450e9ba5abdcb5fe8d09d08b516b7bd974d3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -20770,7 +20770,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -21374,7 +21374,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags 2.13.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/adk-sandbox/src/process.rs
+++ b/adk-sandbox/src/process.rs
@@ -388,6 +388,12 @@ impl ProcessBackend {
         // the compiler needs the same boundary as the binary it produces.
         let compile_result = {
             let mut cmd = Command::new(&self.config.rustc_path);
+            // Cargo applies the workspace's rust-lld setting, but this direct rustc
+            // invocation does not read .cargo/config.toml. Hosted Windows runners put
+            // Git's GNU `link.exe` ahead of MSVC on PATH, so naming rust-lld prevents
+            // rustc from launching the unrelated Unix utility.
+            #[cfg(windows)]
+            cmd.arg("-Clinker=rust-lld");
             cmd.arg(&src_path).arg("-o").arg(&bin_path);
             self.run_command_with_env(cmd, request, &Self::toolchain_env()).await?
         };
@@ -426,11 +432,21 @@ impl ProcessBackend {
 
     /// Executes a raw shell command via the platform shell.
     async fn execute_command(&self, request: &ExecRequest) -> Result<ExecResult, SandboxError> {
-        let cmd = if cfg!(windows) {
+        #[cfg(windows)]
+        let cmd = {
+            use std::os::windows::process::CommandExt;
+
             let mut c = Command::new("cmd");
-            c.arg("/C").arg(&request.code);
+            c.arg("/D").arg("/C");
+            // `cmd.exe` does not follow CommandLineToArgvW escaping. In particular,
+            // Command::arg turns embedded quotes into `\"`, which makes a quoted
+            // executable path part of the program name. The command is already an
+            // explicitly requested shell program, so pass it with cmd's own syntax.
+            c.as_std_mut().raw_arg(&request.code);
             c
-        } else {
+        };
+        #[cfg(not(windows))]
+        let cmd = {
             let mut c = Command::new("sh");
             c.arg("-c").arg(&request.code);
             c
@@ -706,6 +722,21 @@ mod tests {
         let result = backend.execute(request).await.unwrap();
         assert!(result.stdout.contains("hello"), "stdout: {}", result.stdout);
         assert_eq!(result.exit_code, 0);
+    }
+
+    #[tokio::test]
+    #[cfg(windows)]
+    async fn test_command_supports_quoted_script_paths() {
+        let directory = tempfile::tempdir().unwrap();
+        let script = directory.path().join("quoted helper.cmd");
+        std::fs::write(&script, "@echo quoted-path-ok\r\n").unwrap();
+
+        let backend = ProcessBackend::default();
+        let request = make_request(Language::Command, &format!("\"{}\"", script.display()));
+        let result = backend.execute(request).await.unwrap();
+
+        assert_eq!(result.exit_code, 0, "stderr: {}", result.stderr);
+        assert!(result.stdout.contains("quoted-path-ok"), "stdout: {}", result.stdout);
     }
 
     #[tokio::test]

--- a/adk-sandbox/tests/output_cap_tests.rs
+++ b/adk-sandbox/tests/output_cap_tests.rs
@@ -26,41 +26,14 @@ fn shell_request(script: &str) -> ExecRequest {
 }
 
 /// The executable as it must appear inside a shell command string.
-///
-/// On Windows the command reaches `cmd /C` through `Command::arg`, which escapes an
-/// embedded `"` as `\"`. `cmd.exe` does not read that escape, so it strips the outer pair
-/// and tries to run the remaining backslash-quoted text as a program name. The path is
-/// therefore passed **unquoted**, which is only representable when it contains no space —
-/// see [`helper_invocation_supported`].
 #[cfg(windows)]
 fn shell_executable(path: &Path) -> String {
-    path.display().to_string()
+    format!("\"{}\"", path.display())
 }
 
 #[cfg(not(windows))]
 fn shell_executable(path: &Path) -> String {
     format!("'{}'", path.display().to_string().replace('\'', "'\\''"))
-}
-
-/// Whether this platform can express an invocation of the helper.
-///
-/// Windows only: a path containing a space has no unquoted form, and a quoted one cannot
-/// survive `Command::arg` (see [`shell_executable`]). Such a checkout is skipped rather
-/// than reported as a cap failure it is not. Cargo target paths in CI contain no space.
-fn helper_invocation_supported() -> bool {
-    if !cfg!(windows) {
-        return true;
-    }
-    let exe = std::env::current_exe().expect("the test executable path is available");
-    !exe.display().to_string().contains(' ')
-}
-
-/// Emits the skip notice for a checkout whose path the shell cannot receive.
-fn skip_unsupported_path() {
-    eprintln!(
-        "skipped: the test executable path contains a space, which cmd.exe cannot be given \
-         unquoted; the output cap itself is unaffected"
-    );
 }
 
 fn helper_request(stream: &str, bytes: usize) -> ExecRequest {
@@ -120,10 +93,6 @@ fn output_producer() {
 /// 64 MiB of stdout is retained only up to the cap.
 #[tokio::test]
 async fn stdout_far_beyond_the_cap_is_capped() {
-    if !helper_invocation_supported() {
-        skip_unsupported_path();
-        return;
-    }
     let backend = ProcessBackend::new(ProcessConfig::default());
     // 64 MiB: large enough that buffering it all would be obvious, small enough to stay quick.
     let result = backend
@@ -144,10 +113,6 @@ async fn stdout_far_beyond_the_cap_is_capped() {
 /// The same bound applies to stderr.
 #[tokio::test]
 async fn stderr_far_beyond_the_cap_is_capped() {
-    if !helper_invocation_supported() {
-        skip_unsupported_path();
-        return;
-    }
     let backend = ProcessBackend::new(ProcessConfig::default());
     let result = backend
         .execute(helper_request("stderr", 32 * 1_024 * 1_024))
@@ -165,10 +130,6 @@ async fn stderr_far_beyond_the_cap_is_capped() {
 /// would hit the timeout rather than exiting cleanly.
 #[tokio::test]
 async fn a_process_exceeding_the_cap_still_exits_cleanly() {
-    if !helper_invocation_supported() {
-        skip_unsupported_path();
-        return;
-    }
     let backend = ProcessBackend::new(ProcessConfig::default());
     let result = backend
         .execute(helper_request("stdout-then-done", 8 * 1_024 * 1_024))
@@ -192,10 +153,6 @@ async fn small_output_is_returned_intact() {
 /// Truncated output must say so, so a model is not handed a silent partial result.
 #[tokio::test]
 async fn truncated_output_carries_a_notice() {
-    if !helper_invocation_supported() {
-        skip_unsupported_path();
-        return;
-    }
     let backend = ProcessBackend::new(ProcessConfig::default());
     let result = backend
         .execute(helper_request("stdout", 4 * 1_024 * 1_024))
@@ -211,10 +168,6 @@ async fn truncated_output_carries_a_notice() {
 /// A smaller configured cap is honoured.
 #[tokio::test]
 async fn the_cap_is_configurable() {
-    if !helper_invocation_supported() {
-        skip_unsupported_path();
-        return;
-    }
     let config = ProcessConfig { max_output_bytes: 4_096, ..ProcessConfig::default() };
     let backend = ProcessBackend::new(config);
     let result = backend

--- a/adk-sandbox/tests/property_tests.rs
+++ b/adk-sandbox/tests/property_tests.rs
@@ -3,17 +3,21 @@
 //! Uses `proptest` with 100+ iterations per property.
 
 use proptest::prelude::*;
+#[cfg(not(windows))]
 use proptest::test_runner::TestCaseError;
 use std::collections::HashMap;
 use std::time::Duration;
 
-use adk_sandbox::{ExecRequest, Language, ProcessBackend, SandboxBackend, SandboxError};
+use adk_sandbox::{ExecRequest, Language};
+#[cfg(not(windows))]
+use adk_sandbox::{ProcessBackend, SandboxBackend, SandboxError};
 
 // ---------------------------------------------------------------------------
 // Generators
 // ---------------------------------------------------------------------------
 
 /// Generates arbitrary environment variable names (alphanumeric + underscore).
+#[cfg(not(windows))]
 fn arb_env_key() -> impl Strategy<Value = String> {
     "[A-Z][A-Z0-9_]{1,15}".prop_filter("avoid PATH and system vars", |k| {
         !matches!(k.as_str(), "PATH" | "HOME" | "USER" | "SHELL" | "TERM" | "LANG" | "PWD")
@@ -21,11 +25,13 @@ fn arb_env_key() -> impl Strategy<Value = String> {
 }
 
 /// Generates arbitrary environment variable values.
+#[cfg(not(windows))]
 fn arb_env_value() -> impl Strategy<Value = String> {
     "[a-zA-Z0-9_]{1,30}"
 }
 
 /// Generates a small set of environment variables (0 to 5 entries).
+#[cfg(not(windows))]
 fn arb_env_map() -> impl Strategy<Value = HashMap<String, String>> {
     prop::collection::hash_map(arb_env_key(), arb_env_value(), 0..=5)
 }

--- a/deny.toml
+++ b/deny.toml
@@ -36,6 +36,11 @@ ignore = [
     "RUSTSEC-2026-0194",
     "RUSTSEC-2026-0195",
 
+    # pyo3 0.28 — present only in the lockfile through jiter 0.15's disabled
+    # `python` feature. No workspace feature enables or compiles PyO3.
+    "RUSTSEC-2026-0176",
+    "RUSTSEC-2026-0177",
+
     # rsa — Marvin timing side-channel. No upstream fix exists.
     "RUSTSEC-2023-0071",
 
@@ -70,6 +75,7 @@ ignore = [
 # Permissive licenses plus MPL-2.0. MPL-2.0 is file-level copyleft, satisfied by
 # linking without relicensing this workspace; it arrives through the `symphonia`
 # audio decoders and the `cssparser`/`selectors` sanitizer stack.
+# Unicode-DFS-2016 covers the Unicode name tables embedded by Monty.
 allow = [
     "0BSD",
     "Apache-2.0",
@@ -85,6 +91,7 @@ allow = [
     "MPL-2.0",
     "NCSA",
     "Unicode-3.0",
+    "Unicode-DFS-2016",
     "Unlicense",
     "Zlib",
 ]

--- a/docs/official_docs/sandbox/index.md
+++ b/docs/official_docs/sandbox/index.md
@@ -34,10 +34,10 @@ Two things about the process backend worth knowing:
   compiled by a command built outside the shared path, so the compile had no enforcer
   wrapper, no timeout, and no process group. That matters because compilation is not
   inert: `include_str!` reads files and procedural macros run arbitrary code before the
-  produced binary exists. The compile phase does receive toolchain variables (`PATH`,
-  `SDKROOT`, `DEVELOPER_DIR`, `HOME`, `TMPDIR`, `RUSTUP_HOME`, `CARGO_HOME`) when they
-  are set, because `rustc` cannot invoke a linker without them; an OS enforcer is what
-  constrains that phase.
+  produced binary exists. The compile phase receives a platform-specific toolchain
+  allow-list; on Windows this includes `LIB` and uses the Rust toolchain's `rust-lld`
+  linker so an unrelated `link.exe` earlier on `PATH` cannot be selected. An OS
+  enforcer is what constrains that phase.
 
 ### Environment Precedence
 

--- a/docs/security/DEPENDENCY-ADVISORIES.md
+++ b/docs/security/DEPENDENCY-ADVISORIES.md
@@ -8,7 +8,7 @@ The purpose of this file is to provide transparency to consumers about the secur
 
 These accepted advisories are also configured in [`.cargo/audit.toml`](../../.cargo/audit.toml) so that `cargo audit` passes in CI while still surfacing new, unreviewed advisories.
 
-**Last reviewed:** 2026-07-26 (2.0.0 release review)
+**Last reviewed:** 2026-08-01 (2.0.0 release review)
 
 ---
 
@@ -19,10 +19,27 @@ These accepted advisories are also configured in [`.cargo/audit.toml`](../../.ca
 | RUSTSEC-2026-0193, RUSTSEC-2026-0213 | `ammonia` | Lockfile updated to 4.1.4. |
 | RUSTSEC-2026-0204 | `crossbeam-epoch` | Lockfile updated to 0.9.20. |
 | RUSTSEC-2026-0194, RUSTSEC-2026-0195 | `quick-xml` (declared) | `adk-eval` now requires quick-xml 0.41. The transitive 0.26 copy is covered below. |
+| RUSTSEC-2026-0222, RUSTSEC-2026-0223 | `wasmtime` | Lockfile updated from 46.0.1 to 46.0.2. |
 
 ---
 
 ## Active Advisories
+
+### RUSTSEC-2026-0176, RUSTSEC-2026-0177 — pyo3 0.28: memory and thread safety
+
+- **Crate:** `pyo3` (0.28.3)
+- **Severity:** Memory safety
+- **Advisories:**
+  - [RUSTSEC-2026-0176](https://rustsec.org/advisories/RUSTSEC-2026-0176) — out-of-bounds reads in list and tuple iterator skipping
+  - [RUSTSEC-2026-0177](https://rustsec.org/advisories/RUSTSEC-2026-0177) — missing `Sync` bound on Python-callable closures
+- **ADK Impact:** `adk-codeact-monty` → `monty 0.0.19` → `jiter 0.15`. Jiter declares PyO3 as an optional dependency for its `python` feature, so Cargo records it in `Cargo.lock` even when that feature is disabled.
+- **Status:** Patched in PyO3 0.29. Monty 0.0.19 requires jiter 0.15, whose Python feature requires PyO3 0.28; the compatible jiter 0.16 line is outside Monty's version constraint.
+- **Disposition:** Accepted risk — dependency feature is unreachable
+- **Conditions:** Both advisories require PyO3 code to be compiled and the affected Python APIs to be called.
+- **ADK-Specific Context:** No workspace feature enables `jiter/python`; `cargo tree --workspace --all-features -i pyo3@0.28.3` has no reachable package. CodeAct uses jiter's pure-Rust parser through Monty.
+- **Mitigation:** Keep the advisory exceptions synchronized in `.cargo/audit.toml` and `deny.toml`. Remove them when Monty upgrades to a jiter release using PyO3 0.29 or later.
+
+---
 
 ### RUSTSEC-2026-0194, RUSTSEC-2026-0195 — quick-xml 0.26: parser denial of service
 


### PR DESCRIPTION
## What

- Preserves quoted command and executable paths through cmd.exe.
- Selects rust-lld for direct Windows Rust compilation.
- Updates Wasmtime to 46.0.2 and documents unreachable PyO3 advisories.
- Recognizes Monty's OSI-approved Unicode-DFS-2016 data license.

## Why

- Restores the Windows merge tier and nightly supply-chain gates for the v2 release.

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo check --workspace
- cargo nextest run --workspace: 4,067 passed, 83 skipped
- cargo check and clippy for x86_64-pc-windows-msvc
- cargo audit --no-fetch
- cargo deny check
- scripts/check-doc-examples.sh: 96 files validated

Closes #526