### PR TITLE
chore(deps): upgrade LiveKit to 0.8.1 / livekit-api 0.6.1 / datatrack 0.1.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,6 +1779,7 @@ checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
 dependencies = [
  "compression-codecs",
  "compression-core",
+ "futures-io",
  "pin-project-lite",
  "tokio",
 ]
@@ -11146,9 +11147,9 @@ dependencies = [
 
 [[package]]
 name = "libwebrtc"
-version = "0.3.40"
+version = "0.3.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9265d8a465a1e59a06ca04b264a8b97b26ceed9098b1ca90afea65bb35183fa"
+checksum = "69e6f1851a15d193e5416411fde4d371204f298c5126ee8a4ad68aedd7b22993"
 dependencies = [
  "cxx",
  "jni 0.21.1",
@@ -11274,19 +11275,22 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "livekit"
-version = "0.7.51"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68db4cdb8d8de80f4297b4b152d827c0690933e703f86bbf4789c5f010a0a8f7"
+checksum = "b648d1bc1e837ca5d07f6bc57ff55423837800488e268f55f1f5b8e314a7dc6f"
 dependencies = [
  "base64 0.22.1",
  "bmrng",
  "bytes",
  "chrono",
+ "flate2",
  "futures-util",
  "lazy_static",
  "libloading 0.8.9",
  "libwebrtc",
  "livekit-api",
+ "livekit-common",
+ "livekit-data-stream",
  "livekit-datatrack",
  "livekit-protocol",
  "livekit-runtime",
@@ -11303,19 +11307,19 @@ dependencies = [
 
 [[package]]
 name = "livekit-api"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1006f7c009369fe5f16f2eb6e93d6d0dcb2b427306a2f61b26ff5d2e440ec282"
+checksum = "77d266ec6227044e74bde80ccbeaed2a2ee0487b65c20c89cb0a34f30fa3a1ff"
 dependencies = [
- "async-tungstenite",
  "base64 0.21.7",
  "bytes",
  "device-info",
  "flate2",
- "futures-util",
  "hmac 0.12.1",
  "http 1.4.1",
  "jsonwebtoken 10.4.0",
+ "livekit-common",
+ "livekit-net",
  "livekit-protocol",
  "livekit-runtime",
  "log",
@@ -11332,15 +11336,46 @@ dependencies = [
  "signature",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite 0.29.0",
  "url",
 ]
 
 [[package]]
-name = "livekit-datatrack"
-version = "0.1.10"
+name = "livekit-common"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b5f3fd5cc6f6f05bf96d233ad23f8a6ec48517598bed8c566a643e888b278e"
+checksum = "f903bfee33454f21c553dbf14d6f4ffbf062157b23b04fde9821cbb94ff01169"
+dependencies = [
+ "livekit-protocol",
+]
+
+[[package]]
+name = "livekit-data-stream"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23af4bf8a38def67095d248a57eca35425dcdf2ca7876a178237fb1268d502f2"
+dependencies = [
+ "async-compression",
+ "bmrng",
+ "bytes",
+ "chrono",
+ "from_variants",
+ "futures-util",
+ "livekit-common",
+ "livekit-protocol",
+ "log",
+ "parking_lot",
+ "prost 0.12.6",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "uuid 1.23.2",
+]
+
+[[package]]
+name = "livekit-datatrack"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "376a22d6dae592bff4068a551343461b8e683ffe70aab92e037fb91cb9237ad2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -11358,10 +11393,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "livekit-protocol"
-version = "0.7.10"
+name = "livekit-net"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d26880e94e2f9bab298445e7d86a3794453d211a12ddbd051bd9991a343f9ff"
+checksum = "46155c42ad7acccca96a0d8be2bd0f379565f93e85144fb3aa6fa406371fee22"
+dependencies = [
+ "async-trait",
+ "async-tungstenite",
+ "base64 0.21.7",
+ "bytes",
+ "futures-util",
+ "http 1.4.1",
+ "livekit-runtime",
+ "log",
+ "reqwest 0.12.28",
+ "tokio",
+ "tokio-tungstenite 0.29.0",
+ "url",
+]
+
+[[package]]
+name = "livekit-protocol"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "526f22bddf409e5f15449d55cf341647d7c16a1f43df9db9b05be106e4208e1c"
 dependencies = [
  "pbjson",
  "pbjson-types",
@@ -20591,9 +20646,9 @@ dependencies = [
 
 [[package]]
 name = "webrtc-sys"
-version = "0.3.37"
+version = "0.3.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2c1d27e825bb62ff2ceb97b2726a849de43cf7cf9bc5dc83204b43161286912"
+checksum = "6b9ff39cb40280566a5c53e1ca93a79f2bf5839a2ef8b7792972a330f967d1e1"
 dependencies = [
  "cc",
  "cxx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,11 +152,11 @@ sha2 = "0.10"
 hex = "0.4"
 flate2 = "1.0"
 tar = "0.4"
-livekit = { version = "=0.7.51", default-features = false, features = ["tokio", "native-tls"] }
-livekit-api = { version = "=0.5.5", default-features = false, features = ["signal-client-tokio", "services-tokio", "access-token"] }
-livekit-datatrack = { version = "=0.1.10", default-features = false }
-libwebrtc = { version = "=0.3.40", default-features = false }
-webrtc-sys = { version = "=0.3.37", default-features = false }
+livekit = { version = "=0.8.1", default-features = false, features = ["tokio", "native-tls"] }
+livekit-api = { version = "=0.6.1", default-features = false, features = ["services-tokio", "access-token"] }
+livekit-datatrack = { version = "=0.1.13", default-features = false }
+libwebrtc = { version = "=0.3.43", default-features = false }
+webrtc-sys = { version = "=0.3.40", default-features = false }
 
 # ADK internal crates (use { workspace = true } in member crates)
 adk-core = { path = "adk-core", version = "2.0.0" }


### PR DESCRIPTION
Upgrades the LiveKit stack to the newest published releases. **Two files, no source changes, no lockfile pins.**

```
 Cargo.lock | 75 ++++++++++++++++++-----------------
 Cargo.toml | 20 +++++-----
```

## Versions

| | before | after |
|---|---|---|
| `livekit` | `=0.7.51` | `=0.8.1` |
| `livekit-api` | `=0.5.5` | `=0.6.1` |
| `livekit-datatrack` | `=0.1.10` | `=0.1.13` |
| `libwebrtc` | `=0.3.40` | `=0.3.43` |
| `webrtc-sys` | `=0.3.37` | `=0.3.40` |

The `libwebrtc`/`webrtc-sys` bumps are forced, not independent: livekit 0.8.1 requires `libwebrtc ^0.3.43`, which requires `webrtc-sys ^0.3.40`. All five sit at the newest published release.

## Feature change

`signal-client-tokio` removed from `livekit-api`; `services-tokio` was already present. This is a strict reduction — it drops livekit-net/flate2/bytes/base64/serde_json from `adk-audio/livekit`, and is a no-op under `adk-realtime/livekit` because livekit's own `tokio` feature re-enables `signal-client-tokio` on its dependency edge regardless.

Worth noting the tree uses no `livekit_api::services` at all — the only `livekit_api` paths are `access_token::{AccessToken, VideoGrants, AccessTokenError}`.

## Why no source changes were needed

I diffed livekit's full `src/` between 0.7.51 and 0.8.1. The delta is confined to `proto.rs`, `room/` and `rtc_engine/`, and is purely additive — `RoomDataStreamOptions`, `ClientCapability`, `drop_disconnected_updates()`, `RoomSession::token()`. Nothing removed or reshaped, so nothing in this tree had to adapt.

## One thing worth knowing for future bumps

Going to livekit-api **0.6.0** would have required pinning `livekit-protocol` to 0.7.11, because 0.7.12 fails to compile against it:

```
error[E0063]: missing field `wait_until_answered` in initializer of `ConnectWhatsAppCallRequest`
  --> livekit-api-0.6.0/src/services/connector.rs:265:17
```

**0.6.1 fixes exactly that** — `connector.rs:265` now uses `..Default::default()`. So no pin is needed here, and in fact 0.7.11 would be unsatisfiable since both 0.8.1 and 0.6.1 require `^0.7.12`. Going to 0.6.0 instead of 0.6.1 would leave a pin behind that a later `cargo update` re-breaks.

## Validation

Host toolchain, rustc 1.95.0. Required `RUSTFLAGS=""` and `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc` because `.cargo/config.toml` mandates `clang` + `wild`, neither available in this environment.

```
cargo fmt --all -- --check                                      no output (pass)
cargo check --workspace --all-targets                           clean
cargo check -p adk-realtime --features livekit                  clean
cargo check -p adk-realtime --features full                     clean
cargo check -p adk-audio --features livekit                     clean
cargo test  -p adk-realtime                                     66 passed, 0 failed, 12 ignored
cargo test  -p adk-realtime --features livekit                  91 passed, 0 failed, 17 ignored
cargo clippy -p adk-realtime --all-targets -D warnings          clean
cargo clippy -p adk-realtime --features livekit --all-targets   clean
```

The default feature set excludes `livekit`, so the `--features livekit` runs are the ones that actually exercise this change — without them the upgrade is untested.

`cargo tree` confirms `livekit v0.8.1`, `livekit-api v0.6.1`, `livekit-datatrack v0.1.13`, `livekit-protocol v0.7.12`, `libwebrtc v0.3.43`, `webrtc-sys v0.3.40`.

## Context

These versions have been running in production in a downstream fork, which is what prompted the contribution — carrying the delta as a permanent fork divergence meant conflicting on every upstream sync.