### PR TITLE
fix(sandbox): discover Windows SDK linker paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -413,6 +413,9 @@ jobs:
     - name: Run sandbox output-cap portability smoke
       run: cargo test -p adk-sandbox --test output_cap_tests
 
+    - name: Run sandbox Rust compilation portability smoke
+      run: cargo test -p adk-sandbox --test process_enforcement_tests a_working_program_still_runs -- --exact
+
     - name: Build summary
       if: always()
       run: echo "### 🪟 Windows build and sandbox portability smoke passed" >> $env:GITHUB_STEP_SUMMARY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,11 +46,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `cmd.exe` does not implement `CommandLineToArgvW` escaping. The tests now write
   a temporary script — PowerShell on Windows, `sh` elsewhere — so no payload
   crosses the command line.
-- **adk-sandbox's `a_working_program_still_runs` no longer fails outside a
-  Developer shell.** The `compile_lib=true` assertion covers `LIB` forwarding,
-  which has nothing to forward when the host has no `LIB` set. It now states that
-  precondition instead of failing; the `runtime_lib=false` isolation assertion is
-  unconditional as before.
+- **Sandboxed Rust compilation discovers the Windows SDK outside a Developer
+  shell.** `ProcessBackend` now obtains the MSVC `PATH`, `LIB`, `LIBPATH`, and
+  `INCLUDE` values from the installed Build Tools when the parent environment
+  does not provide them. The compiler receives the SDK import-library paths while
+  the generated program still starts with a cleared environment. The exact
+  compile-and-run regression now runs in the PR-tier Windows smoke gate.
 - **adk-sandbox now preserves Windows shell quoting and selects the intended Rust
   linker.** Raw command text reaches `cmd.exe` without `CommandLineToArgvW`
   escaping, so quoted executable and script paths work. Direct sandboxed Rust

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -893,6 +893,7 @@ dependencies = [
  "adk-core",
  "async-trait",
  "bollard",
+ "find-msvc-tools",
  "futures",
  "libc",
  "proptest",

--- a/adk-sandbox/Cargo.toml
+++ b/adk-sandbox/Cargo.toml
@@ -38,6 +38,7 @@ libc = "0.2"
 
 # Optional: Windows AppContainer API
 [target.'cfg(windows)'.dependencies]
+find-msvc-tools = "0.1.9"
 windows-sys = { version = "0.59", optional = true, features = [
     "Win32_Security",
     "Win32_System_Threading",

--- a/adk-sandbox/src/process.rs
+++ b/adk-sandbox/src/process.rs
@@ -68,8 +68,18 @@ const NON_WINDOWS_TOOLCHAIN_ENV_KEYS: &[&str] = &[
 /// `LIB` is the linker's library search path. The remaining Windows-specific
 /// values support temporary files, system DLL discovery, and rustup's default
 /// toolchain location without copying the full developer-shell environment.
-const WINDOWS_TOOLCHAIN_ENV_KEYS: &[&str] =
-    &["PATH", "LIB", "SystemRoot", "TEMP", "TMP", "USERPROFILE", "RUSTUP_HOME", "RUSTUP_TOOLCHAIN"];
+const WINDOWS_TOOLCHAIN_ENV_KEYS: &[&str] = &[
+    "PATH",
+    "LIB",
+    "LIBPATH",
+    "INCLUDE",
+    "SystemRoot",
+    "TEMP",
+    "TMP",
+    "USERPROFILE",
+    "RUSTUP_HOME",
+    "RUSTUP_TOOLCHAIN",
+];
 
 /// Configuration for [`ProcessBackend`].
 ///
@@ -386,6 +396,11 @@ impl ProcessBackend {
         // process group — and Rust compilation is not inert: `include_str!` and
         // procedural macros read files and can run arbitrary code at compile time, so
         // the compiler needs the same boundary as the binary it produces.
+        let toolchain_env = Self::toolchain_env();
+        #[cfg(windows)]
+        let has_msvc_library_path =
+            toolchain_env.iter().any(|(key, _)| key.eq_ignore_ascii_case("LIB"));
+
         let compile_result = {
             let mut cmd = Command::new(&self.config.rustc_path);
             // Cargo applies the workspace's rust-lld setting, but this direct rustc
@@ -395,7 +410,20 @@ impl ProcessBackend {
             #[cfg(windows)]
             cmd.arg("-Clinker=rust-lld");
             cmd.arg(&src_path).arg("-o").arg(&bin_path);
-            self.run_command_with_env(cmd, request, &Self::toolchain_env()).await?
+            self.run_command_with_env(cmd, request, &toolchain_env).await?
+        };
+
+        #[cfg(windows)]
+        let compile_result = {
+            let mut result = compile_result;
+            if result.exit_code != 0 && !has_msvc_library_path {
+                result.stderr.push_str(
+                    "\nWindows Rust linking requires the MSVC Build Tools and Windows SDK. \
+                     Install the `Desktop development with C++` workload; ProcessBackend could \
+                     not discover its LIB paths from this host.",
+                );
+            }
+            result
         };
 
         if compile_result.exit_code != 0 {
@@ -481,11 +509,12 @@ impl ProcessBackend {
     /// `rustc` shells out to a platform linker and resolves it through the environment.
     /// The MSVC linker also reads `LIB` to find the Windows and C runtime libraries.
     /// With the environment cleared it cannot link at all, so compilation gets a small
-    /// platform-specific allowlist from the caller when those values are set.
+    /// platform-specific allowlist. On Windows, missing values are discovered from the
+    /// installed Visual Studio Build Tools and Windows SDK.
     ///
     /// This widens what the compile phase can see compared with the run phase. An OS
     /// enforcer is what constrains it; see [`ProcessBackend::isolation`].
-    fn toolchain_env() -> Vec<(String, String)> {
+    fn toolchain_env() -> Vec<(String, OsString)> {
         // RUSTUP_TOOLCHAIN matters as much as RUSTUP_HOME: `rustc` on PATH is usually a rustup
         // shim, and without it the shim ignores the caller's selection and resolves
         // `rust-toolchain.toml` instead. That either compiles with a different toolchain than the
@@ -495,9 +524,38 @@ impl ProcessBackend {
         let keys =
             if cfg!(windows) { WINDOWS_TOOLCHAIN_ENV_KEYS } else { NON_WINDOWS_TOOLCHAIN_ENV_KEYS };
 
-        keys.iter()
-            .filter_map(|key| std::env::var(key).ok().map(|value| ((*key).to_string(), value)))
-            .collect()
+        let environment: Vec<(String, OsString)> = keys
+            .iter()
+            .filter_map(|key| std::env::var_os(key).map(|value| ((*key).to_string(), value)))
+            .collect();
+
+        #[cfg(windows)]
+        let mut environment = environment;
+
+        #[cfg(windows)]
+        if !environment.iter().any(|(key, _)| key.eq_ignore_ascii_case("LIB"))
+            && let Some(linker) = find_msvc_tools::find(std::env::consts::ARCH, "link.exe")
+        {
+            for (key, value) in linker.get_envs() {
+                let Some(value) = value else {
+                    continue;
+                };
+                let Some(allowed_key) = WINDOWS_TOOLCHAIN_ENV_KEYS
+                    .iter()
+                    .find(|allowed| key.eq_ignore_ascii_case(OsStr::new(allowed)))
+                else {
+                    continue;
+                };
+                if !environment
+                    .iter()
+                    .any(|(existing, _)| existing.eq_ignore_ascii_case(allowed_key))
+                {
+                    environment.push(((*allowed_key).to_string(), value.to_os_string()));
+                }
+            }
+        }
+
+        environment
     }
 
     /// Shared execution logic, with `extra_env` applied below policy and request values.
@@ -505,7 +563,7 @@ impl ProcessBackend {
         &self,
         cmd: Command,
         request: &ExecRequest,
-        extra_env: &[(String, String)],
+        extra_env: &[(String, OsString)],
     ) -> Result<ExecResult, SandboxError> {
         // If a sandbox enforcer is configured, wrap the command.
         // We extract the program and args from the pre-built Command,
@@ -931,6 +989,8 @@ mod tests {
             &[
                 "PATH",
                 "LIB",
+                "LIBPATH",
+                "INCLUDE",
                 "SystemRoot",
                 "TEMP",
                 "TMP",

--- a/adk-sandbox/tests/process_enforcement_tests.rs
+++ b/adk-sandbox/tests/process_enforcement_tests.rs
@@ -123,22 +123,13 @@ fn main() {
         result.stdout
     );
 
-    // The forwarding half only has something to forward when the host itself has
-    // `LIB` set, which on Windows means a Developer shell (or `vcvars64.bat`).
-    // Asserting it unconditionally turns an unconfigured shell into a test
-    // failure and hides the isolation assertion above, which is the one that
-    // matters. CI runs under a Developer environment, so coverage is unchanged.
+    // A Developer shell supplies LIB directly. A regular PowerShell does not, so
+    // ProcessBackend discovers the same SDK paths from the installed MSVC tools.
+    // Either way, the compiler sees LIB and the produced program does not.
     #[cfg(windows)]
-    if std::env::var_os("LIB").is_some() {
-        assert!(
-            result.stdout.contains("compile_lib=true"),
-            "rustc did not receive the MSVC library path: {}",
-            result.stdout
-        );
-    } else {
-        eprintln!(
-            "skipping the compile_lib assertion: LIB is not set on this host, so there is \
-             nothing for the sandbox to forward. Run from a Developer PowerShell to cover it."
-        );
-    }
+    assert!(
+        result.stdout.contains("compile_lib=true"),
+        "rustc did not receive the MSVC library path: {}",
+        result.stdout
+    );
 }

--- a/docs/official_docs/sandbox/index.md
+++ b/docs/official_docs/sandbox/index.md
@@ -35,9 +35,10 @@ Two things about the process backend worth knowing:
   wrapper, no timeout, and no process group. That matters because compilation is not
   inert: `include_str!` reads files and procedural macros run arbitrary code before the
   produced binary exists. The compile phase receives a platform-specific toolchain
-  allow-list; on Windows this includes `LIB` and uses the Rust toolchain's `rust-lld`
-  linker so an unrelated `link.exe` earlier on `PATH` cannot be selected. An OS
-  enforcer is what constrains that phase.
+  allow-list; on Windows this includes the MSVC and Windows SDK paths, discovered
+  from the installed toolchain when the caller is not already in a Developer shell.
+  Compilation uses the Rust toolchain's `rust-lld` linker so an unrelated `link.exe`
+  earlier on `PATH` cannot be selected. An OS enforcer is what constrains that phase.
 
 ### Environment Precedence
 

--- a/examples/sandbox_agent/Cargo.lock
+++ b/examples/sandbox_agent/Cargo.lock
@@ -138,6 +138,7 @@ version = "2.0.0"
 dependencies = [
  "adk-core",
  "async-trait",
+ "find-msvc-tools",
  "libc",
  "serde",
  "serde_json",

--- a/examples/sandbox_workspace_agent/Cargo.lock
+++ b/examples/sandbox_workspace_agent/Cargo.lock
@@ -140,6 +140,7 @@ dependencies = [
  "adk-core",
  "async-trait",
  "bollard",
+ "find-msvc-tools",
  "futures",
  "libc",
  "serde",

--- a/examples/tier_examples/Cargo.lock
+++ b/examples/tier_examples/Cargo.lock
@@ -443,6 +443,7 @@ version = "2.0.0"
 dependencies = [
  "adk-core",
  "async-trait",
+ "find-msvc-tools",
  "libc",
  "serde",
  "serde_json",

--- a/scripts/setup-dev.ps1
+++ b/scripts/setup-dev.ps1
@@ -137,14 +137,12 @@ foreach ($tool in 'rustc', 'cargo') {
 # aws-lc-sys needs cl.exe for its C sources.
 if (Test-Tool 'cl') {
     Write-Ok 'cl.exe (MSVC C/C++ compiler)'
-    # adk-sandbox forwards LIB to rustc so it can reach the MSVC linker. Without
-    # it, a_working_program_still_runs fails even though cl.exe is on PATH.
+    # adk-sandbox forwards LIB to rustc when a Developer shell supplies it and
+    # otherwise discovers the same SDK paths from the installed Build Tools.
     if ($env:LIB) {
         Write-Ok 'LIB set (MSVC library path available to the sandbox tests)'
     } else {
-        Write-Warn 'LIB not set - adk-sandbox a_working_program_still_runs will fail'
-        Write-Host '         Run the test suite from a Developer PowerShell, or call'
-        Write-Host '         vcvars64.bat first.'
+        Write-Ok 'LIB not set (adk-sandbox will discover the installed MSVC SDK paths)'
     }
 } else {
     Write-Warn 'cl.exe not on PATH - install Visual Studio Build Tools with the'


### PR DESCRIPTION
## What

- Discovers MSVC and Windows SDK environment values when `LIB` is absent.
- Keeps SDK variables confined to Rust compilation; generated programs still start from a cleared runtime environment.
- Adds an actionable missing-Build-Tools diagnostic.
- Runs `a_working_program_still_runs` in PR-tier Windows CI.

## Why

Final-main CI Merge repeatedly failed because direct `rustc` compilation uses `rust-lld` after clearing the environment. GitHub's ordinary Windows shell does not export `LIB`, so the linker could not locate `kernel32.lib` and other Windows SDK import libraries.

The prior test guard only skipped the post-execution `compile_lib` assertion; compilation failed before that assertion could run.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy -p adk-sandbox --target x86_64-pc-windows-msvc --all-targets -- -D warnings`
- `cargo nextest run --workspace` — 4,080 passed; 83 skipped
- `cargo nextest run -p adk-sandbox` — 49 passed; 5 skipped
- Release consistency, publish order, and 96 documentation files validated

## Release impact

Resolves the final known Windows full-suite release blocker. The GitHub Windows smoke remains the definitive runtime check for SDK discovery.