### PR TITLE
feat(realtime): let a closed stream say why it closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **adk-realtime: `DisconnectReason`, so a closed stream can say why.**
+  `RealtimeSession::disconnect_reason()` reports the close code and reason the
+  provider sent, and `RealtimeRunner::disconnect_reason()` forwards it. The
+  Gemini session records its close frame before the event stream ends.
+
+  Applications that *poll* `RealtimeRunner::next_event()` never reach the
+  runner's `on_disconnect` dispatch, and `next_event` returns a bare `None`
+  whether the provider deliberately closed an idle session or the socket died.
+  Both therefore landed in the caller's terminal record as the same generic
+  stream failure — one that reads like a network defect when it was a policy
+  close. Google's Live API closes an idle session with `1008` and
+  `"The operation was aborted."`; that string was reachable in logs but nowhere
+  a durable record could use it.
+
+  The trait method is defaulted to `None`, so existing `RealtimeSession`
+  implementations are unaffected and this is not a breaking change.
+
 - **`scripts/setup-dev.ps1` — first-time setup for Windows.** `make setup`,
   `scripts/setup-dev.sh`, and `devenv shell` all require a POSIX shell, so
   Windows had no scripted path. Checks the toolchain and MSVC environment,

--- a/adk-realtime/src/gemini/session.rs
+++ b/adk-realtime/src/gemini/session.rs
@@ -206,6 +206,12 @@ pub struct GeminiRealtimeSession {
     receiver: Arc<Mutex<WsSource>>,
     audio_buffer: Arc<ParkingMutex<BytesMut>>,
     event_queue: Arc<Mutex<std::collections::VecDeque<ServerEvent>>>,
+    /// The close frame the server sent, if it sent one.
+    ///
+    /// Recorded because the event stream reports a deliberate server-side
+    /// close and a dead socket as the same `None`, so a polling caller cannot
+    /// tell an aborted session from a broken one without it.
+    last_disconnect: Arc<ParkingMutex<Option<crate::session::DisconnectReason>>>,
 }
 
 impl GeminiRealtimeSession {
@@ -327,6 +333,7 @@ impl GeminiRealtimeSession {
             writer_task: Arc::new(Mutex::new(Some(writer_task))),
             receiver: Arc::new(Mutex::new(source)),
             audio_buffer: Arc::new(ParkingMutex::new(BytesMut::new())),
+            last_disconnect: Arc::new(ParkingMutex::new(None)),
             event_queue: Arc::new(Mutex::new(std::collections::VecDeque::new())),
         };
 
@@ -484,7 +491,26 @@ impl GeminiRealtimeSession {
                 )))),
             },
             Some(Ok(Message::Close(close_frame))) => {
-                tracing::error!("WebSocket closed by server: {:?}", close_frame);
+                // Structured, because a server-initiated close and a dead
+                // transport both surface downstream as the same `None` and get
+                // the same terminal reason. The code and reason are the only
+                // thing distinguishing "the provider aborted an idle session"
+                // from "the network dropped", and `{:?}` on the whole frame
+                // buries both inside a Debug string nothing can filter on.
+                tracing::error!(
+                    close_code =
+                        close_frame.as_ref().map(|frame| u16::from(frame.code)).unwrap_or_default(),
+                    close_reason =
+                        close_frame.as_ref().map(|frame| frame.reason.as_ref()).unwrap_or(""),
+                    "WebSocket closed by server"
+                );
+                *self.last_disconnect.lock() = Some(crate::session::DisconnectReason {
+                    code: close_frame.as_ref().map(|frame| u16::from(frame.code)),
+                    reason: close_frame
+                        .as_ref()
+                        .map(|frame| frame.reason.to_string())
+                        .unwrap_or_default(),
+                });
                 self.connected.store(false, Ordering::SeqCst);
                 None
             }
@@ -656,6 +682,10 @@ impl RealtimeSession for GeminiRealtimeSession {
 
     fn is_connected(&self) -> bool {
         self.connected.load(Ordering::SeqCst)
+    }
+
+    fn disconnect_reason(&self) -> Option<crate::session::DisconnectReason> {
+        self.last_disconnect.lock().clone()
     }
 
     async fn send_audio(&self, audio: &AudioChunk) -> Result<()> {

--- a/adk-realtime/src/lib.rs
+++ b/adk-realtime/src/lib.rs
@@ -120,4 +120,4 @@ pub use error::{RealtimeError, Result};
 pub use events::{ClientEvent, ServerEvent, ToolCall, ToolResponse};
 pub use model::{BoxedModel, RealtimeModel};
 pub use runner::RealtimeRunner;
-pub use session::{BoxedSession, RealtimeSession, RealtimeSessionExt};
+pub use session::{BoxedSession, DisconnectReason, RealtimeSession, RealtimeSessionExt};

--- a/adk-realtime/src/runner.rs
+++ b/adk-realtime/src/runner.rs
@@ -711,6 +711,17 @@ impl RealtimeRunner {
     ///     }
     /// }
     /// ```
+    /// Why the provider ended the stream, once [`Self::next_event`] has returned
+    /// `None`.
+    ///
+    /// Callers that poll `next_event` never see the runner's `on_disconnect`
+    /// dispatch, so without this a provider that deliberately closed an idle
+    /// session is indistinguishable from a dropped socket — and both get
+    /// recorded as the same generic stream failure.
+    pub async fn disconnect_reason(&self) -> Option<crate::session::DisconnectReason> {
+        self.session_handle().await.ok().and_then(|session| session.disconnect_reason())
+    }
+
     pub async fn next_event(&self) -> Option<Result<ServerEvent>> {
         let session = match self.session_handle().await {
             Ok(session) => session,

--- a/adk-realtime/src/session.rs
+++ b/adk-realtime/src/session.rs
@@ -45,6 +45,33 @@ pub enum ContextMutationOutcome {
 ///     Ok(())
 /// }
 /// ```
+/// Why a provider closed the stream, when it said.
+///
+/// A closed transport and a provider that deliberately hung up both reach a
+/// polling caller as `next_event() -> None`, so without this they produce the
+/// same terminal record. Distinguishing them matters: "the provider aborted an
+/// idle session" and "the network dropped" call for different responses, and
+/// an application that records the first as a generic stream failure sends an
+/// operator looking for a defect that is not there.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DisconnectReason {
+    /// The WebSocket close code, if the peer sent a close frame.
+    pub code: Option<u16>,
+    /// The peer's stated reason. Provider text, so treat it as data.
+    pub reason: String,
+}
+
+impl std::fmt::Display for DisconnectReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.code {
+            Some(code) if !self.reason.is_empty() => write!(f, "{code}:{}", self.reason),
+            Some(code) => write!(f, "{code}"),
+            None if !self.reason.is_empty() => write!(f, "{}", self.reason),
+            None => write!(f, "unknown"),
+        }
+    }
+}
+
 #[async_trait]
 pub trait RealtimeSession: Send + Sync {
     /// Get the session ID.
@@ -52,6 +79,16 @@ pub trait RealtimeSession: Send + Sync {
 
     /// Check if the session is currently connected.
     fn is_connected(&self) -> bool;
+
+    /// Why the stream ended, if the provider said and the session recorded it.
+    ///
+    /// Defaulted to `None` so existing sessions keep compiling; a provider that
+    /// sees a close frame should override it. Only meaningful after the event
+    /// stream has ended — before that it reports whatever the last close was,
+    /// which for a live session is nothing.
+    fn disconnect_reason(&self) -> Option<DisconnectReason> {
+        None
+    }
 
     /// Send raw audio data to the server.
     ///
@@ -191,3 +228,40 @@ impl<T: RealtimeSession> RealtimeSessionExt for T {}
 
 /// A boxed session type for dynamic dispatch.
 pub type BoxedSession = Box<dyn RealtimeSession>;
+
+#[cfg(test)]
+mod disconnect_reason_tests {
+    use super::DisconnectReason;
+
+    /// The string is what ends up in an application's terminal record, so the
+    /// shape is a contract, not a debug convenience.
+    #[test]
+    fn a_code_and_reason_render_together() {
+        let reason =
+            DisconnectReason { code: Some(1008), reason: "The operation was aborted.".to_string() };
+
+        assert_eq!(reason.to_string(), "1008:The operation was aborted.");
+    }
+
+    /// Providers do not always send both halves, and a close with only a code
+    /// still carries the distinction the caller needs.
+    #[test]
+    fn either_half_alone_still_says_something() {
+        assert_eq!(
+            DisconnectReason { code: Some(1011), reason: String::new() }.to_string(),
+            "1011"
+        );
+        assert_eq!(
+            DisconnectReason { code: None, reason: "going away".to_string() }.to_string(),
+            "going away"
+        );
+    }
+
+    /// A transport that simply died sends no close frame at all. Rendering that
+    /// as an empty string would produce terminal records ending in a bare
+    /// separator, which reads as truncation rather than absence.
+    #[test]
+    fn an_absent_close_frame_is_named_rather_than_blank() {
+        assert_eq!(DisconnectReason { code: None, reason: String::new() }.to_string(), "unknown");
+    }
+}


### PR DESCRIPTION
## The problem

`RealtimeRunner::next_event()` returns a bare `None` whether the provider deliberately closed the session or the transport died. An application that **polls** the runner therefore cannot tell the two apart, and records both as the same generic stream failure — one that reads like a network defect when it was actually a policy close.

`on_disconnect()` already exists and already fires, but only from the runner's own `run()` loop. A transport bridge that drives the session by polling `next_event()` never reaches that dispatch. The seam was present and unreachable at the same time, which is why this looks like it should already work.

## What motivated it

Google's Live API closes an idle session with `1008` / `"The operation was aborted."`. We hit this on a production voice call: a caller hung up, the bridge sat on the socket until Gemini aborted it ~2m30s later, and the terminal record said `model_stream_closed` — indistinguishable from a dropped connection. The close text was reachable in logs, but nowhere a durable audit record could use it.

## The change

- `DisconnectReason { code: Option<u16>, reason: String }` with `Display`.
- `RealtimeSession::disconnect_reason()` — **defaulted to `None`**, so every existing implementation compiles untouched. This is additive, not breaking.
- `RealtimeRunner::disconnect_reason()` forwards it, which is what the polling path needs.
- The Gemini session records its close frame before the event stream ends.

`Display` renders `code:reason`, either half alone when that is all the peer sent, and `unknown` when there was no close frame at all — an empty render would leave terminal records ending in a bare separator, which reads as truncation rather than absence. That case is pinned by a test.

## Verification

Against this branch's base (`upstream/main`), inside the project's dev shell:

- `cargo test -p adk-realtime --lib` — **31 passed, 0 failed** (3 new)
- `cargo clippy -p adk-realtime --all-targets` — clean
- `cargo fmt --all` — applied

The existing `runner_tests::a_terminal_disconnect_is_surfaced_once` is unaffected: this does not duplicate or contest the `on_disconnect` dispatch, it reaches a path that dispatch never touches.

## Notes for review

- The trait method is defaulted rather than required on purpose — same shape as `SchemaCache::for_adapter` in #531, so no downstream implementation breaks and nothing fails open.
- Only the Gemini session implements it here. The OpenAI session keeps the `None` default; adding it there is a separate, equally small change if wanted.