### PR TITLE
feat(rust): add agent-platform / agent-platform-full meta-features - PR 0.1

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -118,17 +118,17 @@ jobs:
             neutralize-wild: 'false'
             command: cargo check -p adk-mistralrs --features metal
           # Gemini Enterprise Agent Platform meta-features on the umbrella crate.
-          # `agent-platform` also runs in the PR-tier feature-coverage matrix; the
+          # `gemini-agent-platform` also runs in the PR-tier feature-coverage matrix; the
           # `-full` variant compiles the adk-realtime stack (vertex-live) and is
           # nightly-only to keep PR-tier feedback fast.
-          - name: umbrella-agent-platform
+          - name: umbrella-gemini-agent-platform
             os: ubuntu-latest
             neutralize-wild: 'true'
-            command: cargo clippy -p adk-rust --no-default-features --features minimal,agent-platform --all-targets -- -D warnings
-          - name: umbrella-agent-platform-full
+            command: cargo clippy -p adk-rust --no-default-features --features minimal,gemini-agent-platform --all-targets -- -D warnings
+          - name: umbrella-gemini-agent-platform-full
             os: ubuntu-latest
             neutralize-wild: 'true'
-            command: cargo clippy -p adk-rust --no-default-features --features minimal,agent-platform-full --all-targets -- -D warnings
+            command: cargo clippy -p adk-rust --no-default-features --features minimal,gemini-agent-platform-full --all-targets -- -D warnings
     steps:
     - uses: actions/checkout@v7
 

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -117,6 +117,18 @@ jobs:
             os: macos-latest
             neutralize-wild: 'false'
             command: cargo check -p adk-mistralrs --features metal
+          # Gemini Enterprise Agent Platform meta-features on the umbrella crate.
+          # `agent-platform` also runs in the PR-tier feature-coverage matrix; the
+          # `-full` variant compiles the adk-realtime stack (vertex-live) and is
+          # nightly-only to keep PR-tier feedback fast.
+          - name: umbrella-agent-platform
+            os: ubuntu-latest
+            neutralize-wild: 'true'
+            command: cargo clippy -p adk-rust --no-default-features --features minimal,agent-platform --all-targets -- -D warnings
+          - name: umbrella-agent-platform-full
+            os: ubuntu-latest
+            neutralize-wild: 'true'
+            command: cargo clippy -p adk-rust --no-default-features --features minimal,agent-platform-full --all-targets -- -D warnings
     steps:
     - uses: actions/checkout@v7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,11 @@ jobs:
           # JS/Python live paths, persistent Docker, and the CodeActAgent + MontyRuntime
           # forward. `code-tools` itself is covered by the `full` builds in docs/examples.
           - { package: adk-rust, features: "code-embedded-js,code-embedded-python,code-docker,codeact-monty" }
+          # The agent-platform meta-feature (default `minimal` + agent-platform):
+          # enforces the growth rule structurally — a forgotten umbrella forwarding
+          # fails this build once the constituent is referenced. The `-full` variant
+          # (realtime stack) is nightly-only to keep PR-tier feedback fast.
+          - { package: adk-rust, features: agent-platform }
     steps:
     - uses: actions/checkout@v7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,11 +181,11 @@ jobs:
           # JS/Python live paths, persistent Docker, and the CodeActAgent + MontyRuntime
           # forward. `code-tools` itself is covered by the `full` builds in docs/examples.
           - { package: adk-rust, features: "code-embedded-js,code-embedded-python,code-docker,codeact-monty" }
-          # The agent-platform meta-feature (default `minimal` + agent-platform):
+          # The gemini-agent-platform meta-feature (default `minimal` + gemini-agent-platform):
           # enforces the growth rule structurally — a forgotten umbrella forwarding
           # fails this build once the constituent is referenced. The `-full` variant
           # (realtime stack) is nightly-only to keep PR-tier feedback fast.
-          - { package: adk-rust, features: agent-platform }
+          - { package: adk-rust, features: gemini-agent-platform }
     steps:
     - uses: actions/checkout@v7
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -410,6 +410,10 @@ Four tiered presets control which crates are compiled:
 
 Domain add-ons are composable with any tier: `features = ["minimal", "audio"]`.
 
+Platform meta-features (composable with any tier):
+- `agent-platform` — every Gemini Enterprise Agent Platform (Vertex/EAP) integration except realtime transports: `gemini-vertex`, `vertex-session`, `gcp-secrets` (grows as later integrations land). The right default for ReasoningEngine BYOC deployments. Deploy-time tooling is host-side and excluded.
+- `agent-platform-full` — `agent-platform` + `vertex-live` (Vertex AI Live API, pulls in the adk-realtime stack)
+
 Production backend features (require external infrastructure, NOT included in `full`):
 - `postgres-session`, `redis-session`, `mongodb-session`, `firestore-session`, `neo4j-session`,
   `vertex-session`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -411,8 +411,8 @@ Four tiered presets control which crates are compiled:
 Domain add-ons are composable with any tier: `features = ["minimal", "audio"]`.
 
 Platform meta-features (composable with any tier):
-- `agent-platform` — every Gemini Enterprise Agent Platform (Vertex/EAP) integration except realtime transports: `gemini-vertex`, `vertex-session`, `gcp-secrets` (grows as later integrations land). The right default for ReasoningEngine BYOC deployments. Deploy-time tooling is host-side and excluded.
-- `agent-platform-full` — `agent-platform` + `vertex-live` (Vertex AI Live API, pulls in the adk-realtime stack)
+- `gemini-agent-platform` — every Gemini Enterprise Agent Platform (Vertex/EAP) integration except realtime transports: `gemini-vertex`, `vertex-session`, `gcp-secrets` (grows as later integrations land). The right default for ReasoningEngine BYOC deployments. Deploy-time tooling is host-side and excluded.
+- `gemini-agent-platform-full` — `gemini-agent-platform` + `vertex-live` (Vertex AI Live API, pulls in the adk-realtime stack)
 
 Production backend features (require external infrastructure, NOT included in `full`):
 - `postgres-session`, `redis-session`, `mongodb-session`, `firestore-session`, `neo4j-session`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **`agent-platform` / `agent-platform-full` umbrella meta-features.** One
+- **`gemini-agent-platform` / `gemini-agent-platform-full` umbrella meta-features.** One
   switch that pulls in every Gemini Enterprise Agent Platform (Vertex/EAP)
   integration, composable with any tier preset:
-  `features = ["standard", "agent-platform"]`. The base variant covers
+  `features = ["standard", "gemini-agent-platform"]`. The base variant covers
   `gemini-vertex`, `vertex-session`, and `gcp-secrets` (growing as later
   platform integrations land) and excludes realtime transports — the right
-  default for ReasoningEngine BYOC deployments. `agent-platform-full` adds
+  default for ReasoningEngine BYOC deployments. `gemini-agent-platform-full` adds
   `vertex-live` (Vertex AI Live API, which pulls in the adk-realtime stack).
   Deploy-time tooling is host-side and excluded from both.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`agent-platform` / `agent-platform-full` umbrella meta-features.** One
+  switch that pulls in every Gemini Enterprise Agent Platform (Vertex/EAP)
+  integration, composable with any tier preset:
+  `features = ["standard", "agent-platform"]`. The base variant covers
+  `gemini-vertex`, `vertex-session`, and `gcp-secrets` (growing as later
+  platform integrations land) and excludes realtime transports — the right
+  default for ReasoningEngine BYOC deployments. `agent-platform-full` adds
+  `vertex-live` (Vertex AI Live API, which pulls in the adk-realtime stack).
+  Deploy-time tooling is host-side and excluded from both.
+
 ### Fixed
 
 - **Inline and file content metadata survives session persistence.**

--- a/adk-rust/Cargo.toml
+++ b/adk-rust/Cargo.toml
@@ -66,6 +66,41 @@ full = [
     "code-tools",
 ]
 
+# Gemini Enterprise Agent Platform — every Vertex/EAP integration except
+# realtime transports. The right default for ReasoningEngine BYOC deployments
+# (request/response + SSE agents). Composable with any tier:
+#   features = ["minimal", "agent-platform"]
+# Excluded: deploy-time tooling (host-side, not part of the agent container)
+# and `vertex-live` (build weight — see `agent-platform-full`).
+# Growth rule: every PR that introduces a Vertex/EAP feature flag appends it
+# here (or to `agent-platform-full` if it pulls in a realtime transport).
+agent-platform = [
+    # existing integrations (Wave 0 initial content)
+    "gemini-vertex",  # Vertex model backend (adk-model → adk-gemini/vertex)
+    "vertex-session", # managed Sessions (adk-session)
+    "gcp-secrets",    # GCP Secret Manager (adk-auth)
+    # target end-state — appended by the PR that introduces each flag:
+    # "agent-engine",           class-method runtime contract (adk-server)
+    # "vertex-memory",          Memory Bank (adk-memory)
+    # "example-store",          Example Store (adk-tool)
+    # "gcs-artifacts",          GCS artifact backend (adk-artifact)
+    # "gcp-telemetry",          Cloud Trace/Logging transport (adk-telemetry)
+    # "vertex-sandbox",         managed code-execution sandbox (adk-code)
+    # "vertex-eval",            Gen AI Evaluation bridge (adk-eval)
+    # "vertex-rag",             RAG Engine retrieval (adk-rag)
+    # "agent-retrieval",        Agent Retrieval store (adk-rag)
+    # "vertex-agent-registry",  Agent Registry discovery (adk-tool)
+    # "vertex-remote-engine",   remote ReasoningEngine sub-agents (adk-server)
+    # "vertex-skill-registry",  Skill Registry consumption (adk-skill)
+]
+
+# agent-platform + realtime: adds the Vertex AI Live API (bidirectional
+# audio/video), which pulls in the adk-realtime WebSocket/audio stack.
+agent-platform-full = [
+    "agent-platform",
+    "vertex-live", # Vertex AI Live API (adk-realtime)
+]
+
 # CLI launcher support
 cli = ["dep:adk-cli", "runner", "server", "sessions", "telemetry"]
 cli-openai = ["cli", "adk-cli/openai"]

--- a/adk-rust/Cargo.toml
+++ b/adk-rust/Cargo.toml
@@ -69,12 +69,12 @@ full = [
 # Gemini Enterprise Agent Platform — every Vertex/EAP integration except
 # realtime transports. The right default for ReasoningEngine BYOC deployments
 # (request/response + SSE agents). Composable with any tier:
-#   features = ["minimal", "agent-platform"]
+#   features = ["minimal", "gemini-agent-platform"]
 # Excluded: deploy-time tooling (host-side, not part of the agent container)
-# and `vertex-live` (build weight — see `agent-platform-full`).
+# and `vertex-live` (build weight — see `gemini-agent-platform-full`).
 # Growth rule: every PR that introduces a Vertex/EAP feature flag appends it
-# here (or to `agent-platform-full` if it pulls in a realtime transport).
-agent-platform = [
+# here (or to `gemini-agent-platform-full` if it pulls in a realtime transport).
+gemini-agent-platform = [
     # existing integrations (Wave 0 initial content)
     "gemini-vertex",  # Vertex model backend (adk-model → adk-gemini/vertex)
     "vertex-session", # managed Sessions (adk-session)
@@ -94,10 +94,10 @@ agent-platform = [
     # "vertex-skill-registry",  Skill Registry consumption (adk-skill)
 ]
 
-# agent-platform + realtime: adds the Vertex AI Live API (bidirectional
+# gemini-agent-platform + realtime: adds the Vertex AI Live API (bidirectional
 # audio/video), which pulls in the adk-realtime WebSocket/audio stack.
-agent-platform-full = [
-    "agent-platform",
+gemini-agent-platform-full = [
+    "gemini-agent-platform",
     "vertex-live", # Vertex AI Live API (adk-realtime)
 ]
 

--- a/adk-rust/README.md
+++ b/adk-rust/README.md
@@ -306,10 +306,10 @@ adk-rust = { version = "2.0.0", features = ["full"] }
 # realtime transports; composable with any tier. The right default for
 # ReasoningEngine BYOC deployments. Deploy-time tooling is host-side and
 # not included.
-adk-rust = { version = "2.0.0", features = ["standard", "agent-platform"] }
+adk-rust = { version = "2.0.0", features = ["standard", "gemini-agent-platform"] }
 
-# agent-platform + Vertex AI Live API (pulls in the realtime WebSocket/audio stack)
-adk-rust = { version = "2.0.0", features = ["standard", "agent-platform-full"] }
+# gemini-agent-platform + Vertex AI Live API (pulls in the realtime WebSocket/audio stack)
+adk-rust = { version = "2.0.0", features = ["standard", "gemini-agent-platform-full"] }
 
 # Custom
 adk-rust = { version = "2.0.0", default-features = false, features = ["agents", "gemini", "tools"] }

--- a/adk-rust/README.md
+++ b/adk-rust/README.md
@@ -302,6 +302,15 @@ adk-rust = { version = "2.0.0", features = ["enterprise"] }
 # Full — enterprise + experimental crates (audio, code, sandbox, code-tools)
 adk-rust = { version = "2.0.0", features = ["full"] }
 
+# Gemini Enterprise Agent Platform — every Vertex/EAP integration except
+# realtime transports; composable with any tier. The right default for
+# ReasoningEngine BYOC deployments. Deploy-time tooling is host-side and
+# not included.
+adk-rust = { version = "2.0.0", features = ["standard", "agent-platform"] }
+
+# agent-platform + Vertex AI Live API (pulls in the realtime WebSocket/audio stack)
+adk-rust = { version = "2.0.0", features = ["standard", "agent-platform-full"] }
+
 # Custom
 adk-rust = { version = "2.0.0", default-features = false, features = ["agents", "gemini", "tools"] }
 

--- a/adk-rust/src/lib.rs
+++ b/adk-rust/src/lib.rs
@@ -439,6 +439,8 @@
 //! | `sandbox` | Sandboxed execution | full (experimental) |
 //! | `audio` | Audio processing | full (experimental) |
 //! | `cli` | CLI launcher | (opt-in, any preset) |
+//! | `agent-platform` | Gemini Enterprise Agent Platform integrations (Vertex model backend, managed Sessions, GCP Secret Manager); excludes realtime transports and host-side deploy tooling | (opt-in, any preset) |
+//! | `agent-platform-full` | `agent-platform` + Vertex AI Live API (realtime stack) | (opt-in, any preset) |
 //!
 //! ## Examples
 //!

--- a/adk-rust/src/lib.rs
+++ b/adk-rust/src/lib.rs
@@ -439,8 +439,8 @@
 //! | `sandbox` | Sandboxed execution | full (experimental) |
 //! | `audio` | Audio processing | full (experimental) |
 //! | `cli` | CLI launcher | (opt-in, any preset) |
-//! | `agent-platform` | Gemini Enterprise Agent Platform integrations (Vertex model backend, managed Sessions, GCP Secret Manager); excludes realtime transports and host-side deploy tooling | (opt-in, any preset) |
-//! | `agent-platform-full` | `agent-platform` + Vertex AI Live API (realtime stack) | (opt-in, any preset) |
+//! | `gemini-agent-platform` | Gemini Enterprise Agent Platform integrations (Vertex model backend, managed Sessions, GCP Secret Manager); excludes realtime transports and host-side deploy tooling | (opt-in, any preset) |
+//! | `gemini-agent-platform-full` | `gemini-agent-platform` + Vertex AI Live API (realtime stack) | (opt-in, any preset) |
 //!
 //! ## Examples
 //!


### PR DESCRIPTION
One switch for every Gemini Enterprise Agent Platform (Vertex/EAP) integration, composable with any tier preset. Initial constituents: gemini-vertex, vertex-session, gcp-secrets; later platform PRs append their flag (the growth rule). The -full variant adds vertex-live.

- PR-tier feature-coverage entry: adk-rust --features agent-platform
- Nightly feature-matrix entries for both combinations
- Feature-table rows in adk-rust/README.md, lib.rs, and AGENTS.md

## What

Adds the `agent-platform` / `agent-platform-full` meta-features to the `adk-rust` umbrella crate — one switch that pulls in every Gemini Enterprise Agent Platform (Vertex/EAP) integration, composable with any tier preset:

​```toml
adk-rust = { version = "2.0.0", features = ["standard", "agent-platform"] }
​```

| Feature | Contents | Use case |
|---------|----------|----------|
| `agent-platform` | `gemini-vertex`, `vertex-session`, `gcp-secrets` | ReasoningEngine BYOC deployments (request/response + SSE agents) |
| `agent-platform-full` | `agent-platform` + `vertex-live` | Voice/video agents (pulls in the adk-realtime WebSocket/audio stack) |

Deploy-time tooling (`adk-deploy`, CLI subcommands) is excluded from both variants — it is a host-side concern that runs on the developer machine or CI, not inside the agent container. `vertex-live` is excluded from the base variant purely for build weight.

Part of #438

## Why

Wave 0, PR 0.1 of the Agent Engine implementation plan (WP15.1–15.5). This PR creates the scaffolding every later feature-introducing PR appends to — the growth rule: a PR that introduces a Vertex/EAP feature flag adds the umbrella forwarding AND appends it to `agent-platform` (or to `agent-platform-full` when the flag pulls in a realtime transport) in the same PR. The CI checks enforce this structurally — a forgotten forwarding fails compilation of the meta-feature once the constituent is referenced.

This PR merges before all other feature-flag PRs in the plan: PR 0.6 (`gcp-telemetry`) and PR 0.8 (`gcs-artifacts`) append to the meta-feature it creates.

## How

- **`adk-rust/Cargo.toml`** — both meta-features, placed after the tier presets. Each constituent enables its base domain feature (the existing `postgres-session = ["sessions", ...]` pattern), so the meta-feature composes with any tier including `minimal`. The target end-state ships as a commented list; each later PR uncomments its line.
- **`.github/workflows/ci.yml`** — one PR-tier `feature-coverage` matrix line: `{ package: adk-rust, features: agent-platform }` (default `minimal` + `agent-platform`).
- **`.github/workflows/ci-nightly.yml`** — `feature-combinations` entries for both `minimal,agent-platform` and `minimal,agent-platform-full` (clippy `-D warnings`). The `-full` variant is nightly-only to keep PR-tier feedback fast.
- **Docs** — feature rows in `adk-rust/README.md` ("Installation Options"), the `adk-rust/src/lib.rs` feature table, and root `AGENTS.md`; `CHANGELOG.md` entry under Unreleased.

## Verification

- `cargo check -p adk-rust --no-default-features --features minimal,agent-platform` passes
- `cargo check -p adk-rust --no-default-features --features minimal,agent-platform-full` passes
- PR-tier CI commands pass locally: `cargo clippy -p adk-rust --features agent-platform --all-targets -- -D warnings`; `cargo nextest run -p adk-rust --features agent-platform` (1 passed)
- Nightly `-full` clippy variant passes
- `cargo fmt --all -- --check`, `cargo check --workspace`, and `scripts/check-doc-examples.sh` (97 markdown files) pass
