### PR TITLE
ci: optimize PR gating without reducing coverage

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: 'Prefix for the build cache.'
     required: false
     default: ${{ github.job }}
+  enable-cache:
+    description: 'Enable the persistent Rust build cache.'
+    required: false
+    default: 'true'
   neutralize-wild:
     description: >-
       Strip the Linux `wild` linker sections from .cargo/config.toml. Set to
@@ -53,6 +57,7 @@ runs:
     #    caller-supplied prefix; rust-cache appends the Cargo.lock hash itself,
     #    so a dependency change cannot be masked by a stale cache.
     - name: Configure Rust build cache
+      if: inputs.enable-cache == 'true'
       uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       with:
         prefix-key: ${{ inputs.cache-key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       uses: ./.github/actions/setup-rust
       with:
         components: rustfmt
-        cache-key: fmt
+        enable-cache: 'false'
 
     - name: Check formatting
       run: cargo fmt --all -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,11 @@
 name: CI
 
+# PR tier only. Post-merge coverage belongs to ci-merge.yml; running this full
+# workflow on main duplicated every PR job after each merge.
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -26,15 +27,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
-    - uses: cachix/install-nix-action@v30
+
+    # ws-fmt is exactly `cargo fmt --all`; use the shared pinned toolchain
+    # directly instead of spending ~3 minutes bootstrapping Nix + devenv.
+    - name: Setup Rust
+      uses: ./.github/actions/setup-rust
       with:
-        nix_path: nixpkgs=channel:nixos-unstable
-    - uses: cachix/cachix-action@v17
-      with:
-        name: devenv
-    - run: nix profile install nixpkgs#devenv
+        components: rustfmt
+        cache-key: fmt
+
     - name: Check formatting
-      run: CI=true devenv shell ws-fmt -- --check
+      run: cargo fmt --all -- --check
 
   # ── Lint: clippy (parallel with test) ──────────────────────────
   clippy:
@@ -419,3 +422,36 @@ jobs:
     - name: Build summary
       if: always()
       run: echo "### 🪟 Windows build and sandbox portability smoke passed" >> $env:GITHUB_STEP_SUMMARY
+
+  # ── Stable branch-protection contract ──────────────────────────────────
+  # Matrix entries remain individually visible for diagnosis, while branch
+  # protection only needs this stable aggregate context. Adding a feature or
+  # example shard therefore cannot silently drift out of the required set.
+  pr-gate:
+    name: pr-gate
+    if: always()
+    needs:
+      - fmt
+      - clippy
+      - test
+      - feature-coverage
+      - docs
+      - examples-compile
+      - templates
+      - macos
+      - windows
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+    - name: Require every PR-tier job to pass
+      shell: bash
+      env:
+        JOB_RESULTS: ${{ toJSON(needs) }}
+      run: |
+        failed_jobs="$(jq -r 'to_entries[] | select(.value.result != "success") | "\(.key)=\(.value.result)"' <<<"$JOB_RESULTS")"
+        if [[ -n "$failed_jobs" ]]; then
+          echo "::error::PR tier did not pass:"
+          echo "$failed_jobs"
+          exit 1
+        fi
+        echo "All PR-tier jobs passed."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,7 +166,7 @@ is preserved (see the `ci-pipeline-restructure` spec). No coverage is dropped �
 expensive axes move to a later tier.
 
 - **PR tier** (`ci.yml` + `semver.yml`, on pull requests) — the merge-blocking
-  set: `fmt` (prerequisite gate), `clippy --workspace --all-targets -D warnings`,
+  coverage: `fmt` (prerequisite gate), `clippy --workspace --all-targets -D warnings`,
   `nextest --workspace` (Linux, runs at most once), `feature-coverage` for
   feature-gated modules default builds skip (e.g. `adk-agent --features codeact`),
   `docs` (`cargo doc --workspace --no-deps` plus doctests), standalone examples
@@ -181,8 +181,10 @@ expensive axes move to a later tier.
   checks, and `#[ignore]` integration tests gated on available secrets. Not
   branch-protection-required.
 
-Only the PR tier gates merges. See CONTRIBUTING.md ("Branch Protection — Required
-Status Checks") for the authoritative required-check set.
+Only the PR tier gates merges. Branch protection requires the aggregate
+`pr-gate` context plus the separate `semver` context; `pr-gate` fails unless
+every `ci.yml` dependency and matrix entry succeeds. See CONTRIBUTING.md
+("Branch Protection — Required Status Checks") for the authoritative set.
 
 ### Local git hooks (lefthook)
 
@@ -747,7 +749,7 @@ pub async fn swap_adapter(&self, adapter_name: &str) -> Result<()> { ... }
 - **Reference**: Include `Fixes #123` or similar in the PR description.
 - **Scope**: Keep PRs focused — one logical change per PR. Don't mix unrelated changes.
 - **Local gates before pushing**: Run `fmt`, `clippy`, `test`, and `check` via `devenv shell`. These are local shorthand, not CI job names — `check` has no CI job at all.
-- **CI gates that block merge**: The PR tier only (see [CI cost tiers](#ci-cost-tiers)). CONTRIBUTING.md ("Branch Protection — Required Status Checks") is authoritative for the required-check set.
+- **CI gates that block merge**: `pr-gate` (all `ci.yml` PR-tier jobs) and `semver`; see [CI cost tiers](#ci-cost-tiers). CONTRIBUTING.md ("Branch Protection — Required Status Checks") is authoritative.
 
 ### PR Checklist requirements
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -311,7 +311,7 @@ expensive axes just move to a later tier.
 
 | Tier | Trigger | Checks | Blocks merge? |
 |------|---------|--------|---------------|
-| **PR** | pull request (`ci.yml` + `semver.yml`) | `fmt` (prerequisite gate), `clippy --workspace -D warnings`, `nextest --workspace` on Linux (at most once), `feature-coverage` (feature-gated modules like `adk-agent --features codeact`), docs and doctests, standalone examples (4 shards), `templates`, a compile-only macOS build, a Windows workspace build with a targeted sandbox portability smoke, and `semver` (stable strict, beta warn-only) | Yes — this is the required-check set |
+| **PR** | pull request (`ci.yml` + `semver.yml`) | `fmt` (prerequisite gate), `clippy --workspace -D warnings`, `nextest --workspace` on Linux (at most once), `feature-coverage` (feature-gated modules like `adk-agent --features codeact`), docs and doctests, standalone examples (4 shards), `templates`, a compile-only macOS build, a Windows workspace build with a targeted sandbox portability smoke, and `semver` (stable strict, beta warn-only) | Yes — aggregated by `pr-gate`, plus `semver` |
 | **Merge** | `push: main` (`ci-merge.yml`) | cross-platform `nextest --workspace` on macOS/Windows, doc-example compilation | No — runs post-merge |
 | **Nightly** | `schedule` (`ci-nightly.yml`) | feature-combination matrix, `cargo-audit`/`cargo-deny` supply-chain, `#[ignore]` integration tests gated on secrets | No — runs on a schedule |
 
@@ -329,56 +329,25 @@ change lands (or on a schedule) and are informational — they MUST NOT be marke
 branch-protection-required, because requiring a check that doesn't run on a PR
 would block every PR waiting for a status that never arrives.
 
-Branch protection for `main` is configured through the GitHub API / repo settings
-(there is no committed config file). The authoritative required-check set is the
-list below. When updating branch protection, use exactly these status-check
-contexts.
+The `CI / pr-gate` job depends on every job group in `ci.yml` and runs with
+`if: always()`. It succeeds only when every dependency succeeds, including all
+matrix entries. Matrix jobs remain visible individually for diagnosis, but adding
+or removing a matrix entry no longer requires a matching branch-ruleset edit.
 
 ### Required on PRs (branch-protection-required)
 
-These are the Tier-1 jobs from `ci.yml` and `semver.yml`. The status-check context
-name is the job name (matrix jobs include the matrix value in parentheses):
+Require exactly these stable contexts in the `main` ruleset:
 
 | Check context | Workflow | Job |
 |---------------|----------|-----|
-| `fmt` | `ci.yml` | `fmt` |
-| `clippy` | `ci.yml` | `clippy` |
-| `test` | `ci.yml` | `test` |
-| `feature-coverage (adk-agent, codeact)` | `ci.yml` | `feature-coverage` (matrix) |
-| `feature-coverage (adk-agent, ambient)` | `ci.yml` | `feature-coverage` (matrix) |
-| `feature-coverage (adk-model, openrouter)` | `ci.yml` | `feature-coverage` (matrix) |
-| `feature-coverage (adk-sandbox, wasm)` | `ci.yml` | `feature-coverage` (matrix) |
-| `feature-coverage (adk-sandbox, sandbox-linux)` | `ci.yml` | `feature-coverage` (matrix) |
-| `feature-coverage (adk-realtime, integration)` | `ci.yml` | `feature-coverage` (matrix) |
-| `feature-coverage (adk-managed, memory)` | `ci.yml` | `feature-coverage` (matrix) |
-| `feature-coverage (adk-audio, fx)` | `ci.yml` | `feature-coverage` (matrix) |
-| `feature-coverage (adk-rag, lancedb)` | `ci.yml` | `feature-coverage` (matrix) |
-| `feature-coverage (adk-auth, sso)` | `ci.yml` | `feature-coverage` (matrix) |
-| `feature-coverage (adk-server, a2a-v1)` | `ci.yml` | `feature-coverage` (matrix) |
-| `feature-coverage (adk-session, vertex-session)` | `ci.yml` | `feature-coverage` (matrix) |
-| `feature-coverage (adk-acp, server)` | `ci.yml` | `feature-coverage` (matrix) |
-| `docs` | `ci.yml` | `docs` |
-| `examples-compile (0/4)` | `ci.yml` | `examples-compile` (matrix) |
-| `examples-compile (1/4)` | `ci.yml` | `examples-compile` (matrix) |
-| `examples-compile (2/4)` | `ci.yml` | `examples-compile` (matrix) |
-| `examples-compile (3/4)` | `ci.yml` | `examples-compile` (matrix) |
-| `templates` | `ci.yml` | `templates` |
-| `macos` | `ci.yml` | `macos` (compile-only build) |
-| `windows` | `ci.yml` | `windows` (workspace build + sandbox portability smoke) |
+| `pr-gate` | `ci.yml` | Aggregate of every PR-tier CI job below |
 | `semver` | `semver.yml` | `semver` (stable-tier strict; beta is warn-only within the same job) |
 
-Notes:
-- Matrix-job contexts include the matrix value. If you append a
-  `feature-coverage` entry or change the four `examples-compile` shards, update
-  both this table and branch protection.
-- `semver` is a single job that runs the strict stable-crate check (which can fail
-  the job) and a warn-only beta/experimental check (which never fails). Requiring
-  the `semver` job therefore requires only the stable-tier semver gate, keeping the
-  beta check advisory (Requirement 5.3).
-- The always-on `feature-coverage (adk-agent, codeact)` job is the merge-blocking
-  CodeAct signal. (`adk-codeact-monty` itself is a workspace member since Monty
-  reached crates.io, so `clippy`/`test` cover it like any other crate; the
-  former `codeact-monty.yml` workflow is gone.)
+`pr-gate` covers `fmt`, `clippy`, Linux workspace tests, every
+`feature-coverage` matrix entry, docs and doctests, every standalone-example
+shard, templates, the macOS build, and the Windows build plus sandbox portability
+smokes. `semver` stays separate because its workflow has an independent trigger
+and keeps stable crates strict while beta/experimental crates remain advisory.
 
 ### NOT required (informational tiers)
 
@@ -392,54 +361,17 @@ These run post-merge or on a schedule and MUST NOT be branch-protection-required
 
 ### Applying the required-check set
 
-A maintainer with admin rights can apply the set above with the GitHub CLI. This
-requires new PR-tier job names to be stable and green first (spec tasks 6 and 10),
-since branch protection waits on a context that must actually report:
+A maintainer with admin rights applies this through **Settings → Rules →
+Rulesets → `adk-rust-ruleset` → Require status checks to pass**. First merge the
+workflow change and confirm that `CI / pr-gate` has reported successfully on a
+pull request. Then remove the individual CI/matrix contexts and retain only:
 
-```bash
-gh api -X PUT repos/zavora-ai/adk-rust/branches/main/protection \
-  --input - <<'JSON'
-{
-  "required_status_checks": {
-    "strict": true,
-    "checks": [
-      { "context": "fmt" },
-      { "context": "clippy" },
-      { "context": "test" },
-      { "context": "feature-coverage (adk-agent, codeact)" },
-      { "context": "feature-coverage (adk-agent, ambient)" },
-      { "context": "feature-coverage (adk-model, openrouter)" },
-      { "context": "feature-coverage (adk-sandbox, wasm)" },
-      { "context": "feature-coverage (adk-sandbox, sandbox-linux)" },
-      { "context": "feature-coverage (adk-realtime, integration)" },
-      { "context": "feature-coverage (adk-managed, memory)" },
-      { "context": "feature-coverage (adk-audio, fx)" },
-      { "context": "feature-coverage (adk-rag, lancedb)" },
-      { "context": "feature-coverage (adk-auth, sso)" },
-      { "context": "feature-coverage (adk-server, a2a-v1)" },
-      { "context": "feature-coverage (adk-session, vertex-session)" },
-      { "context": "feature-coverage (adk-acp, server)" },
-      { "context": "docs" },
-      { "context": "examples-compile (0/4)" },
-      { "context": "examples-compile (1/4)" },
-      { "context": "examples-compile (2/4)" },
-      { "context": "examples-compile (3/4)" },
-      { "context": "templates" },
-      { "context": "macos" },
-      { "context": "windows" },
-      { "context": "semver" }
-    ]
-  },
-  "enforce_admins": false,
-  "required_pull_request_reviews": { "required_approving_review_count": 1 },
-  "restrictions": null
-}
-JSON
-```
+- `pr-gate`
+- `semver`
 
-Adjust `required_pull_request_reviews`, `enforce_admins`, and `restrictions` to
-match the project's review policy; the merge-blocking contract for this spec is the
-`checks` list above.
+Keep **Require branches to be up to date before merging** enabled. Do not change
+the ruleset's review, deletion, or non-fast-forward policies as part of this
+status-check migration.
 
 ## Build Commands
 


### PR DESCRIPTION
## What changed

- Run the PR-tier `CI` workflow only for pull requests and manual dispatches; `ci-merge.yml` remains the single post-merge workflow on `main`.
- Replace the formatting job's Nix/devenv bootstrap with the shared pinned Rust setup and the equivalent `cargo fmt --all -- --check` command.
- Add a stable `pr-gate` job that fails unless all nine CI job groups succeed, including every feature and example matrix entry.
- Document a safe ruleset migration from individual matrix contexts to `pr-gate` plus the independently triggered `semver` context.

## Why

The PR-tier workflow was running again after every merge alongside the dedicated merge tier. The latest duplicated `main` CI run consumed **210.55 runner-minutes**, and its formatting prerequisite alone took **2m46s** before the rest of the suite could fan out.

The live ruleset also required 23 individual contexts while the documentation listed 25, leaving two feature matrix entries outside branch protection. Aggregating the workflow result removes that drift risk without removing coverage.

## Impact

All existing format, clippy, Linux test, feature, docs/doctest, example, template, macOS, and Windows checks still run on every PR. Matrix jobs remain individually visible for diagnosis. After this PR merges and `pr-gate` has reported successfully, maintainers can reduce the `main` ruleset to the stable `pr-gate` and `semver` contexts.

## Validation

- `actionlint .github/workflows/ci.yml`
- workflow YAML/dependency validation plus aggregate success/failure simulations
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo nextest run --workspace` — 4,083 passed, 83 skipped
- pre-push `cargo check --workspace`

## Rollout note

Do not change the live ruleset before this PR is merged. Once the new context exists on `main`, retain strict up-to-date checks and replace the individual CI contexts with `pr-gate`; keep `semver` required.