### PR TITLE
ci: prevent pull request cache thrashing

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -18,6 +18,18 @@ inputs:
     description: 'Prefix for the build cache.'
     required: false
     default: ${{ github.job }}
+  cache-shared-key:
+    description: >-
+      Stable key shared by jobs that compile the same target. When set,
+      rust-cache uses this instead of its automatic job-id key.
+    required: false
+    default: ''
+  cache-save:
+    description: >-
+      Save the cache after the job. Set to "false" on pull requests so their
+      merge-ref caches do not evict reusable default-branch caches.
+    required: false
+    default: 'true'
   enable-cache:
     description: 'Enable the persistent Rust build cache.'
     required: false
@@ -61,3 +73,5 @@ runs:
       uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       with:
         prefix-key: ${{ inputs.cache-key }}
+        shared-key: ${{ inputs.cache-shared-key }}
+        save-if: ${{ inputs.cache-save }}

--- a/.github/workflows/ci-merge.yml
+++ b/.github/workflows/ci-merge.yml
@@ -51,7 +51,11 @@ jobs:
       uses: ./.github/actions/setup-rust
       with:
         neutralize-wild: 'false'
+        # Keep the existing main cache prefixes, but replace the automatic job
+        # id with an explicit shared key. PR compile jobs can now restore these
+        # entries without invalidating the already-warm main caches.
         cache-key: cross-platform-test-${{ matrix.os }}
+        cache-shared-key: cross-platform-test
 
     - name: Install system dependencies (macOS)
       if: runner.os == 'macOS'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,16 +59,6 @@ jobs:
         name: devenv
     - run: nix profile install nixpkgs#devenv
 
-    - name: Cache cargo artifacts
-      uses: actions/cache@v6
-      with:
-        path: |
-          ~/.cache/sccache
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: clippy-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: clippy-${{ runner.os }}-
 
     - name: Run clippy
       run: CI=true devenv shell ws-clippy --message-format=json | tee clippy.json
@@ -101,17 +91,6 @@ jobs:
       with:
         name: devenv
     - run: nix profile install nixpkgs#devenv
-
-    - name: Cache cargo artifacts
-      uses: actions/cache@v6
-      with:
-        path: |
-          ~/.cache/sccache
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: test-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: test-${{ runner.os }}-
 
     - name: Run tests
       run: CI=true devenv shell ws-test-ci | tee test.log
@@ -197,6 +176,7 @@ jobs:
       with:
         components: clippy
         cache-key: feature-coverage-${{ matrix.package }}-${{ matrix.features }}
+        cache-save: 'false'
 
     # protoc is required by lancedb's build script (adk-rag --features lancedb).
     # Unconditional rather than gated on the matrix entry: the job header
@@ -233,17 +213,6 @@ jobs:
       with:
         name: devenv
     - run: nix profile install nixpkgs#devenv
-
-    - name: Cache cargo artifacts
-      uses: actions/cache@v6
-      with:
-        path: |
-          ~/.cache/sccache
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: docs-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: docs-${{ runner.os }}-
 
     - name: Check documentation coverage
       env:
@@ -298,6 +267,7 @@ jobs:
       uses: ./.github/actions/setup-rust
       with:
         cache-key: pr-examples-compile-${{ matrix.shard }}
+        cache-save: 'false'
 
     - name: Install system dependencies
       run: |
@@ -326,17 +296,6 @@ jobs:
       with:
         name: devenv
     - run: nix profile install nixpkgs#devenv
-
-    - name: Cache cargo artifacts
-      uses: actions/cache@v6
-      with:
-        path: |
-          ~/.cache/sccache
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: templates-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: templates-${{ runner.os }}-
 
     - name: Check cargo-adk templates
       run: |
@@ -374,7 +333,9 @@ jobs:
       uses: ./.github/actions/setup-rust
       with:
         neutralize-wild: 'false'
-        cache-key: macos
+        cache-key: cross-platform-test-macos-latest
+        cache-shared-key: cross-platform-test
+        cache-save: 'false'
 
     - name: Install system dependencies
       run: brew install cmake protobuf
@@ -400,7 +361,9 @@ jobs:
       uses: ./.github/actions/setup-rust
       with:
         neutralize-wild: 'false'
-        cache-key: windows
+        cache-key: cross-platform-test-windows-latest
+        cache-shared-key: cross-platform-test
+        cache-save: 'false'
 
     - name: Install cmake
       uses: lukka/get-cmake@latest

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -28,6 +28,7 @@ jobs:
       uses: ./.github/actions/setup-rust
       with:
         cache-key: semver
+        cache-save: 'false'
 
     - name: Install cargo-semver-checks
       uses: taiki-e/install-action@v2.85.5


### PR DESCRIPTION
## Problem

A cache written on a pull request is scoped to `refs/pull/*/merge`, so `main` and other PRs can never read it — but it still counts against the repository's cache budget, and a multi-gigabyte entry evicts the default-branch caches that every job *does* reuse. PR runs were paying to make everyone else colder.

## Approach

**The PR tier restores; the merge tier saves.**

`setup-rust` gains two inputs:

| Input | Maps to | Why |
|---|---|---|
| `cache-shared-key` | rust-cache `shared-key` | Replaces rust-cache's automatic per-job id with a stable key, so a PR job can restore an entry a *different* (merge-tier) job wrote |
| `cache-save` | rust-cache `save-if` | Lets a PR job restore without writing |

`ci.yml` is `pull_request`-only, so its jobs pass `cache-save: 'false'` unconditionally — there is no non-PR invocation whose write would be useful, which is why this is a flat `false` rather than an event conditional.

The `macos` and `windows` jobs adopt `cache-shared-key: cross-platform-test` with prefix keys matching `ci-merge.yml`'s `cross-platform-test` matrix, so they restore exactly what the merge tier wrote on `main`:

| | prefix-key | shared-key | saves |
|---|---|---|---|
| `ci.yml` macos (PR) | `cross-platform-test-macos-latest` | `cross-platform-test` | no |
| `ci-merge.yml` (main) | `cross-platform-test-${{ matrix.os }}` → identical | `cross-platform-test` | **yes** |

I verified the composed keys are identical on both sides, so the restore genuinely hits.

## Also: four dead cache steps removed

Converting the hand-rolled steps in `ci.yml` (`clippy`, `test`, `docs`, `templates`) to `actions/cache/restore@v6` left them unable to write — and **nothing else in the repository writes their keys**: no workflow uses the saving form of `actions/cache`, and `ci-merge.yml` has no raw cache steps at all. They could only ever miss, while still costing a lookup per job and reading as though caching worked.

They are removed rather than left in place, so the workflow says plainly that those jobs are cold. To warm them later, give them the `setup-rust` composite with a `cache-shared-key` that a merge-tier job also warms — that's the fix, not restoring these steps.

`feature-coverage` and `pr-examples-compile` keep the composite without a shared key, so they also restore nothing today; they start hitting the moment a merge-tier job warms a matching key.

## Verification

- `ci.yml` parses; all 10 jobs intact (`fmt`, `clippy`, `test`, `feature-coverage`, `docs`, `examples-compile`, `templates`, `macos`, `windows`, `pr-gate`).
- Release gates unaffected and green: `check-release-consistency`, `check-doc-versions` (2.0.0, 115 features), `check-publish-order` (41 crates, 8 tiers), `check-doc-examples` (96 files).
- The real signal is this PR's own run: the `macos`/`windows` jobs should now report a cache **restore** without a save.