### PR TITLE
fix(tool): honor MCP tool safety annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **MCP tool annotations now control per-tool safety metadata.** Discovered
+  `readOnlyHint` and `idempotentHint` values flow into ADK tool metadata,
+  automatic dispatch, and reconnect replay decisions. Tools without hints keep
+  the conservative sequential, no-replay defaults.
 - **`LlmAgent` skill injection preserves prompt-cache prefixes.** Contextual
   skills are injected into the current user turn instead of leading the request,
   so stable instructions and prior conversation history remain reusable by

--- a/adk-tool/README.md
+++ b/adk-tool/README.md
@@ -301,10 +301,13 @@ The refresher handles these error conditions automatically:
 - Session not found (server restart)
 - Connection reset
 
-Discovery calls reconnect and retry automatically. `tools/call` does not replay
-by default because a lost response can leave a mutating tool's external result
-uncertain. Opt in only for read-only tools or operations protected by a stable
-provider idempotency guarantee:
+Discovery calls reconnect and retry automatically. Discovered tool wrappers
+also replay when the server publishes `readOnlyHint: true` or
+`idempotentHint: true`. Missing hints keep replay disabled because a lost
+response can leave a mutating tool's external result uncertain. The direct
+`call_tool_value` and `ConnectionRefresher::call_tool` paths do not have
+discovered per-tool metadata; opt them in only for read-only tools or operations
+protected by a stable provider idempotency guarantee:
 
 ```rust
 let refresher = ConnectionRefresher::new(client, Arc::new(factory))
@@ -314,6 +317,9 @@ let toolset = McpToolset::new(client)
     .with_connection_factory(Arc::new(factory))
     .with_tool_call_retries();
 ```
+
+MCP annotations are server-published hints. Trust them only for servers inside
+the application's security boundary.
 
 ### Google Search
 

--- a/adk-tool/src/mcp/toolset.rs
+++ b/adk-tool/src/mcp/toolset.rs
@@ -20,7 +20,7 @@ use rmcp::{
         GetPromptResult, GetTaskParams, GetTaskPayloadParams, GetTaskPayloadRequest,
         GetTaskRequest, Prompt, ReadResourceRequestParams, Resource, ResourceContents,
         ResourceTemplate, ServerResult, SubscribeRequestParams, TaskMetadata, TaskSupport,
-        UnsubscribeRequestParams,
+        ToolAnnotations, UnsubscribeRequestParams,
     },
     service::RunningService,
 };
@@ -32,6 +32,12 @@ use tracing::{debug, warn};
 
 /// Shared factory object used to recreate MCP connections for refresh/retry.
 type DynConnectionFactory<S> = Arc<dyn ConnectionFactory<S>>;
+
+fn mcp_tool_safety(annotations: Option<&ToolAnnotations>) -> (bool, bool) {
+    let read_only = annotations.and_then(|value| value.read_only_hint).unwrap_or(false);
+    let idempotent = annotations.and_then(|value| value.idempotent_hint).unwrap_or(false);
+    (read_only, read_only || idempotent)
+}
 
 /// Preserve every MCP content block in ADK's multimodal tool-result envelope.
 /// `FunctionResponseData::from_tool_result` consumes this shape in the agent loop.
@@ -736,6 +742,7 @@ where
                 connection_factory: self.connection_factory.clone(),
                 refresh_config: self.refresh_config.clone(),
                 retry_tool_calls: self.retry_tool_calls,
+                annotations: mcp_tool.annotations,
                 task_support,
                 server_supports_tasks,
                 task_config: self.task_config.clone(),
@@ -926,6 +933,8 @@ where
     connection_factory: Option<DynConnectionFactory<S>>,
     refresh_config: RefreshConfig,
     retry_tool_calls: bool,
+    /// Safety hints published by the MCP server for this tool.
+    annotations: Option<ToolAnnotations>,
     /// Per-tool task contract published by the MCP server.
     task_support: TaskSupport,
     /// Whether the negotiated server capabilities permit task-augmented tool calls.
@@ -960,6 +969,8 @@ where
         params: CallToolRequestParams,
     ) -> Result<rmcp::model::CallToolResult> {
         let has_connection_factory = self.connection_factory.is_some();
+        let (_, metadata_allows_replay) = mcp_tool_safety(self.annotations.as_ref());
+        let replay_allowed = self.retry_tool_calls || metadata_allows_replay;
         let mut attempt = 0u32;
 
         loop {
@@ -976,13 +987,13 @@ where
                         attempt,
                         &self.refresh_config,
                         has_connection_factory,
-                        self.retry_tool_calls,
+                        replay_allowed,
                     ) {
                         return Err(mcp_tool_call_error(
                             &self.name,
                             &error,
                             has_connection_factory,
-                            self.retry_tool_calls,
+                            replay_allowed,
                         ));
                     }
 
@@ -1009,7 +1020,7 @@ where
                             &self.name,
                             &error,
                             has_connection_factory,
-                            self.retry_tool_calls,
+                            replay_allowed,
                         ));
                     }
                     attempt += 1;
@@ -1155,6 +1166,14 @@ where
         self.task_support != TaskSupport::Forbidden
     }
 
+    fn is_read_only(&self) -> bool {
+        mcp_tool_safety(self.annotations.as_ref()).0
+    }
+
+    fn is_concurrency_safe(&self) -> bool {
+        mcp_tool_safety(self.annotations.as_ref()).1
+    }
+
     fn parameters_schema(&self) -> Option<Value> {
         self.input_schema.clone()
     }
@@ -1286,6 +1305,23 @@ mod tests {
         let config = RefreshConfig::default().with_max_attempts(3);
         assert!(should_retry_mcp_operation("EOF", 0, &config, true, true));
         assert!(should_retry_mcp_operation("connection reset by peer", 1, &config, true, true));
+    }
+
+    #[test]
+    fn mcp_tool_safety_defaults_to_conservative_values() {
+        assert_eq!(mcp_tool_safety(None), (false, false));
+        assert_eq!(mcp_tool_safety(Some(&ToolAnnotations::default())), (false, false));
+    }
+
+    #[test]
+    fn mcp_tool_safety_maps_read_only_and_idempotent_hints() {
+        let mut read_only = ToolAnnotations::default();
+        read_only.read_only_hint = Some(true);
+        assert_eq!(mcp_tool_safety(Some(&read_only)), (true, true));
+
+        let mut idempotent = ToolAnnotations::default();
+        idempotent.idempotent_hint = Some(true);
+        assert_eq!(mcp_tool_safety(Some(&idempotent)), (false, true));
     }
 
     #[test]

--- a/docs/official_docs/mcp/client.md
+++ b/docs/official_docs/mcp/client.md
@@ -55,6 +55,15 @@ non-reproducible.
 the server's input and output schemas unchanged. The selected model provider
 normalizes a copy of the schema when it builds its request.
 
+The adapter also retains MCP tool annotations. A `readOnlyHint` marks the ADK
+tool as read-only and concurrency-safe; an `idempotentHint` permits safe replay
+after reconnecting but does not by itself make the tool eligible for automatic
+parallel dispatch. Missing hints keep both behaviors disabled.
+
+> **Important:** MCP annotations are server-published hints. Use automatic
+> replay and dispatch metadata only with servers inside the application's trust
+> boundary.
+
 ```rust
 let reviewed = McpToolset::new(client).with_filter(|name| {
     matches!(name, "read_order" | "read_policy" | "request_replacement")


### PR DESCRIPTION
## What

- retain `rmcp::model::ToolAnnotations` on discovered MCP tool wrappers
- map `readOnlyHint` and `idempotentHint` to ADK read-only, concurrency, and per-tool reconnect replay decisions
- preserve conservative behavior when hints are absent
- document the trust-boundary requirement for server-published hints

## Why

MCP annotations were discarded during tool discovery. Read-only tools therefore remained serialized, and safe per-tool replay required enabling the toolset-wide override for mutating tools as well.

## Impact

- `ToolExecutionStrategy::Auto` can parallelize discovered MCP tools marked read-only
- read-only or idempotent MCP tools can replay after reconnecting without enabling replay for every tool in the toolset
- tools without annotations remain sequential and are not replayed

## Verification

- `cargo nextest run -p adk-tool --features mcp` — 141 passed, 8 skipped
- `cargo clippy -p adk-tool --all-targets --features mcp -- -D warnings`
- `cargo fmt --all -- --check`
- pre-commit workspace clippy and formatting hooks
- pre-push workspace check hook

Fixes #511