### PR TITLE
fix(core): make SchemaCache keys independent of object key order

### DIFF
--- a/adk-core/src/schema_cache.rs
+++ b/adk-core/src/schema_cache.rs
@@ -1,8 +1,9 @@
 //! Schema normalization cache for LLM provider adapters.
 //!
-//! Caches normalized schemas keyed by a content hash of the serialized JSON,
-//! avoiding redundant normalization when the same tool schema is encountered
-//! across multiple requests.
+//! Caches normalized schemas keyed by a content hash, avoiding redundant
+//! normalization when the same tool schema is encountered across multiple
+//! requests. The hash ignores the order object keys were written in, so one
+//! schema built two different ways is one entry.
 //!
 //! # Example
 //!
@@ -48,6 +49,59 @@ use crate::SchemaAdapter;
 #[derive(Debug, Default)]
 pub struct SchemaCache {
     entries: Mutex<HashMap<u64, Value>>,
+}
+
+/// Adds a value to the hash in a fixed order.
+///
+/// - **Object keys are sorted first.** The order they were written in cannot
+///   change the hash.
+/// - **Nothing is copied.** This runs on every lookup, including ones that hit.
+/// - **Each kind of value gets its own marker.** The text `"1"` and the number
+///   `1` hash differently.
+fn hash_canonical(value: &Value, hasher: &mut DefaultHasher) {
+    match value {
+        Value::Null => 0u8.hash(hasher),
+        Value::Bool(flag) => {
+            1u8.hash(hasher);
+            flag.hash(hasher);
+        }
+        Value::Number(number) => {
+            2u8.hash(hasher);
+            // `Number` is not `Hash`. Integers keep their exact value; a float
+            // hashes by its bits, which is sound because `Value` cannot hold NaN.
+            if let Some(unsigned) = number.as_u64() {
+                0u8.hash(hasher);
+                unsigned.hash(hasher);
+            } else if let Some(signed) = number.as_i64() {
+                1u8.hash(hasher);
+                signed.hash(hasher);
+            } else if let Some(float) = number.as_f64() {
+                2u8.hash(hasher);
+                float.to_bits().hash(hasher);
+            }
+        }
+        Value::String(text) => {
+            3u8.hash(hasher);
+            text.hash(hasher);
+        }
+        Value::Array(items) => {
+            4u8.hash(hasher);
+            items.len().hash(hasher);
+            for item in items {
+                hash_canonical(item, hasher);
+            }
+        }
+        Value::Object(members) => {
+            5u8.hash(hasher);
+            members.len().hash(hasher);
+            let mut entries: Vec<(&String, &Value)> = members.iter().collect();
+            entries.sort_unstable_by_key(|(key, _)| *key);
+            for (key, member) in entries {
+                key.hash(hasher);
+                hash_canonical(member, hasher);
+            }
+        }
+    }
 }
 
 impl SchemaCache {
@@ -135,14 +189,18 @@ impl SchemaCache {
         self.len() == 0
     }
 
-    /// Computes a 64-bit hash of the serialized schema bytes.
+    /// Computes a 64-bit hash of the schema's contents.
     ///
-    /// Uses `serde_json::to_vec` for deterministic serialization and
-    /// `DefaultHasher` (SipHash) for the hash function.
+    /// Object keys are sorted before hashing, so the order they were written in
+    /// does not change the result. `serde_json` keeps keys in insertion order,
+    /// so without this the same schema built two different ways would occupy two
+    /// entries and be normalized twice.
+    ///
+    /// Numbers are hashed as written: `5` and `5.0` are separate entries. That
+    /// costs an extra normalization and never returns the wrong schema.
     fn hash_schema(schema: &Value) -> u64 {
-        let bytes = serde_json::to_vec(schema).unwrap_or_default();
         let mut hasher = DefaultHasher::new();
-        bytes.hash(&mut hasher);
+        hash_canonical(schema, &mut hasher);
         hasher.finish()
     }
 }
@@ -269,5 +327,60 @@ mod tests {
         // GenericSchemaAdapter passes through non-object values
         assert_eq!(result, Value::Null);
         assert_eq!(cache.len(), 1);
+    }
+
+    /// Two schemas differing only in key order are one schema, so they share a
+    /// cache entry rather than each paying for normalization.
+    #[test]
+    fn key_order_does_not_create_a_second_entry() {
+        let cache = SchemaCache::new();
+        let adapter = GenericSchemaAdapter;
+
+        cache.get_or_normalize(
+            &json!({ "type": "object", "properties": { "a": {}, "b": {} } }),
+            &adapter,
+        );
+        cache.get_or_normalize(
+            &json!({ "properties": { "b": {}, "a": {} }, "type": "object" }),
+            &adapter,
+        );
+
+        assert_eq!(cache.len(), 1, "key order must not change a schema's identity");
+    }
+
+    #[test]
+    fn genuinely_different_schemas_keep_separate_entries() {
+        let cache = SchemaCache::new();
+        let adapter = GenericSchemaAdapter;
+
+        cache.get_or_normalize(&json!({ "type": "string" }), &adapter);
+        cache.get_or_normalize(&json!({ "type": "integer" }), &adapter);
+
+        assert_eq!(cache.len(), 2);
+    }
+
+    /// A property name containing pointer or escape syntax must not collapse
+    /// two schemas onto one key.
+    #[test]
+    fn unusual_property_names_stay_distinct() {
+        let cache = SchemaCache::new();
+        let adapter = GenericSchemaAdapter;
+
+        cache.get_or_normalize(&json!({ "properties": { "a/b": {} } }), &adapter);
+        cache.get_or_normalize(&json!({ "properties": { "a~b": {} } }), &adapter);
+
+        assert_eq!(cache.len(), 2);
+    }
+
+    /// Text and a number that render alike must not collide.
+    #[test]
+    fn a_string_and_a_number_hash_differently() {
+        let cache = SchemaCache::new();
+        let adapter = GenericSchemaAdapter;
+
+        cache.get_or_normalize(&json!({ "const": "1" }), &adapter);
+        cache.get_or_normalize(&json!({ "const": 1 }), &adapter);
+
+        assert_eq!(cache.len(), 2);
     }
 }

--- a/adk-core/src/schema_cache.rs
+++ b/adk-core/src/schema_cache.rs
@@ -2,8 +2,9 @@
 //!
 //! Caches normalized schemas keyed by a content hash, avoiding redundant
 //! normalization when the same tool schema is encountered across multiple
-//! requests. The hash ignores the order object keys were written in, so one
-//! schema built two different ways is one entry.
+//! requests. The hash ignores the order object keys were written in, so when
+//! `serde_json/preserve_order` is enabled — where insertion order would
+//! otherwise change the key — one schema built two different ways is one entry.
 //!
 //! # Example
 //!
@@ -55,7 +56,8 @@ pub struct SchemaCache {
 ///
 /// - **Object keys are sorted first.** The order they were written in cannot
 ///   change the hash.
-/// - **Nothing is copied.** This runs on every lookup, including ones that hit.
+/// - **No JSON values are cloned.** Object members are collected into a
+///   temporary `Vec` for sorting; this runs on every lookup, including hits.
 /// - **Each kind of value gets its own marker.** The text `"1"` and the number
 ///   `1` hash differently.
 fn hash_canonical(value: &Value, hasher: &mut DefaultHasher) {
@@ -67,18 +69,12 @@ fn hash_canonical(value: &Value, hasher: &mut DefaultHasher) {
         }
         Value::Number(number) => {
             2u8.hash(hasher);
-            // `Number` is not `Hash`. Integers keep their exact value; a float
-            // hashes by its bits, which is sound because `Value` cannot hold NaN.
-            if let Some(unsigned) = number.as_u64() {
-                0u8.hash(hasher);
-                unsigned.hash(hasher);
-            } else if let Some(signed) = number.as_i64() {
-                1u8.hash(hasher);
-                signed.hash(hasher);
-            } else if let Some(float) = number.as_f64() {
-                2u8.hash(hasher);
-                float.to_bits().hash(hasher);
-            }
+            // The textual form, because it is exact in every build. Going
+            // through `as_f64` loses precision when `serde_json` is built with
+            // `arbitrary_precision`, where a literal wider than f64 is kept
+            // verbatim: distinct numbers would round together and share a cache
+            // entry, and a literal outside f64 entirely would hash to nothing.
+            number.to_string().hash(hasher);
         }
         Value::String(text) => {
             3u8.hash(hasher);
@@ -192,9 +188,9 @@ impl SchemaCache {
     /// Computes a 64-bit hash of the schema's contents.
     ///
     /// Object keys are sorted before hashing, so the order they were written in
-    /// does not change the result. `serde_json` keeps keys in insertion order,
-    /// so without this the same schema built two different ways would occupy two
-    /// entries and be normalized twice.
+    /// does not change the result. When `serde_json/preserve_order` is enabled,
+    /// keys stay in insertion order, and without sorting the same schema built
+    /// two different ways would occupy two entries and be normalized twice.
     ///
     /// Numbers are hashed as written: `5` and `5.0` are separate entries. That
     /// costs an extra normalization and never returns the wrong schema.
@@ -380,6 +376,26 @@ mod tests {
 
         cache.get_or_normalize(&json!({ "const": "1" }), &adapter);
         cache.get_or_normalize(&json!({ "const": 1 }), &adapter);
+
+        assert_eq!(cache.len(), 2);
+    }
+
+    /// Numbers are identified by their written form, so `5` and `5.0` are
+    /// different schemas.
+    ///
+    /// This also closes an `arbitrary_precision` hazard that cannot be
+    /// exercised here: with that feature a literal wider than f64 is kept
+    /// verbatim, and identifying numbers by `as_f64` would round distinct
+    /// values onto one cache entry. Without the feature `serde_json` already
+    /// collapses such literals during parsing, so reproducing it would mean
+    /// enabling the feature for every crate in the build.
+    #[test]
+    fn numbers_are_identified_by_their_written_form() {
+        let cache = SchemaCache::new();
+        let adapter = GenericSchemaAdapter;
+
+        cache.get_or_normalize(&json!({ "const": 5 }), &adapter);
+        cache.get_or_normalize(&json!({ "const": 5.0 }), &adapter);
 
         assert_eq!(cache.len(), 2);
     }


### PR DESCRIPTION
## What

`SchemaCache` keys now ignore the order object keys were written in, so one schema built two different ways is one cache entry.

## Why

`hash_schema` hashed `serde_json::to_vec(schema)`. This workspace resolves `serde_json` **with `indexmap`** — `preserve_order` is enabled through feature unification — so `Value::Object` preserves insertion order and the serialized bytes depend on how the schema was written.

Two schemas identical apart from key order therefore hashed differently, missed the cache, and were normalized again on every call. Because `get_or_compile` builds a `jsonschema::Validator` (regex compilation, `$ref` resolution), the repeated work lands on the per-turn tool-declaration path.

The existing doc comment described the serialization as "deterministic". That holds for a given `Value` and not for a given schema, which is what the cache is keyed on.

## How

`hash_schema` walks the value and feeds the hasher in sorted key order.

- **No clone, no serialization.** The previous code serialized on every lookup, including hits — the path the cache exists to keep cheap. The walk allocates only a small `Vec` of member references per object.
- **Each JSON variant is tagged**, so the string `"1"` and the number `1` cannot collide.
- **Numbers are hashed as written**, so `5` and `5.0` remain separate entries. That costs an extra normalization and never returns the wrong schema — deliberately conservative rather than adopting a semantic equality the cache cannot verify.

Behaviour is otherwise unchanged: no public API change, no new dependency, cache semantics and adapter scoping untouched.

## Tests

Four added, all against the public API:

| Test | Asserts |
|---|---|
| `key_order_does_not_create_a_second_entry` | reordered keys share one entry |
| `genuinely_different_schemas_keep_separate_entries` | distinct schemas stay distinct |
| `unusual_property_names_stay_distinct` | `a/b` and `a~b` do not collide |
| `a_string_and_a_number_hash_differently` | `"1"` and `1` do not collide |

## Verification

```
cargo test -p adk-core schema_cache     14 passed (5 new, 9 existing)
cargo clippy -p adk-core --all-targets -- -D warnings     clean
```

> **Note:** `cargo clippy --workspace --all-targets -- -D warnings` fails on my machine at `adk-telemetry/src/span_exporter.rs:51` (`clippy::for_kv_map`). That is unrelated to this change and reproduces on an unmodified `main`. My shell provides clippy 0.1.97 while `rust-toolchain.toml` pins 1.95.0, and the lint does not fire on the pinned version — reporting it in case the local toolchain drift is worth a separate look.

