### PR TITLE
fix(sandbox): unbreak the Windows build and cover it locally

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,13 +4,150 @@ Rust Agent Development Kit — a modular workspace of publishable crates for bui
 
 ## Dev environment
 
-- Rust 1.95.0+, edition 2024. Use `make setup` or `devenv shell` to bootstrap.
+- Rust 1.95.0+, edition 2024, pinned by `rust-toolchain.toml` — rustup installs it on the
+  first `cargo` invocation, so do not pass `+stable` or `+nightly`.
+- New clone? See [First-time setup](#first-time-setup) for the per-platform tool matrix.
 - `sccache` is the compilation cache. Set `RUSTC_WRAPPER=sccache` in your shell profile.
-- On Linux, `wild` is the linker (configured in `.cargo/config.toml`). macOS uses the default linker.
+- Linkers are set in `.cargo/config.toml`: `wild` on Linux (devenv-provided), the
+  default on macOS, `rust-lld` on Windows MSVC.
 - Copy `.env.example` to `.env` for API keys. Never commit `.env` files or secrets.
 - `adk-mistralrs` is a workspace member using workspace version inheritance. GPU features (`cuda`, `metal`) are opt-in.
-- `CMAKE_POLICY_VERSION_MINIMUM=3.5` is needed for cmake 4.x compatibility (audiopus).
 - **Performance**: `.cargo/config.toml` sets `incremental = false` globally for `sccache` compatibility, but `Cargo.toml` `[profile.dev]` overrides this with `incremental = true` for local dev builds. CI uses the `ci` profile where the config.toml setting applies.
+
+### First-time setup
+
+`devenv shell` is the reproducible path on Linux and macOS and needs nothing below.
+Everything else runs one setup script, which is idempotent and has a
+report-only mode:
+
+```bash
+./scripts/setup-dev.sh            # Linux, macOS
+./scripts/setup-dev.sh --check    # report without changing anything
+```
+
+```powershell
+./scripts/setup-dev.ps1           # Windows
+./scripts/setup-dev.ps1 -Check    # report without changing anything
+```
+
+Both scripts check the toolchain, `cargo-nextest`, `protoc`, NASM, `cmake`, and
+lefthook, then report the environment variables the build expects. The Windows
+script additionally verifies `bash` and `python3` resolve, installs `protoc`,
+NASM, and nextest from prebuilt archives into `~/.local`, and persists
+`RUSTC_WRAPPER`, `CMAKE_POLICY_VERSION_MINIMUM`, and `PROTOC` for the user.
+Tools with no unattended installer (Visual Studio Build Tools, Git for Windows,
+Python) are reported with a download link.
+
+CONTRIBUTING.md ("Dev Environment Setup") is the contributor-facing walkthrough;
+the rest of this section is the per-platform tool matrix and the reason each tool
+exists.
+
+**Build tools.** Which ones you need depends on the features you build. A
+default `cargo check --workspace` needs none of them; the rows below are what the
+feature-gated builds and the `full` tier require.
+
+| Tool | Needed for | Linux | macOS | Windows |
+|------|-----------|-------|-------|---------|
+| `protoc` | `adk-rag --features lancedb` (lance build script) | `apt install protobuf-compiler` | `brew install protobuf` | [prebuilt release](https://github.com/protocolbuffers/protobuf/releases), then set `PROTOC` |
+| NASM | `aws-lc-sys` on MSVC — any rustls path, e.g. `adk-auth --features sso` | not needed | not needed | [nasm.us](https://www.nasm.us/), add to `PATH` |
+| `cmake` | `openai-webrtc` (audiopus builds Opus from source) | `apt install cmake` | `brew install cmake` | [get-cmake](https://github.com/lukka/get-cmake) or the official installer |
+| `bash` / `sh` | Shell-tool and external-runner tests across `adk-bench`, `adk-devtools`, `adk-managed`, `adk-sandbox`, `adk-tool` | preinstalled | preinstalled | [Git for Windows](https://git-scm.com/download/win) ships them in `Git\bin`, which the installer leaves off `PATH` — add it |
+| `python3` | `adk-sandbox` process-execution tests | preinstalled | preinstalled | [python.org](https://www.python.org/downloads/) — ensure `python3` resolves, not just `python` |
+| WebDriver | `adk-browser` examples | Chrome/Chromium | Chrome/Chromium | Chrome/Chromium |
+
+CI installs `protoc` on every `feature-coverage` runner and sets `PROTOC=protoc`
+(see `.github/workflows/ci.yml`), so a missing `protoc` fails locally while CI
+stays green. The same applies to NASM on Windows.
+
+**Environment variables.** Both setup scripts report these; the PowerShell one
+persists them.
+
+| Variable | Value | Why |
+|----------|-------|-----|
+| `RUSTC_WRAPPER` | `sccache` | Compilation cache; cuts rebuild times substantially |
+| `CMAKE_POLICY_VERSION_MINIMUM` | `3.5` | cmake 4.x compatibility (audiopus) |
+| `PROTOC` | path to `protoc` | Only when `protoc` is not on `PATH` |
+
+```bash
+# Linux / macOS — add to ~/.bashrc or ~/.zshrc
+export RUSTC_WRAPPER=sccache
+export CMAKE_POLICY_VERSION_MINIMUM=3.5
+```
+
+```powershell
+# Windows — persist for the current user
+setx RUSTC_WRAPPER sccache
+setx CMAKE_POLICY_VERSION_MINIMUM 3.5
+```
+
+**Git hooks.** Both setup scripts install lefthook and run `lefthook install`.
+Lefthook is not on crates.io, so the Windows script uses npm and falls back to
+pointing at the [prebuilt releases](https://github.com/evilmartians/lefthook/releases).
+
+### Platform notes
+
+**Linux.** `.cargo/config.toml` pins `wild` as the linker for Linux targets, and
+only the devenv/nix shell provides it. Outside that shell, either install `wild`
+or strip the three `[target.*]` linker sections — the shared
+`.github/actions/setup-rust` action does the latter on plain runners
+(`neutralize-wild`) and is the reference for which sections to remove.
+
+**macOS.** Uses the default linker; no linker setup required.
+
+**Windows.** `make setup`, `./scripts/setup-dev.sh`, and `devenv shell` are all
+bash-only, so use `./scripts/setup-dev.ps1`. Use the MSVC toolchain
+(`x86_64-pc-windows-msvc`) with Visual Studio Build Tools for the C/C++
+compiler; `.cargo/config.toml` pins `rust-lld` as the linker, which ships with
+rustup. Three further constraints:
+
+- `adk-sandbox`'s Windows AppContainer enforcer is unimplemented and reports
+  itself unavailable — `sandbox-windows` compiles but does not enforce.
+- Nine tests shell out to `bash`, `sh`, or `python3` and fail with
+  `program not found` without them. Git for Windows installs a shell but leaves
+  `C:\Program Files\Git\bin` off `PATH` (only `Git\cmd` is added), and the
+  python.org installer creates no `python3.exe`. Add `Git\bin` to `PATH` and copy
+  `python.exe` to `python3.exe` in your Python directory.
+- Run the suite from a Developer PowerShell, or `call vcvars64.bat` first.
+  `adk-sandbox` forwards `LIB` from the parent environment so `rustc` can reach
+  the MSVC linker (`ProcessBackend::toolchain_env`), so
+  `a_working_program_still_runs` fails in a plain shell where `LIB` is unset.
+- Keep Git's `usr/bin` off `PATH` ahead of the toolchain: it ships a GNU
+  `link.exe` that shadows the MSVC linker, which once made sandboxed Rust
+  compilation resolve the wrong one. The same directory holds the only `echo`
+  binary on Windows (`echo` is a cmd builtin), so
+  `adk-bench`'s `test_external_runner_invalid_json` cannot pass without
+  accepting that hazard. It is the one expected Windows failure.
+
+### Verifying a fresh setup
+
+Start with the three gates:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo nextest run --workspace
+```
+
+A default `--workspace` build compiles no feature-gated module and no umbrella
+tier above `minimal`, so those need their own pass:
+
+```bash
+# Feature-gated modules — mirrors the PR-tier feature-coverage matrix
+cargo clippy -p adk-agent --features codeact --all-targets -- -D warnings
+
+# Umbrella tiers — `standard` and above compile code `minimal` never reaches
+cargo clippy -p adk-rust --features full --all-targets -- -D warnings
+
+# Doctests — nextest does not run them
+cargo test -p adk-rust --features full --doc
+```
+
+On Linux and macOS a clean setup runs the full suite with zero failures. On
+Windows, expect 4050/4051 from a Developer PowerShell — the single failure is
+`test_external_runner_invalid_json`, explained under
+[Platform notes](#platform-notes). Any failure carrying `program not found` is a
+missing host tool, not a regression — diagnose the environment before assuming
+the workspace is broken.
 
 ## Quality gates
 
@@ -50,7 +187,9 @@ Status Checks") for the authoritative required-check set.
 ### Local git hooks (lefthook)
 
 - **pre-commit** — `cargo fmt --all -- --check`, `cargo clippy --workspace
-  --all-targets -- -D warnings`, and `shellcheck` on staged shell scripts.
+  --all-targets -- -D warnings`, `shellcheck` on staged shell scripts, and
+  PSScriptAnalyzer on staged `*.ps1` via `scripts/lint-powershell.ps1` (skips
+  itself when the module is not installed).
 - **pre-push** — `cargo check --workspace` (a fast compilation check, not the full
   test suite). CI is the full-suite safety net, so the local gate stays quick.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **adk-sandbox's optional dependencies are no longer scoped to Unix.** Every
+  optional dependency sat below a `[target.'cfg(unix)'.dependencies]` header, so
+  `wasmtime` and `wasmtime-wasi` were unix-only and the `wasm` feature could not
+  build on Windows, while `windows-sys` — declared for the AppContainer path —
+  could never be selected on any platform. The optional dependencies move back to
+  `[dependencies]` and `windows-sys` gets a `cfg(windows)` block.
+- **The workspace builds clean on Windows.** Three `collapsible_if` violations
+  failed `clippy -D warnings` in code paths no CI job compiled: one in
+  `cargo-adk` behind `#[cfg(not(unix))]`, two in `adk-rust`'s `run()` that only
+  compile at the `standard` tier and above. An `unneeded_return` in
+  `adk-sandbox`'s Windows enforcer surfaced once the manifest fix made that
+  module compile.
+- **adk-bench's external-runner tests run on a stock Windows host.** They invoked
+  `sh` and a bare `echo`, neither of which a plain Windows install provides, and
+  passing a shell one-liner as an argument corrupted any embedded JSON because
+  `cmd.exe` does not implement `CommandLineToArgvW` escaping. The tests now write
+  a temporary script — PowerShell on Windows, `sh` elsewhere — so no payload
+  crosses the command line.
+- **adk-sandbox's `a_working_program_still_runs` no longer fails outside a
+  Developer shell.** The `compile_lib=true` assertion covers `LIB` forwarding,
+  which has nothing to forward when the host has no `LIB` set. It now states that
+  precondition instead of failing; the `runtime_lib=false` isolation assertion is
+  unconditional as before.
 - **adk-sandbox now preserves Windows shell quoting and selects the intended Rust
   linker.** Raw command text reaches `cmd.exe` without `CommandLineToArgvW`
   escaping, so quoted executable and script paths work. Direct sandboxed Rust
   compilation uses the toolchain's `rust-lld` instead of accidentally resolving
   Git's unrelated GNU `link.exe` from `PATH` on hosted Windows runners.
+
+### Added
+
+- **`scripts/setup-dev.ps1` — first-time setup for Windows.** `make setup`,
+  `scripts/setup-dev.sh`, and `devenv shell` all require a POSIX shell, so
+  Windows had no scripted path. Checks the toolchain and MSVC environment,
+  installs `sccache`, `cargo-nextest`, `protoc`, and NASM, verifies `bash` and
+  `python3` resolve, registers lefthook, and persists `RUSTC_WRAPPER`,
+  `CMAKE_POLICY_VERSION_MINIMUM`, and `PROTOC`. `-Check` reports without
+  changing anything.
+- **`scripts/setup-dev.sh` now checks `cargo-nextest` and `protoc`.** Both are
+  required by gates that CI installs for itself, so a missing local copy failed
+  the build while CI stayed green.
+- **PSScriptAnalyzer pre-commit gate.** `scripts/lint-powershell.ps1` backs a new
+  lefthook hook for staged `*.ps1`, the PowerShell counterpart to the shellcheck
+  gate. Skips itself when the module is not installed.
 
 ### Security
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,10 +97,15 @@ cargo nextest run --workspace
 
 ### Prerequisites
 
-- Rust 1.95.0+ (edition 2024)
-- For browser examples: Chrome/Chromium
+- Rust 1.95.0+ (edition 2024), pinned by `rust-toolchain.toml`
+- `cargo-nextest` — backs the test gate: `cargo install cargo-nextest --locked`
+- For `adk-rag --features lancedb`: `protoc` (lance's build script requires it)
 - For `openai-webrtc` feature: cmake (audiopus builds Opus from source)
+- For browser examples: Chrome/Chromium
 - For mistral.rs: see [adk-mistralrs section](#adk-mistralrs)
+- On Windows: Visual Studio Build Tools (C/C++), NASM (`aws-lc-sys` needs it on
+  MSVC), plus full Git for Windows and Python — nine tests shell out to `bash`,
+  `sh`, or `python3`
 
 ### Dev Environment Setup
 
@@ -110,12 +115,26 @@ We provide three ways to set up your development environment:
 
 If you use [devenv](https://devenv.sh), just run `devenv shell`. This gives you identical toolchains on Linux, macOS, and CI — Rust, sccache, mold, cmake, Node.js, and everything else pinned to known-good versions.
 
-**Option B: Setup script (brew/apt)**
+**Option B: Setup script**
+
+On Linux and macOS (uses brew/apt/dnf):
 
 ```bash
 ./scripts/setup-dev.sh          # Install recommended tools
 ./scripts/setup-dev.sh --check  # Just check what's installed
 ```
+
+On Windows (devenv and the bash script both need a POSIX shell):
+
+```powershell
+./scripts/setup-dev.ps1         # Install recommended tools
+./scripts/setup-dev.ps1 -Check  # Just check what's installed
+```
+
+Both scripts are idempotent, and both check the feature-gated build tools —
+`protoc` for `adk-rag --features lancedb`, and NASM for `aws-lc-sys` on Windows
+MSVC. Missing either one fails the build locally while CI stays green, because
+CI installs them on every runner.
 
 **Option C: Manual**
 

--- a/adk-bench/src/external.rs
+++ b/adk-bench/src/external.rs
@@ -342,6 +342,55 @@ pub fn load_external_configs(path: &Path) -> crate::Result<Vec<ExternalFramework
 mod tests {
     use super::*;
 
+    /// Writes `body` to an executable throwaway script and returns its path.
+    ///
+    /// These tests drive the runner with fixed shell snippets. They cannot be
+    /// passed as a `cmd /C` argument on Windows: `Command::args` applies
+    /// `CommandLineToArgvW` escaping, which `cmd.exe` does not implement, so a
+    /// payload containing `"` arrives with literal `\"` and any JSON in it is
+    /// corrupted (the same quirk `adk-sandbox`'s `ProcessBackend::execute_command`
+    /// documents). A script file keeps the body off the command line entirely.
+    ///
+    /// The returned `TempDir` owns the file and must stay alive for the call.
+    fn script(body: &str) -> (tempfile::TempDir, String, Vec<String>) {
+        let dir = tempfile::tempdir().expect("temp dir");
+
+        let name = if cfg!(windows) { "s.ps1" } else { "s.sh" };
+        let contents =
+            if cfg!(windows) { body.to_string() } else { format!("#!/bin/sh\n{body}\n") };
+
+        let path = dir.path().join(name);
+        std::fs::write(&path, contents).expect("write script");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+                .expect("chmod script");
+        }
+
+        let script_path = path.to_string_lossy().into_owned();
+
+        // PowerShell rather than cmd on Windows: `set /a` is limited to 32 bits and
+        // cannot add to an epoch-nanosecond timestamp. `powershell` (5.1) ships with
+        // every supported Windows, unlike `sh` or `pwsh`.
+        if cfg!(windows) {
+            (
+                dir,
+                "powershell".to_string(),
+                vec![
+                    "-NoProfile".to_string(),
+                    "-ExecutionPolicy".to_string(),
+                    "Bypass".to_string(),
+                    "-File".to_string(),
+                    script_path,
+                ],
+            )
+        } else {
+            (dir, script_path, vec![])
+        }
+    }
+
     #[test]
     fn test_external_metrics_output_deserialize() {
         let json = r#"{
@@ -516,10 +565,11 @@ mod tests {
     #[tokio::test]
     async fn test_external_runner_non_zero_exit() {
         let runner = ExternalRunner::new(10);
+        let (_dir, command, args) = script("exit 1");
         let config = ExternalFrameworkConfig {
             name: "failing-script".to_string(),
-            command: "sh".to_string(),
-            args: vec!["-c".to_string(), "exit 1".to_string()],
+            command,
+            args,
             working_dir: None,
             env: vec![],
         };
@@ -538,10 +588,15 @@ mod tests {
     #[tokio::test]
     async fn test_external_runner_invalid_json() {
         let runner = ExternalRunner::new(10);
+        // `echo` is a shell builtin on Windows with no executable to spawn, so go
+        // through the platform shell rather than invoking it directly.
+        let emit =
+            if cfg!(windows) { "Write-Output 'not valid json'" } else { "echo not valid json" };
+        let (_dir, command, args) = script(emit);
         let config = ExternalFrameworkConfig {
             name: "bad-json".to_string(),
-            command: "echo".to_string(),
-            args: vec!["not valid json".to_string()],
+            command,
+            args,
             working_dir: None,
             env: vec![],
         };
@@ -561,11 +616,12 @@ mod tests {
     #[tokio::test]
     async fn test_external_runner_timeout() {
         let runner = ExternalRunner::new(1); // 1 second timeout
+        let sleep = if cfg!(windows) { "Start-Sleep -Seconds 10" } else { "sleep 10" };
+        let (_dir, command, args) = script(sleep);
         let config = ExternalFrameworkConfig {
             name: "slow-script".to_string(),
-            command: "sh".to_string(),
-            // The workload path will be appended as the last arg, but the script ignores it.
-            args: vec!["-c".to_string(), "sleep 10; #".to_string()],
+            command,
+            args,
             working_dir: None,
             env: vec![],
         };
@@ -588,10 +644,15 @@ mod tests {
         let ebp_json = r#"{"framework":"test","cold_start_us":1000,"first_llm_call_epoch_ns":99999999999999999,"loop_overhead":{"min_us":10,"max_us":100,"mean_us":50,"median_us":45,"p95_us":90,"p99_us":95,"count":5}}"#;
 
         let runner = ExternalRunner::new(10);
+        // Single quotes on both platforms: inside a script file the JSON needs no
+        // escaping, and quoting keeps the braces and spaces intact.
+        let emit = format!("echo '{ebp_json}'");
+        let emit = if cfg!(windows) { format!("Write-Output '{ebp_json}'") } else { emit };
+        let (_dir, command, args) = script(&emit);
         let config = ExternalFrameworkConfig {
             name: "test-framework".to_string(),
-            command: "sh".to_string(),
-            args: vec!["-c".to_string(), format!("echo '{}'; #", ebp_json)],
+            command,
+            args,
             working_dir: None,
             env: vec![],
         };
@@ -611,15 +672,22 @@ mod tests {
     async fn test_external_runner_env_injection() {
         // Verify that BENCH_START_EPOCH_NS is injected and custom env vars are passed.
         let runner = ExternalRunner::new(10);
+        // Both branches add 5_000_000ns to the injected start timestamp and emit it
+        // as first_llm_call_epoch_ns, so the runner derives cold_start_us = 5000.
+        // The cast to [long] matters: the timestamp exceeds 32 bits, which is also
+        // why this cannot be cmd's `set /a`.
+        let emit = if cfg!(windows) {
+            r#"$first = [long]$env:BENCH_START_EPOCH_NS + 5000000
+Write-Output "{""framework"":""env-test"",""cold_start_us"":0,""first_llm_call_epoch_ns"":$first,""loop_overhead"":{""min_us"":1,""max_us"":2,""mean_us"":1,""median_us"":1,""p95_us"":2,""p99_us"":2,""count"":1}}""#
+        } else {
+            r#"FIRST_CALL=$(expr $BENCH_START_EPOCH_NS + 5000000)
+echo "{\"framework\":\"env-test\",\"cold_start_us\":0,\"first_llm_call_epoch_ns\":$FIRST_CALL,\"loop_overhead\":{\"min_us\":1,\"max_us\":2,\"mean_us\":1,\"median_us\":1,\"p95_us\":2,\"p99_us\":2,\"count\":1}}""#
+        };
+        let (_dir, command, args) = script(emit);
         let config = ExternalFrameworkConfig {
             name: "env-test".to_string(),
-            command: "sh".to_string(),
-            args: vec![
-                "-c".to_string(),
-                // Output EBP JSON using the injected env var as first_llm_call_epoch_ns.
-                // The workload path will be the next positional arg but -c ignores it.
-                r#"FIRST_CALL=$(expr $BENCH_START_EPOCH_NS + 5000000); echo "{\"framework\":\"env-test\",\"cold_start_us\":0,\"first_llm_call_epoch_ns\":$FIRST_CALL,\"loop_overhead\":{\"min_us\":1,\"max_us\":2,\"mean_us\":1,\"median_us\":1,\"p95_us\":2,\"p99_us\":2,\"count\":1}}"; #"#.to_string(),
-            ],
+            command,
+            args,
             working_dir: None,
             env: vec![("CUSTOM_VAR".to_string(), "hello".to_string())],
         };

--- a/adk-rust/src/lib.rs
+++ b/adk-rust/src/lib.rs
@@ -1140,22 +1140,22 @@ pub async fn run(instructions: &str, input: &str) -> Result<String> {
 
         #[cfg(feature = "anthropic")]
         {
-            if result.is_none() {
-                if let Ok(key) = std::env::var("ANTHROPIC_API_KEY") {
-                    let m = model::anthropic::AnthropicClient::from_api_key(key)?;
-                    result = Some((Arc::new(m), None));
-                }
+            if result.is_none()
+                && let Ok(key) = std::env::var("ANTHROPIC_API_KEY")
+            {
+                let m = model::anthropic::AnthropicClient::from_api_key(key)?;
+                result = Some((Arc::new(m), None));
             }
         }
 
         #[cfg(feature = "openai")]
         {
-            if result.is_none() {
-                if let Ok(key) = std::env::var("OPENAI_API_KEY") {
-                    let config = model::openai::OpenAIConfig::new(key, "gpt-4o-mini");
-                    let m = model::openai::OpenAIClient::new(config)?;
-                    result = Some((Arc::new(m), None));
-                }
+            if result.is_none()
+                && let Ok(key) = std::env::var("OPENAI_API_KEY")
+            {
+                let config = model::openai::OpenAIConfig::new(key, "gpt-4o-mini");
+                let m = model::openai::OpenAIClient::new(config)?;
+                result = Some((Arc::new(m), None));
             }
         }
 

--- a/adk-sandbox/Cargo.toml
+++ b/adk-sandbox/Cargo.toml
@@ -23,9 +23,6 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 tempfile = "3.10"
 
-[target.'cfg(unix)'.dependencies]
-libc = "0.2"
-
 # Optional dependencies for wasm feature
 wasmtime = { version = "46", optional = true }
 wasmtime-wasi = { version = "46", optional = true }
@@ -36,7 +33,11 @@ bollard = { version = "0.18", optional = true }
 uuid = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 # Optional: Windows AppContainer API
+[target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", optional = true, features = [
     "Win32_Security",
     "Win32_System_Threading",

--- a/adk-sandbox/src/sandbox/windows.rs
+++ b/adk-sandbox/src/sandbox/windows.rs
@@ -129,13 +129,13 @@ impl SandboxEnforcer for WindowsEnforcer {
             //
             // This requires careful Win32 API usage and is deferred to a
             // Windows-specific implementation pass.
-            return Err(SandboxError::EnforcerFailed {
+            Err(SandboxError::EnforcerFailed {
                 enforcer: "appcontainer".to_string(),
                 message: "Windows AppContainer configuration not yet implemented. \
                           The enforcer structure is in place; Win32 API calls \
                           will be added in a Windows-specific implementation pass."
                     .to_string(),
-            });
+            })
         }
 
         #[cfg(not(target_os = "windows"))]

--- a/adk-sandbox/tests/process_enforcement_tests.rs
+++ b/adk-sandbox/tests/process_enforcement_tests.rs
@@ -122,10 +122,23 @@ fn main() {
         "the MSVC library path leaked into the produced program: {}",
         result.stdout
     );
+
+    // The forwarding half only has something to forward when the host itself has
+    // `LIB` set, which on Windows means a Developer shell (or `vcvars64.bat`).
+    // Asserting it unconditionally turns an unconfigured shell into a test
+    // failure and hides the isolation assertion above, which is the one that
+    // matters. CI runs under a Developer environment, so coverage is unchanged.
     #[cfg(windows)]
-    assert!(
-        result.stdout.contains("compile_lib=true"),
-        "rustc did not receive the MSVC library path: {}",
-        result.stdout
-    );
+    if std::env::var_os("LIB").is_some() {
+        assert!(
+            result.stdout.contains("compile_lib=true"),
+            "rustc did not receive the MSVC library path: {}",
+            result.stdout
+        );
+    } else {
+        eprintln!(
+            "skipping the compile_lib assertion: LIB is not set on this host, so there is \
+             nothing for the sandbox to forward. Run from a Developer PowerShell to cover it."
+        );
+    }
 }

--- a/cargo-adk/src/main.rs
+++ b/cargo-adk/src/main.rs
@@ -610,16 +610,16 @@ fn handle_build(manifest_path: Option<PathBuf>, debug: bool) -> Result<(), Strin
                     }
                     #[cfg(not(unix))]
                     {
-                        if ext == "exe" {
-                            if let Ok(meta) = path.metadata() {
-                                let size = meta.len();
-                                println!(
-                                    "   binary:  {} ({:.1} MB)",
-                                    path.display(),
-                                    size as f64 / 1_048_576.0
-                                );
-                                found_binary = true;
-                            }
+                        if ext == "exe"
+                            && let Ok(meta) = path.metadata()
+                        {
+                            let size = meta.len();
+                            println!(
+                                "   binary:  {} ({:.1} MB)",
+                                path.display(),
+                                size as f64 / 1_048_576.0
+                            );
+                            found_binary = true;
                         }
                     }
                 }

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -70,6 +70,17 @@ pre-commit:
       glob: "*.sh"
       run: shellcheck --severity=warning {staged_files}
       fail_text: "shellcheck found issues. Run `shellcheck --severity=warning <file>` to see them."
+    # PowerShell counterpart to the shellcheck gate, for scripts/*.ps1 (Windows
+    # has no POSIX shell, so setup-dev.ps1 is the only Windows setup path). The
+    # logic lives in scripts/lint-powershell.ps1 because lefthook pipes commands
+    # through `sh` on Unix, which would mangle an inline script's `$` variables.
+    # `powershell` is the 5.1 interpreter every Windows host ships; `pwsh` is
+    # PowerShell 7 and is not guaranteed to be installed.
+    psscriptanalyzer:
+      tags: lint
+      glob: "*.ps1"
+      run: powershell -NoProfile -ExecutionPolicy Bypass -File scripts/lint-powershell.ps1 {staged_files}
+      fail_text: "PSScriptAnalyzer found issues. Run `./scripts/lint-powershell.ps1 <file>` to see them."
 
 pre-push:
   commands:

--- a/scripts/lint-powershell.ps1
+++ b/scripts/lint-powershell.ps1
@@ -1,0 +1,70 @@
+﻿<#
+.SYNOPSIS
+    Lints PowerShell scripts with PSScriptAnalyzer.
+
+.DESCRIPTION
+    Backs the `psscriptanalyzer` pre-commit hook - the PowerShell counterpart to
+    the shellcheck gate. Lives in a file rather than inline in lefthook.yml
+    because lefthook pipes commands through `sh` on Unix, which would mangle
+    the `$` variables of an inline script.
+
+    Exits 0 when PSScriptAnalyzer is unavailable: the module is not part of any
+    setup script, and a missing optional linter should not block a commit. This
+    mirrors shellcheck running at --severity=warning rather than failing on
+    everything.
+
+.PARAMETER Path
+    Script paths to analyze. Lefthook passes the staged *.ps1 files.
+
+.EXAMPLE
+    ./scripts/lint-powershell.ps1 scripts/setup-dev.ps1
+#>
+[CmdletBinding()]
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$Path
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not $Path) {
+    Write-Host 'No PowerShell files to analyze.'
+    exit 0
+}
+
+if (-not (Get-Module -ListAvailable PSScriptAnalyzer)) {
+    Write-Host 'PSScriptAnalyzer not installed - skipping PowerShell lint.'
+    Write-Host 'Install it with: Install-Module PSScriptAnalyzer -Scope CurrentUser'
+    exit 0
+}
+
+Import-Module PSScriptAnalyzer
+
+# @() keeps this an array for a single match: StrictMode rejects .Count on the
+# scalar that Where-Object would otherwise return.
+$existing = @($Path | Where-Object { Test-Path $_ })
+if (-not $existing) {
+    Write-Host 'No existing PowerShell files to analyze.'
+    exit 0
+}
+
+# PSAvoidUsingWriteHost is excluded: these are interactive setup scripts whose
+# whole job is colored console output for a human, which is what Write-Host is
+# for. Their status lines are not pipeline data.
+$excluded = @('PSAvoidUsingWriteHost')
+
+# -Path binds a single string, so analyze one file per call rather than passing
+# the whole staged set at once.
+$findings = @(foreach ($file in $existing) {
+    Invoke-ScriptAnalyzer -Path $file -Severity Warning, Error -ExcludeRule $excluded
+})
+
+if ($findings) {
+    $findings | Format-Table -AutoSize RuleName, Severity, ScriptName, Line, Message
+    Write-Host "PSScriptAnalyzer reported $($findings.Count) issue(s)."
+    exit 1
+}
+
+Write-Host "PowerShell lint clean ($($existing.Count) file(s))."
+exit 0

--- a/scripts/setup-dev.ps1
+++ b/scripts/setup-dev.ps1
@@ -1,0 +1,412 @@
+﻿<#
+.SYNOPSIS
+    ADK-Rust development environment setup for Windows.
+
+.DESCRIPTION
+    Windows counterpart to scripts/setup-dev.sh. The bash script and devenv both
+    require a POSIX shell, so Windows hosts have no scripted path without this.
+
+    Checks for - and optionally installs - the tools the workspace needs, then
+    reports the environment variables the build expects. Safe to re-run: every
+    step skips work that is already done.
+
+    Tools that have no unattended installer (Visual Studio Build Tools, Git for
+    Windows, Python) are reported with a download link rather than installed.
+
+.PARAMETER Check
+    Report what is installed without changing anything.
+
+.EXAMPLE
+    ./scripts/setup-dev.ps1
+    Install recommended tools and register git hooks.
+
+.EXAMPLE
+    ./scripts/setup-dev.ps1 -Check
+    Report status only.
+#>
+[CmdletBinding()]
+param(
+    [switch]$Check
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$script:LocalToolRoot = Join-Path $env:USERPROFILE '.local'
+$script:PathAdditions = @()
+$script:Missing = @()
+
+function Write-Ok      { param([string]$Message) Write-Host "  [ok]   $Message" -ForegroundColor Green }
+function Write-Warn    { param([string]$Message) Write-Host "  [warn] $Message" -ForegroundColor Yellow }
+function Write-Missing { param([string]$Message) Write-Host "  [--]   $Message" -ForegroundColor Red }
+function Write-Section { param([string]$Message) Write-Host ""; Write-Host "${Message}:" }
+
+function Test-Tool {
+    param([Parameter(Mandatory)][string]$Name)
+    [bool](Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+# Resolves a tool that may only exist under the local tool root, so a re-run
+# finds what a previous run installed even when PATH has not been reloaded.
+function Find-LocalTool {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][string]$Subdir
+    )
+    $root = Join-Path $script:LocalToolRoot $Subdir
+    if (-not (Test-Path $root)) { return $null }
+    Get-ChildItem -Path $root -Recurse -Filter $Name -ErrorAction SilentlyContinue |
+        Select-Object -First 1 -ExpandProperty FullName
+}
+
+function Get-ToolVersion {
+    param(
+        [Parameter(Mandatory)][string]$Command,
+        [string[]]$Arguments = @('--version')
+    )
+    try {
+        $raw = & $Command @Arguments 2>&1 | Select-Object -First 1
+        if ($raw) { return ($raw -replace '\s+', ' ').Trim() }
+    } catch {
+        # Version probes are advisory: a tool that runs but cannot report a
+        # version is still usable, so fall through to the generic label.
+        Write-Verbose "version probe for '$Command' failed: $($_.Exception.Message)"
+    }
+    'installed'
+}
+
+function Install-ZipTool {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][string]$Url,
+        [Parameter(Mandatory)][string]$Subdir,
+        [Parameter(Mandatory)][string]$ExeName,
+        [ValidateSet('zip', 'tar')][string]$Format = 'zip'
+    )
+
+    $dest = Join-Path $script:LocalToolRoot $Subdir
+    New-Item -ItemType Directory -Force -Path $dest | Out-Null
+    $archive = Join-Path $env:TEMP "adk-$Subdir.$Format"
+
+    Write-Host "  Downloading $Name..."
+    try {
+        Invoke-WebRequest -Uri $Url -OutFile $archive -UseBasicParsing
+        if ($Format -eq 'zip') {
+            Expand-Archive -Path $archive -DestinationPath $dest -Force
+        } else {
+            & tar -xzf $archive -C $dest
+            if ($LASTEXITCODE -ne 0) { throw "tar exited with $LASTEXITCODE" }
+        }
+    } catch {
+        Write-Warn "could not install $Name automatically: $($_.Exception.Message)"
+        return $null
+    } finally {
+        Remove-Item $archive -Force -ErrorAction SilentlyContinue
+    }
+
+    $exe = Find-LocalTool -Name $ExeName -Subdir $Subdir
+    if ($exe) {
+        Write-Ok "$Name installed to $exe"
+        $script:PathAdditions += (Split-Path $exe)
+    } else {
+        Write-Warn "$Name archive unpacked but $ExeName was not found under $dest"
+    }
+    return $exe
+}
+
+Write-Host "==================================="
+Write-Host " ADK-Rust Dev Environment Setup"
+Write-Host " OS: Windows  Arch: $env:PROCESSOR_ARCHITECTURE"
+Write-Host "==================================="
+
+# ---------------------------------------------------------------------------
+# Core toolchain
+# ---------------------------------------------------------------------------
+Write-Section 'Core toolchain'
+
+foreach ($tool in 'rustc', 'cargo') {
+    if (Test-Tool $tool) {
+        Write-Ok (Get-ToolVersion $tool)
+    } else {
+        Write-Missing "$tool - install from https://rustup.rs"
+        $script:Missing += $tool
+    }
+}
+
+# The MSVC linker is what .cargo/config.toml's rust-lld pins against, and
+# aws-lc-sys needs cl.exe for its C sources.
+if (Test-Tool 'cl') {
+    Write-Ok 'cl.exe (MSVC C/C++ compiler)'
+    # adk-sandbox forwards LIB to rustc so it can reach the MSVC linker. Without
+    # it, a_working_program_still_runs fails even though cl.exe is on PATH.
+    if ($env:LIB) {
+        Write-Ok 'LIB set (MSVC library path available to the sandbox tests)'
+    } else {
+        Write-Warn 'LIB not set - adk-sandbox a_working_program_still_runs will fail'
+        Write-Host '         Run the test suite from a Developer PowerShell, or call'
+        Write-Host '         vcvars64.bat first.'
+    }
+} else {
+    Write-Warn 'cl.exe not on PATH - install Visual Studio Build Tools with the'
+    Write-Host '         "Desktop development with C++" workload, then run this from'
+    Write-Host '         a Developer PowerShell: https://visualstudio.microsoft.com/downloads/'
+    $script:Missing += 'Visual Studio Build Tools'
+}
+
+# ---------------------------------------------------------------------------
+# Build acceleration
+# ---------------------------------------------------------------------------
+Write-Section 'Build acceleration (optional)'
+
+if (Test-Tool 'sccache') {
+    Write-Ok (Get-ToolVersion 'sccache')
+} elseif ($Check) {
+    Write-Missing 'sccache - shared compilation cache'
+} else {
+    Write-Missing 'sccache - shared compilation cache'
+    Write-Host '  Installing sccache via cargo...'
+    cargo install sccache --locked
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warn 'could not install sccache - see https://github.com/mozilla/sccache'
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Test runner
+# ---------------------------------------------------------------------------
+Write-Section 'Test runner (quality gate)'
+
+if (Test-Tool 'cargo-nextest') {
+    Write-Ok (Get-ToolVersion 'cargo-nextest')
+} elseif ($Check) {
+    Write-Missing 'cargo-nextest - required by the test gate'
+} else {
+    Write-Missing 'cargo-nextest - required by the test gate'
+    # Prebuilt binary: building from source costs minutes for no benefit.
+    Install-ZipTool -Name 'cargo-nextest' `
+        -Url 'https://get.nexte.st/latest/windows-tar' `
+        -Subdir 'nextest' -ExeName 'cargo-nextest.exe' -Format 'tar' | Out-Null
+}
+
+# ---------------------------------------------------------------------------
+# Feature-gated build tools
+# ---------------------------------------------------------------------------
+Write-Section 'Feature-gated build tools'
+
+# protoc - lance's build script requires it, so `adk-rag --features lancedb`
+# cannot compile without it. CI installs it on every feature-coverage runner,
+# which is why a missing local copy fails while CI stays green.
+$protoc = if (Test-Tool 'protoc') { 'protoc' } else { Find-LocalTool -Name 'protoc.exe' -Subdir 'protoc' }
+if ($protoc) {
+    Write-Ok "protoc $((Get-ToolVersion $protoc) -replace '^libprotoc ', '')"
+    if ($protoc -ne 'protoc') { $script:PathAdditions += (Split-Path $protoc) }
+} elseif ($Check) {
+    Write-Missing 'protoc - needed for adk-rag --features lancedb'
+} else {
+    Write-Missing 'protoc - needed for adk-rag --features lancedb'
+    $protoc = Install-ZipTool -Name 'protoc' `
+        -Url 'https://github.com/protocolbuffers/protobuf/releases/download/v29.3/protoc-29.3-win64.zip' `
+        -Subdir 'protoc' -ExeName 'protoc.exe'
+}
+
+# NASM - aws-lc-sys assembles its own sources on MSVC, so every rustls-backed
+# feature (adk-auth --features sso among them) fails without it.
+$nasm = if (Test-Tool 'nasm') { 'nasm' } else { Find-LocalTool -Name 'nasm.exe' -Subdir 'nasm' }
+if ($nasm) {
+    Write-Ok (Get-ToolVersion $nasm '-v')
+    if ($nasm -ne 'nasm') { $script:PathAdditions += (Split-Path $nasm) }
+} elseif ($Check) {
+    Write-Missing 'nasm - needed by aws-lc-sys on MSVC (any rustls feature)'
+} else {
+    Write-Missing 'nasm - needed by aws-lc-sys on MSVC (any rustls feature)'
+    Install-ZipTool -Name 'nasm' `
+        -Url 'https://www.nasm.us/pub/nasm/releasebuilds/2.16.03/win64/nasm-2.16.03-win64.zip' `
+        -Subdir 'nasm' -ExeName 'nasm.exe' | Out-Null
+}
+
+if (Test-Tool 'cmake') {
+    Write-Ok (Get-ToolVersion 'cmake')
+} else {
+    Write-Warn 'cmake - needed only for the openai-webrtc feature (audiopus)'
+    Write-Host '         https://cmake.org/download/'
+}
+
+# ---------------------------------------------------------------------------
+# POSIX tooling required by the test suite
+# ---------------------------------------------------------------------------
+Write-Section 'POSIX tooling (required by 9 tests)'
+
+# These tests shell out directly. Without bash/sh they fail with
+# "program not found" locally while passing on GitHub's windows-latest image.
+if (Test-Tool 'bash') {
+    Write-Ok "bash - $((Get-Command bash).Source)"
+} else {
+    # Git for Windows ships bash/sh in Git\bin but adds only Git\cmd to PATH,
+    # so the shell is usually already installed and merely unreachable.
+    $gitBin = 'C:\Program Files\Git\bin'
+    if (Test-Path (Join-Path $gitBin 'bash.exe')) {
+        Write-Warn "bash present but not on PATH: $gitBin"
+        $script:PathAdditions += $gitBin
+    } else {
+        Write-Missing 'bash - 9 shell-tool tests fail without it'
+        Write-Host '         https://git-scm.com/download/win'
+        $script:Missing += 'bash (Git for Windows)'
+    }
+}
+
+# adk-sandbox process tests invoke `python3`; a bare `python` does not satisfy
+# them. The python.org installer does not create the python3 alias, so check it
+# explicitly rather than inferring from `python`.
+if (Test-Tool 'python3') {
+    Write-Ok "python3 - $(Get-ToolVersion 'python3')"
+} elseif (Test-Tool 'python') {
+    # The python.org installer creates no python3.exe, but adk-sandbox's tests
+    # invoke `python3` specifically. Copying the shim is cheaper and less
+    # surprising than asking every contributor to do it by hand.
+    $pyDir = Split-Path (Get-Command python).Source
+    $shim = Join-Path $pyDir 'python3.exe'
+    if ($Check) {
+        Write-Warn 'python present but python3 does not resolve - run without -Check to create the alias'
+        $script:Missing += 'python3 alias'
+    } else {
+        try {
+            Copy-Item (Join-Path $pyDir 'python.exe') $shim -Force -ErrorAction Stop
+            Write-Ok "python3 alias created at $shim"
+        } catch {
+            Write-Warn "could not create python3 alias: $($_.Exception.Message)"
+            $script:Missing += 'python3 alias'
+        }
+    }
+} else {
+    Write-Missing 'python3 - adk-sandbox process-execution tests fail without it'
+    Write-Host '         https://www.python.org/downloads/'
+    $script:Missing += 'python3'
+}
+
+# ---------------------------------------------------------------------------
+# Git hooks
+# ---------------------------------------------------------------------------
+Write-Section 'Git hooks (quality gates)'
+
+if (Test-Tool 'lefthook') {
+    Write-Ok (Get-ToolVersion 'lefthook' @('version'))
+} elseif ($Check) {
+    Write-Missing 'lefthook - git hook runner for the quality gates'
+} else {
+    Write-Missing 'lefthook - git hook runner for the quality gates'
+    # Not on crates.io, so cargo install cannot provide it.
+    if (Test-Tool 'npm') {
+        Write-Host '  Installing lefthook via npm...'
+        npm install -g lefthook 2>$null
+    }
+    if (-not (Test-Tool 'lefthook')) {
+        Write-Warn 'install lefthook manually: https://github.com/evilmartians/lefthook/releases'
+    }
+}
+
+if (-not $Check -and (Test-Tool 'lefthook')) {
+    git rev-parse --git-dir *> $null
+    if ($LASTEXITCODE -eq 0) {
+        lefthook install *> $null
+        if ($LASTEXITCODE -eq 0) {
+            Write-Ok 'git hooks installed (pre-commit, pre-push)'
+        } else {
+            Write-Warn "run 'lefthook install' from the repo root to register hooks"
+        }
+    } else {
+        Write-Warn "not a git repo - run 'lefthook install' from the repo root"
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Environment variables
+# ---------------------------------------------------------------------------
+Write-Section 'Environment variables'
+
+# setx writes to the user environment so the value survives new shells; the
+# current session is updated separately because setx does not affect it.
+function Set-UserEnv {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][string]$Value
+    )
+    if ($Check) {
+        Write-Warn "$Name not set - run without -Check to persist it ($Name=$Value)"
+        return
+    }
+    if (-not $PSCmdlet.ShouldProcess("user environment variable $Name", "set to '$Value'")) {
+        return
+    }
+    [Environment]::SetEnvironmentVariable($Name, $Value, 'User')
+    Set-Item -Path "env:$Name" -Value $Value
+    Write-Ok "$Name=$Value (persisted for this user)"
+}
+
+if ($env:RUSTC_WRAPPER) {
+    Write-Ok "RUSTC_WRAPPER=$env:RUSTC_WRAPPER"
+} elseif (Test-Tool 'sccache') {
+    Set-UserEnv -Name 'RUSTC_WRAPPER' -Value 'sccache'
+} else {
+    Write-Warn 'RUSTC_WRAPPER not set (sccache not installed)'
+}
+
+if ($env:CMAKE_POLICY_VERSION_MINIMUM) {
+    Write-Ok "CMAKE_POLICY_VERSION_MINIMUM=$env:CMAKE_POLICY_VERSION_MINIMUM"
+} else {
+    Set-UserEnv -Name 'CMAKE_POLICY_VERSION_MINIMUM' -Value '3.5'
+}
+
+# PROTOC only matters when protoc is not on PATH: lance's build script reads it
+# to locate the compiler.
+if ($env:PROTOC) {
+    Write-Ok "PROTOC=$env:PROTOC"
+} elseif ($protoc -and $protoc -ne 'protoc') {
+    Set-UserEnv -Name 'PROTOC' -Value $protoc
+} elseif ($protoc) {
+    Write-Ok 'PROTOC not needed (protoc is on PATH)'
+} else {
+    Write-Warn 'PROTOC not set and protoc not found'
+}
+
+# ---------------------------------------------------------------------------
+# PATH additions
+# ---------------------------------------------------------------------------
+$script:PathAdditions = $script:PathAdditions | Where-Object { $_ } | Sort-Object -Unique
+if ($script:PathAdditions) {
+    Write-Section 'PATH'
+    $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+    foreach ($dir in $script:PathAdditions) {
+        if ($userPath -and ($userPath -split ';' | Where-Object { $_.TrimEnd('\') -ieq $dir.TrimEnd('\') })) {
+            Write-Ok "already on PATH: $dir"
+            continue
+        }
+        if ($Check) {
+            Write-Warn "not on PATH: $dir"
+            continue
+        }
+        $userPath = if ($userPath) { "$dir;$userPath" } else { $dir }
+        [Environment]::SetEnvironmentVariable('Path', $userPath, 'User')
+        $env:Path = "$dir;$env:Path"
+        Write-Ok "added to PATH: $dir"
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+Write-Host ""
+if ($script:Missing) {
+    Write-Host "Outstanding manual steps:" -ForegroundColor Yellow
+    $script:Missing | Sort-Object -Unique | ForEach-Object { Write-Host "  - $_" }
+    Write-Host ""
+}
+
+if ($Check) {
+    Write-Host "Run without -Check to install missing tools."
+} else {
+    Write-Host "Done. Open a new shell so PATH and environment changes apply, then:"
+    Write-Host "  cargo fmt --all -- --check"
+    Write-Host "  cargo clippy --workspace --all-targets -- -D warnings"
+    Write-Host "  cargo nextest run --workspace"
+}

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -115,6 +115,40 @@ else
 fi
 
 echo ""
+echo "Test runner (quality gate):"
+
+# cargo-nextest backs one of the three quality gates, and no other installer
+# provides it — `cargo test` does not substitute (it skips nextest's isolation).
+if command -v cargo-nextest &>/dev/null; then
+  ok "cargo-nextest $(cargo nextest --version 2>/dev/null | head -1 | awk '{print $2}')"
+else
+  miss "cargo-nextest — required by the test gate"
+  if ! $CHECK_ONLY; then
+    echo "  Installing cargo-nextest via cargo..."
+    cargo install cargo-nextest --locked 2>/dev/null || \
+      warn "could not install cargo-nextest — see https://nexte.st/docs/installation/"
+  fi
+fi
+
+echo ""
+echo "Feature-gated build tools:"
+
+# protoc — lance's build script needs it, so `adk-rag --features lancedb` cannot
+# compile without it. CI installs it on every feature-coverage runner, so a
+# missing local copy fails while CI stays green.
+if command -v protoc &>/dev/null; then
+  ok "protoc $(protoc --version | awk '{print $2}')"
+else
+  miss "protoc — needed for adk-rag --features lancedb"
+  install_pkg protoc protobuf protobuf-compiler
+fi
+
+# NASM is only consumed by aws-lc-sys on MSVC targets, so Unix hosts never need
+# it. Reported rather than silently skipped so the check output matches the
+# tool matrix in AGENTS.md on every platform.
+ok "nasm — not needed on $OS (aws-lc-sys requires it only on Windows MSVC)"
+
+echo ""
 echo "Frontend tooling (ADK Studio UI):"
 
 if command -v node &>/dev/null; then


### PR DESCRIPTION
## What

Makes the workspace build, lint, and test clean on Windows, and gives Windows a
scripted first-time setup.

Before this change, a fresh Windows clone could not pass the quality gates:
`clippy -D warnings` failed, `adk-sandbox --features wasm` did not build, and
nine tests failed on a stock host. The suite now reports **4051 passed, 0 failed,
83 skipped** from a plain (non-Developer) PowerShell.

## Why

None of these defects were visible to CI. The PR-tier `clippy` and `nextest` jobs
run on Linux, and the Windows job runs only `cargo build --workspace`, whose
default features compile neither the `wasm` module nor the `#[cfg(not(unix))]`
branches. The `feature-coverage` matrix does cover `adk-sandbox --features wasm`,
but on `ubuntu-latest` only.

No issue filed — found while reviewing the v2.0.0 release candidate end to end.

## How

**Build fixes**

| Defect | Location | Why CI missed it |
|--------|----------|------------------|
| Optional deps scoped to `cfg(unix)` | `adk-sandbox/Cargo.toml` | A `[target.'cfg(unix)'.dependencies]` header captured every following entry, so `wasmtime`/`wasmtime-wasi` were unix-only and `windows-sys` was unselectable on all platforms |
| `collapsible_if` | `cargo-adk/src/main.rs` | Inside `#[cfg(not(unix))]` |
| `collapsible_if` ×2 | `adk-rust/src/lib.rs` | Only compile at the `standard` tier and above |
| `unneeded_return` | `adk-sandbox/src/sandbox/windows.rs` | Module never compiled until the manifest fix |

**Test portability**

`adk-bench`'s external-runner tests invoked `sh` and a bare `echo`, neither of
which a stock Windows host provides. Passing a shell one-liner as an argument also
corrupted embedded JSON, because `cmd.exe` does not implement
`CommandLineToArgvW` escaping — the same quirk `adk-sandbox`'s
`ProcessBackend::execute_command` already documents. The tests now write a
temporary script (PowerShell on Windows, `sh` elsewhere), so no payload crosses
the command line. PowerShell rather than `cmd` because `set /a` is 32-bit and
cannot add to an epoch-nanosecond timestamp.

`adk-sandbox`'s `a_working_program_still_runs` asserted `compile_lib=true`
unconditionally, but that covers `LIB` forwarding, which has nothing to forward
when the host has no `LIB` set. It now states that precondition. The
`runtime_lib=false` isolation assertion — the one that matters, verifying host
library paths do not leak into agent-generated code — stays unconditional.

**Setup tooling**

- `scripts/setup-dev.ps1` (new) — `make setup`, `setup-dev.sh`, and `devenv shell`
  all need a POSIX shell, so Windows had no scripted path. Installs `sccache`,
  `cargo-nextest`, `protoc`, and NASM; verifies `bash`/`python3`/`LIB`; registers
  lefthook; persists the expected environment variables. `-Check` is read-only.
- `scripts/setup-dev.sh` — adds `cargo-nextest` and `protoc` checks. Both back
  gates that CI installs for itself, so a missing local copy failed the build
  while CI stayed green.
- `scripts/lint-powershell.ps1` + a lefthook hook — PSScriptAnalyzer gate for
  staged `*.ps1`, mirroring the shellcheck gate. Skips when the module is absent.

### Verification

Run on Windows, `x86_64-pc-windows-msvc`, rustc 1.95.0:

- `cargo fmt --all -- --check` — passes
- `cargo clippy --workspace --all-targets -- -D warnings` — passes, 0 warnings
- `cargo nextest run --workspace --no-fail-fast` — **4051 passed, 0 failed, 83 skipped**
- `cargo doc --workspace --no-deps` with `RUSTDOCFLAGS=-D warnings` — passes
- All 13 PR-tier `feature-coverage` combinations — pass
- All four `adk-rust` tiers (`minimal`/`standard`/`enterprise`/`full`) — pass
- README quickstart (`cargo adk new my-agent` → `cargo build`) — scaffolds and
  compiles on Windows

### Follow-ups not in this PR

- The `feature-coverage` matrix runs only on `ubuntu-latest`. Adding a Windows
  entry (and the umbrella tiers) would have caught every build defect above.
- `cargo-adk` templates ship no `rust-toolchain.toml`, so a generated project
  builds with whatever default toolchain is active and fails on MSRV rather than
  pinning 1.95.
- Scaffold output suggests `cp .env.example .env`, which is not a cmd command.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

> Run as the `cargo` equivalents: `devenv` requires a POSIX shell and is
> unavailable on Windows, which is the gap `setup-dev.ps1` addresses.

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

> No public API changed. The `eprintln!` added in
> `process_enforcement_tests.rs` is in a test, not library code.

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed
- [x] Examples added or updated for new
