### PR TITLE
fix(core): bind schema cache to adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Schema caches keep adapter results isolated.** `SchemaCache` binds one
+  `SchemaAdapter` instance at construction, so the same input schema cannot
+  return a result produced by another provider or adapter configuration. The
+  deprecated per-call adapter API also keys entries by normalized output to
+  preserve correctness during migration.
 - **`LlmAgent` skill injection preserves prompt-cache prefixes.** Contextual
   skills are injected into the current user turn instead of leading the request,
   so stable instructions and prior conversation history remain reusable by

--- a/adk-core/src/schema_cache.rs
+++ b/adk-core/src/schema_cache.rs
@@ -1,42 +1,43 @@
 //! Schema normalization cache for LLM provider adapters.
 //!
-//! Caches normalized schemas keyed by a content hash, avoiding redundant
-//! normalization when the same tool schema is encountered across multiple
-//! requests. The hash ignores the order object keys were written in, so when
-//! `serde_json/preserve_order` is enabled — where insertion order would
-//! otherwise change the key — one schema built two different ways is one entry.
+//! Binds one adapter to each cache and stores normalized schemas by content hash,
+//! avoiding redundant normalization without allowing one adapter's result to be
+//! returned for another adapter. The hash ignores the order object keys were
+//! written in, so when `serde_json/preserve_order` is enabled — where insertion
+//! order would otherwise change the key — one schema built two different ways is
+//! one entry.
 //!
 //! # Example
 //!
 //! ```rust
-//! use adk_core::{SchemaCache, SchemaAdapter, GenericSchemaAdapter};
+//! use adk_core::{GenericSchemaAdapter, SchemaCache};
 //! use serde_json::json;
+//! use std::sync::Arc;
 //!
-//! let cache = SchemaCache::new();
-//! let adapter = GenericSchemaAdapter;
+//! let cache = SchemaCache::for_adapter(Arc::new(GenericSchemaAdapter));
 //! let schema = json!({"type": "object", "properties": {"name": {"type": "string"}}});
 //!
 //! // First call normalizes and caches
-//! let result1 = cache.get_or_normalize(&schema, &adapter);
+//! let result1 = cache.normalize(&schema);
 //!
 //! // Second call returns cached value without re-normalizing
-//! let result2 = cache.get_or_normalize(&schema, &adapter);
+//! let result2 = cache.normalize(&schema);
 //! assert_eq!(result1, result2);
 //! ```
 
 use std::collections::HashMap;
 use std::hash::{DefaultHasher, Hash, Hasher};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use serde_json::Value;
 
-use crate::SchemaAdapter;
+use crate::{GenericSchemaAdapter, SchemaAdapter};
 
 /// A thread-safe cache for normalized JSON Schemas.
 ///
-/// Stores normalized schemas keyed by a 64-bit hash of the serialized input schema.
-/// This avoids re-running normalization transforms on unchanged schemas across
-/// repeated `generate_content()` calls.
+/// An adapter-bound cache stores normalized schemas keyed by a 64-bit hash of the
+/// input schema. Binding the adapter at construction prevents results produced by
+/// different adapter instances from sharing an entry.
 ///
 /// # Thread Safety
 ///
@@ -46,10 +47,18 @@ use crate::SchemaAdapter;
 /// # Placement
 ///
 /// Intended to live on model instances so each provider adapter maintains its own
-/// cache of normalized schemas.
-#[derive(Debug, Default)]
+/// cache of normalized schemas. Use [`SchemaCache::new`] for the generic adapter
+/// or [`SchemaCache::for_adapter`] for a provider-specific adapter.
+#[derive(Debug)]
 pub struct SchemaCache {
-    entries: Mutex<HashMap<u64, Value>>,
+    adapter: Arc<dyn SchemaAdapter>,
+    entries: Mutex<HashMap<CacheKey, Value>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum CacheKey {
+    Bound(u64),
+    Legacy { schema: u64, normalized: u64 },
 }
 
 /// Adds a value to the hash in a fixed order.
@@ -101,51 +110,86 @@ fn hash_canonical(value: &Value, hasher: &mut DefaultHasher) {
 }
 
 impl SchemaCache {
-    /// Creates a new empty schema cache.
+    /// Creates an empty cache bound to [`GenericSchemaAdapter`].
+    ///
+    /// Use [`SchemaCache::for_adapter`] when normalization requires a
+    /// provider-specific adapter.
     ///
     /// # Example
     ///
     /// ```rust
     /// use adk_core::SchemaCache;
+    /// use serde_json::json;
     ///
     /// let cache = SchemaCache::new();
+    /// let normalized = cache.normalize(&json!({"type": "string"}));
     /// ```
     pub fn new() -> Self {
-        Self { entries: Mutex::new(HashMap::new()) }
+        Self::for_adapter(Arc::new(GenericSchemaAdapter))
     }
 
-    /// Returns the normalized schema for the given input, using the cache if available.
+    /// Creates an empty cache bound to one schema adapter.
     ///
-    /// If the schema has been normalized before (based on content hash), the cached
-    /// result is returned. Otherwise, `adapter.normalize_schema()` is called and the
-    /// result is stored in the cache.
-    ///
-    /// # Arguments
-    ///
-    /// * `schema` - The raw JSON Schema to normalize.
-    /// * `adapter` - The provider-specific schema adapter to use for normalization.
-    ///
-    /// # Returns
-    ///
-    /// The normalized JSON Schema value.
+    /// The cache owns the adapter, so every entry is guaranteed to have been
+    /// produced by that adapter instance.
     ///
     /// # Example
     ///
     /// ```rust
-    /// use adk_core::{SchemaCache, SchemaAdapter, GenericSchemaAdapter};
-    /// use serde_json::json;
+    /// use adk_core::{GenericSchemaAdapter, SchemaCache};
+    /// use std::sync::Arc;
     ///
-    /// let cache = SchemaCache::new();
-    /// let adapter = GenericSchemaAdapter;
+    /// let cache = SchemaCache::for_adapter(Arc::new(GenericSchemaAdapter));
+    /// assert!(cache.is_empty());
+    /// ```
+    pub fn for_adapter(adapter: Arc<dyn SchemaAdapter>) -> Self {
+        Self { adapter, entries: Mutex::new(HashMap::new()) }
+    }
+
+    /// Returns the schema normalized by this cache's adapter.
+    ///
+    /// If the same input schema has been normalized before, the cached result is
+    /// returned. Otherwise, the bound adapter normalizes the schema and the
+    /// result is stored.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use adk_core::{GenericSchemaAdapter, SchemaCache};
+    /// use serde_json::json;
+    /// use std::sync::Arc;
+    ///
+    /// let cache = SchemaCache::for_adapter(Arc::new(GenericSchemaAdapter));
     /// let schema = json!({"$schema": "draft-07", "type": "string"});
     ///
-    /// let normalized = cache.get_or_normalize(&schema, &adapter);
+    /// let normalized = cache.normalize(&schema);
     /// assert!(normalized.get("$schema").is_none());
     /// ```
-    pub fn get_or_normalize(&self, schema: &Value, adapter: &dyn SchemaAdapter) -> Value {
+    pub fn normalize(&self, schema: &Value) -> Value {
         let hash = Self::hash_schema(schema);
         let mut cache = self.entries.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
-        cache.entry(hash).or_insert_with(|| adapter.normalize_schema(schema.clone())).clone()
+        cache
+            .entry(CacheKey::Bound(hash))
+            .or_insert_with(|| self.adapter.normalize_schema(schema.clone()))
+            .clone()
+    }
+
+    /// Returns a schema normalized by the supplied adapter.
+    ///
+    /// This compatibility path normalizes before looking up the result because a
+    /// borrowed trait object has no stable identity that the cache can safely
+    /// retain. Use [`SchemaCache::for_adapter`] and [`SchemaCache::normalize`] to
+    /// avoid repeated normalization.
+    #[deprecated(
+        note = "bind the adapter with SchemaCache::for_adapter and call SchemaCache::normalize"
+    )]
+    pub fn get_or_normalize(&self, schema: &Value, adapter: &dyn SchemaAdapter) -> Value {
+        let schema_hash = Self::hash_schema(schema);
+        let normalized = adapter.normalize_schema(schema.clone());
+        let key =
+            CacheKey::Legacy { schema: schema_hash, normalized: Self::hash_schema(&normalized) };
+        let mut cache = self.entries.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        cache.entry(key).or_insert(normalized).clone()
     }
 
     /// Clears all cached entries.
@@ -156,15 +200,15 @@ impl SchemaCache {
     /// # Example
     ///
     /// ```rust
-    /// use adk_core::{SchemaCache, GenericSchemaAdapter};
+    /// use adk_core::{GenericSchemaAdapter, SchemaCache};
     /// use serde_json::json;
+    /// use std::sync::Arc;
     ///
-    /// let cache = SchemaCache::new();
-    /// let adapter = GenericSchemaAdapter;
+    /// let cache = SchemaCache::for_adapter(Arc::new(GenericSchemaAdapter));
     /// let schema = json!({"type": "string"});
     ///
     /// // Populate cache
-    /// cache.get_or_normalize(&schema, &adapter);
+    /// cache.normalize(&schema);
     ///
     /// // Invalidate all entries
     /// cache.clear();
@@ -201,46 +245,115 @@ impl SchemaCache {
     }
 }
 
+impl Default for SchemaCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use crate::GenericSchemaAdapter;
 
+    fn generic_cache() -> SchemaCache {
+        SchemaCache::for_adapter(Arc::new(GenericSchemaAdapter))
+    }
+
+    #[derive(Debug)]
+    struct TaggedAdapter(&'static str);
+
+    impl SchemaAdapter for TaggedAdapter {
+        fn normalize_schema(&self, mut schema: Value) -> Value {
+            schema
+                .as_object_mut()
+                .expect("test schema should be an object")
+                .insert("normalized_by".to_string(), Value::String(self.0.to_string()));
+            schema
+        }
+    }
+
+    #[derive(Debug)]
+    struct CountingAdapter(Arc<AtomicUsize>);
+
+    impl SchemaAdapter for CountingAdapter {
+        fn normalize_schema(&self, schema: Value) -> Value {
+            self.0.fetch_add(1, Ordering::Relaxed);
+            schema
+        }
+    }
+
     #[test]
     fn test_cache_returns_normalized_schema() {
-        let cache = SchemaCache::new();
-        let adapter = GenericSchemaAdapter;
+        let cache = generic_cache();
         let schema = json!({
             "$schema": "http://json-schema.org/draft-07/schema#",
             "type": "object",
             "properties": { "name": { "type": "string" } }
         });
 
-        let result = cache.get_or_normalize(&schema, &adapter);
+        let result = cache.normalize(&schema);
         assert!(result.get("$schema").is_none());
         assert_eq!(result["type"], "object");
     }
 
     #[test]
     fn test_cache_returns_same_result_on_repeated_calls() {
-        let cache = SchemaCache::new();
-        let adapter = GenericSchemaAdapter;
+        let cache = generic_cache();
         let schema = json!({
             "type": "object",
             "properties": { "x": { "type": "integer", "const": 42 } }
         });
 
-        let first = cache.get_or_normalize(&schema, &adapter);
-        let second = cache.get_or_normalize(&schema, &adapter);
+        let first = cache.normalize(&schema);
+        let second = cache.normalize(&schema);
         assert_eq!(first, second);
     }
 
     #[test]
-    fn test_cache_stores_entries() {
+    fn repeated_calls_only_invoke_the_bound_adapter_once() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let cache = SchemaCache::for_adapter(Arc::new(CountingAdapter(Arc::clone(&calls))));
+        let schema = json!({"type": "string"});
+
+        cache.normalize(&schema);
+        cache.normalize(&schema);
+
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn adapter_instances_cannot_share_entries() {
+        let schema = json!({"type": "object"});
+        let alpha = SchemaCache::for_adapter(Arc::new(TaggedAdapter("alpha")));
+        let beta = SchemaCache::for_adapter(Arc::new(TaggedAdapter("beta")));
+
+        assert_eq!(alpha.normalize(&schema)["normalized_by"], "alpha");
+        assert_eq!(beta.normalize(&schema)["normalized_by"], "beta");
+        assert_eq!(alpha.len(), 1);
+        assert_eq!(beta.len(), 1);
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn deprecated_api_keeps_adapter_results_separate() {
         let cache = SchemaCache::new();
-        let adapter = GenericSchemaAdapter;
+        let schema = json!({"type": "object"});
+
+        let alpha = cache.get_or_normalize(&schema, &TaggedAdapter("alpha"));
+        let beta = cache.get_or_normalize(&schema, &TaggedAdapter("beta"));
+
+        assert_eq!(alpha["normalized_by"], "alpha");
+        assert_eq!(beta["normalized_by"], "beta");
+        assert_eq!(cache.len(), 2);
+    }
+
+    #[test]
+    fn test_cache_stores_entries() {
+        let cache = generic_cache();
 
         assert!(cache.is_empty());
         assert_eq!(cache.len(), 0);
@@ -248,24 +361,23 @@ mod tests {
         let schema1 = json!({"type": "string"});
         let schema2 = json!({"type": "number"});
 
-        cache.get_or_normalize(&schema1, &adapter);
+        cache.normalize(&schema1);
         assert_eq!(cache.len(), 1);
 
-        cache.get_or_normalize(&schema2, &adapter);
+        cache.normalize(&schema2);
         assert_eq!(cache.len(), 2);
 
         // Same schema doesn't add a new entry
-        cache.get_or_normalize(&schema1, &adapter);
+        cache.normalize(&schema1);
         assert_eq!(cache.len(), 2);
     }
 
     #[test]
     fn test_cache_clear_removes_all_entries() {
-        let cache = SchemaCache::new();
-        let adapter = GenericSchemaAdapter;
+        let cache = generic_cache();
 
-        cache.get_or_normalize(&json!({"type": "string"}), &adapter);
-        cache.get_or_normalize(&json!({"type": "number"}), &adapter);
+        cache.normalize(&json!({"type": "string"}));
+        cache.normalize(&json!({"type": "number"}));
         assert_eq!(cache.len(), 2);
 
         cache.clear();
@@ -274,14 +386,13 @@ mod tests {
 
     #[test]
     fn test_cache_different_schemas_produce_different_entries() {
-        let cache = SchemaCache::new();
-        let adapter = GenericSchemaAdapter;
+        let cache = generic_cache();
 
         let schema_a = json!({"type": "string", "format": "hostname"});
         let schema_b = json!({"type": "string", "format": "email"});
 
-        let result_a = cache.get_or_normalize(&schema_a, &adapter);
-        let result_b = cache.get_or_normalize(&schema_b, &adapter);
+        let result_a = cache.normalize(&schema_a);
+        let result_b = cache.normalize(&schema_b);
 
         // "hostname" is stripped, "email" is preserved
         assert!(result_a.get("format").is_none());
@@ -304,22 +415,20 @@ mod tests {
 
     #[test]
     fn test_cache_handles_empty_schema() {
-        let cache = SchemaCache::new();
-        let adapter = GenericSchemaAdapter;
+        let cache = generic_cache();
         let schema = json!({});
 
-        let result = cache.get_or_normalize(&schema, &adapter);
+        let result = cache.normalize(&schema);
         assert_eq!(result, json!({}));
         assert_eq!(cache.len(), 1);
     }
 
     #[test]
     fn test_cache_handles_null_schema() {
-        let cache = SchemaCache::new();
-        let adapter = GenericSchemaAdapter;
+        let cache = generic_cache();
         let schema = Value::Null;
 
-        let result = cache.get_or_normalize(&schema, &adapter);
+        let result = cache.normalize(&schema);
         // GenericSchemaAdapter passes through non-object values
         assert_eq!(result, Value::Null);
         assert_eq!(cache.len(), 1);
@@ -329,28 +438,20 @@ mod tests {
     /// cache entry rather than each paying for normalization.
     #[test]
     fn key_order_does_not_create_a_second_entry() {
-        let cache = SchemaCache::new();
-        let adapter = GenericSchemaAdapter;
+        let cache = generic_cache();
 
-        cache.get_or_normalize(
-            &json!({ "type": "object", "properties": { "a": {}, "b": {} } }),
-            &adapter,
-        );
-        cache.get_or_normalize(
-            &json!({ "properties": { "b": {}, "a": {} }, "type": "object" }),
-            &adapter,
-        );
+        cache.normalize(&json!({ "type": "object", "properties": { "a": {}, "b": {} } }));
+        cache.normalize(&json!({ "properties": { "b": {}, "a": {} }, "type": "object" }));
 
         assert_eq!(cache.len(), 1, "key order must not change a schema's identity");
     }
 
     #[test]
     fn genuinely_different_schemas_keep_separate_entries() {
-        let cache = SchemaCache::new();
-        let adapter = GenericSchemaAdapter;
+        let cache = generic_cache();
 
-        cache.get_or_normalize(&json!({ "type": "string" }), &adapter);
-        cache.get_or_normalize(&json!({ "type": "integer" }), &adapter);
+        cache.normalize(&json!({ "type": "string" }));
+        cache.normalize(&json!({ "type": "integer" }));
 
         assert_eq!(cache.len(), 2);
     }
@@ -359,11 +460,10 @@ mod tests {
     /// two schemas onto one key.
     #[test]
     fn unusual_property_names_stay_distinct() {
-        let cache = SchemaCache::new();
-        let adapter = GenericSchemaAdapter;
+        let cache = generic_cache();
 
-        cache.get_or_normalize(&json!({ "properties": { "a/b": {} } }), &adapter);
-        cache.get_or_normalize(&json!({ "properties": { "a~b": {} } }), &adapter);
+        cache.normalize(&json!({ "properties": { "a/b": {} } }));
+        cache.normalize(&json!({ "properties": { "a~b": {} } }));
 
         assert_eq!(cache.len(), 2);
     }
@@ -371,11 +471,10 @@ mod tests {
     /// Text and a number that render alike must not collide.
     #[test]
     fn a_string_and_a_number_hash_differently() {
-        let cache = SchemaCache::new();
-        let adapter = GenericSchemaAdapter;
+        let cache = generic_cache();
 
-        cache.get_or_normalize(&json!({ "const": "1" }), &adapter);
-        cache.get_or_normalize(&json!({ "const": 1 }), &adapter);
+        cache.normalize(&json!({ "const": "1" }));
+        cache.normalize(&json!({ "const": 1 }));
 
         assert_eq!(cache.len(), 2);
     }
@@ -391,11 +490,10 @@ mod tests {
     /// enabling the feature for every crate in the build.
     #[test]
     fn numbers_are_identified_by_their_written_form() {
-        let cache = SchemaCache::new();
-        let adapter = GenericSchemaAdapter;
+        let cache = generic_cache();
 
-        cache.get_or_normalize(&json!({ "const": 5 }), &adapter);
-        cache.get_or_normalize(&json!({ "const": 5.0 }), &adapter);
+        cache.normalize(&json!({ "const": 5 }));
+        cache.normalize(&json!({ "const": 5.0 }));
 
         assert_eq!(cache.len(), 2);
     }

--- a/adk-model/src/anthropic/client.rs
+++ b/adk-model/src/anthropic/client.rs
@@ -191,7 +191,8 @@ impl AnthropicClient {
             } else {
                 use std::sync::LazyLock;
                 static ADAPTER: AnthropicSchemaAdapter = AnthropicSchemaAdapter;
-                static SCHEMA_CACHE: LazyLock<SchemaCache> = LazyLock::new(SchemaCache::new);
+                static SCHEMA_CACHE: LazyLock<SchemaCache> =
+                    LazyLock::new(|| SchemaCache::for_adapter(Arc::new(AnthropicSchemaAdapter)));
                 convert::convert_tools(&filtered_tools, &ADAPTER, &SCHEMA_CACHE)?
             }
         };

--- a/adk-model/src/anthropic/convert.rs
+++ b/adk-model/src/anthropic/convert.rs
@@ -227,7 +227,7 @@ pub fn convert_tools(
 
             let input_schema =
                 decl.get("parameters").cloned().unwrap_or_else(|| adapter.empty_schema());
-            let normalized_schema = cache.get_or_normalize(&input_schema, adapter);
+            let normalized_schema = cache.normalize(&input_schema);
 
             let normalized_name = adapter.normalize_tool_name(name);
 
@@ -691,7 +691,7 @@ mod tests {
         );
 
         let adapter = AnthropicSchemaAdapter;
-        let cache = SchemaCache::new();
+        let cache = SchemaCache::for_adapter(std::sync::Arc::new(AnthropicSchemaAdapter));
         let claude_tools =
             convert_tools(&tools, &adapter, &cache).expect("tool conversion should succeed");
         assert_eq!(claude_tools.len(), 1);
@@ -712,7 +712,7 @@ mod tests {
         );
 
         let adapter = AnthropicSchemaAdapter;
-        let cache = SchemaCache::new();
+        let cache = SchemaCache::for_adapter(std::sync::Arc::new(AnthropicSchemaAdapter));
         let claude_tools =
             convert_tools(&tools, &adapter, &cache).expect("tool conversion should succeed");
         assert_eq!(claude_tools.len(), 1);

--- a/adk-model/src/gemini/client.rs
+++ b/adk-model/src/gemini/client.rs
@@ -682,7 +682,7 @@ impl GeminiModel {
                 // adapter's empty_schema fallback when none is provided.
                 let schema =
                     tool_decl.get("parameters").cloned().unwrap_or_else(|| adapter.empty_schema());
-                let normalized_schema = cache.get_or_normalize(&schema, adapter);
+                let normalized_schema = cache.normalize(&schema);
 
                 // Build the FunctionDeclaration with normalized values
                 let description =
@@ -696,7 +696,7 @@ impl GeminiModel {
 
                 // Preserve response schema if present (normalized like parameters)
                 if let Some(response) = tool_decl.get("response") {
-                    func_decl_json["response"] = cache.get_or_normalize(response, adapter);
+                    func_decl_json["response"] = cache.normalize(response);
                 }
 
                 // Preserve behavior if present
@@ -1042,7 +1042,9 @@ impl GeminiModel {
         if !req.tools.is_empty() {
             let adapter = self.schema_adapter();
             use std::sync::LazyLock;
-            static SCHEMA_CACHE: LazyLock<SchemaCache> = LazyLock::new(SchemaCache::new);
+            static SCHEMA_CACHE: LazyLock<SchemaCache> = LazyLock::new(|| {
+                SchemaCache::for_adapter(std::sync::Arc::new(GeminiSchemaAdapter::new()))
+            });
             let (gemini_tools, tool_config) =
                 Self::build_gemini_tools(&req.tools, adapter, &SCHEMA_CACHE)?;
             for tool in gemini_tools {
@@ -1125,7 +1127,9 @@ impl GeminiModel {
 
         let adapter = self.schema_adapter();
         use std::sync::LazyLock;
-        static SCHEMA_CACHE: LazyLock<SchemaCache> = LazyLock::new(SchemaCache::new);
+        static SCHEMA_CACHE: LazyLock<SchemaCache> = LazyLock::new(|| {
+            SchemaCache::for_adapter(std::sync::Arc::new(GeminiSchemaAdapter::new()))
+        });
         let (gemini_tools, tool_config) = Self::build_gemini_tools(tools, adapter, &SCHEMA_CACHE)?;
         if !gemini_tools.is_empty() {
             cache_builder = cache_builder.with_tools(gemini_tools);
@@ -1481,7 +1485,7 @@ mod native_tool_tests {
     }
 
     fn test_cache() -> SchemaCache {
-        SchemaCache::new()
+        SchemaCache::for_adapter(std::sync::Arc::new(GeminiSchemaAdapter::new()))
     }
 
     #[test]

--- a/adk-model/src/openai/client.rs
+++ b/adk-model/src/openai/client.rs
@@ -184,7 +184,8 @@ impl Llm for AzureOpenAIClient {
         // Normalize tool schemas at request time using the schema adapter.
         let adapter = self.schema_adapter();
         use std::sync::LazyLock;
-        static SCHEMA_CACHE: LazyLock<SchemaCache> = LazyLock::new(SchemaCache::new);
+        static SCHEMA_CACHE: LazyLock<SchemaCache> =
+            LazyLock::new(|| SchemaCache::for_adapter(std::sync::Arc::new(OpenAiSchemaAdapter)));
         let request_body =
             build_request_json(&deployment_id, &request, &None, true, adapter, &SCHEMA_CACHE)?;
 

--- a/adk-model/src/openai/convert.rs
+++ b/adk-model/src/openai/convert.rs
@@ -250,7 +250,7 @@ pub fn convert_tools(
             let parameters = decl
                 .get("parameters")
                 .cloned()
-                .map(|schema| cache.get_or_normalize(&schema, adapter))
+                .map(|schema| cache.normalize(&schema))
                 .or_else(|| Some(adapter.empty_schema()));
 
             ChatCompletionTools::Function(ChatCompletionTool {
@@ -800,7 +800,7 @@ mod tests {
         );
 
         let adapter = OpenAiSchemaAdapter;
-        let cache = SchemaCache::new();
+        let cache = SchemaCache::for_adapter(std::sync::Arc::new(OpenAiSchemaAdapter));
         let openai_tools = convert_tools(&tools, &adapter, &cache);
         assert_eq!(openai_tools.len(), 1);
         if let ChatCompletionTools::Function(tool) = &openai_tools[0] {

--- a/adk-model/src/openai_compatible.rs
+++ b/adk-model/src/openai_compatible.rs
@@ -3,8 +3,8 @@
 use crate::openai::convert;
 use crate::retry::{RetryConfig, execute_with_retry, is_retryable_model_error};
 use adk_core::{
-    AdkError, Content, ErrorCategory, ErrorComponent, FinishReason, Llm, LlmRequest, LlmResponse,
-    LlmResponseStream, Part, SchemaAdapter, SchemaCache, UsageMetadata,
+    AdkError, Content, ErrorCategory, ErrorComponent, FinishReason, GenericSchemaAdapter, Llm,
+    LlmRequest, LlmResponse, LlmResponseStream, Part, SchemaAdapter, SchemaCache, UsageMetadata,
 };
 use async_openai::types::chat::{
     CreateChatCompletionRequestArgs, ReasoningEffort, ResponseFormat, ResponseFormatJsonSchema,
@@ -486,7 +486,8 @@ impl Llm for OpenAICompatible {
         // Normalize tool schemas at request time using the schema adapter.
         let adapter = self.schema_adapter();
         use std::sync::LazyLock;
-        static SCHEMA_CACHE: LazyLock<SchemaCache> = LazyLock::new(SchemaCache::new);
+        static SCHEMA_CACHE: LazyLock<SchemaCache> =
+            LazyLock::new(|| SchemaCache::for_adapter(std::sync::Arc::new(GenericSchemaAdapter)));
         let request_body = build_request_json(
             &model,
             &request,

--- a/docs/official_docs/tools/schema-normalization.md
+++ b/docs/official_docs/tools/schema-normalization.md
@@ -142,24 +142,26 @@ let adapter = GenericSchemaAdapter;
 Normalized schemas are cached by content hash to avoid redundant computation:
 
 ```rust
-use adk_core::{SchemaCache, GenericSchemaAdapter, SchemaAdapter};
+use adk_core::{GenericSchemaAdapter, SchemaCache};
 use serde_json::json;
+use std::sync::Arc;
 
-let cache = SchemaCache::new();
-let adapter = GenericSchemaAdapter;
+let cache = SchemaCache::for_adapter(Arc::new(GenericSchemaAdapter));
 let schema = json!({"type": "object", "properties": {"name": {"type": "string"}}});
 
 // First call normalizes and caches
-let result = cache.get_or_normalize(&schema, &adapter);
+let result = cache.normalize(&schema);
 
 // Subsequent calls return cached result (no re-normalization)
-let cached = cache.get_or_normalize(&schema, &adapter);
+let cached = cache.normalize(&schema);
 
 // Invalidate when tools change
 cache.clear();
 ```
 
-The cache lives on model instances and is automatically used during `generate_content()`.
+Each cache owns one adapter instance, so entries normalized for different
+providers or adapter configurations cannot collide. Provider clients use these
+caches automatically during `generate_content()`.
 
 ## Tool Name Truncation
 

--- a/examples/schema_normalization/README.md
+++ b/examples/schema_normalization/README.md
@@ -59,10 +59,16 @@ pub trait SchemaAdapter: Send + Sync + Debug {
 Normalized schemas are cached by content hash to avoid redundant computation:
 
 ```rust
-let cache = SchemaCache::new();
-let normalized = cache.get_or_normalize(&raw_schema, &adapter);
+use adk_core::{GenericSchemaAdapter, SchemaCache};
+use serde_json::json;
+use std::sync::Arc;
+
+let cache = SchemaCache::for_adapter(Arc::new(GenericSchemaAdapter));
+let raw_schema = json!({"type": "object"});
+let normalized = cache.normalize(&raw_schema);
 // Second call returns cached result
-let cached = cache.get_or_normalize(&raw_schema, &adapter);
+let cached = cache.normalize(&raw_schema);
+assert_eq!(normalized, cached);
 ```
 
 ### Tool Name Truncation

--- a/examples/schema_normalization/src/main.rs
+++ b/examples/schema_normalization/src/main.rs
@@ -25,6 +25,7 @@ use adk_gemini::schema_adapter::GeminiSchemaAdapter;
 use adk_model::anthropic::AnthropicSchemaAdapter;
 use adk_model::openai::{OpenAiSchemaAdapter, OpenAiStrictSchemaAdapter};
 use serde_json::json;
+use std::sync::Arc;
 
 fn main() {
     tracing_subscriber::fmt().with_env_filter("info").with_target(false).init();
@@ -184,19 +185,18 @@ fn main() {
     // --- Schema Cache Demo ---
     println!("\n━━━ Schema Cache ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
 
-    let cache = SchemaCache::new();
-    let adapter = GeminiSchemaAdapter::new();
+    let cache = SchemaCache::for_adapter(Arc::new(GeminiSchemaAdapter::new()));
 
     println!("  Cache empty: {} entries", cache.len());
 
-    let _result1 = cache.get_or_normalize(&raw_schema, &adapter);
+    let _result1 = cache.normalize(&raw_schema);
     println!("  After first normalize: {} entry (computed)", cache.len());
 
-    let _result2 = cache.get_or_normalize(&raw_schema, &adapter);
+    let _result2 = cache.normalize(&raw_schema);
     println!("  After second normalize: {} entry (cache hit!)", cache.len());
 
     let different_schema = json!({"type": "string", "format": "email"});
-    let _result3 = cache.get_or_normalize(&different_schema, &adapter);
+    let _result3 = cache.normalize(&different_schema);
     println!("  After different schema: {} entries", cache.len());
 
     cache.clear();


### PR DESCRIPTION
## What

- Bind each `SchemaCache` to one owned `SchemaAdapter` instance.
- Add `SchemaCache::for_adapter(...)` and the adapter-owned `normalize(...)` path.
- Keep `get_or_normalize(...)` as a correct, deprecated migration path.
- Migrate Gemini, OpenAI-compatible, Azure OpenAI, and Anthropic request construction.
- Update the schema-normalization example, documentation, and changelog.

## Why

The cache key contained only the input schema hash while the adapter was supplied per call. Reusing one cache with two adapters returned the first adapter's normalized result for both calls.

## How

- Adapter-bound entries use the canonical input schema hash within a cache that owns its adapter.
- The deprecated borrowed-adapter path normalizes before lookup and separates entries by normalized output, because a borrowed trait object has no stable identity the cache can retain.
- Regression tests cover distinct configured adapter instances and verify that cache hits invoke the bound adapter only once.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo nextest run --workspace` — 4,075 passed, 83 skipped
- `cargo nextest run -p adk-core -p adk-model` — 453 passed, 3 skipped
- `cargo test -p adk-core --doc` — 62 passed, 15 ignored
- `cargo test -p adk-model --features "openai anthropic" convert_tools`
- `cargo check --manifest-path examples/schema_normalization/Cargo.toml`
- `scripts/check-doc-examples.sh`
- `cargo semver-checks check-release -p adk-core --default-features`

Closes #532