### PR TITLE
fix(core): preserve content part metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Inline and file content metadata survives session persistence.**
+  `Part::InlineData`, `Part::FileData`, `Part::FunctionResponse`, and multimodal
+  function-response parts retain optional annotations; inline data also retains
+  its optional source URI. ACP image conversion now round-trips both fields, and
+  Vertex sessions route metadata-bearing content through lossless `rawEvent`
+  persistence. Existing payloads continue to deserialize with empty metadata.
 - **`LlmAgent` skill injection preserves prompt-cache prefixes.** Contextual
   skills are injected into the current user turn instead of leading the request,
   so stable instructions and prior conversation history remain reusable by

--- a/adk-acp/src/connection.rs
+++ b/adk-acp/src/connection.rs
@@ -278,7 +278,7 @@ pub async fn prompt_agent_with_policy(
 ///
 /// let mut content = Content::new("user");
 /// content.parts.push(Part::Text { text: "What is in this image?".into() });
-/// content.parts.push(Part::InlineData { mime_type: "image/png".into(), data: png_bytes });
+/// content.parts.push(Part::inline_data("image/png", png_bytes));
 ///
 /// let config = AcpAgentConfig::new("my-coding-agent --acp");
 /// let response = prompt_agent_content_with_policy(

--- a/adk-acp/src/content.rs
+++ b/adk-acp/src/content.rs
@@ -10,10 +10,10 @@
 //! | ACP `ContentBlock`                     | [`adk_core::Part`]                              |
 //! |----------------------------------------|-------------------------------------------------|
 //! | `Text`                                 | `Part::Text`                                    |
-//! | `Image { data, mime_type, uri? }`      | `Part::InlineData { mime_type, data }` (uri dropped) |
-//! | `Audio { data, mime_type }`            | `Part::InlineData { mime_type, data }`          |
+//! | `Image { data, mime_type, uri? }`      | `Part::InlineData { mime_type, data, uri, annotations }` |
+//! | `Audio { data, mime_type }`            | `Part::InlineData { mime_type, data, annotations }` |
 //! | `ResourceLink`                         | `Part::Text` (human-readable reference)         |
-//! | `ResourceLink` (outbound)              | `Part::FileData { mime_type, file_uri }`        |
+//! | `ResourceLink` (outbound)              | `Part::FileData { mime_type, file_uri, annotations }` |
 //! | `Resource { resource: Text }`          | `Part::EmbeddedResource(Text)`                  |
 //! | `Resource { resource: Blob }`          | `Part::EmbeddedResource(Blob)` (base64 decode)  |
 //!
@@ -26,7 +26,7 @@ use adk_core::{
     TextResourceContents,
 };
 use agent_client_protocol::schema::v1::{
-    AudioContent, BlobResourceContents as AcpBlobResourceContents, ContentBlock,
+    Annotations, AudioContent, BlobResourceContents as AcpBlobResourceContents, ContentBlock,
     EmbeddedResource as AcpEmbeddedResource, EmbeddedResourceResource, ImageContent, ResourceLink,
     TextContent, TextResourceContents as AcpTextResourceContents,
 };
@@ -64,11 +64,21 @@ pub fn block_to_part(block: &ContentBlock) -> Result<Part, AcpError> {
         ContentBlock::Text(text) => Ok(Part::Text { text: text.text.clone() }),
         ContentBlock::Image(image) => {
             let data = decode_base64(&image.data)?;
-            Ok(Part::InlineData { mime_type: image.mime_type.clone(), data })
+            Ok(Part::InlineData {
+                mime_type: image.mime_type.clone(),
+                data,
+                uri: image.uri.clone(),
+                annotations: annotations_to_value(image.annotations.as_ref())?,
+            })
         }
         ContentBlock::Audio(audio) => {
             let data = decode_base64(&audio.data)?;
-            Ok(Part::InlineData { mime_type: audio.mime_type.clone(), data })
+            Ok(Part::InlineData {
+                mime_type: audio.mime_type.clone(),
+                data,
+                uri: None,
+                annotations: annotations_to_value(audio.annotations.as_ref())?,
+            })
         }
         ContentBlock::ResourceLink(link) => Ok(Part::Text { text: resource_link_text(link) }),
         ContentBlock::Resource(resource) => embedded_resource_to_part(resource),
@@ -106,23 +116,36 @@ pub fn part_to_block(part: &Part) -> Option<ContentBlock> {
     match part {
         Part::Text { text } => Some(ContentBlock::Text(TextContent::new(text.clone()))),
         Part::InlineData { data, .. } if data.len() > MAX_INLINE_DATA_SIZE => None,
-        Part::InlineData { mime_type, data } if mime_type.starts_with("audio/") => {
+        Part::InlineData { mime_type, data, annotations, .. }
+            if mime_type.starts_with("audio/") =>
+        {
             let encoded = general_purpose::STANDARD.encode(data);
-            Some(ContentBlock::Audio(AudioContent::new(encoded, mime_type.clone())))
+            Some(ContentBlock::Audio(
+                AudioContent::new(encoded, mime_type.clone())
+                    .annotations(annotations_from_value(annotations.as_ref())),
+            ))
         }
-        Part::InlineData { mime_type, data } if mime_type.starts_with("image/") => {
+        Part::InlineData { mime_type, data, uri, annotations }
+            if mime_type.starts_with("image/") =>
+        {
             let encoded = general_purpose::STANDARD.encode(data);
-            Some(ContentBlock::Image(ImageContent::new(encoded, mime_type.clone())))
+            Some(ContentBlock::Image(
+                ImageContent::new(encoded, mime_type.clone())
+                    .uri(uri.clone())
+                    .annotations(annotations_from_value(annotations.as_ref())),
+            ))
         }
         Part::InlineData { .. } => None,
-        Part::FileData { mime_type, file_uri } => {
+        Part::FileData { mime_type, file_uri, annotations } => {
             let name = file_uri
                 .rsplit('/')
                 .find(|segment| !segment.is_empty())
                 .unwrap_or(file_uri)
                 .to_string();
             Some(ContentBlock::ResourceLink(
-                ResourceLink::new(name, file_uri.clone()).mime_type(Some(mime_type.clone())),
+                ResourceLink::new(name, file_uri.clone())
+                    .mime_type(Some(mime_type.clone()))
+                    .annotations(annotations_from_value(annotations.as_ref())),
             ))
         }
         Part::EmbeddedResource { resource } => embedded_resource_to_block(resource),
@@ -151,7 +174,7 @@ pub fn part_to_block(part: &Part) -> Option<ContentBlock> {
 ///
 /// let mut content = Content::new("user");
 /// content.parts.push(Part::Text { text: "describe this".into() });
-/// content.parts.push(Part::InlineData { mime_type: "image/png".into(), data: vec![1, 2, 3] });
+/// content.parts.push(Part::inline_data("image/png", vec![1, 2, 3]));
 ///
 /// let blocks = content_to_blocks(&content);
 /// assert_eq!(blocks.len(), 2);
@@ -232,6 +255,19 @@ fn decode_base64(data: &str) -> Result<Vec<u8>, AcpError> {
     Ok(decoded)
 }
 
+fn annotations_to_value(
+    annotations: Option<&Annotations>,
+) -> Result<Option<serde_json::Value>, AcpError> {
+    annotations
+        .map(serde_json::to_value)
+        .transpose()
+        .map_err(|error| AcpError::Protocol(format!("invalid ACP annotations: {error}")))
+}
+
+fn annotations_from_value(annotations: Option<&serde_json::Value>) -> Option<Annotations> {
+    annotations.and_then(|value| serde_json::from_value(value.clone()).ok())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -268,8 +304,29 @@ mod tests {
         let block = ContentBlock::Image(ImageContent::new(encoded, "image/png"));
         let part = block_to_part(&block).expect("image maps");
         assert!(
-            matches!(part, Part::InlineData { mime_type, data } if mime_type == "image/png" && data == raw)
+            matches!(part, Part::InlineData { mime_type, data, .. } if mime_type == "image/png" && data == raw)
         );
+    }
+
+    #[test]
+    fn image_uri_and_annotations_round_trip() {
+        let annotations = Annotations::new().priority(Some(0.8));
+        let block = ContentBlock::Image(
+            ImageContent::new(general_purpose::STANDARD.encode([1_u8, 2, 3]), "image/png")
+                .uri(Some("file:///screenshots/result.png".to_string()))
+                .annotations(Some(annotations.clone())),
+        );
+
+        let part = block_to_part(&block).expect("image maps");
+        assert_eq!(part.uri(), Some("file:///screenshots/result.png"));
+        assert_eq!(part.annotations(), Some(&serde_json::to_value(&annotations).unwrap()));
+
+        let round_tripped = part_to_block(&part).expect("image maps back");
+        let ContentBlock::Image(image) = round_tripped else {
+            panic!("expected image block");
+        };
+        assert_eq!(image.uri.as_deref(), Some("file:///screenshots/result.png"));
+        assert_eq!(image.annotations, Some(annotations));
     }
 
     #[test]
@@ -279,7 +336,7 @@ mod tests {
         let block = ContentBlock::Audio(AudioContent::new(encoded, "audio/mp3"));
         let part = block_to_part(&block).expect("audio maps");
         assert!(
-            matches!(part, Part::InlineData { mime_type, data } if mime_type == "audio/mp3" && data == raw)
+            matches!(part, Part::InlineData { mime_type, data, .. } if mime_type == "audio/mp3" && data == raw)
         );
     }
 
@@ -424,7 +481,7 @@ mod tests {
 
     #[test]
     fn inline_audio_part_maps_to_audio_block() {
-        let part = Part::InlineData { mime_type: "audio/wav".into(), data: vec![1, 2, 3] };
+        let part = Part::inline_data("audio/wav", vec![1, 2, 3]);
         match part_to_block(&part) {
             Some(ContentBlock::Audio(audio)) => {
                 assert_eq!(audio.mime_type, "audio/wav");
@@ -436,7 +493,7 @@ mod tests {
 
     #[test]
     fn inline_image_part_maps_to_image_block() {
-        let part = Part::InlineData { mime_type: "image/png".into(), data: vec![9, 8, 7] };
+        let part = Part::inline_data("image/png", vec![9, 8, 7]);
         match part_to_block(&part) {
             Some(ContentBlock::Image(image)) => {
                 assert_eq!(image.mime_type, "image/png");
@@ -448,13 +505,14 @@ mod tests {
 
     #[test]
     fn outbound_binary_mapping_rejects_unsupported_or_oversized_payloads() {
-        let unsupported =
-            Part::InlineData { mime_type: "application/octet-stream".into(), data: vec![1, 2, 3] };
+        let unsupported = Part::inline_data("application/octet-stream", vec![1, 2, 3]);
         assert!(part_to_block(&unsupported).is_none());
 
         let oversized = Part::InlineData {
             mime_type: "image/png".into(),
             data: vec![0; MAX_INLINE_DATA_SIZE + 1],
+            uri: None,
+            annotations: None,
         };
         assert!(part_to_block(&oversized).is_none());
 
@@ -473,6 +531,7 @@ mod tests {
         let part = Part::FileData {
             mime_type: "application/pdf".into(),
             file_uri: "https://example.com/reports/quarterly.pdf".into(),
+            annotations: None,
         };
         match part_to_block(&part) {
             Some(ContentBlock::ResourceLink(link)) => {
@@ -513,11 +572,12 @@ mod tests {
     fn content_to_blocks_maps_rich_content_and_skips_unrepresentable_parts() {
         let mut content = Content::new("user");
         content.parts.push(Part::Text { text: "describe these".into() });
-        content.parts.push(Part::InlineData { mime_type: "image/png".into(), data: vec![1, 2, 3] });
-        content.parts.push(Part::InlineData { mime_type: "audio/wav".into(), data: vec![4, 5, 6] });
+        content.parts.push(Part::inline_data("image/png", vec![1, 2, 3]));
+        content.parts.push(Part::inline_data("audio/wav", vec![4, 5, 6]));
         content.parts.push(Part::FileData {
             mime_type: "application/pdf".into(),
             file_uri: "file:///reports/result.pdf".into(),
+            annotations: None,
         });
         content.parts.push(Part::EmbeddedResource {
             resource: EmbeddedResource::Text(TextResourceContents::new(

--- a/adk-acp/src/server/handler.rs
+++ b/adk-acp/src/server/handler.rs
@@ -1209,7 +1209,7 @@ mod tests {
         let image = ContentBlock::Image(ImageContent::new(encoded, "image/png"));
         let content = prompt_content(&[image]).expect("handler accepts image content");
         assert!(
-            matches!(&content.parts[0], adk_core::Part::InlineData { mime_type, data }
+            matches!(&content.parts[0], adk_core::Part::InlineData { mime_type, data, .. }
                 if mime_type == "image/png" && data == &raw),
             "image content must map to Part::InlineData"
         );
@@ -1221,7 +1221,7 @@ mod tests {
         let audio = ContentBlock::Audio(AudioContent::new(encoded_audio, "audio/mp3"));
         let content = prompt_content(&[audio]).expect("handler accepts audio content");
         assert!(
-            matches!(&content.parts[0], adk_core::Part::InlineData { mime_type, data }
+            matches!(&content.parts[0], adk_core::Part::InlineData { mime_type, data, .. }
                 if mime_type == "audio/mp3" && data == &raw_audio),
             "audio content must map to Part::InlineData"
         );

--- a/adk-acp/src/server/streamer.rs
+++ b/adk-acp/src/server/streamer.rs
@@ -64,7 +64,7 @@ impl ResponseStreamer {
                             .raw_input(args.clone()),
                     ));
                 }
-                Part::FunctionResponse { function_response, id } => {
+                Part::FunctionResponse { function_response, id, .. } => {
                     let call_id =
                         id.clone().unwrap_or_else(|| format!("{}-call", function_response.name));
                     let mut fields = ToolCallUpdateFields::new()
@@ -122,15 +122,22 @@ fn tool_result_content(response: &FunctionResponseData) -> Vec<ToolCallContent> 
         }
     }
     for inline in &response.inline_data {
-        let part =
-            Part::InlineData { mime_type: inline.mime_type.clone(), data: inline.data.clone() };
+        let part = Part::InlineData {
+            mime_type: inline.mime_type.clone(),
+            data: inline.data.clone(),
+            uri: inline.uri.clone(),
+            annotations: inline.annotations.clone(),
+        };
         if let Some(block) = crate::content::part_to_block(&part) {
             content.push(ToolCallContent::from(block));
         }
     }
     for file in &response.file_data {
-        let part =
-            Part::FileData { mime_type: file.mime_type.clone(), file_uri: file.file_uri.clone() };
+        let part = Part::FileData {
+            mime_type: file.mime_type.clone(),
+            file_uri: file.file_uri.clone(),
+            annotations: file.annotations.clone(),
+        };
         if let Some(block) = crate::content::part_to_block(&part) {
             content.push(ToolCallContent::from(block));
         }
@@ -285,27 +292,37 @@ mod tests {
 
     #[test]
     fn replays_inline_image_and_audio_with_exact_wire_payloads() {
-        use agent_client_protocol::schema::v1::{AudioContent, ImageContent};
+        use agent_client_protocol::schema::v1::{Annotations, AudioContent, ImageContent};
+
+        let annotations = Annotations::new().priority(Some(0.8));
+        let annotation_value = serde_json::to_value(&annotations).unwrap();
 
         let mut event = Event::new("inv-media");
         let mut content = Content::new("user");
         content.parts.push(Part::InlineData {
             mime_type: "image/png".into(),
             data: vec![0x89, 0x50, 0x4e, 0x47],
+            uri: Some("file:///screenshots/result.png".into()),
+            annotations: Some(annotation_value.clone()),
         });
-        content
-            .parts
-            .push(Part::InlineData { mime_type: "audio/mpeg".into(), data: vec![1, 2, 3, 4, 5] });
+        content.parts.push(Part::InlineData {
+            mime_type: "audio/mpeg".into(),
+            data: vec![1, 2, 3, 4, 5],
+            uri: None,
+            annotations: Some(annotation_value),
+        });
         event.set_content(content);
 
         assert_eq!(
             ResponseStreamer::map_event(&event),
             vec![
                 SessionUpdate::UserMessageChunk(ContentChunk::new(ContentBlock::Image(
-                    ImageContent::new("iVBORw==", "image/png"),
+                    ImageContent::new("iVBORw==", "image/png")
+                        .uri(Some("file:///screenshots/result.png".into()))
+                        .annotations(Some(annotations.clone())),
                 ))),
                 SessionUpdate::UserMessageChunk(ContentChunk::new(ContentBlock::Audio(
-                    AudioContent::new("AQIDBAU=", "audio/mpeg"),
+                    AudioContent::new("AQIDBAU=", "audio/mpeg").annotations(Some(annotations)),
                 ))),
             ],
         );
@@ -351,6 +368,7 @@ mod tests {
                 serde_json::json!({"content":"fn main() {}"}),
             ),
             id: Some("call-1".into()),
+            annotations: None,
         });
         event.set_content(content);
 
@@ -371,13 +389,17 @@ mod tests {
                 vec![InlineDataPart {
                     mime_type: "image/png".into(),
                     data: vec![0x89, 0x50, 0x4e, 0x47],
+                    uri: None,
+                    annotations: None,
                 }],
                 vec![FileDataPart {
                     mime_type: "application/pdf".into(),
                     file_uri: "https://example.com/reports/result.pdf".into(),
+                    annotations: None,
                 }],
             ),
             id: Some("call-media".into()),
+            annotations: None,
         });
         event.set_content(content);
 
@@ -498,6 +520,7 @@ mod tests {
                 serde_json::json!({"path":"src/lib.rs","content":"fn main() {}"}),
             ),
             id: Some(call_id.into()),
+            annotations: None,
         });
         result_event.set_content(result_content);
 
@@ -523,6 +546,7 @@ mod tests {
                 serde_json::json!({"path":"src/main.rs","content":"fn main() {}"}),
             ),
             id: Some("call-1".into()),
+            annotations: None,
         });
         event.set_content(content);
 
@@ -548,6 +572,7 @@ mod tests {
                 serde_json::json!({"paths":["a.rs","b.rs"]}),
             ),
             id: Some("call-2".into()),
+            annotations: None,
         });
         event.set_content(content);
 

--- a/adk-agent/src/codeact/agent.rs
+++ b/adk-agent/src/codeact/agent.rs
@@ -1359,7 +1359,7 @@ pub fn extract_code_block(text: &str) -> String {
 fn completion_for(content: &Content, tool: &str, call_id: u64) -> Option<Value> {
     let want_id = call_id.to_string();
     let by_id = content.parts.iter().find_map(|part| match part {
-        Part::FunctionResponse { function_response, id }
+        Part::FunctionResponse { function_response, id, .. }
             if function_response.name == tool && id.as_deref() == Some(want_id.as_str()) =>
         {
             Some(function_response.response.clone())
@@ -1370,7 +1370,7 @@ fn completion_for(content: &Content, tool: &str, call_id: u64) -> Option<Value> 
         return by_id;
     }
     content.parts.iter().find_map(|part| match part {
-        Part::FunctionResponse { function_response, id }
+        Part::FunctionResponse { function_response, id, .. }
             if function_response.name == tool && id.is_none() =>
         {
             Some(function_response.response.clone())
@@ -2931,6 +2931,7 @@ mod tests {
             parts: vec![Part::FunctionResponse {
                 function_response: adk_core::FunctionResponseData::new("slow", json!({"ok": true})),
                 id: None,
+                annotations: None,
             }],
         };
         let events = drive(
@@ -3073,6 +3074,7 @@ mod tests {
             parts: vec![Part::FunctionResponse {
                 function_response: FunctionResponseData::new("slow", json!({"ok": true})),
                 id: None,
+                annotations: None,
             }],
         };
         let ctx2 = Arc::new(MockInvocationContext::new(completion).with_state(state));

--- a/adk-agent/src/llm_agent.rs
+++ b/adk-agent/src/llm_agent.rs
@@ -1724,6 +1724,7 @@ impl ToolExecutor<'_> {
                             serde_json::json!({ "error": e.to_string() }),
                         ),
                         id: id.clone(),
+                        annotations: None,
                     }],
                 };
                 return ToolExecutionResult {
@@ -1762,6 +1763,7 @@ impl ToolExecutor<'_> {
                                 }),
                             ),
                             id: id.clone(),
+                            annotations: None,
                         }],
                     });
                     run_after_tool_callbacks = false;
@@ -1777,6 +1779,7 @@ impl ToolExecutor<'_> {
                                 }),
                             ),
                             id: id.clone(),
+                            annotations: None,
                         }],
                     });
                     run_after_tool_callbacks = false;
@@ -1816,6 +1819,7 @@ impl ToolExecutor<'_> {
                                 synthetic_result,
                             ),
                             id: id.clone(),
+                            annotations: None,
                         }],
                     });
                     executed_tool = Some(tool_ref.clone());
@@ -1829,6 +1833,7 @@ impl ToolExecutor<'_> {
                                 serde_json::json!({ "error": e.to_string() }),
                             ),
                             id: id.clone(),
+                            annotations: None,
                         }],
                     });
                     run_after_tool_callbacks = false;
@@ -1858,6 +1863,7 @@ impl ToolExecutor<'_> {
                                     serde_json::json!({ "error": e.to_string() }),
                                 ),
                                 id: id.clone(),
+                                annotations: None,
                             }],
                         });
                         run_after_tool_callbacks = false;
@@ -1886,6 +1892,7 @@ impl ToolExecutor<'_> {
                             serde_json::json!({ "error": msg }),
                         ),
                         id: id.clone(),
+                        annotations: None,
                     }],
                 });
                 run_after_tool_callbacks = false;
@@ -2055,6 +2062,7 @@ impl ToolExecutor<'_> {
                             final_function_response,
                         ),
                         id: id.clone(),
+                        annotations: None,
                     }],
                 });
             } else {
@@ -2068,6 +2076,7 @@ impl ToolExecutor<'_> {
                             }),
                         ),
                         id: id.clone(),
+                        annotations: None,
                     }],
                 });
             }
@@ -2101,6 +2110,7 @@ impl ToolExecutor<'_> {
                                     serde_json::json!({ "error": e.to_string() }),
                                 ),
                                 id: id.clone(),
+                                annotations: None,
                             }],
                         };
                         break;
@@ -2126,6 +2136,7 @@ impl ToolExecutor<'_> {
                                         modified_value,
                                     ),
                                     id: id.clone(),
+                                    annotations: None,
                                 }],
                             };
                             break;
@@ -2140,6 +2151,7 @@ impl ToolExecutor<'_> {
                                         serde_json::json!({ "error": e.to_string() }),
                                     ),
                                     id: id.clone(),
+                                    annotations: None,
                                 }],
                             };
                             break;
@@ -2185,6 +2197,7 @@ impl ToolExecutor<'_> {
                                     modified_result,
                                 ),
                                 id: id.clone(),
+                                annotations: None,
                             }],
                         };
                     }
@@ -2197,6 +2210,7 @@ impl ToolExecutor<'_> {
                                     serde_json::json!({ "error": e.to_string() }),
                                 ),
                                 id: id.clone(),
+                                annotations: None,
                             }],
                         };
                     }
@@ -2898,6 +2912,7 @@ impl Agent for LlmAgent {
                                             }),
                                         ),
                                         id: call.id.clone(),
+                                        annotations: None,
                                     }],
                                 };
                                 conversation_history.push(error_content.clone());

--- a/adk-browser/src/tools/screenshot.rs
+++ b/adk-browser/src/tools/screenshot.rs
@@ -82,8 +82,12 @@ impl Tool for ScreenshotTool {
                 .decode(&base64_image)
                 .map_err(|e| adk_core::AdkError::tool(format!("Failed to decode base64: {}", e)))?;
 
-            let part =
-                adk_core::Part::InlineData { mime_type: "image/png".to_string(), data: image_data };
+            let part = adk_core::Part::InlineData {
+                mime_type: "image/png".to_string(),
+                data: image_data,
+                uri: None,
+                annotations: None,
+            };
 
             artifacts.save(artifact_name, &part).await?;
             saved = true;

--- a/adk-cli/src/launcher.rs
+++ b/adk-cli/src/launcher.rs
@@ -674,12 +674,12 @@ impl StreamPrinter {
                 self.flush_pending_thinking();
                 self.print_tool_response(&function_response.name, &function_response.response);
             }
-            Part::InlineData { mime_type, data } => {
+            Part::InlineData { mime_type, data, .. } => {
                 self.flush_pending_thinking();
                 print!("\n[inline-data] mime={mime_type} bytes={}\n", data.len());
                 let _ = io::stdout().flush();
             }
-            Part::FileData { mime_type, file_uri } => {
+            Part::FileData { mime_type, file_uri, .. } => {
                 self.flush_pending_thinking();
                 print!("\n[file-data] mime={mime_type} uri={file_uri}\n");
                 let _ = io::stdout().flush();
@@ -962,16 +962,17 @@ mod tests {
                 serde_json::json!({"temp": 72}),
             ),
             id: None,
+            annotations: None,
         });
 
         // InlineData
-        printer
-            .handle_part(&Part::InlineData { mime_type: "image/png".into(), data: vec![0u8; 100] });
+        printer.handle_part(&Part::inline_data("image/png", vec![0u8; 100]));
 
         // FileData
         printer.handle_part(&Part::FileData {
             mime_type: "audio/wav".into(),
             file_uri: "gs://bucket/file.wav".into(),
+            annotations: None,
         });
 
         // No panics, no state corruption

--- a/adk-core/README.md
+++ b/adk-core/README.md
@@ -114,10 +114,10 @@ let content = Content::new("user")
 // Part variants
 enum Part {
     Text { text: String },
-    InlineData { mime_type: String, data: Vec<u8> },  // Max 10MB (MAX_INLINE_DATA_SIZE)
-    FileData { mime_type: String, file_uri: String },
+    InlineData { mime_type: String, data: Vec<u8>, uri: Option<String>, annotations: Option<Value> },
+    FileData { mime_type: String, file_uri: String, annotations: Option<Value> },
     FunctionCall { name: String, args: Value, id: Option<String> },
-    FunctionResponse { function_response: FunctionResponseData, id: Option<String> },
+    FunctionResponse { function_response: FunctionResponseData, id: Option<String>, annotations: Option<Value> },
 }
 ```
 
@@ -136,14 +136,23 @@ Ok(json!({
 let frd = FunctionResponseData::with_inline_data(
     "chart_tool",
     json!({"title": "Q4 Chart"}),
-    vec![InlineDataPart { mime_type: "image/png".into(), data: png_bytes }],
+    vec![InlineDataPart {
+        mime_type: "image/png".into(),
+        data: png_bytes,
+        uri: None,
+        annotations: None,
+    }],
 );
 
 // File references (URIs to external files)
 let frd = FunctionResponseData::with_file_data(
     "doc_tool",
     json!({"status": "ok"}),
-    vec![FileDataPart { mime_type: "application/pdf".into(), file_uri: "gs://bucket/report.pdf".into() }],
+    vec![FileDataPart {
+        mime_type: "application/pdf".into(),
+        file_uri: "gs://bucket/report.pdf".into(),
+        annotations: None,
+    }],
 );
 ```
 

--- a/adk-core/src/event.rs
+++ b/adk-core/src/event.rs
@@ -298,6 +298,7 @@ impl Event {
     ///             serde_json::json!({ "stdout": "ok\n", "exit_code": 0 }),
     ///         ),
     ///         id: Some("call_1".to_string()),
+    ///         annotations: None,
     ///     }],
     /// });
     ///
@@ -315,7 +316,7 @@ impl Event {
             .parts
             .iter()
             .filter_map(|part| match part {
-                crate::types::Part::FunctionResponse { function_response, id } => {
+                crate::types::Part::FunctionResponse { function_response, id, .. } => {
                     Some(ToolResultView {
                         call_id: id.as_deref(),
                         name: &function_response.name,
@@ -595,6 +596,7 @@ mod tests {
                     serde_json::json!({"temp": 72}),
                 ),
                 id: Some("call_123".to_string()),
+                annotations: None,
             }],
         });
         // Has function response -> NOT final (model needs to respond)
@@ -625,6 +627,7 @@ mod tests {
                     serde_json::json!({"result": "done"}),
                 ),
                 id: Some("call_tool".to_string()),
+                annotations: None,
             }],
         });
         // Even with function response, skip_summarization makes it final
@@ -717,6 +720,7 @@ mod tests {
                         serde_json::json!({"output": "42"}),
                     ),
                     id: Some("call_exec".to_string()),
+                    annotations: None,
                 },
             ],
         });
@@ -766,6 +770,7 @@ mod tests {
                         serde_json::json!({}),
                     ),
                     id: Some("call_1".to_string()),
+                    annotations: None,
                 },
                 Part::Text { text: "Done".to_string() },
             ],

--- a/adk-core/src/intra_compaction.rs
+++ b/adk-core/src/intra_compaction.rs
@@ -203,6 +203,7 @@ mod tests {
                     serde_json::json!({"temp": 72}),
                 ),
                 id: None,
+                annotations: None,
             }],
         });
         let tokens = estimate_tokens(&[event], 4);

--- a/adk-core/src/types.rs
+++ b/adk-core/src/types.rs
@@ -17,6 +17,8 @@ pub const MAX_INLINE_DATA_SIZE: usize = 10 * 1024 * 1024;
 /// let part = InlineDataPart {
 ///     mime_type: "image/png".to_string(),
 ///     data: vec![0x89, 0x50, 0x4E, 0x47],
+///     uri: None,
+///     annotations: None,
 /// };
 /// ```
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -25,6 +27,12 @@ pub struct InlineDataPart {
     pub mime_type: String,
     /// Raw binary data.
     pub data: Vec<u8>,
+    /// Optional source URI associated with the inline payload.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uri: Option<String>,
+    /// Optional protocol or presentation annotations preserved with the payload.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<serde_json::Value>,
 }
 
 /// Data part for file references in a function response.
@@ -39,6 +47,7 @@ pub struct InlineDataPart {
 /// let part = FileDataPart {
 ///     mime_type: "application/pdf".to_string(),
 ///     file_uri: "gs://my-bucket/report.pdf".to_string(),
+///     annotations: None,
 /// };
 /// ```
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -47,6 +56,9 @@ pub struct FileDataPart {
     pub mime_type: String,
     /// URI to the file (URL, gs://, etc.).
     pub file_uri: String,
+    /// Optional protocol or presentation annotations preserved with the reference.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<serde_json::Value>,
 }
 
 /// Text contents of an embedded resource.
@@ -357,6 +369,12 @@ pub enum Part {
         mime_type: String,
         /// Raw binary data.
         data: Vec<u8>,
+        /// Optional source URI associated with the inline payload.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        uri: Option<String>,
+        /// Optional protocol or presentation annotations.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        annotations: Option<serde_json::Value>,
     },
     /// File data referenced by URI (URL or cloud storage path).
     ///
@@ -371,6 +389,7 @@ pub enum Part {
     /// let image_url = Part::FileData {
     ///     mime_type: "image/jpeg".to_string(),
     ///     file_uri: "https://example.com/image.jpg".to_string(),
+    ///     annotations: None,
     /// };
     /// ```
     FileData {
@@ -378,6 +397,9 @@ pub enum Part {
         mime_type: String,
         /// URI to the file (URL, gs://, etc.)
         file_uri: String,
+        /// Optional protocol or presentation annotations.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        annotations: Option<serde_json::Value>,
     },
     /// A function (tool) call from the model.
     FunctionCall {
@@ -402,6 +424,9 @@ pub enum Part {
         /// Tool call ID for OpenAI-style providers. None for Gemini.
         #[serde(skip_serializing_if = "Option::is_none")]
         id: Option<String>,
+        /// Optional protocol or presentation annotations.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        annotations: Option<serde_json::Value>,
     },
     /// Server-side tool call data from Gemini 3 built-in tool invocations.
     /// Stored as opaque JSON to avoid coupling core types to provider-specific schemas.
@@ -492,7 +517,12 @@ impl Content {
             data.len(),
             MAX_INLINE_DATA_SIZE
         );
-        self.parts.push(Part::InlineData { mime_type: mime_type.into(), data });
+        self.parts.push(Part::InlineData {
+            mime_type: mime_type.into(),
+            data,
+            uri: None,
+            annotations: None,
+        });
         self
     }
 
@@ -508,7 +538,11 @@ impl Content {
         mime_type: impl Into<String>,
         file_uri: impl Into<String>,
     ) -> Self {
-        self.parts.push(Part::FileData { mime_type: mime_type.into(), file_uri: file_uri.into() });
+        self.parts.push(Part::FileData {
+            mime_type: mime_type.into(),
+            file_uri: file_uri.into(),
+            annotations: None,
+        });
         self
     }
 
@@ -570,6 +604,25 @@ impl Part {
         }
     }
 
+    /// Returns the source URI for inline or referenced file data.
+    pub fn uri(&self) -> Option<&str> {
+        match self {
+            Part::InlineData { uri, .. } => uri.as_deref(),
+            Part::FileData { file_uri, .. } => Some(file_uri.as_str()),
+            _ => None,
+        }
+    }
+
+    /// Returns protocol or presentation annotations attached to this part.
+    pub fn annotations(&self) -> Option<&serde_json::Value> {
+        match self {
+            Part::InlineData { annotations, .. }
+            | Part::FileData { annotations, .. }
+            | Part::FunctionResponse { annotations, .. } => annotations.as_ref(),
+            _ => None,
+        }
+    }
+
     /// Returns true if this part contains media (image, audio, video)
     pub fn is_media(&self) -> bool {
         matches!(self, Part::InlineData { .. } | Part::FileData { .. })
@@ -599,12 +652,12 @@ impl Part {
             data.len(),
             MAX_INLINE_DATA_SIZE
         );
-        Part::InlineData { mime_type: mime_type.into(), data }
+        Part::InlineData { mime_type: mime_type.into(), data, uri: None, annotations: None }
     }
 
     /// Create a new file data part from URI
     pub fn file_data(mime_type: impl Into<String>, file_uri: impl Into<String>) -> Self {
-        Part::FileData { mime_type: mime_type.into(), file_uri: file_uri.into() }
+        Part::FileData { mime_type: mime_type.into(), file_uri: file_uri.into(), annotations: None }
     }
 }
 
@@ -653,6 +706,7 @@ mod tests {
         let part = Part::FileData {
             mime_type: "image/jpeg".to_string(),
             file_uri: "https://example.com/image.jpg".to_string(),
+            annotations: None,
         };
         let json = serde_json::to_string(&part).unwrap();
         assert!(json.contains("image/jpeg"));
@@ -664,7 +718,7 @@ mod tests {
         let text_part = Part::Text { text: "hello".to_string() };
         assert_eq!(text_part.text(), Some("hello"));
 
-        let data_part = Part::InlineData { mime_type: "image/png".to_string(), data: vec![] };
+        let data_part = Part::inline_data("image/png", vec![]);
         assert_eq!(data_part.text(), None);
     }
 
@@ -673,12 +727,13 @@ mod tests {
         let text_part = Part::Text { text: "hello".to_string() };
         assert_eq!(text_part.mime_type(), None);
 
-        let inline_part = Part::InlineData { mime_type: "image/png".to_string(), data: vec![] };
+        let inline_part = Part::inline_data("image/png", vec![]);
         assert_eq!(inline_part.mime_type(), Some("image/png"));
 
         let file_part = Part::FileData {
             mime_type: "image/jpeg".to_string(),
             file_uri: "https://example.com".to_string(),
+            annotations: None,
         };
         assert_eq!(file_part.mime_type(), Some("image/jpeg"));
     }
@@ -691,6 +746,7 @@ mod tests {
         let file_part = Part::FileData {
             mime_type: "image/jpeg".to_string(),
             file_uri: "https://example.com/img.jpg".to_string(),
+            annotations: None,
         };
         assert_eq!(file_part.file_uri(), Some("https://example.com/img.jpg"));
     }
@@ -700,12 +756,13 @@ mod tests {
         let text_part = Part::Text { text: "hello".to_string() };
         assert!(!text_part.is_media());
 
-        let inline_part = Part::InlineData { mime_type: "image/png".to_string(), data: vec![] };
+        let inline_part = Part::inline_data("image/png", vec![]);
         assert!(inline_part.is_media());
 
         let file_part = Part::FileData {
             mime_type: "image/jpeg".to_string(),
             file_uri: "https://example.com".to_string(),
+            annotations: None,
         };
         assert!(file_part.is_media());
     }
@@ -717,12 +774,12 @@ mod tests {
 
         let inline = Part::inline_data("image/png", vec![1, 2, 3]);
         assert!(
-            matches!(inline, Part::InlineData { mime_type, data } if mime_type == "image/png" && data == vec![1, 2, 3])
+            matches!(inline, Part::InlineData { mime_type, data, .. } if mime_type == "image/png" && data == vec![1, 2, 3])
         );
 
         let file = Part::file_data("image/jpeg", "https://example.com/img.jpg");
         assert!(
-            matches!(file, Part::FileData { mime_type, file_uri } if mime_type == "image/jpeg" && file_uri == "https://example.com/img.jpg")
+            matches!(file, Part::FileData { mime_type, file_uri, .. } if mime_type == "image/jpeg" && file_uri == "https://example.com/img.jpg")
         );
     }
 
@@ -773,7 +830,7 @@ mod tests {
         assert!(!text.is_thinking());
         assert_eq!(text.thinking_text(), None);
 
-        let data = Part::InlineData { mime_type: "image/png".to_string(), data: vec![] };
+        let data = Part::inline_data("image/png", vec![]);
         assert!(!data.is_thinking());
         assert_eq!(data.thinking_text(), None);
     }
@@ -873,7 +930,12 @@ mod tests {
 
     #[test]
     fn test_inline_data_part_serde_round_trip() {
-        let part = InlineDataPart { mime_type: "image/png".to_string(), data: vec![1, 2, 3, 4] };
+        let part = InlineDataPart {
+            mime_type: "image/png".to_string(),
+            data: vec![1, 2, 3, 4],
+            uri: Some("file:///screenshots/result.png".to_string()),
+            annotations: Some(serde_json::json!({"audience": ["user"], "priority": 0.8})),
+        };
         let json = serde_json::to_string(&part).unwrap();
         let deserialized: InlineDataPart = serde_json::from_str(&json).unwrap();
         assert_eq!(part, deserialized);
@@ -884,10 +946,64 @@ mod tests {
         let part = FileDataPart {
             mime_type: "application/pdf".to_string(),
             file_uri: "gs://bucket/report.pdf".to_string(),
+            annotations: Some(serde_json::json!({"audience": ["assistant"]})),
         };
         let json = serde_json::to_string(&part).unwrap();
         let deserialized: FileDataPart = serde_json::from_str(&json).unwrap();
         assert_eq!(part, deserialized);
+    }
+
+    #[test]
+    fn part_metadata_survives_session_serialization() {
+        let annotations = serde_json::json!({"audience": ["user"], "priority": 0.8});
+        let parts = vec![
+            Part::InlineData {
+                mime_type: "image/png".to_string(),
+                data: vec![1, 2, 3],
+                uri: Some("file:///screenshots/result.png".to_string()),
+                annotations: Some(annotations.clone()),
+            },
+            Part::FileData {
+                mime_type: "application/pdf".to_string(),
+                file_uri: "file:///reports/result.pdf".to_string(),
+                annotations: Some(annotations.clone()),
+            },
+            Part::FunctionResponse {
+                function_response: FunctionResponseData::new(
+                    "render_report",
+                    serde_json::json!({"ok": true}),
+                ),
+                id: Some("call-1".to_string()),
+                annotations: Some(annotations.clone()),
+            },
+        ];
+
+        let encoded = serde_json::to_value(&parts).unwrap();
+        let decoded: Vec<Part> = serde_json::from_value(encoded).unwrap();
+
+        assert_eq!(decoded, parts);
+        assert_eq!(decoded[0].uri(), Some("file:///screenshots/result.png"));
+        assert_eq!(decoded[0].annotations(), Some(&annotations));
+        assert_eq!(decoded[1].annotations(), Some(&annotations));
+        assert_eq!(decoded[2].annotations(), Some(&annotations));
+    }
+
+    #[test]
+    fn part_metadata_fields_default_when_deserializing_existing_payloads() {
+        let inline: Part = serde_json::from_value(serde_json::json!({
+            "mime_type": "image/png",
+            "data": [1, 2, 3]
+        }))
+        .unwrap();
+        assert_eq!(inline.uri(), None);
+        assert_eq!(inline.annotations(), None);
+
+        let file: Part = serde_json::from_value(serde_json::json!({
+            "mime_type": "application/pdf",
+            "file_uri": "file:///reports/result.pdf"
+        }))
+        .unwrap();
+        assert_eq!(file.annotations(), None);
     }
 
     #[test]
@@ -901,8 +1017,12 @@ mod tests {
 
     #[test]
     fn test_function_response_data_with_inline_data() {
-        let inline =
-            vec![InlineDataPart { mime_type: "image/png".to_string(), data: vec![0x89, 0x50] }];
+        let inline = vec![InlineDataPart {
+            mime_type: "image/png".to_string(),
+            data: vec![0x89, 0x50],
+            uri: None,
+            annotations: None,
+        }];
         let frd = FunctionResponseData::with_inline_data(
             "chart_tool",
             serde_json::json!({"ok": true}),
@@ -917,6 +1037,7 @@ mod tests {
         let files = vec![FileDataPart {
             mime_type: "application/pdf".to_string(),
             file_uri: "gs://bucket/doc.pdf".to_string(),
+            annotations: None,
         }];
         let frd = FunctionResponseData::with_file_data(
             "doc_tool",
@@ -929,11 +1050,16 @@ mod tests {
 
     #[test]
     fn test_function_response_data_with_multimodal() {
-        let inline =
-            vec![InlineDataPart { mime_type: "image/png".to_string(), data: vec![1, 2, 3] }];
+        let inline = vec![InlineDataPart {
+            mime_type: "image/png".to_string(),
+            data: vec![1, 2, 3],
+            uri: None,
+            annotations: None,
+        }];
         let files = vec![FileDataPart {
             mime_type: "audio/wav".to_string(),
             file_uri: "https://example.com/audio.wav".to_string(),
+            annotations: None,
         }];
         let frd = FunctionResponseData::with_multimodal(
             "multi_tool",
@@ -963,10 +1089,16 @@ mod tests {
         let frd = FunctionResponseData::with_multimodal(
             "tool",
             serde_json::json!({"status": "ok"}),
-            vec![InlineDataPart { mime_type: "image/png".to_string(), data: vec![1, 2] }],
+            vec![InlineDataPart {
+                mime_type: "image/png".to_string(),
+                data: vec![1, 2],
+                uri: None,
+                annotations: None,
+            }],
             vec![FileDataPart {
                 mime_type: "application/pdf".to_string(),
                 file_uri: "gs://b/f.pdf".to_string(),
+                annotations: None,
             }],
         );
         let json = serde_json::to_string(&frd).unwrap();
@@ -980,6 +1112,8 @@ mod tests {
         let oversized = vec![InlineDataPart {
             mime_type: "image/png".to_string(),
             data: vec![0u8; MAX_INLINE_DATA_SIZE + 1],
+            uri: None,
+            annotations: None,
         }];
         let _ = FunctionResponseData::with_inline_data("tool", serde_json::json!({}), oversized);
     }
@@ -990,6 +1124,8 @@ mod tests {
         let oversized = vec![InlineDataPart {
             mime_type: "image/png".to_string(),
             data: vec![0u8; MAX_INLINE_DATA_SIZE + 1],
+            uri: None,
+            annotations: None,
         }];
         let _ =
             FunctionResponseData::with_multimodal("tool", serde_json::json!({}), oversized, vec![]);

--- a/adk-core/tests/function_response_property_tests.rs
+++ b/adk-core/tests/function_response_property_tests.rs
@@ -14,8 +14,9 @@ fn arb_mime_type() -> impl Strategy<Value = String> {
 }
 
 fn arb_inline_data_part() -> impl Strategy<Value = InlineDataPart> {
-    (arb_mime_type(), prop::collection::vec(any::<u8>(), 0..1024))
-        .prop_map(|(mime_type, data)| InlineDataPart { mime_type, data })
+    (arb_mime_type(), prop::collection::vec(any::<u8>(), 0..1024)).prop_map(|(mime_type, data)| {
+        InlineDataPart { mime_type, data, uri: None, annotations: None }
+    })
 }
 
 fn arb_file_uri() -> impl Strategy<Value = String> {
@@ -27,8 +28,11 @@ fn arb_file_uri() -> impl Strategy<Value = String> {
 }
 
 fn arb_file_data_part() -> impl Strategy<Value = FileDataPart> {
-    (arb_mime_type(), arb_file_uri())
-        .prop_map(|(mime_type, file_uri)| FileDataPart { mime_type, file_uri })
+    (arb_mime_type(), arb_file_uri()).prop_map(|(mime_type, file_uri)| FileDataPart {
+        mime_type,
+        file_uri,
+        annotations: None,
+    })
 }
 
 fn arb_json_value() -> impl Strategy<Value = serde_json::Value> {

--- a/adk-managed/src/session_loop.rs
+++ b/adk-managed/src/session_loop.rs
@@ -534,6 +534,7 @@ impl SessionLoop {
                                 .unwrap_or("image/png")
                                 .to_string(),
                             file_uri: url.to_string(),
+                            annotations: None,
                         });
                     }
                 }
@@ -541,6 +542,7 @@ impl SessionLoop {
                     parts.push(Part::FileData {
                         mime_type: "application/octet-stream".to_string(),
                         file_uri: file_id.clone(),
+                        annotations: None,
                     });
                 }
             }

--- a/adk-memory/tests/memory_entry_property_tests.rs
+++ b/adk-memory/tests/memory_entry_property_tests.rs
@@ -42,7 +42,12 @@ fn arb_inline_data_part() -> impl Strategy<Value = Part> {
         ],
         proptest::collection::vec(any::<u8>(), 0..64),
     )
-        .prop_map(|(mime_type, data)| Part::InlineData { mime_type, data })
+        .prop_map(|(mime_type, data)| Part::InlineData {
+            mime_type,
+            data,
+            uri: None,
+            annotations: None,
+        })
 }
 
 /// Generate a Part::FileData variant.
@@ -51,7 +56,11 @@ fn arb_file_data_part() -> impl Strategy<Value = Part> {
         prop_oneof![Just("image/jpeg".to_string()), Just("application/pdf".to_string()),],
         "https://example\\.com/[a-z]{3,10}\\.[a-z]{3}",
     )
-        .prop_map(|(mime_type, file_uri)| Part::FileData { mime_type, file_uri })
+        .prop_map(|(mime_type, file_uri)| Part::FileData {
+            mime_type,
+            file_uri,
+            annotations: None,
+        })
 }
 
 /// Generate an arbitrary Part that round-trips cleanly through serde.

--- a/adk-mistralrs/src/convert.rs
+++ b/adk-mistralrs/src/convert.rs
@@ -68,7 +68,7 @@ pub fn content_to_message(content: &Content) -> IndexMap<String, Value> {
 
     // Handle function responses
     for part in &content.parts {
-        if let Part::FunctionResponse { id, function_response } = part {
+        if let Part::FunctionResponse { id, function_response, .. } = part {
             message
                 .insert("tool_call_id".to_string(), Value::String(id.clone().unwrap_or_default()));
             message.insert("name".to_string(), Value::String(function_response.name.clone()));
@@ -291,14 +291,14 @@ impl ImageFormat {
 /// A DynamicImage if the part contains valid image data, None otherwise.
 pub fn image_part_to_mistralrs(part: &Part) -> Option<DynamicImage> {
     match part {
-        Part::InlineData { mime_type, data } => {
+        Part::InlineData { mime_type, data, .. } => {
             if ImageFormat::is_supported_mime_type(mime_type) {
                 image::load_from_memory(data).ok()
             } else {
                 None
             }
         }
-        Part::FileData { mime_type, file_uri } => {
+        Part::FileData { mime_type, file_uri, .. } => {
             if ImageFormat::is_supported_mime_type(mime_type) {
                 image_from_uri(file_uri).ok()
             } else {
@@ -498,14 +498,14 @@ impl AudioFormat {
 /// An AudioInput if the part contains valid audio data, None otherwise.
 pub fn audio_part_to_mistralrs(part: &Part) -> Option<AudioInput> {
     match part {
-        Part::InlineData { mime_type, data } => {
+        Part::InlineData { mime_type, data, .. } => {
             if AudioFormat::is_supported_mime_type(mime_type) {
                 AudioInput::from_bytes(data).ok()
             } else {
                 None
             }
         }
-        Part::FileData { mime_type, file_uri } => {
+        Part::FileData { mime_type, file_uri, .. } => {
             if AudioFormat::is_supported_mime_type(mime_type) {
                 audio_from_uri(file_uri).ok()
             } else {

--- a/adk-mistralrs/src/vision.rs
+++ b/adk-mistralrs/src/vision.rs
@@ -373,7 +373,7 @@ impl MistralRsVisionModel {
                 .parts
                 .iter()
                 .filter_map(|part| match part {
-                    Part::InlineData { mime_type, data } => {
+                    Part::InlineData { mime_type, data, .. } => {
                         if is_image_mime_type(mime_type) {
                             image_from_bytes(data).ok()
                         } else {
@@ -389,7 +389,7 @@ impl MistralRsVisionModel {
                 .parts
                 .iter()
                 .filter_map(|part| match part {
-                    Part::InlineData { mime_type, data } => {
+                    Part::InlineData { mime_type, data, .. } => {
                         if is_audio_mime_type(mime_type) {
                             audio_from_bytes(data).ok()
                         } else {

--- a/adk-mistralrs/tests/audio_content_tests.rs
+++ b/adk-mistralrs/tests/audio_content_tests.rs
@@ -157,10 +157,7 @@ fn test_audio_format_ogg() {
 
 #[test]
 fn test_audio_part_to_mistralrs_with_unsupported_mime() {
-    let part = Part::InlineData {
-        mime_type: "application/octet-stream".to_string(),
-        data: vec![0, 1, 2, 3],
-    };
+    let part = Part::inline_data("application/octet-stream", vec![0, 1, 2, 3]);
 
     let result = audio_part_to_mistralrs(&part);
     assert!(result.is_none(), "Unsupported MIME type should return None");

--- a/adk-mistralrs/tests/image_content_tests.rs
+++ b/adk-mistralrs/tests/image_content_tests.rs
@@ -174,7 +174,7 @@ fn test_png_image_from_bytes() {
 #[test]
 fn test_image_part_to_mistralrs_with_png() {
     let png_data = generate_minimal_png();
-    let part = Part::InlineData { mime_type: "image/png".to_string(), data: png_data };
+    let part = Part::inline_data("image/png", png_data);
 
     let result = image_part_to_mistralrs(&part);
     assert!(result.is_some(), "PNG part should convert to image");
@@ -182,10 +182,7 @@ fn test_image_part_to_mistralrs_with_png() {
 
 #[test]
 fn test_image_part_to_mistralrs_with_unsupported_mime() {
-    let part = Part::InlineData {
-        mime_type: "application/octet-stream".to_string(),
-        data: vec![0, 1, 2, 3],
-    };
+    let part = Part::inline_data("application/octet-stream", vec![0, 1, 2, 3]);
 
     let result = image_part_to_mistralrs(&part);
     assert!(result.is_none(), "Unsupported MIME type should return None");
@@ -198,7 +195,7 @@ fn test_extract_images_from_content() {
         role: "user".to_string(),
         parts: vec![
             Part::Text { text: "Describe this image".to_string() },
-            Part::InlineData { mime_type: "image/png".to_string(), data: png_data },
+            Part::inline_data("image/png", png_data),
         ],
     };
 
@@ -256,6 +253,7 @@ fn test_file_data_part_with_image_mime() {
     let part = Part::FileData {
         mime_type: "image/jpeg".to_string(),
         file_uri: "https://example.com/image.jpg".to_string(),
+        annotations: None,
     };
 
     // FileData with image MIME type should be recognized as media
@@ -269,6 +267,7 @@ fn test_file_data_part_with_audio_mime() {
     let part = Part::FileData {
         mime_type: "audio/wav".to_string(),
         file_uri: "https://example.com/audio.wav".to_string(),
+        annotations: None,
     };
 
     assert!(part.is_media());
@@ -290,7 +289,7 @@ fn test_content_with_file_uri() {
     // Second part is FileData
     assert!(matches!(
         &content.parts[1],
-        Part::FileData { mime_type, file_uri }
+        Part::FileData { mime_type, file_uri, .. }
         if mime_type == "image/jpeg" && file_uri == "https://example.com/photo.jpg"
     ));
 }
@@ -301,7 +300,7 @@ fn test_part_constructors() {
     let file_part = Part::file_data("image/png", "https://example.com/img.png");
     assert!(matches!(
         file_part,
-        Part::FileData { mime_type, file_uri }
+        Part::FileData { mime_type, file_uri, .. }
         if mime_type == "image/png" && file_uri == "https://example.com/img.png"
     ));
 
@@ -309,7 +308,7 @@ fn test_part_constructors() {
     let inline_part = Part::inline_data("image/jpeg", vec![1, 2, 3]);
     assert!(matches!(
         inline_part,
-        Part::InlineData { mime_type, data }
+        Part::InlineData { mime_type, data, .. }
         if mime_type == "image/jpeg" && data == vec![1, 2, 3]
     ));
 }

--- a/adk-mistralrs/tests/multimodal_generation_tests.rs
+++ b/adk-mistralrs/tests/multimodal_generation_tests.rs
@@ -67,7 +67,7 @@ fn arb_text_and_image_content() -> impl Strategy<Value = Content> {
         let png_data = generate_minimal_png();
         Content {
             role: "user".to_string(),
-            parts: vec![Part::Text { text }, Part::InlineData { mime_type, data: png_data }],
+            parts: vec![Part::Text { text }, Part::inline_data(mime_type, png_data)],
         }
     })
 }
@@ -80,10 +80,7 @@ fn arb_text_and_audio_content() -> impl Strategy<Value = Content> {
             role: "user".to_string(),
             parts: vec![
                 Part::Text { text },
-                Part::InlineData {
-                    mime_type,
-                    data: vec![0u8; 44], // Minimal WAV header size
-                },
+                Part::inline_data(mime_type, vec![0u8; 44]), // Minimal WAV header size
             ],
         }
     })
@@ -98,8 +95,8 @@ fn arb_multimodal_content() -> impl Strategy<Value = Content> {
                 role: "user".to_string(),
                 parts: vec![
                     Part::Text { text },
-                    Part::InlineData { mime_type: image_mime, data: png_data },
-                    Part::InlineData { mime_type: audio_mime, data: vec![0u8; 44] },
+                    Part::inline_data(image_mime, png_data),
+                    Part::inline_data(audio_mime, vec![0u8; 44]),
                 ],
             }
         },
@@ -265,11 +262,8 @@ fn test_mixed_valid_invalid_images() {
     let content = Content {
         role: "user".to_string(),
         parts: vec![
-            Part::InlineData { mime_type: "image/png".to_string(), data: png_data },
-            Part::InlineData {
-                mime_type: "image/jpeg".to_string(),
-                data: vec![0, 1, 2, 3], // Invalid JPEG data
-            },
+            Part::inline_data("image/png", png_data),
+            Part::inline_data("image/jpeg", vec![0, 1, 2, 3]), // Invalid JPEG data
         ],
     };
 
@@ -303,8 +297,8 @@ fn test_multimodal_with_multiple_images() {
         role: "user".to_string(),
         parts: vec![
             Part::Text { text: "Describe these images".to_string() },
-            Part::InlineData { mime_type: "image/png".to_string(), data: png_data1 },
-            Part::InlineData { mime_type: "image/png".to_string(), data: png_data2 },
+            Part::inline_data("image/png", png_data1),
+            Part::inline_data("image/png", png_data2),
         ],
     };
 
@@ -321,11 +315,8 @@ fn test_unsupported_mime_type_ignored() {
         role: "user".to_string(),
         parts: vec![
             Part::Text { text: "Test".to_string() },
-            Part::InlineData {
-                mime_type: "application/octet-stream".to_string(),
-                data: vec![0, 1, 2, 3],
-            },
-            Part::InlineData { mime_type: "video/mp4".to_string(), data: vec![0, 1, 2, 3] },
+            Part::inline_data("application/octet-stream", vec![0, 1, 2, 3]),
+            Part::inline_data("video/mp4", vec![0, 1, 2, 3]),
         ],
     };
 

--- a/adk-mistralrs/tests/vision_integration_tests.rs
+++ b/adk-mistralrs/tests/vision_integration_tests.rs
@@ -102,7 +102,7 @@ async fn test_vision_streaming() {
     let content = Content {
         role: "user".to_string(),
         parts: vec![
-            Part::InlineData { mime_type: "image/jpeg".to_string(), data: image_bytes },
+            Part::inline_data("image/jpeg", image_bytes),
             Part::Text { text: "What is in this image? Answer briefly.".to_string() },
         ],
     };

--- a/adk-model/examples/openrouter/llm_support.rs
+++ b/adk-model/examples/openrouter/llm_support.rs
@@ -34,7 +34,7 @@ pub fn print_llm_responses(responses: &[LlmResponse]) {
                             trim_for_display(&args.to_string())
                         );
                     }
-                    Part::FunctionResponse { function_response, id } => {
+                    Part::FunctionResponse { function_response, id, .. } => {
                         println!(
                             "  function_response: id={} name={} body={}",
                             id.as_deref().unwrap_or("<none>"),
@@ -42,10 +42,10 @@ pub fn print_llm_responses(responses: &[LlmResponse]) {
                             trim_for_display(&function_response.response.to_string())
                         );
                     }
-                    Part::InlineData { mime_type, data } => {
+                    Part::InlineData { mime_type, data, .. } => {
                         println!("  inline_data: mime_type={mime_type} bytes={}", data.len());
                     }
-                    Part::FileData { mime_type, file_uri } => {
+                    Part::FileData { mime_type, file_uri, .. } => {
                         println!("  file_data: mime_type={mime_type} uri={file_uri}");
                     }
                     Part::ServerToolCall { server_tool_call } => {

--- a/adk-model/src/anthropic/client.rs
+++ b/adk-model/src/anthropic/client.rs
@@ -1008,6 +1008,7 @@ mod tests {
                         serde_json::json!({"result": "ok"}),
                     ),
                     id: Some("call_1".to_string()),
+                    annotations: None,
                 }],
             },
             Content {

--- a/adk-model/src/anthropic/convert.rs
+++ b/adk-model/src/anthropic/convert.rs
@@ -66,7 +66,7 @@ pub fn content_to_message(
                 };
                 Some(ContentBlock::ToolUse(block))
             }
-            Part::FunctionResponse { function_response, id } => {
+            Part::FunctionResponse { function_response, id, .. } => {
                 Some(ContentBlock::ToolResult(ToolResultBlock {
                     tool_use_id: id.clone().unwrap_or_else(|| "unknown".to_string()),
                     content: Some(tool_result_content(&function_response.response)),
@@ -74,7 +74,7 @@ pub fn content_to_message(
                     cache_control: None,
                 }))
             }
-            Part::InlineData { mime_type, data } => {
+            Part::InlineData { mime_type, data, .. } => {
                 let media_type = match mime_type.as_str() {
                     "image/jpeg" => Some(ImageMediaType::Jpeg),
                     "image/png" => Some(ImageMediaType::Png),
@@ -107,7 +107,7 @@ pub fn content_to_message(
                     ))))
                 }
             }
-            Part::FileData { mime_type, file_uri } => {
+            Part::FileData { mime_type, file_uri, .. } => {
                 if mime_type == "application/pdf" {
                     Some(ContentBlock::Document(DocumentBlock::new_with_url_pdf(
                         UrlPdfSource::new(file_uri.clone()),
@@ -512,10 +512,7 @@ mod tests {
             role: "user".to_string(),
             parts: vec![
                 Part::Text { text: "What is in this image?".to_string() },
-                Part::InlineData {
-                    mime_type: "image/png".to_string(),
-                    data: vec![0x89, 0x50, 0x4E, 0x47],
-                },
+                Part::inline_data("image/png", vec![0x89, 0x50, 0x4E, 0x47]),
             ],
         };
         let msg = content_to_message(&content, false).unwrap();
@@ -540,10 +537,10 @@ mod tests {
             role: "user".to_string(),
             parts: vec![
                 Part::Text { text: "Check this".to_string() },
-                Part::InlineData {
-                    mime_type: "audio/wav".to_string(), // Not supported by Anthropic images
-                    data: vec![0x52, 0x49, 0x46, 0x46],
-                },
+                Part::inline_data(
+                    "audio/wav", // Not supported by Anthropic images
+                    vec![0x52, 0x49, 0x46, 0x46],
+                ),
             ],
         };
         let msg = content_to_message(&content, false).unwrap();
@@ -563,8 +560,8 @@ mod tests {
             role: "user".to_string(),
             parts: vec![
                 Part::Text { text: "Compare".to_string() },
-                Part::InlineData { mime_type: "image/jpeg".to_string(), data: vec![0xFF, 0xD8] },
-                Part::InlineData { mime_type: "image/webp".to_string(), data: vec![0x52, 0x49] },
+                Part::inline_data("image/jpeg", vec![0xFF, 0xD8]),
+                Part::inline_data("image/webp", vec![0x52, 0x49]),
             ],
         };
         let msg = content_to_message(&content, false).unwrap();
@@ -580,10 +577,7 @@ mod tests {
     fn test_content_to_message_pdf_inline_data_maps_to_document_block() {
         let content = Content {
             role: "user".to_string(),
-            parts: vec![Part::InlineData {
-                mime_type: "application/pdf".to_string(),
-                data: b"%PDF-1.4".to_vec(),
-            }],
+            parts: vec![Part::inline_data("application/pdf", b"%PDF-1.4".to_vec())],
         };
         let msg = content_to_message(&content, false).unwrap();
 
@@ -599,10 +593,7 @@ mod tests {
     fn test_content_to_message_pdf_file_uri_maps_to_document_block() {
         let content = Content {
             role: "user".to_string(),
-            parts: vec![Part::FileData {
-                mime_type: "application/pdf".to_string(),
-                file_uri: "https://example.com/test.pdf".to_string(),
-            }],
+            parts: vec![Part::file_data("application/pdf", "https://example.com/test.pdf")],
         };
         let msg = content_to_message(&content, false).unwrap();
 
@@ -620,10 +611,7 @@ mod tests {
             role: "user".to_string(),
             parts: vec![
                 Part::Text { text: "Describe this".to_string() },
-                Part::FileData {
-                    mime_type: "image/jpeg".to_string(),
-                    file_uri: "https://example.com/photo.jpg".to_string(),
-                },
+                Part::file_data("image/jpeg", "https://example.com/photo.jpg"),
             ],
         };
         let msg = content_to_message(&content, false).unwrap();
@@ -641,10 +629,7 @@ mod tests {
     fn test_content_to_message_webp_file_data_maps_to_url_image() {
         let content = Content {
             role: "user".to_string(),
-            parts: vec![Part::FileData {
-                mime_type: "image/webp".to_string(),
-                file_uri: "https://example.com/image.webp".to_string(),
-            }],
+            parts: vec![Part::file_data("image/webp", "https://example.com/image.webp")],
         };
         let msg = content_to_message(&content, false).unwrap();
 
@@ -659,10 +644,7 @@ mod tests {
     fn test_content_to_message_unsupported_file_data_falls_back_to_text() {
         let content = Content {
             role: "user".to_string(),
-            parts: vec![Part::FileData {
-                mime_type: "audio/wav".to_string(),
-                file_uri: "https://example.com/audio.wav".to_string(),
-            }],
+            parts: vec![Part::file_data("audio/wav", "https://example.com/audio.wav")],
         };
         let msg = content_to_message(&content, false).unwrap();
 
@@ -731,6 +713,7 @@ mod tests {
                     Value::String("hello".to_string()),
                 ),
                 id: Some("tool_123".to_string()),
+                annotations: None,
             }],
         };
 

--- a/adk-model/src/azure_ai/convert.rs
+++ b/adk-model/src/azure_ai/convert.rs
@@ -109,7 +109,9 @@ fn content_to_message(content: &Content) -> Value {
             })
         }
         "function" | "tool" => {
-            if let Some(Part::FunctionResponse { function_response, id }) = content.parts.first() {
+            if let Some(Part::FunctionResponse { function_response, id, .. }) =
+                content.parts.first()
+            {
                 let tool_call_id = id.clone().unwrap_or_else(|| "unknown".to_string());
                 serde_json::json!({
                     "role": "tool",
@@ -487,6 +489,7 @@ mod tests {
                     serde_json::json!({"temp": 72}),
                 ),
                 id: Some("call_123".to_string()),
+                annotations: None,
             }],
         };
         let msg = content_to_message(&content);
@@ -751,6 +754,7 @@ mod tests {
                     serde_json::json!({"ok": true}),
                 ),
                 id: None,
+                annotations: None,
             }],
         };
         let msg = content_to_message(&content);

--- a/adk-model/src/bedrock/convert.rs
+++ b/adk-model/src/bedrock/convert.rs
@@ -244,7 +244,7 @@ fn convert_one_part(
                 .ok()?;
             Some(ContentBlock::ToolUse(tool_use))
         }
-        Part::FunctionResponse { function_response, id } => {
+        Part::FunctionResponse { function_response, id, .. } => {
             let tool_result = ToolResultBlock::builder()
                 .tool_use_id(id.clone().unwrap_or_else(|| "unknown".to_string()))
                 .content(ToolResultContentBlock::Text(crate::tool_result::serialize_tool_result(
@@ -263,7 +263,7 @@ fn convert_one_part(
                 Some(ContentBlock::Text(thinking.clone()))
             }
         }
-        Part::InlineData { mime_type, data } => {
+        Part::InlineData { mime_type, data, .. } => {
             if let Some(fmt) = mime_to_bedrock_image_format(mime_type) {
                 let source = ImageSource::Bytes(aws_smithy_types::Blob::new(data.as_slice()));
                 ImageBlock::builder()
@@ -543,6 +543,8 @@ fn bedrock_content_blocks_to_parts(blocks: &[ContentBlock]) -> Vec<Part> {
                         Some(Part::InlineData {
                             mime_type: mime_type.to_string(),
                             data: blob.as_ref().to_vec(),
+                            uri: None,
+                            annotations: None,
                         })
                     } else {
                         None
@@ -869,6 +871,7 @@ mod tests {
                     serde_json::json!({"temp": 72}),
                 ),
                 id: Some("call_123".to_string()),
+                annotations: None,
             }],
         }];
 
@@ -908,6 +911,7 @@ mod tests {
                         serde_json::json!({"tier": "growth"}),
                     ),
                     id: Some("call_review".to_string()),
+                    annotations: None,
                 }],
             },
             Content {
@@ -918,6 +922,7 @@ mod tests {
                         serde_json::json!({"components_analyzed": 2}),
                     ),
                     id: Some("call_threats".to_string()),
+                    annotations: None,
                 }],
             },
         ];
@@ -1285,10 +1290,7 @@ mod tests {
             role: "user".to_string(),
             parts: vec![
                 Part::Text { text: "What is in this image?".to_string() },
-                Part::InlineData {
-                    mime_type: "image/png".to_string(),
-                    data: vec![0x89, 0x50, 0x4E, 0x47],
-                },
+                Part::inline_data("image/png", vec![0x89, 0x50, 0x4E, 0x47]),
             ],
         }];
 
@@ -1302,10 +1304,7 @@ mod tests {
 
     #[test]
     fn test_inline_jpeg_converts_to_image_block() {
-        let parts = vec![Part::InlineData {
-            mime_type: "image/jpeg".to_string(),
-            data: vec![0xFF, 0xD8, 0xFF],
-        }];
+        let parts = vec![Part::inline_data("image/jpeg", vec![0xFF, 0xD8, 0xFF])];
         let blocks = adk_parts_to_bedrock(&parts);
         assert_eq!(blocks.len(), 1);
         let img = blocks[0].as_image().unwrap();
@@ -1314,10 +1313,7 @@ mod tests {
 
     #[test]
     fn test_inline_pdf_converts_to_document_block() {
-        let parts = vec![Part::InlineData {
-            mime_type: "application/pdf".to_string(),
-            data: b"%PDF-1.4".to_vec(),
-        }];
+        let parts = vec![Part::inline_data("application/pdf", b"%PDF-1.4".to_vec())];
         let blocks = adk_parts_to_bedrock(&parts);
         assert_eq!(blocks.len(), 1);
         assert!(blocks[0].is_document());
@@ -1325,10 +1321,7 @@ mod tests {
 
     #[test]
     fn test_inline_csv_converts_to_document_block() {
-        let parts = vec![Part::InlineData {
-            mime_type: "text/csv".to_string(),
-            data: b"a,b,c\n1,2,3".to_vec(),
-        }];
+        let parts = vec![Part::inline_data("text/csv", b"a,b,c\n1,2,3".to_vec())];
         let blocks = adk_parts_to_bedrock(&parts);
         assert_eq!(blocks.len(), 1);
         assert!(blocks[0].is_document());
@@ -1336,20 +1329,14 @@ mod tests {
 
     #[test]
     fn test_unsupported_mime_type_skipped() {
-        let parts = vec![Part::InlineData {
-            mime_type: "application/octet-stream".to_string(),
-            data: vec![0xCA, 0xFE],
-        }];
+        let parts = vec![Part::inline_data("application/octet-stream", vec![0xCA, 0xFE])];
         let blocks = adk_parts_to_bedrock(&parts);
         assert!(blocks.is_empty());
     }
 
     #[test]
     fn test_file_data_image_url_becomes_text_reference() {
-        let parts = vec![Part::FileData {
-            mime_type: "image/jpeg".to_string(),
-            file_uri: "https://example.com/photo.jpg".to_string(),
-        }];
+        let parts = vec![Part::file_data("image/jpeg", "https://example.com/photo.jpg")];
         let blocks = adk_parts_to_bedrock(&parts);
         assert_eq!(blocks.len(), 1);
         let text = blocks[0].as_text().unwrap();
@@ -1359,10 +1346,8 @@ mod tests {
 
     #[test]
     fn test_file_data_unsupported_mime_skipped() {
-        let parts = vec![Part::FileData {
-            mime_type: "application/octet-stream".to_string(),
-            file_uri: "https://example.com/data.bin".to_string(),
-        }];
+        let parts =
+            vec![Part::file_data("application/octet-stream", "https://example.com/data.bin")];
         let blocks = adk_parts_to_bedrock(&parts);
         assert!(blocks.is_empty());
     }
@@ -1379,7 +1364,7 @@ mod tests {
         let parts = bedrock_content_blocks_to_parts(&[ContentBlock::Image(image_block)]);
         assert_eq!(parts.len(), 1);
         match &parts[0] {
-            Part::InlineData { mime_type, data } => {
+            Part::InlineData { mime_type, data, .. } => {
                 assert_eq!(mime_type, "image/png");
                 assert_eq!(data, &image_bytes);
             }

--- a/adk-model/src/deepseek/convert.rs
+++ b/adk-model/src/deepseek/convert.rs
@@ -234,16 +234,16 @@ pub fn content_to_message(content: &Content) -> Message {
                     },
                 });
             }
-            Part::FunctionResponse { function_response, id } => {
+            Part::FunctionResponse { function_response, id, .. } => {
                 // Tool response - set tool_call_id and content
                 tool_call_id = id.clone();
                 text_parts
                     .push(crate::tool_result::serialize_tool_result(&function_response.response));
             }
-            Part::InlineData { mime_type, data } => {
+            Part::InlineData { mime_type, data, .. } => {
                 text_parts.push(attachment::inline_attachment_to_text(mime_type, data));
             }
-            Part::FileData { mime_type, file_uri } => {
+            Part::FileData { mime_type, file_uri, .. } => {
                 text_parts.push(attachment::file_attachment_to_text(mime_type, file_uri));
             }
             Part::Thinking { thinking, .. } => {
@@ -449,10 +449,7 @@ mod tests {
     fn content_to_message_keeps_inline_attachment_payload() {
         let content = Content {
             role: "user".to_string(),
-            parts: vec![Part::InlineData {
-                mime_type: "application/pdf".to_string(),
-                data: b"%PDF".to_vec(),
-            }],
+            parts: vec![Part::inline_data("application/pdf", b"%PDF".to_vec())],
         };
         let message = content_to_message(&content);
         let payload = message.content.unwrap_or_default();
@@ -464,10 +461,7 @@ mod tests {
     fn content_to_message_keeps_file_attachment_payload() {
         let content = Content {
             role: "user".to_string(),
-            parts: vec![Part::FileData {
-                mime_type: "text/csv".to_string(),
-                file_uri: "https://example.com/data.csv".to_string(),
-            }],
+            parts: vec![Part::file_data("text/csv", "https://example.com/data.csv")],
         };
         let message = content_to_message(&content);
         let payload = message.content.unwrap_or_default();

--- a/adk-model/src/gemini/client.rs
+++ b/adk-model/src/gemini/client.rs
@@ -499,6 +499,8 @@ impl GeminiModel {
                         converted_parts.push(Part::InlineData {
                             mime_type: inline_data.mime_type.clone(),
                             data: decoded,
+                            uri: None,
+                            annotations: None,
                         });
                     }
                     adk_gemini::Part::FunctionCall { function_call, thought_signature } => {
@@ -519,6 +521,7 @@ impl GeminiModel {
                                     .unwrap_or(serde_json::Value::Null),
                             ),
                             id: None,
+                            annotations: None,
                         });
                     }
                     adk_gemini::Part::ToolCall { .. } | adk_gemini::Part::ExecutableCode { .. } => {
@@ -536,6 +539,7 @@ impl GeminiModel {
                         converted_parts.push(Part::FileData {
                             mime_type: file_data.mime_type.clone(),
                             file_uri: file_data.file_uri.clone(),
+                            annotations: None,
                         });
                     }
                 }
@@ -828,7 +832,7 @@ impl GeminiModel {
                                     thought_signature: signature.clone(),
                                 });
                             }
-                            Part::InlineData { data, mime_type } => {
+                            Part::InlineData { data, mime_type, .. } => {
                                 let encoded = attachment::encode_base64(data);
                                 gemini_parts.push(adk_gemini::Part::InlineData {
                                     inline_data: adk_gemini::Blob {
@@ -837,7 +841,7 @@ impl GeminiModel {
                                     },
                                 });
                             }
-                            Part::FileData { mime_type, file_uri } => {
+                            Part::FileData { mime_type, file_uri, .. } => {
                                 gemini_parts.push(adk_gemini::Part::Text {
                                     text: attachment::file_attachment_to_text(mime_type, file_uri),
                                     thought: None,
@@ -949,7 +953,7 @@ impl GeminiModel {
                     // recovered from the preceding FunctionCall (Gemini 3.x requirement)
                     let mut gemini_parts = Vec::new();
                     for part in &content.parts {
-                        if let Part::FunctionResponse { function_response, id } = part {
+                        if let Part::FunctionResponse { function_response, id, .. } = part {
                             let sig = fn_call_signatures.get(&function_response.name).cloned();
 
                             // Build nested FunctionResponsePart entries for multimodal data
@@ -1928,7 +1932,7 @@ mod tests {
         assert!(content.parts.iter().any(|part| {
             matches!(
                 part,
-                Part::InlineData { mime_type, data }
+                Part::InlineData { mime_type, data, .. }
                     if mime_type == "image/png" && data.as_slice() == image_bytes.as_slice()
             )
         }));
@@ -2009,6 +2013,8 @@ mod tests {
             vec![adk_core::InlineDataPart {
                 mime_type: "image/png".to_string(),
                 data: vec![0x89, 0x50, 0x4E, 0x47],
+                uri: None,
+                annotations: None,
             }],
         );
         let gemini_fr = convert_function_response_to_gemini_fr(&frd);
@@ -2031,6 +2037,7 @@ mod tests {
             vec![adk_core::FileDataPart {
                 mime_type: "application/pdf".to_string(),
                 file_uri: "gs://bucket/report.pdf".to_string(),
+                annotations: None,
             }],
         );
         let gemini_fr = convert_function_response_to_gemini_fr(&frd);
@@ -2050,12 +2057,23 @@ mod tests {
             "multi",
             serde_json::json!({}),
             vec![
-                adk_core::InlineDataPart { mime_type: "image/png".to_string(), data: vec![1, 2] },
-                adk_core::InlineDataPart { mime_type: "image/jpeg".to_string(), data: vec![3, 4] },
+                adk_core::InlineDataPart {
+                    mime_type: "image/png".to_string(),
+                    data: vec![1, 2],
+                    uri: None,
+                    annotations: None,
+                },
+                adk_core::InlineDataPart {
+                    mime_type: "image/jpeg".to_string(),
+                    data: vec![3, 4],
+                    uri: None,
+                    annotations: None,
+                },
             ],
             vec![adk_core::FileDataPart {
                 mime_type: "application/pdf".to_string(),
                 file_uri: "gs://b/f.pdf".to_string(),
+                annotations: None,
             }],
         );
         let gemini_fr = convert_function_response_to_gemini_fr(&frd);

--- a/adk-model/src/gemini/interactions_convert.rs
+++ b/adk-model/src/gemini/interactions_convert.rs
@@ -202,9 +202,18 @@ fn media_part(
     let mime = mime_type.unwrap_or(default_mime).to_string();
     if let Some(encoded) = data {
         let bytes = BASE64_STANDARD.decode(encoded).ok()?;
-        Some(Part::InlineData { mime_type: mime, data: bytes })
+        Some(Part::InlineData {
+            mime_type: mime,
+            data: bytes,
+            uri: uri.map(str::to_string),
+            annotations: None,
+        })
     } else {
-        uri.map(|file_uri| Part::FileData { mime_type: mime, file_uri: file_uri.to_string() })
+        uri.map(|file_uri| Part::FileData {
+            mime_type: mime,
+            file_uri: file_uri.to_string(),
+            annotations: None,
+        })
     }
 }
 
@@ -446,7 +455,7 @@ fn append_steps(content: &Content, steps: &mut Vec<Step>) {
         }
         "function" => {
             for part in &content.parts {
-                if let Part::FunctionResponse { function_response, id } = part {
+                if let Part::FunctionResponse { function_response, id, .. } = part {
                     steps.push(Step::FunctionResult {
                         call_id: id.clone().unwrap_or_default(),
                         name: Some(function_response.name.clone()),
@@ -476,11 +485,11 @@ fn content_parts(content: &Content) -> Vec<IxContent> {
 fn part_to_content(part: &Part) -> Option<IxContent> {
     match part {
         Part::Text { text } => Some(IxContent::text(text.clone())),
-        Part::InlineData { mime_type, data } => {
+        Part::InlineData { mime_type, data, .. } => {
             let encoded = crate::attachment::encode_base64(data);
             Some(inline_content(mime_type, encoded))
         }
-        Part::FileData { mime_type, file_uri } => Some(uri_content(mime_type, file_uri)),
+        Part::FileData { mime_type, file_uri, .. } => Some(uri_content(mime_type, file_uri)),
         _ => None,
     }
 }
@@ -1097,6 +1106,7 @@ mod tests {
                         serde_json::json!({"temp": 72}),
                     ),
                     id: Some("call-1".to_string()),
+                    annotations: None,
                 }],
             },
         ]);
@@ -1532,7 +1542,7 @@ mod tests {
         let response = to_llm_response(&interaction);
         let content = response.content.expect("should carry content");
         match &content.parts[0] {
-            Part::InlineData { mime_type, data } => {
+            Part::InlineData { mime_type, data, .. } => {
                 assert_eq!(mime_type, "image/png");
                 assert_eq!(data, &bytes);
             }
@@ -1558,7 +1568,7 @@ mod tests {
         let response = to_llm_response(&interaction);
         let content = response.content.expect("should carry content");
         match &content.parts[0] {
-            Part::FileData { mime_type, file_uri } => {
+            Part::FileData { mime_type, file_uri, .. } => {
                 assert_eq!(mime_type, "image/jpeg");
                 assert_eq!(file_uri, "https://example.com/cat.jpg");
             }
@@ -2045,6 +2055,7 @@ mod tests {
                         serde_json::json!({ "temp": 72, "conditions": "sunny" }),
                     ),
                     id: Some(call_id.clone()),
+                    annotations: None,
                 }],
             },
         ]);

--- a/adk-model/src/groq/convert.rs
+++ b/adk-model/src/groq/convert.rs
@@ -186,15 +186,15 @@ pub fn content_to_message(content: &Content) -> Message {
                     },
                 });
             }
-            Part::FunctionResponse { function_response, id } => {
+            Part::FunctionResponse { function_response, id, .. } => {
                 tool_call_id = id.clone();
                 text_parts
                     .push(crate::tool_result::serialize_tool_result(&function_response.response));
             }
-            Part::InlineData { mime_type, data } => {
+            Part::InlineData { mime_type, data, .. } => {
                 text_parts.push(attachment::inline_attachment_to_text(mime_type, data));
             }
-            Part::FileData { mime_type, file_uri } => {
+            Part::FileData { mime_type, file_uri, .. } => {
                 text_parts.push(attachment::file_attachment_to_text(mime_type, file_uri));
             }
             // Server-side tool parts are Gemini-specific; skip for Groq
@@ -364,10 +364,7 @@ mod tests {
     fn content_to_message_keeps_inline_attachment_payload() {
         let content = Content {
             role: "user".to_string(),
-            parts: vec![Part::InlineData {
-                mime_type: "application/octet-stream".to_string(),
-                data: vec![0xCA, 0xFE],
-            }],
+            parts: vec![Part::inline_data("application/octet-stream", vec![0xCA, 0xFE])],
         };
         let message = content_to_message(&content);
         let payload = message.content.unwrap_or_default();
@@ -379,10 +376,7 @@ mod tests {
     fn content_to_message_keeps_file_attachment_payload() {
         let content = Content {
             role: "user".to_string(),
-            parts: vec![Part::FileData {
-                mime_type: "application/pdf".to_string(),
-                file_uri: "https://example.com/report.pdf".to_string(),
-            }],
+            parts: vec![Part::file_data("application/pdf", "https://example.com/report.pdf")],
         };
         let message = content_to_message(&content);
         let payload = message.content.unwrap_or_default();

--- a/adk-model/src/ollama/convert.rs
+++ b/adk-model/src/ollama/convert.rs
@@ -13,10 +13,10 @@ pub fn content_to_chat_message(content: &Content) -> Option<ChatMessage> {
         .filter_map(|p| match p {
             Part::Text { text } => Some(text.clone()),
             Part::Thinking { thinking, .. } => Some(thinking.clone()),
-            Part::InlineData { mime_type, data } => {
+            Part::InlineData { mime_type, data, .. } => {
                 Some(attachment::inline_attachment_to_text(mime_type, data))
             }
-            Part::FileData { mime_type, file_uri } => {
+            Part::FileData { mime_type, file_uri, .. } => {
                 Some(attachment::file_attachment_to_text(mime_type, file_uri))
             }
             _ => None,
@@ -166,10 +166,7 @@ mod tests {
     fn content_to_chat_message_keeps_inline_attachment_payload() {
         let content = Content {
             role: "user".to_string(),
-            parts: vec![Part::InlineData {
-                mime_type: "application/pdf".to_string(),
-                data: b"%PDF".to_vec(),
-            }],
+            parts: vec![Part::inline_data("application/pdf", b"%PDF".to_vec())],
         };
         let message = content_to_chat_message(&content).expect("message should be created");
         assert!(message.content.contains("application/pdf"));
@@ -180,10 +177,7 @@ mod tests {
     fn content_to_chat_message_keeps_file_attachment_payload() {
         let content = Content {
             role: "user".to_string(),
-            parts: vec![Part::FileData {
-                mime_type: "text/csv".to_string(),
-                file_uri: "https://example.com/data.csv".to_string(),
-            }],
+            parts: vec![Part::file_data("text/csv", "https://example.com/data.csv")],
         };
         let message = content_to_chat_message(&content).expect("message should be created");
         assert!(message.content.contains("text/csv"));

--- a/adk-model/src/openai/convert.rs
+++ b/adk-model/src/openai/convert.rs
@@ -42,10 +42,10 @@ pub fn content_to_message(content: &Content) -> ChatCompletionRequestMessage {
                                 },
                             ))
                         }
-                        Part::InlineData { mime_type, data } => {
+                        Part::InlineData { mime_type, data, .. } => {
                             Some(inline_data_part_to_openai(mime_type, data))
                         }
-                        Part::FileData { mime_type, file_uri } => {
+                        Part::FileData { mime_type, file_uri, .. } => {
                             if mime_type.starts_with("image/") {
                                 Some(ChatCompletionRequestUserMessageContentPart::ImageUrl(
                                     ChatCompletionRequestMessageContentPartImage {
@@ -125,7 +125,9 @@ pub fn content_to_message(content: &Content) -> ChatCompletionRequestMessage {
         }
         "function" | "tool" => {
             // Tool response message
-            if let Some(Part::FunctionResponse { function_response, id }) = content.parts.first() {
+            if let Some(Part::FunctionResponse { function_response, id, .. }) =
+                content.parts.first()
+            {
                 let tool_call_id = id.clone().unwrap_or_else(|| "unknown".to_string());
                 ChatCompletionRequestToolMessageArgs::default()
                     .tool_call_id(tool_call_id)
@@ -482,10 +484,7 @@ mod tests {
             role: "user".to_string(),
             parts: vec![
                 Part::Text { text: "What is in this image?".to_string() },
-                Part::InlineData {
-                    mime_type: "image/png".to_string(),
-                    data: vec![0x89, 0x50, 0x4E, 0x47], // PNG magic bytes
-                },
+                Part::inline_data("image/png", vec![0x89, 0x50, 0x4E, 0x47]), // PNG magic bytes
             ],
         };
         let msg = content_to_message(&content);
@@ -523,8 +522,8 @@ mod tests {
             role: "user".to_string(),
             parts: vec![
                 Part::Text { text: "Compare these".to_string() },
-                Part::InlineData { mime_type: "image/jpeg".to_string(), data: vec![0xFF, 0xD8] },
-                Part::InlineData { mime_type: "image/png".to_string(), data: vec![0x89, 0x50] },
+                Part::inline_data("image/jpeg", vec![0xFF, 0xD8]),
+                Part::inline_data("image/png", vec![0x89, 0x50]),
             ],
         };
         let msg = content_to_message(&content);
@@ -546,10 +545,7 @@ mod tests {
             role: "user".to_string(),
             parts: vec![
                 Part::Text { text: "Transcribe this".to_string() },
-                Part::InlineData {
-                    mime_type: "audio/wav".to_string(),
-                    data: vec![0x52, 0x49, 0x46, 0x46],
-                },
+                Part::inline_data("audio/wav", vec![0x52, 0x49, 0x46, 0x46]),
             ],
         };
         let msg = content_to_message(&content);
@@ -573,10 +569,7 @@ mod tests {
     fn test_user_message_with_pdf_inline_data_falls_back_to_text_part() {
         let content = Content {
             role: "user".to_string(),
-            parts: vec![Part::InlineData {
-                mime_type: "application/pdf".to_string(),
-                data: b"%PDF".to_vec(),
-            }],
+            parts: vec![Part::inline_data("application/pdf", b"%PDF".to_vec())],
         };
         let msg = content_to_message(&content);
 
@@ -604,6 +597,7 @@ mod tests {
             parts: vec![Part::FileData {
                 mime_type: "application/pdf".to_string(),
                 file_uri: "https://example.com/report.pdf".to_string(),
+                annotations: None,
             }],
         };
         let msg = content_to_message(&content);
@@ -634,6 +628,7 @@ mod tests {
                 Part::FileData {
                     mime_type: "image/jpeg".to_string(),
                     file_uri: "https://example.com/photo.jpg".to_string(),
+                    annotations: None,
                 },
             ],
         };
@@ -820,13 +815,11 @@ mod tests {
     #[test]
     fn test_image_detail_serializes_as_auto_not_null() {
         for part in [
-            Part::InlineData {
-                mime_type: "image/png".to_string(),
-                data: vec![0x89, 0x50, 0x4E, 0x47],
-            },
+            Part::inline_data("image/png", vec![0x89, 0x50, 0x4E, 0x47]),
             Part::FileData {
                 mime_type: "image/jpeg".to_string(),
                 file_uri: "https://example.com/photo.jpg".to_string(),
+                annotations: None,
             },
         ] {
             let content = Content {

--- a/adk-model/src/openai/responses_convert.rs
+++ b/adk-model/src/openai/responses_convert.rs
@@ -104,7 +104,7 @@ fn content_to_input_items(content: &Content) -> Vec<InputItem> {
                 })));
             }
 
-            Part::FunctionResponse { function_response, id } => {
+            Part::FunctionResponse { function_response, id, .. } => {
                 let call_id = id.clone().unwrap_or_else(|| "unknown".to_string());
                 let output_text =
                     crate::tool_result::serialize_tool_result(&function_response.response);
@@ -118,7 +118,7 @@ fn content_to_input_items(content: &Content) -> Vec<InputItem> {
                 )));
             }
 
-            Part::InlineData { mime_type, data } => {
+            Part::InlineData { mime_type, data, .. } => {
                 if mime_type.starts_with("image/") {
                     let data_uri =
                         format!("data:{mime_type};base64,{}", attachment::encode_base64(data));

--- a/adk-model/src/openrouter/convert_chat.rs
+++ b/adk-model/src/openrouter/convert_chat.rs
@@ -106,11 +106,11 @@ fn adk_content_to_chat_message(content: &Content) -> Result<OpenRouterChatMessag
             Part::Thinking { thinking, .. } => {
                 push_text_fragment(thinking, &mut text_fragments, &mut structured_parts)
             }
-            Part::InlineData { mime_type, data } => {
+            Part::InlineData { mime_type, data, .. } => {
                 flush_text_fragments(&mut text_fragments, &mut structured_parts);
                 structured_parts.push(chat_part_from_inline_data(mime_type, data)?);
             }
-            Part::FileData { mime_type, file_uri } => {
+            Part::FileData { mime_type, file_uri, .. } => {
                 flush_text_fragments(&mut text_fragments, &mut structured_parts);
                 structured_parts.push(chat_part_from_file_uri(mime_type, file_uri));
             }
@@ -179,7 +179,7 @@ fn adk_content_to_chat_message(content: &Content) -> Result<OpenRouterChatMessag
 }
 
 fn tool_response_chat_message(content: &Content) -> OpenRouterChatMessage {
-    if let Some(Part::FunctionResponse { function_response, id }) = content.parts.first() {
+    if let Some(Part::FunctionResponse { function_response, id, .. }) = content.parts.first() {
         return OpenRouterChatMessage {
             role: "tool".to_string(),
             tool_call_id: id.clone().or_else(|| Some(format!("call_{}", function_response.name))),
@@ -518,6 +518,7 @@ mod tests {
                     serde_json::json!({ "temperature": "22C" }),
                 ),
                 id: Some("call_weather".to_string()),
+                annotations: None,
             }],
         }])
         .expect("messages should convert");

--- a/adk-model/src/openrouter/convert_responses.rs
+++ b/adk-model/src/openrouter/convert_responses.rs
@@ -85,11 +85,11 @@ fn adk_content_to_response_item(
             Part::Thinking { thinking, .. } => {
                 push_text_fragment(thinking, &mut text_fragments, &mut structured_parts)
             }
-            Part::InlineData { mime_type, data } => {
+            Part::InlineData { mime_type, data, .. } => {
                 flush_text_fragments(&mut text_fragments, &mut structured_parts);
                 structured_parts.push(response_part_from_inline_data(mime_type, data));
             }
-            Part::FileData { mime_type, file_uri } => {
+            Part::FileData { mime_type, file_uri, .. } => {
                 flush_text_fragments(&mut text_fragments, &mut structured_parts);
                 structured_parts.push(response_part_from_file_uri(mime_type, file_uri));
             }
@@ -103,7 +103,7 @@ fn adk_content_to_response_item(
                     ..Default::default()
                 });
             }
-            Part::FunctionResponse { function_response, id } => {
+            Part::FunctionResponse { function_response, id, .. } => {
                 return Ok(OpenRouterResponseInputItem {
                     kind: "function_call_output".to_string(),
                     id: id.clone(),

--- a/adk-model/tests/multimodal_conversion_tests.rs
+++ b/adk-model/tests/multimodal_conversion_tests.rs
@@ -15,8 +15,9 @@ fn arb_mime_type() -> impl Strategy<Value = String> {
 }
 
 fn arb_inline_data_part() -> impl Strategy<Value = InlineDataPart> {
-    (arb_mime_type(), prop::collection::vec(any::<u8>(), 0..1024))
-        .prop_map(|(mime_type, data)| InlineDataPart { mime_type, data })
+    (arb_mime_type(), prop::collection::vec(any::<u8>(), 0..1024)).prop_map(|(mime_type, data)| {
+        InlineDataPart { mime_type, data, uri: None, annotations: None }
+    })
 }
 
 fn arb_file_uri() -> impl Strategy<Value = String> {
@@ -28,8 +29,11 @@ fn arb_file_uri() -> impl Strategy<Value = String> {
 }
 
 fn arb_file_data_part() -> impl Strategy<Value = FileDataPart> {
-    (arb_mime_type(), arb_file_uri())
-        .prop_map(|(mime_type, file_uri)| FileDataPart { mime_type, file_uri })
+    (arb_mime_type(), arb_file_uri()).prop_map(|(mime_type, file_uri)| FileDataPart {
+        mime_type,
+        file_uri,
+        annotations: None,
+    })
 }
 
 /// Simulate the conversion logic: build a Gemini FunctionResponse with nested parts.

--- a/adk-payments/src/guardrail/redaction.rs
+++ b/adk-payments/src/guardrail/redaction.rs
@@ -131,7 +131,7 @@ impl SensitivePaymentDataGuardrail {
                         thought_signature: thought_signature.clone(),
                     });
                 }
-                Part::FunctionResponse { function_response, id } => {
+                Part::FunctionResponse { function_response, id, annotations } => {
                     let redacted_response = self.redact_json(&function_response.response);
                     if redacted_response != function_response.response {
                         changed = true;
@@ -142,6 +142,7 @@ impl SensitivePaymentDataGuardrail {
                             redacted_response,
                         ),
                         id: id.clone(),
+                        annotations: annotations.clone(),
                     });
                 }
                 _ => new_parts.push(part.clone()),
@@ -473,6 +474,7 @@ mod tests {
                         }),
                     ),
                     id: None,
+                    annotations: None,
                 },
             ],
         };

--- a/adk-payments/src/journal/evidence_store.rs
+++ b/adk-payments/src/journal/evidence_store.rs
@@ -75,6 +75,8 @@ impl EvidenceStore for ArtifactBackedEvidenceStore {
                 part: Part::InlineData {
                     mime_type: command.content_type.clone(),
                     data: command.body.clone(),
+                    uri: None,
+                    annotations: None,
                 },
                 version: None,
             })
@@ -105,7 +107,7 @@ impl EvidenceStore for ArtifactBackedEvidenceStore {
 
         match response {
             Ok(response) => {
-                let Part::InlineData { mime_type, data } = response.part else {
+                let Part::InlineData { mime_type, data, .. } = response.part else {
                     return Err(AdkError::new(
                         ErrorComponent::Artifact,
                         ErrorCategory::Internal,

--- a/adk-realtime/src/agent.rs
+++ b/adk-realtime/src/agent.rs
@@ -847,6 +847,8 @@ impl Agent for RealtimeAgent {
                                     parts: vec![Part::InlineData {
                                         mime_type: "audio/pcm".to_string(),
                                         data: delta,
+                                        uri: None,
+                                        annotations: None,
                                     }],
                                 });
                                 yield Ok(audio_event);
@@ -949,6 +951,7 @@ impl Agent for RealtimeAgent {
                                     parts: vec![Part::FunctionResponse {
                                         function_response: adk_core::FunctionResponseData::new(name.clone(), result.clone()),
                                         id: Some(call_id.clone()),
+                                        annotations: None,
                                     }],
                                 });
                                 yield Ok(tool_event);
@@ -1359,6 +1362,7 @@ mod tool_safety_tests {
                             serde_json::json!({ "cached": true }),
                         ),
                         id: None,
+                        annotations: None,
                     }],
                 }))
             })

--- a/adk-realtime/src/gemini/session.rs
+++ b/adk-realtime/src/gemini/session.rs
@@ -917,7 +917,7 @@ pub(crate) fn translate_client_message(
             adk_core::types::Part::Text { text } => {
                 gemini_parts.push(GeminiPart { text: Some(text), inline_data: None });
             }
-            adk_core::types::Part::InlineData { mime_type, data } => {
+            adk_core::types::Part::InlineData { mime_type, data, .. } => {
                 // Gemini natively encodes binary artifacts (images/audio) via a base64 payload envelope.
                 let encoded = base64::engine::general_purpose::STANDARD.encode(&data);
                 gemini_parts.push(GeminiPart {
@@ -1053,7 +1053,7 @@ mod tests {
     fn test_gemini_translate_text_and_inline_data() {
         let parts = vec![
             Part::Text { text: "Look:".to_string() },
-            Part::InlineData { mime_type: "image/png".to_string(), data: vec![0x1, 0x2] },
+            Part::inline_data("image/png", vec![0x1, 0x2]),
         ];
         let msg = translate_client_message("user", parts);
 
@@ -1087,7 +1087,7 @@ mod tests {
     #[test]
     fn test_gemini_system_override_non_text_first() {
         let parts = vec![
-            Part::InlineData { mime_type: "image/png".to_string(), data: vec![0x1] },
+            Part::inline_data("image/png", vec![0x1]),
             Part::Text { text: "Analyze this".to_string() },
         ];
         let msg = translate_client_message("system", parts);
@@ -1106,7 +1106,7 @@ mod tests {
 
     #[test]
     fn test_gemini_system_override_no_text() {
-        let parts = vec![Part::InlineData { mime_type: "image/png".to_string(), data: vec![0x1] }];
+        let parts = vec![Part::inline_data("image/png", vec![0x1])];
         let msg = translate_client_message("system", parts);
 
         let content = msg.client_content.unwrap();
@@ -1125,6 +1125,7 @@ mod tests {
             Part::FileData {
                 mime_type: "image/jpeg".to_string(),
                 file_uri: "http://example.com/img".to_string(),
+                annotations: None,
             }, // Should be skipped
             Part::Thinking { thinking: "Hmm".to_string(), signature: None }, // Should be skipped
             Part::Text { text: "Last".to_string() },

--- a/adk-realtime/src/integration/mod.rs
+++ b/adk-realtime/src/integration/mod.rs
@@ -733,6 +733,7 @@ impl IntegratedRealtimeRunner {
         content.parts.push(adk_core::Part::FunctionResponse {
             function_response: adk_core::FunctionResponseData::new(&call.name, result.clone()),
             id: Some(call.call_id.clone()),
+            annotations: None,
         });
 
         if let Some(ref session_service) = self.session_service {
@@ -1400,7 +1401,7 @@ mod session_persistence_tests {
         );
 
         let has_function_response = content.parts.iter().any(|p| match p {
-            adk_core::Part::FunctionResponse { function_response, id } => {
+            adk_core::Part::FunctionResponse { function_response, id, .. } => {
                 id.as_deref() == Some("call-abc-123")
                     && function_response.response == short_circuit_value
             }

--- a/adk-realtime/src/openai/protocol.rs
+++ b/adk-realtime/src/openai/protocol.rs
@@ -366,7 +366,7 @@ pub(crate) fn translate_client_message(role: &str, parts: Vec<adk_core::types::P
             adk_core::types::Part::Text { text } => {
                 content.push(json!({ "type": "input_text", "text": text }));
             }
-            adk_core::types::Part::InlineData { mime_type, data } => {
+            adk_core::types::Part::InlineData { mime_type, data, .. } => {
                 if mime_type.starts_with("audio/") {
                     use base64::Engine;
                     let encoded = base64::engine::general_purpose::STANDARD.encode(&data);
@@ -435,7 +435,7 @@ mod tests {
     fn test_openai_translate_text_and_audio() {
         let parts = vec![
             Part::Text { text: "Listen:".to_string() },
-            Part::InlineData { mime_type: "audio/wav".to_string(), data: vec![0x1, 0x2, 0x3] },
+            Part::inline_data("audio/wav", vec![0x1, 0x2, 0x3]),
         ];
         let value = translate_client_message("user", parts);
         let content = value["item"]["content"].as_array().unwrap();
@@ -450,7 +450,7 @@ mod tests {
     fn test_openai_skips_unsupported_parts() {
         let parts = vec![
             Part::Text { text: "First".to_string() },
-            Part::InlineData { mime_type: "image/png".to_string(), data: vec![0x1] },
+            Part::inline_data("image/png", vec![0x1]),
             Part::Thinking { thinking: "Hmm".to_string(), signature: None },
             Part::Text { text: "Last".to_string() },
         ];

--- a/adk-runner/tests/context_tests.rs
+++ b/adk-runner/tests/context_tests.rs
@@ -493,6 +493,7 @@ fn conversation_history_preserves_tool_role() {
                 serde_json::json!({"success": true}),
             ),
             id: Some("call_1".into()),
+            annotations: None,
         }],
     });
     mutable.append_event(tool_event);
@@ -563,6 +564,7 @@ fn conversation_history_for_agent_filters_other_agents_events() {
                 serde_json::json!({"name": "Alice"}),
             ),
             id: Some("call_1".into()),
+            annotations: None,
         }],
     });
     mutable.append_event(coord_tool_resp);
@@ -629,6 +631,7 @@ fn conversation_history_for_agent_keeps_own_events() {
                 serde_json::json!({"jobs": []}),
             ),
             id: Some("call_2".into()),
+            annotations: None,
         }],
     });
     mutable.append_event(tool_resp);
@@ -669,6 +672,7 @@ fn conversation_history_for_agent_excludes_other_agents_function_responses() {
                 serde_json::json!({"data": "value"}),
             ),
             id: None,
+            annotations: None,
         }],
     });
     mutable.append_event(other_tool);
@@ -746,6 +750,7 @@ fn conversation_history_for_agent_double_transfer_sees_own_prior_events() {
                 serde_json::json!({"jobs": ["job_1", "job_2"]}),
             ),
             id: Some("call_s1".into()),
+            annotations: None,
         }],
     });
     mutable.append_event(sourcing_resp1);
@@ -785,6 +790,7 @@ fn conversation_history_for_agent_double_transfer_sees_own_prior_events() {
                 serde_json::json!({"ranked": ["job_1"]}),
             ),
             id: Some("call_c2".into()),
+            annotations: None,
         }],
     });
     mutable.append_event(coord_resp);

--- a/adk-server/src/a2a/parts.rs
+++ b/adk-server/src/a2a/parts.rs
@@ -10,7 +10,7 @@ pub fn adk_parts_to_a2a(
         .iter()
         .map(|part| match part {
             Part::Text { text } => Ok(crate::a2a::Part::text(text.clone())),
-            Part::InlineData { mime_type, data } => {
+            Part::InlineData { mime_type, data, .. } => {
                 let encoded = general_purpose::STANDARD.encode(data);
                 Ok(crate::a2a::Part::file(crate::a2a::FileContent {
                     name: None,
@@ -19,7 +19,7 @@ pub fn adk_parts_to_a2a(
                     uri: None,
                 }))
             }
-            Part::FileData { mime_type, file_uri } => {
+            Part::FileData { mime_type, file_uri, .. } => {
                 // FileData contains a URI reference to a file
                 Ok(crate::a2a::Part::file(crate::a2a::FileContent {
                     name: None,
@@ -48,7 +48,7 @@ pub fn adk_parts_to_a2a(
                 // Convert thinking traces to text for A2A protocol
                 Ok(crate::a2a::Part::text(thinking.clone()))
             }
-            Part::FunctionResponse { function_response, id } => {
+            Part::FunctionResponse { function_response, id, .. } => {
                 let mut data = Map::new();
                 let mut resp_data = Map::new();
                 resp_data.insert("name".to_string(), Value::String(function_response.name.clone()));
@@ -102,6 +102,8 @@ pub fn a2a_parts_to_adk(parts: &[crate::a2a::Part]) -> Result<Vec<Part>> {
                     Ok(Part::InlineData {
                         mime_type: file.mime_type.clone().unwrap_or_default(),
                         data,
+                        uri: file.uri.clone(),
+                        annotations: None,
                     })
                 } else {
                     Err(adk_core::AdkError::agent("File part with URI not supported"))
@@ -129,6 +131,7 @@ pub fn a2a_parts_to_adk(parts: &[crate::a2a::Part]) -> Result<Vec<Part>> {
                     Ok(Part::FunctionResponse {
                         function_response: adk_core::FunctionResponseData::new(name, response),
                         id,
+                        annotations: None,
                     })
                 } else {
                     Err(adk_core::AdkError::agent("Unknown data part format"))

--- a/adk-server/src/a2a/v1/convert.rs
+++ b/adk-server/src/a2a/v1/convert.rs
@@ -33,11 +33,14 @@ pub fn wire_part_to_adk(part: &a2a_protocol_types::Part) -> Result<adk_core::Par
             Ok(adk_core::Part::InlineData {
                 mime_type: part.media_type.clone().unwrap_or_default(),
                 data,
+                uri: None,
+                annotations: None,
             })
         }
         a2a_protocol_types::PartContent::Url(uri) => Ok(adk_core::Part::FileData {
             mime_type: part.media_type.clone().unwrap_or_default(),
             file_uri: uri.clone(),
+            annotations: None,
         }),
         a2a_protocol_types::PartContent::Data(data) => wire_data_to_adk(data),
         _ => {
@@ -72,6 +75,7 @@ fn wire_data_to_adk(data: &Value) -> Result<adk_core::Part, A2aError> {
         Ok(adk_core::Part::FunctionResponse {
             function_response: adk_core::FunctionResponseData::new(name, response),
             id,
+            annotations: None,
         })
     } else if let Some(stc) = data.get("server_tool_call") {
         Ok(adk_core::Part::ServerToolCall { server_tool_call: stc.clone() })
@@ -98,11 +102,11 @@ fn wire_data_to_adk(data: &Value) -> Result<adk_core::Part, A2aError> {
 pub fn adk_part_to_wire(part: &adk_core::Part) -> Result<a2a_protocol_types::Part, A2aError> {
     match part {
         adk_core::Part::Text { text } => Ok(a2a_protocol_types::Part::text(text.clone())),
-        adk_core::Part::InlineData { mime_type, data } => {
+        adk_core::Part::InlineData { mime_type, data, .. } => {
             let encoded = general_purpose::STANDARD.encode(data);
             Ok(a2a_protocol_types::Part::raw(encoded).with_media_type(mime_type.clone()))
         }
-        adk_core::Part::FileData { mime_type, file_uri } => {
+        adk_core::Part::FileData { mime_type, file_uri, .. } => {
             Ok(a2a_protocol_types::Part::url(file_uri.clone()).with_media_type(mime_type.clone()))
         }
         adk_core::Part::FunctionCall { name, args, id, .. } => {
@@ -115,7 +119,7 @@ pub fn adk_part_to_wire(part: &adk_core::Part) -> Result<a2a_protocol_types::Par
             let data = json!({ "function_call": Value::Object(call_data) });
             Ok(a2a_protocol_types::Part::data(data))
         }
-        adk_core::Part::FunctionResponse { function_response, id } => {
+        adk_core::Part::FunctionResponse { function_response, id, .. } => {
             let mut resp_data = Map::new();
             resp_data.insert("name".to_string(), Value::String(function_response.name.clone()));
             resp_data.insert("response".to_string(), function_response.response.clone());
@@ -399,7 +403,7 @@ mod tests {
         let wire = a2a_protocol_types::Part::raw(&encoded).with_media_type("image/png");
         let adk = wire_part_to_adk(&wire).unwrap();
         match adk {
-            adk_core::Part::InlineData { mime_type, data } => {
+            adk_core::Part::InlineData { mime_type, data, .. } => {
                 assert_eq!(mime_type, "image/png");
                 assert_eq!(data, b"binary data");
             }
@@ -413,7 +417,7 @@ mod tests {
             .with_media_type("application/pdf");
         let adk = wire_part_to_adk(&wire).unwrap();
         match adk {
-            adk_core::Part::FileData { mime_type, file_uri } => {
+            adk_core::Part::FileData { mime_type, file_uri, .. } => {
                 assert_eq!(mime_type, "application/pdf");
                 assert_eq!(file_uri, "https://example.com/f.pdf");
             }
@@ -454,7 +458,7 @@ mod tests {
         let wire = a2a_protocol_types::Part::data(data);
         let adk = wire_part_to_adk(&wire).unwrap();
         match adk {
-            adk_core::Part::FunctionResponse { function_response, id } => {
+            adk_core::Part::FunctionResponse { function_response, id, .. } => {
                 assert_eq!(function_response.name, "get_weather");
                 assert_eq!(function_response.response["temp"], 72);
                 assert_eq!(id.as_deref(), Some("call_1"));
@@ -518,6 +522,8 @@ mod tests {
         let adk = adk_core::Part::InlineData {
             mime_type: "image/png".to_string(),
             data: b"binary".to_vec(),
+            uri: None,
+            annotations: None,
         };
         let wire = adk_part_to_wire(&adk).unwrap();
         match wire.content {
@@ -535,6 +541,7 @@ mod tests {
         let adk = adk_core::Part::FileData {
             mime_type: "application/pdf".to_string(),
             file_uri: "https://example.com/f.pdf".to_string(),
+            annotations: None,
         };
         let wire = adk_part_to_wire(&adk).unwrap();
         assert!(
@@ -571,6 +578,7 @@ mod tests {
                 json!({"result": 42}),
             ),
             id: Some("r1".to_string()),
+            annotations: None,
         };
         let wire = adk_part_to_wire(&adk).unwrap();
         match wire.content {
@@ -636,11 +644,13 @@ mod tests {
         let original = adk_core::Part::InlineData {
             mime_type: "image/jpeg".to_string(),
             data: vec![0xFF, 0xD8, 0xFF, 0xE0],
+            uri: None,
+            annotations: None,
         };
         let wire = adk_part_to_wire(&original).unwrap();
         let back = wire_part_to_adk(&wire).unwrap();
         match back {
-            adk_core::Part::InlineData { mime_type, data } => {
+            adk_core::Part::InlineData { mime_type, data, .. } => {
                 assert_eq!(mime_type, "image/jpeg");
                 assert_eq!(data, vec![0xFF, 0xD8, 0xFF, 0xE0]);
             }
@@ -653,11 +663,12 @@ mod tests {
         let original = adk_core::Part::FileData {
             mime_type: "text/plain".to_string(),
             file_uri: "gs://bucket/file.txt".to_string(),
+            annotations: None,
         };
         let wire = adk_part_to_wire(&original).unwrap();
         let back = wire_part_to_adk(&wire).unwrap();
         match back {
-            adk_core::Part::FileData { mime_type, file_uri } => {
+            adk_core::Part::FileData { mime_type, file_uri, .. } => {
                 assert_eq!(mime_type, "text/plain");
                 assert_eq!(file_uri, "gs://bucket/file.txt");
             }

--- a/adk-server/src/rest/controllers/runtime.rs
+++ b/adk-server/src/rest/controllers/runtime.rs
@@ -581,6 +581,8 @@ fn build_content_with_attachments(
                 content.parts.push(adk_core::Part::InlineData {
                     mime_type: attachment.mime_type.clone(),
                     data,
+                    uri: None,
+                    annotations: None,
                 });
             }
             Err(e) => {
@@ -621,6 +623,8 @@ fn build_content_from_parts(parts: &[MessagePart]) -> Result<adk_core::Content, 
                     content.parts.push(adk_core::Part::InlineData {
                         mime_type: inline_data.mime_type.clone(),
                         data,
+                        uri: None,
+                        annotations: None,
                     });
                 }
                 Err(e) => {
@@ -848,7 +852,7 @@ fn translate_ag_ui_event(event: &adk_core::Event, thread_id: &str, run_id: &str)
                     }));
                 }
             }
-            adk_core::Part::FunctionResponse { function_response, id } => {
+            adk_core::Part::FunctionResponse { function_response, id, .. } => {
                 let tool_call_id =
                     id.clone().unwrap_or_else(|| format!("{}-tool-result-{}", event.id, index));
                 let response_content = serde_json::to_string(&function_response.response)

--- a/adk-session/src/vertex.rs
+++ b/adk-session/src/vertex.rs
@@ -2860,7 +2860,12 @@ fn content_to_vertex(content: &Content) -> Result<VertexContentPayload> {
             Part::Text { text } => {
                 VertexPartPayload { text: Some(text.clone()), ..VertexPartPayload::default() }
             }
-            Part::InlineData { mime_type, data } => {
+            Part::InlineData { mime_type, data, uri, annotations } => {
+                if uri.is_some() || annotations.is_some() {
+                    return Err(VertexAiSessionService::invalid_input(format!(
+                        "ADK InlineData content part {index} has metadata that the Vertex AI GA v1 wire type cannot represent; the event must use rawEvent persistence",
+                    )));
+                }
                 if mime_type.trim().is_empty() {
                     return Err(VertexAiSessionService::invalid_input(format!(
                         "ADK InlineData content part {index} has an empty MIME type",
@@ -2876,7 +2881,12 @@ fn content_to_vertex(content: &Content) -> Result<VertexContentPayload> {
                     ..VertexPartPayload::default()
                 }
             }
-            Part::FileData { mime_type, file_uri } => {
+            Part::FileData { mime_type, file_uri, annotations } => {
+                if annotations.is_some() {
+                    return Err(VertexAiSessionService::invalid_input(format!(
+                        "ADK FileData content part {index} has annotations that the Vertex AI GA v1 wire type cannot represent; the event must use rawEvent persistence",
+                    )));
+                }
                 if mime_type.trim().is_empty() || file_uri.trim().is_empty() {
                     return Err(VertexAiSessionService::invalid_input(format!(
                         "ADK FileData content part {index} requires a non-empty MIME type and URI",
@@ -2933,10 +2943,21 @@ fn content_to_vertex(content: &Content) -> Result<VertexContentPayload> {
                     ..VertexPartPayload::default()
                 }
             }
-            Part::FunctionResponse { function_response, id } => {
+            Part::FunctionResponse { function_response, id, annotations } => {
                 if id.is_some() {
                     return Err(VertexAiSessionService::invalid_input(format!(
                         "ADK FunctionResponse content part {index} has an id, but the Vertex AI GA v1 FunctionResponse wire type has no id field; the event must use rawEvent persistence",
+                    )));
+                }
+                if annotations.is_some()
+                    || function_response
+                        .inline_data
+                        .iter()
+                        .any(|part| part.uri.is_some() || part.annotations.is_some())
+                    || function_response.file_data.iter().any(|part| part.annotations.is_some())
+                {
+                    return Err(VertexAiSessionService::invalid_input(format!(
+                        "ADK FunctionResponse content part {index} has metadata that the Vertex AI GA v1 wire type cannot represent; the event must use rawEvent persistence",
                     )));
                 }
                 if function_response.name.trim().is_empty() {
@@ -3115,6 +3136,8 @@ fn content_from_vertex(content: VertexContentPayload) -> Result<Content> {
                     &inline_data.data,
                     &format!("content part {index} inlineData"),
                 )?,
+                uri: None,
+                annotations: None,
             }
         } else if let Some(file_data) = part.file_data {
             reject_extra_fields(index, "fileData", &file_data.extra)?;
@@ -3126,7 +3149,11 @@ fn content_from_vertex(content: VertexContentPayload) -> Result<Content> {
                     "vertex fileData content part {index} has an empty required MIME type or URI",
                 )));
             }
-            Part::FileData { mime_type: file_data.mime_type, file_uri: file_data.file_uri }
+            Part::FileData {
+                mime_type: file_data.mime_type,
+                file_uri: file_data.file_uri,
+                annotations: None,
+            }
         } else if let Some(function_call) = part.function_call {
             if video_metadata.is_some() {
                 return Err(VertexAiSessionService::session_error(format!(
@@ -3208,6 +3235,8 @@ fn content_from_vertex(content: VertexContentPayload) -> Result<Content> {
                                     "functionResponse part {index}.{response_index} inlineData"
                                 ),
                             )?,
+                            uri: None,
+                            annotations: None,
                         });
                     }
                     (None, Some(data)) => {
@@ -3220,6 +3249,7 @@ fn content_from_vertex(content: VertexContentPayload) -> Result<Content> {
                         file_data.push(FileDataPart {
                             mime_type: data.mime_type,
                             file_uri: data.file_uri,
+                            annotations: None,
                         });
                     }
                     _ => {
@@ -3238,6 +3268,7 @@ fn content_from_vertex(content: VertexContentPayload) -> Result<Content> {
                     file_data,
                 },
                 id: None,
+                annotations: None,
             }
         } else if let Some(executable_code) = part.executable_code {
             if video_metadata.is_some() {
@@ -3900,12 +3931,41 @@ fn validate_content_json_depth_with_trust(
                     trust,
                 )?;
             }
-            Part::FunctionResponse { function_response, .. } => {
+            Part::FunctionResponse { function_response, annotations, .. } => {
                 validate_lossless_json_depth_with_trust(
                     &function_response.response,
                     &format!("{part_path}.functionResponse.response"),
                     trust,
                 )?;
+                if let Some(annotations) = annotations {
+                    validate_lossless_json_depth_with_trust(
+                        annotations,
+                        &format!("{part_path}.functionResponse.annotations"),
+                        trust,
+                    )?;
+                }
+                for (media_index, media) in function_response.inline_data.iter().enumerate() {
+                    if let Some(annotations) = &media.annotations {
+                        validate_lossless_json_depth_with_trust(
+                            annotations,
+                            &format!(
+                                "{part_path}.functionResponse.inlineData[{media_index}].annotations"
+                            ),
+                            trust,
+                        )?;
+                    }
+                }
+                for (media_index, media) in function_response.file_data.iter().enumerate() {
+                    if let Some(annotations) = &media.annotations {
+                        validate_lossless_json_depth_with_trust(
+                            annotations,
+                            &format!(
+                                "{part_path}.functionResponse.fileData[{media_index}].annotations"
+                            ),
+                            trust,
+                        )?;
+                    }
+                }
             }
             Part::ServerToolCall { server_tool_call } => {
                 validate_lossless_json_depth_with_trust(
@@ -3921,11 +3981,16 @@ fn validate_content_json_depth_with_trust(
                     trust,
                 )?;
             }
-            Part::Thinking { .. }
-            | Part::Text { .. }
-            | Part::InlineData { .. }
-            | Part::FileData { .. }
-            | Part::EmbeddedResource { .. } => {}
+            Part::InlineData { annotations, .. } | Part::FileData { annotations, .. } => {
+                if let Some(annotations) = annotations {
+                    validate_lossless_json_depth_with_trust(
+                        annotations,
+                        &format!("{part_path}.annotations"),
+                        trust,
+                    )?;
+                }
+            }
+            Part::Thinking { .. } | Part::Text { .. } | Part::EmbeddedResource { .. } => {}
         }
     }
     Ok(())
@@ -4790,6 +4855,8 @@ mod tests {
             parts: vec![Part::InlineData {
                 mime_type: "application/octet-stream".to_string(),
                 data: vec![0; 256],
+                uri: None,
+                annotations: None,
             }],
         });
         let preflight = build_append_event_payload_with_limit(&event, 64)
@@ -5254,6 +5321,69 @@ mod tests {
     }
 
     #[test]
+    fn test_content_metadata_uses_lossless_raw_event_fallback() {
+        let annotations = serde_json::json!({"audience": ["user"], "priority": 0.8});
+        let parts = vec![
+            Part::InlineData {
+                mime_type: "image/png".to_string(),
+                data: vec![1, 2, 3],
+                uri: Some("file:///screenshots/result.png".to_string()),
+                annotations: Some(annotations.clone()),
+            },
+            Part::FileData {
+                mime_type: "application/pdf".to_string(),
+                file_uri: "gs://reports/result.pdf".to_string(),
+                annotations: Some(annotations.clone()),
+            },
+            Part::FunctionResponse {
+                function_response: FunctionResponseData::with_multimodal(
+                    "render_report",
+                    serde_json::json!({"ok": true}),
+                    vec![InlineDataPart {
+                        mime_type: "image/png".to_string(),
+                        data: vec![4, 5, 6],
+                        uri: Some("file:///screenshots/tool-result.png".to_string()),
+                        annotations: Some(annotations.clone()),
+                    }],
+                    vec![FileDataPart {
+                        mime_type: "application/pdf".to_string(),
+                        file_uri: "gs://reports/tool-result.pdf".to_string(),
+                        annotations: Some(annotations.clone()),
+                    }],
+                ),
+                id: None,
+                annotations: Some(annotations),
+            },
+        ];
+
+        for part in &parts {
+            let error = content_to_vertex(&Content {
+                role: "model".to_string(),
+                parts: vec![part.clone()],
+            })
+            .expect_err("metadata must not be dropped by canonical Vertex persistence");
+            assert!(error.message.contains("rawEvent persistence"));
+        }
+
+        let content = Content { role: "model".to_string(), parts };
+        let mut event = Event::new("inv-content-metadata");
+        event.author = "model".to_string();
+        event.llm_response.content = Some(content.clone());
+        let payload =
+            build_append_event_payload(&event).expect("metadata must use rawEvent persistence");
+        assert!(payload.get("content").is_none());
+        assert_eq!(payload["rawEvent"]["_adkRust"]["contentSource"], "raw");
+
+        let restored: Event =
+            serde_json::from_str(payload["rawEvent"]["_adkRust"]["adkEvent"].as_str().unwrap())
+                .expect("restore private event");
+        assert_eq!(
+            serde_json::to_value(restored.llm_response.content).unwrap(),
+            serde_json::to_value(Some(content)).unwrap(),
+        );
+    }
+
+    #[test]
     fn test_noncanonical_base64_thought_signatures_round_trip_raw() {
         for (event_id, part) in [
             (
@@ -5375,6 +5505,7 @@ mod tests {
                         serde_json::json!({ "ok": true }),
                     ),
                     id: Some("call-1".to_string()),
+                    annotations: None,
                 },
             ],
         };
@@ -5607,6 +5738,7 @@ mod tests {
             Part::FunctionResponse {
                 function_response: FunctionResponseData::new("tool", deep_value()),
                 id: None,
+                annotations: None,
             },
             Part::ServerToolCall { server_tool_call: deep_value() },
             Part::ServerToolResponse { server_tool_response: deep_value() },

--- a/adk-session/tests/session_contract_vertex.rs
+++ b/adk-session/tests/session_contract_vertex.rs
@@ -2011,10 +2011,13 @@ async fn test_vertex_content_round_trip_preserves_supported_parts() {
             Part::InlineData {
                 mime_type: "application/octet-stream".to_string(),
                 data: vec![0, 1, 2, 253, 254, 255],
+                uri: None,
+                annotations: None,
             },
             Part::FileData {
                 mime_type: "image/png".to_string(),
                 file_uri: "gs://bucket/image.png".to_string(),
+                annotations: None,
             },
             Part::FunctionCall {
                 name: "lookup".to_string(),
@@ -2029,13 +2032,17 @@ async fn test_vertex_content_round_trip_preserves_supported_parts() {
                     inline_data: vec![InlineDataPart {
                         mime_type: "image/gif".to_string(),
                         data: vec![71, 73, 70],
+                        uri: None,
+                        annotations: None,
                     }],
                     file_data: vec![FileDataPart {
                         mime_type: "application/pdf".to_string(),
                         file_uri: "gs://bucket/result.pdf".to_string(),
+                        annotations: None,
                     }],
                 },
                 id: None,
+                annotations: None,
             },
         ],
     });

--- a/adk-tool/src/builtin/load_artifacts.rs
+++ b/adk-tool/src/builtin/load_artifacts.rs
@@ -78,7 +78,7 @@ impl Tool for LoadArtifactsTool {
                             "type": "text",
                             "text": text,
                         }),
-                        adk_core::Part::InlineData { mime_type, data } => {
+                        adk_core::Part::InlineData { mime_type, data, .. } => {
                             // Base64 encode binary data for JSON transport
                             let encoded = STANDARD.encode(&data);
                             json!({

--- a/adk-tool/src/sampling/mod.rs
+++ b/adk-tool/src/sampling/mod.rs
@@ -354,6 +354,8 @@ pub fn sampling_request_to_llm_request(request: &SamplingRequest, model_name: &s
                 parts: vec![Part::InlineData {
                     mime_type: mime_type.clone(),
                     data: base64_decode_lossy(data),
+                    uri: None,
+                    annotations: None,
                 }],
             },
         };
@@ -405,7 +407,7 @@ fn content_to_sampling_content(content: &Content) -> SamplingContent {
     for part in &content.parts {
         match part {
             Part::Text { text } => return SamplingContent::text(text.clone()),
-            Part::InlineData { mime_type, data } => {
+            Part::InlineData { mime_type, data, .. } => {
                 return SamplingContent::image(base64_encode(data), mime_type.clone());
             }
             _ => continue,

--- a/docs/official_docs/acp/server.md
+++ b/docs/official_docs/acp/server.md
@@ -103,11 +103,13 @@ both directions. Embedded-resource prompt content maps to
 `Part::EmbeddedResource`, preserving the source URI, optional MIME type, and
 contents; text resources are preserved verbatim while binary resources are
 base64-encoded on the wire and decoded to raw bytes internally. Image and audio
-prompt content maps to `Part::InlineData`, preserving the MIME type and decoded
-bytes. Because the prompt handler accepts embedded-resource, image, and audio
-content, the server advertises the `embedded_context`, `image`, and `audio`
-prompt capabilities. A prompt carrying a content type the server has not
-advertised is rejected with a descriptive error rather than partially handled.
+prompt content maps to `Part::InlineData`, preserving the MIME type, decoded
+bytes, annotations, and an image's optional source URI. These fields remain in
+session JSON and are restored by `session/load`. Because the prompt handler
+accepts embedded-resource, image, and audio content, the server advertises the
+`embedded_context`, `image`, and `audio` prompt capabilities. A prompt carrying
+a content type the server has not advertised is rejected with a descriptive
+error rather than partially handled.
 
 ## Load and history replay
 

--- a/docs/official_docs/core/core.md
+++ b/docs/official_docs/core/core.md
@@ -65,16 +65,29 @@ pub enum Part {
     Text { text: String },
     
     // Binary data embedded in the message
-    InlineData { mime_type: String, data: Vec<u8> },
+    InlineData {
+        mime_type: String,
+        data: Vec<u8>,
+        uri: Option<String>,
+        annotations: Option<Value>,
+    },
     
     // Reference to external file (URL or cloud storage)
-    FileData { mime_type: String, file_uri: String },
+    FileData {
+        mime_type: String,
+        file_uri: String,
+        annotations: Option<Value>,
+    },
     
     // Model requesting a tool call
     FunctionCall { name: String, args: Value, id: Option<String> },
     
     // Result of a tool execution
-    FunctionResponse { function_response: FunctionResponseData, id: Option<String> },
+    FunctionResponse {
+        function_response: FunctionResponseData,
+        id: Option<String>,
+        annotations: Option<Value>,
+    },
     
     // A complete resource embedded in the message (source URI + inline contents)
     EmbeddedResource { resource: EmbeddedResource },

--- a/examples/acp_full_protocol/src/lib.rs
+++ b/examples/acp_full_protocol/src/lib.rs
@@ -160,6 +160,7 @@ impl Agent for ScriptedAgent {
                         content.parts.push(Part::FunctionResponse {
                             function_response: FunctionResponseData::new(CONFIRM_TOOL, result),
                             id: Some(CONFIRM_CALL_ID.to_string()),
+                            annotations: None,
                         });
                         result_event.set_content(content);
                         yield Ok(result_event);
@@ -196,7 +197,7 @@ impl Agent for ScriptedAgent {
                     Part::EmbeddedResource { resource } => {
                         echoes.push(describe_embedded(resource));
                     }
-                    Part::InlineData { mime_type, data } => {
+                    Part::InlineData { mime_type, data, .. } => {
                         echoes.push(format!("inline-data:{mime_type}:{}", data.len()));
                     }
                     _ => {}
@@ -254,6 +255,7 @@ impl Agent for ScriptedAgent {
                     json!({ "path": "src/main.rs", "content": "fn main() {}" }),
                 ),
                 id: Some("read-1".to_string()),
+                annotations: None,
             });
             result_event.set_content(result_content);
             yield Ok(result_event);

--- a/examples/openai_vision_detail/src/main.rs
+++ b/examples/openai_vision_detail/src/main.rs
@@ -64,10 +64,13 @@ async fn main() -> anyhow::Result<()> {
                 Part::InlineData {
                     mime_type: "image/png".to_string(),
                     data: vec![0x89, 0x50, 0x4E, 0x47],
+                    uri: None,
+                    annotations: None,
                 },
                 Part::FileData {
                     mime_type: "image/jpeg".to_string(),
                     file_uri: "https://example.com/photo.jpg".to_string(),
+                    annotations: None,
                 },
             ],
         }],


### PR DESCRIPTION
## What

- Adds optional URI and annotation metadata to inline-data, file-data, and function-response content types.
- Preserves ACP image, audio, and resource metadata across prompt storage and session replay.
- Routes metadata-bearing Vertex session events through lossless `rawEvent` persistence.
- Migrates provider and runtime consumers, tests, examples, and documentation.

## Why

ACP content annotations and image source URIs were discarded when mapped into `adk_core::Part`, so persisted sessions could not replay the original content metadata. Vertex canonical content cannot represent these fields and previously would have dropped them.

## Compatibility

Direct struct and enum literal users must initialize the new optional fields. Helper constructors default them to `None`, and existing serialized payloads remain compatible through Serde defaults.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- Feature-specific clippy for ACP server, Vertex sessions, A2A v1, and all model providers
- 451 core and ACP tests pass
- 88 ACP all-feature tests pass
- 159 MCP sampling tests pass
- 96 Vertex session tests pass; 2 skipped
- Workspace doctests and rustdoc warnings gate pass
- 98 standalone examples compile
- 96 documentation files validate

Fixes #400