### PR TITLE
docs(managed): close checkpoint example

### DIFF
--- a/docs/official_docs/managed-agents/runtime.md
+++ b/docs/official_docs/managed-agents/runtime.md
@@ -317,6 +317,11 @@ let manager = CheckpointManager::new("session-1".to_string()).with_store(Arc::cl
 manager.flush().await?;
 
 let restored = CheckpointManager::restore("session-1".to_string(), store).await?;
+assert_eq!(restored.session_id(), "session-1");
+# Ok(())
+# }
+```
+
 ## Status reporting
 
 `ManagedAgentRuntime::status` reads the same handle the session loop writes to, so normal


### PR DESCRIPTION
## What

- Complete the managed-runtime checkpoint example with a result assertion and async-function return.
- Close the Rust code fence before the status-reporting section.

## Why

The unterminated fence renders the remainder of the page as Rust code and leaves the async example incomplete.

## Impact

The checkpoint example renders correctly and the following status-reporting documentation is readable as Markdown.

## Verification

- `bash scripts/check-doc-examples.sh` — validated 96 Markdown files
- pre-push `cargo check --workspace`