### PR TITLE
chore(adk-audio): drop the `webrtc-vad` dependency, which gates no code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,6 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.28.0",
  "tracing",
- "webrtc-vad",
 ]
 
 [[package]]
@@ -20672,15 +20671,6 @@ dependencies = [
  "scratch",
  "semver",
  "zip 0.6.6",
-]
-
-[[package]]
-name = "webrtc-vad"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a1e40fd6ca90be95459152a2537f2ba4286ee1b13073f7ebcaa74fc94e3008"
-dependencies = [
- "cc",
 ]
 
 [[package]]

--- a/adk-audio/Cargo.toml
+++ b/adk-audio/Cargo.toml
@@ -36,8 +36,22 @@ base64 = { version = "0.22", optional = true }
 rubato = { version = "4.0", optional = true }
 dasp = { version = "0.11", features = ["signal"], optional = true }
 
-# VAD (optional)
-webrtc-vad = { version = "0.4", optional = true }
+# VAD
+#
+# There is deliberately no VAD backend dependency here. `webrtc-vad` used to be
+# declared under the `vad` feature but was never imported by a single line of
+# this crate, so it only ever cost consumers a C toolchain and a linker hazard:
+# it builds libfvad, which exports the upstream WebRTC signal-processing symbols
+# (`WebRtcSpl_*`) unmangled. Any binary that also links LiveKit's `webrtc-sys`
+# gets the same symbols from the full libwebrtc and fails to link outright:
+#
+#     wild: error: Duplicate symbols detected: WebRtcSpl_DivW32W16,
+#       defined in libwebrtc_vad-*.rlib @ ...-division_operations.o
+#       and         libwebrtc_sys-*.rlib @ division_operations.o
+#
+# A real backend lands here once `wavekat-vad` gains its pure-Rust `earshot`
+# backend; it must be pinned to an immutable revision and must not re-introduce
+# a C VAD into the dependency graph.
 
 # Local inference (optional)
 ort = { version = "2.0.0-rc.11", optional = true }
@@ -76,7 +90,11 @@ tts = ["dep:reqwest", "dep:base64"]
 stt = ["dep:reqwest", "dep:tokio-tungstenite"]
 music = ["dep:reqwest"]
 fx = ["dep:rubato", "dep:dasp"]
-vad = ["dep:webrtc-vad"]
+# The `VadProcessor` trait is compiled unconditionally, so this feature has
+# never gated any code (`#[cfg(feature = "vad")]` appears nowhere in the crate).
+# It is retained as a no-op so existing consumers and `desktop-audio` keep
+# building; it no longer drags a C VAD implementation into the graph.
+vad = []
 streaming = []
 
 # Desktop audio I/O (cpal-based, not included in `all` — requires audio hardware)

--- a/adk-audio/src/traits/vad.rs
+++ b/adk-audio/src/traits/vad.rs
@@ -1,4 +1,33 @@
 //! Voice Activity Detection trait.
+//!
+//! # No backend ships with this crate
+//!
+//! `adk-audio` defines the [`VadProcessor`] boundary but implements it nowhere.
+//! Callers supply their own detector. The `vad` Cargo feature gates no code —
+//! it once pulled `webrtc-vad`, which this crate never imported.
+//!
+//! # `&self` is the constraint on any streaming backend
+//!
+//! [`VadProcessor::is_speech`] takes `&self`, and the trait is `Send + Sync`, so
+//! implementors are shared immutably (`Arc<dyn VadProcessor>` throughout
+//! [`crate::pipeline`] and the desktop turn detector). Every serious streaming
+//! VAD — Silero, TEN, Earshot — is *recurrent*: classifying a frame mutates
+//! per-stream state. Such a detector cannot implement this trait without
+//! interior mutability, and a `Mutex` in the per-frame path is exactly what a
+//! real-time audio loop must not have.
+//!
+//! So a stateful backend cannot simply implement `VadProcessor`. It needs one
+//! detector instance per stream, owned mutably by that stream, with an explicit
+//! `reset()` at session boundaries — and a documented compatibility wrapper for
+//! existing `Arc<dyn VadProcessor>` callers, not a silent lock.
+//!
+//! # This is a primitive, not a policy
+//!
+//! A `VadProcessor` reports whether audio contains speech. It carries no
+//! call-control authority on its own: endpointing, answering-machine detection,
+//! barge-in, and turn-taking are separate decisions layered above it. Provider
+//! server VAD remains the conversational turn-taking authority unless an
+//! application explicitly chooses otherwise.
 
 /// A detected speech segment within an audio frame.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/examples/desktop_audio/Cargo.lock
+++ b/examples/desktop_audio/Cargo.lock
@@ -52,7 +52,6 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tracing",
- "webrtc-vad",
 ]
 
 [[package]]
@@ -3150,15 +3149,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "webrtc-vad"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a1e40fd6ca90be95459152a2537f2ba4286ee1b13073f7ebcaa74fc94e3008"
-dependencies = [
- "cc",
 ]
 
 [[package]]


### PR DESCRIPTION

## What this changes

`adk-audio` declares `webrtc-vad` behind an optional `vad` feature. This removes the
dependency and keeps `vad` as an empty, no-op feature key so no existing manifest
breaks.

## Why — the short version

The `vad` feature never gated any code. It cost users a C toolchain build, and in one
combination it makes two crates of this framework fail to link against each other.

## Why — the longer version

### 1. The feature gates nothing

```
$ git grep 'feature = "vad"' -- '*.rs'
$ git grep 'webrtc_vad'      -- '*.rs'
```

Both return nothing, across the whole workspace. There is no `#[cfg(feature = "vad")]`
anywhere, no `use webrtc_vad::`, and no re-export. Enabling `vad` compiles and links
libfvad into the user's binary and then never calls it.

The VAD *extension point* — the `VadProcessor` trait in `adk-audio/src/traits/vad.rs` —
is unconditional and is untouched by this change. Anyone implementing that trait keeps
working exactly as before. What is being removed is a dependency the trait was never
wired to.

### 2. It makes `adk-audio` and `adk-realtime` fail to compose

This is the part that motivated the change rather than merely tidying up.

`webrtc-vad` builds libfvad, which compiles the upstream WebRTC signal-processing C
sources and exports their symbols **unmangled** — `WebRtcSpl_DivW32W16`,
`WebRtcSpl_DownBy2IntToShort`, `WebRtcSpl_Resample48khzTo32khz`, and others.

`adk-realtime` declares `webrtc-sys` and `libwebrtc` directly
(`adk-realtime/Cargo.toml`, behind its `livekit` feature). Those link the full libwebrtc,
which exports **the same symbols, from identically-named object files**.

So a binary that pulls in both gets duplicate symbol definitions and fails to link:

```
error: Duplicate symbols detected: WebRtcSpl_DivW32W16,
  defined in libwebrtc_vad-*.rlib @ *-division_operations.o
  and         libwebrtc_sys-*.rlib @ division_operations.o
```

**What we observed, and what we infer.** We hit this error directly, with `webrtc-vad`
and `webrtc-sys` in one dependency graph — the message above is from our build. We did
*not* build the specific `adk-audio` + `adk-realtime` pairing described below, so treat
that part as reasoning from the manifests rather than a reproduction.

The reasoning: `adk-audio`'s `desktop-audio` feature force-enables `vad`,

```toml
desktop-audio = ["dep:cpal", "vad"]
```

so "desktop voice agent using local audio I/O plus a LiveKit realtime session" —
`adk-audio` with `desktop-audio`, `adk-realtime` with `livekit` — puts both rlibs in one
binary. Same crates, same symbols, same linker as the failure we saw. If you would like
that combination built and confirmed before merging, say so and we will do it.

Removing the dependency removes the collision entirely: nothing else in the tree
compiles those C sources.

### 3. It is a build-time cost with no return

For anyone who enables `vad` or `desktop-audio`, the dependency means:

- a C toolchain is required to build, which complicates cross-compilation and breaks
  hermetic or sandboxed builds (Nix, some container and CI setups)
- extra build time
- supply-chain surface on a wrapper whose last release was in 2019

…in exchange for no functionality, per section 1.

### 4. The feature name misleads

A user reading the feature table on docs.rs sees `vad` and reasonably concludes
`adk-audio` offers voice activity detection. It offers a trait with no implementation in
this crate. That is a fine thing to offer, but the feature flag implies more than the
crate delivers, and the flag is what people read first.

## Why this is safe to merge

- **No code references the crate.** The two greps in section 1 are the whole proof.
- **No public API changes.** No re-export, so nothing disappears from the crate surface.
- **No manifest breaks.** `vad = []` is retained, so `features = ["vad"]` and
  `desktop-audio` continue to resolve. Existing dependants build unchanged.
- **No behaviour changes.** A feature that gates no code cannot alter a code path.
- **Nobody can be depending on it transitively.** Rust does not allow importing a
  dependency you have not declared, so any real user of `webrtc-vad` already declares it
  themselves and is unaffected.

The one visible consequence is lockfile churn: consumers with a committed `Cargo.lock`
will need a `cargo update`. That is why this PR also regenerates the affected example
lockfiles — the CI `examples-compile` job builds them with `--locked` and would
otherwise fail on staleness rather than on anything substantive.

## One thing left for maintainers to decide

Keeping `vad = []` is the non-breaking choice and is what this PR does. It does leave an
empty feature whose name still suggests functionality.

Two options, both yours rather than mine:

- **Keep the no-op key**, with the comment this PR adds so the next person does not
  "fix" the empty feature by re-adding a dependency.
- **Remove the feature name in the next major**, along with its reference in
  `desktop-audio`. Removing a feature is semver-breaking even when it does nothing, so it
  did not belong in a cleanup PR.

If it is useful, a `build.rs` emitting `cargo::warning=` when `vad` is enabled would put
a deprecation notice in front of the people who actually turned it on. Happy to add that
here or in a follow-up.

## Context

Found while building a Rust voice gateway on this framework: our binary stopped linking
once both libraries were in the dependency graph. We removed the dependency locally and
the link succeeded; the detector we actually use is a pure-Rust one, so nothing in
`adk-audio` needed to change to replace it.
