### PR TITLE
fix(agent): preserve cache prefix for skill injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`LlmAgent` skill injection preserves prompt-cache prefixes.** Contextual
+  skills are injected into the current user turn instead of leading the request,
+  so stable instructions and prior conversation history remain reusable by
+  provider prompt caches across turns.
 - **adk-sandbox's optional dependencies are no longer scoped to Unix.** Every
   optional dependency sat below a `[target.'cfg(unix)'.dependencies]` header, so
   `wasmtime` and `wasmtime-wasi` were unix-only and the `wasm` feature could not

--- a/adk-agent/README.md
+++ b/adk-agent/README.md
@@ -150,6 +150,10 @@ let agent = LlmAgentBuilder::new("assistant")
     .build()?;
 ```
 
+The selected skill is injected into the current user turn, after global and
+agent instructions plus prior conversation history. This keeps the stable
+prompt prefix reusable by provider prompt caches across turns.
+
 Skills are also supported on all workflow agents (`LoopAgent`, `SequentialAgent`, `ParallelAgent`, `ConditionalAgent`, `LlmConditionalAgent`).
 
 ### Workflow Agents

--- a/adk-agent/src/llm_agent.rs
+++ b/adk-agent/src/llm_agent.rs
@@ -24,7 +24,7 @@ use adk_plugin::{
 use crate::skill_shim::load_skill_index;
 use crate::{
     guardrails::{GuardrailSet, enforce_guardrails},
-    skill_shim::{SelectionPolicy, SkillIndex, select_skill_prompt_block},
+    skill_shim::{SelectionPolicy, SkillIndex, apply_skill_injection},
     tool_call_markup::normalize_option_content,
     workflow::with_user_content_override,
 };
@@ -286,28 +286,6 @@ impl PromptConfig {
     ) -> Result<Vec<Content>> {
         let mut preamble = Vec::new();
 
-        if let Some(index) = &self.skills_index {
-            let user_query = ctx
-                .user_content()
-                .parts
-                .iter()
-                .filter_map(|part| match part {
-                    Part::Text { text } => Some(text.as_str()),
-                    _ => None,
-                })
-                .collect::<Vec<_>>()
-                .join("\n");
-
-            if let Some((_matched, skill_block)) = select_skill_prompt_block(
-                index.as_ref(),
-                &user_query,
-                &self.skill_policy,
-                self.max_skill_chars,
-            ) {
-                preamble.push(Content::new("user").with_text(skill_block));
-            }
-        }
-
         if let Some(provider) = &self.global_instruction_provider {
             let instruction = provider(ctx.clone() as Arc<dyn ReadonlyContext>).await?;
             if !instruction.is_empty() {
@@ -342,7 +320,15 @@ impl PromptConfig {
             if ctx.run_config().transfer_targets.is_empty() { None } else { Some(agent_name) };
         let mut session_history =
             ctx.session().conversation_history_scoped(agent_filter, ctx.branch());
-        let current_user_content = ctx.user_content().clone();
+        let mut current_user_content = ctx.user_content().clone();
+        if let Some(index) = &self.skills_index {
+            apply_skill_injection(
+                &mut current_user_content,
+                index.as_ref(),
+                &self.skill_policy,
+                self.max_skill_chars,
+            );
+        }
         if let Some(index) = session_history.iter().rposition(|content| content.role == "user") {
             session_history[index] = current_user_content.clone();
         } else {
@@ -784,6 +770,9 @@ impl LlmAgentBuilder {
     }
 
     /// Set a preloaded skills index for this agent.
+    ///
+    /// The best matching skill is injected into the current user turn so stable
+    /// instructions and conversation history remain available for prompt caching.
     #[cfg(feature = "skills")]
     pub fn with_skills(mut self, index: SkillIndex) -> Self {
         self.skills_index = Some(Arc::new(index));

--- a/adk-agent/src/skill_shim.rs
+++ b/adk-agent/src/skill_shim.rs
@@ -1,7 +1,8 @@
 #[cfg(feature = "skills")]
-pub(crate) use adk_skill::{
-    SelectionPolicy, SkillIndex, apply_skill_injection, load_skill_index, select_skill_prompt_block,
-};
+pub(crate) use adk_skill::{SelectionPolicy, SkillIndex, apply_skill_injection, load_skill_index};
+
+#[cfg(all(feature = "skills", feature = "codeact"))]
+pub(crate) use adk_skill::select_skill_prompt_block;
 
 #[cfg(not(feature = "skills"))]
 mod disabled {
@@ -17,6 +18,7 @@ mod disabled {
         _disabled: (),
     }
 
+    #[cfg(feature = "codeact")]
     pub(crate) fn select_skill_prompt_block(
         _index: &SkillIndex,
         _query: &str,
@@ -37,6 +39,7 @@ mod disabled {
 }
 
 #[cfg(not(feature = "skills"))]
-pub(crate) use disabled::{
-    SelectionPolicy, SkillIndex, apply_skill_injection, select_skill_prompt_block,
-};
+pub(crate) use disabled::{SelectionPolicy, SkillIndex, apply_skill_injection};
+
+#[cfg(all(not(feature = "skills"), feature = "codeact"))]
+pub(crate) use disabled::select_skill_prompt_block;

--- a/adk-agent/tests/llm_agent_tests.rs
+++ b/adk-agent/tests/llm_agent_tests.rs
@@ -103,6 +103,7 @@ impl adk_core::Llm for SpyLlm {
 struct TestContext {
     content: Content,
     config: RunConfig,
+    session: DummySession,
 }
 
 impl TestContext {
@@ -113,7 +114,12 @@ impl TestContext {
                 parts: vec![Part::Text { text: message.to_string() }],
             },
             config: RunConfig::default(),
+            session: DummySession::default(),
         }
+    }
+
+    fn with_history(message: &str, history: Vec<Content>) -> Self {
+        Self { session: DummySession { history }, ..Self::new(message) }
     }
 }
 
@@ -165,12 +171,15 @@ impl InvocationContext for TestContext {
         false
     }
     fn session(&self) -> &dyn adk_core::Session {
-        &DummySession
+        &self.session
     }
 }
 
 // Dummy session for testing
-struct DummySession;
+#[derive(Default)]
+struct DummySession {
+    history: Vec<Content>,
+}
 
 impl adk_core::Session for DummySession {
     fn id(&self) -> &str {
@@ -186,7 +195,7 @@ impl adk_core::Session for DummySession {
         &DummyState
     }
     fn conversation_history(&self) -> Vec<adk_core::Content> {
-        Vec::new()
+        self.history.clone()
     }
 }
 
@@ -425,7 +434,7 @@ fn test_llm_agent_builder_with_callbacks() {
 
 #[cfg(feature = "skills")]
 #[tokio::test]
-async fn test_llm_agent_injects_skill_prompt_block() {
+async fn test_llm_agent_injects_skill_after_cacheable_prefix() {
     let temp = tempfile::tempdir().unwrap();
     let root = temp.path();
     std::fs::create_dir_all(root.join(".skills")).unwrap();
@@ -435,12 +444,15 @@ async fn test_llm_agent_injects_skill_prompt_block() {
     )
     .unwrap();
 
-    let model = SpyLlm::new("ok");
+    let model = SpyLlm::new("{}");
     let captured = model.last_request.clone();
 
     let builder = LlmAgentBuilder::new("skill_agent")
         .description("Agent with skills")
         .model(Arc::new(model))
+        .global_instruction("GLOBAL INSTRUCTION")
+        .instruction("AGENT INSTRUCTION")
+        .output_schema(serde_json::json!({"type": "object"}))
         .with_skills_from_root(root)
         .unwrap()
         .with_skill_policy(SelectionPolicy {
@@ -450,7 +462,14 @@ async fn test_llm_agent_injects_skill_prompt_block() {
         });
 
     let agent = builder.build().unwrap();
-    let ctx = Arc::new(TestContext::new("Please search this repository"));
+    let ctx = Arc::new(TestContext::with_history(
+        "Please search this repository",
+        vec![
+            Content::new("user").with_text("Earlier question"),
+            Content::new("model").with_text("Earlier answer"),
+            Content::new("user").with_text("Please search this repository"),
+        ],
+    ));
     let mut stream = agent.run(ctx).await.unwrap();
 
     use futures::StreamExt;
@@ -459,16 +478,21 @@ async fn test_llm_agent_injects_skill_prompt_block() {
     }
 
     let request = captured.lock().unwrap().clone().expect("expected captured request");
-    let combined = request
+    let messages = request
         .contents
         .iter()
-        .flat_map(|c| c.parts.iter())
-        .filter_map(|p| p.text())
-        .collect::<Vec<_>>()
-        .join("\n");
+        .map(|content| content.parts.iter().filter_map(Part::text).collect::<Vec<_>>().join("\n"))
+        .collect::<Vec<_>>();
 
-    assert!(combined.contains("[skill:search]"));
-    assert!(combined.contains("Use rg --files then rg <pattern>."));
+    assert_eq!(messages.len(), 6);
+    assert_eq!(messages[0], "GLOBAL INSTRUCTION");
+    assert_eq!(messages[1], "AGENT INSTRUCTION");
+    assert!(messages[2].starts_with("You MUST respond with valid JSON"));
+    assert_eq!(messages[3], "Earlier question");
+    assert_eq!(messages[4], "Earlier answer");
+    assert!(messages[5].starts_with("[skill:search]"));
+    assert!(messages[5].contains("Use rg --files then rg <pattern>."));
+    assert!(messages[5].ends_with("Please search this repository"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What

- Inject the selected `LlmAgent` skill into the current user turn.
- Preserve global instructions, agent instructions, output-schema guidance, and prior conversation history as a stable prompt prefix.
- Add regression coverage for the complete request ordering.
- Document the cache behavior in the crate README and changelog.

## Why

Contextual skill selection changes with each user message. Placing that dynamic block at the start of every request invalidates provider prompt caches before otherwise-stable instructions and conversation history can be reused.

## How

- Reuse `apply_skill_injection` to attach the selected skill to a clone of the current user content.
- Keep the existing `SelectionPolicy` and skill-budget behavior unchanged.
- Replace the current user event in scoped session history with the injected clone.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo nextest run --workspace` — 4,072 passed, 83 skipped
- `cargo clippy -p adk-agent --all-targets --features codeact -- -D warnings`
- `cargo clippy -p adk-agent --all-targets --features codeact,skills -- -D warnings`

Fixes #527