### PR TITLE
fix(realtime): give the OpenAI session a single writer, and bound teardown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,11 @@ jobs:
           # in combination because no job compiled it.
           - { package: adk-agent, features: ambient }
           - { package: adk-realtime, features: integration }
+          # The OpenAI realtime session and its WebSocket transport are gated behind
+          # `openai`, which is not in adk-realtime's default features, so `--workspace`
+          # never compiled them and no job ever *ran* their tests. The nightly `full`
+          # clippy build compiles them but executes nothing.
+          - { package: adk-realtime, features: openai }
           - { package: adk-managed, features: memory }
           - { package: adk-audio, features: fx }
           - { package: adk-rag, features: lancedb }

--- a/adk-realtime/AGENTS.md
+++ b/adk-realtime/AGENTS.md
@@ -82,9 +82,18 @@ For bidirectional WebSocket sessions:
 
 - one dedicated `writer_task` MUST own the sink
 - all outbound messages MUST go through a bounded `tokio::sync::mpsc`
-- `close()` MUST send `Message::Close(...)` through that channel and await writer shutdown
+- `close()` MUST offer `Message::Close(...)` to that channel **without waiting for queue space**, and MUST bound its wait for writer shutdown, abandoning the task when the grace period expires
 
 You MUST NOT allow multiple methods to write directly to the sink through a shared mutex.
+
+Teardown MUST terminate even when the peer never reads. A peer that has stopped
+draining TCP stalls the in-flight write for as long as it likes, so both of the
+obvious "graceful" choices reintroduce the hang the writer task exists to remove:
+blocking to enqueue the close frame waits for space in a queue the peer is not
+draining, and an unbounded `handle.await` waits for a task that cannot exit until
+that same write completes. Offer the frame, wait a bounded grace period, then drop
+the sink — which closes the connection at the transport level, the outcome a
+graceful close was asking for anyway.
 
 **References**
 - **PROJECT RULE:** this is an architectural rule for this repository, not a literal sentence from one upstream doc.

--- a/adk-realtime/src/openai/session.rs
+++ b/adk-realtime/src/openai/session.rs
@@ -5,11 +5,13 @@ use crate::error::{RealtimeError, Result};
 use crate::events::ServerEvent;
 use crate::openai::protocol::OpenAITransportLink;
 use async_trait::async_trait;
-use futures::{SinkExt, StreamExt};
+use futures::{Sink, SinkExt, StreamExt};
 use serde_json::Value;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use tokio::sync::Mutex;
+use std::time::Duration;
+use tokio::sync::{Mutex, mpsc, oneshot};
+use tokio::task::JoinHandle;
 use tokio_tungstenite::{
     connect_async,
     tungstenite::{
@@ -20,8 +22,23 @@ use tokio_tungstenite::{
 
 type WsStream =
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
-type WsSink = futures::stream::SplitSink<WsStream, Message>;
 type WsSource = futures::stream::SplitStream<WsStream>;
+
+/// Outbound queue depth, in frames.
+///
+/// Matches `WRITER_CHANNEL_CAPACITY` in the Gemini session, which already uses this
+/// pattern. Sized against realtime audio rather than throughput: at 20 ms frames this
+/// is ~1.3 s of buffered speech, past which a producer should feel backpressure rather
+/// than keep queueing audio that will be stale by the time it reaches the wire.
+const OUTBOUND_CAPACITY: usize = 64;
+
+/// How long [`OpenAITransportLink::close`] waits for the writer to finish before
+/// abandoning it.
+///
+/// Teardown has to terminate. A peer that has stopped reading stalls the in-flight
+/// write for as long as it likes, so an unbounded wait here would reintroduce the
+/// hang the writer task exists to remove.
+const CLOSE_GRACE: Duration = Duration::from_secs(5);
 
 /// OpenAI Realtime session.
 ///
@@ -29,7 +46,14 @@ type WsSource = futures::stream::SplitStream<WsStream>;
 pub struct OpenAIRealtimeSession {
     session_id: String,
     connected: Arc<AtomicBool>,
-    sender: Arc<Mutex<WsSink>>,
+    outbound: mpsc::Sender<Message>,
+    /// Signals the writer to stop draining the queue and close.
+    ///
+    /// Deliberately not the outbound queue: a close that queues behind the backlog is
+    /// exactly as slow as the backlog, and a realtime session's queue is full in the
+    /// ordinary case of a healthy-but-slow link, not only when the peer is dead.
+    close: Mutex<Option<oneshot::Sender<()>>>,
+    writer: Mutex<Option<JoinHandle<()>>>,
     receiver: Arc<Mutex<WsSource>>,
 }
 
@@ -62,6 +86,95 @@ fn redacted_payload(text: &str) -> String {
     "<redacted>".to_string()
 }
 
+/// Owns the write half of the socket and drains `outbound` into it.
+///
+/// Sole owner by construction: no caller can hold a lock on the sink across the
+/// network write, so no caller can block another — which is what lets `close` run
+/// while a send is still in flight.
+///
+/// Stops on `close` (which preempts the queue), on a peer error, or when every sender
+/// has been dropped. Writes a Close frame on the way out and marks the session
+/// disconnected.
+async fn writer_loop<S>(
+    mut sink: S,
+    mut outbound: mpsc::Receiver<Message>,
+    mut close: oneshot::Receiver<()>,
+    connected: Arc<AtomicBool>,
+) where
+    S: Sink<Message> + Unpin,
+    S::Error: std::fmt::Display,
+{
+    let mut peer_is_gone = false;
+
+    loop {
+        // `biased` so a pending close wins against a backlog that is still draining;
+        // without it teardown is at the mercy of random branch order.
+        let message = tokio::select! {
+            biased;
+            _ = &mut close => break,
+            message = outbound.recv() => match message {
+                Some(message) => message,
+                None => break,
+            },
+        };
+
+        if let Err(error) = sink.send(message).await {
+            tracing::warn!(error = %error, "openai realtime write failed; connection is gone");
+            peer_is_gone = true;
+            break;
+        }
+    }
+
+    // Best effort: a peer that already failed a write will not accept this either, and
+    // a stalled peer never resolves it — which is why `shutdown_writer` bounds the wait
+    // rather than trusting this to return.
+    if !peer_is_gone {
+        let _ = sink.send(Message::Close(None)).await;
+    }
+
+    connected.store(false, Ordering::SeqCst);
+}
+
+/// Signals the writer to close, then waits a bounded time for it to finish.
+///
+/// Split out from [`OpenAITransportLink::close`] so the bound can be tested against a
+/// stalled peer without a live socket.
+///
+/// Returns an error when the grace period expires, so a caller that cares about a
+/// clean shutdown can still tell the difference — `RealtimeRunner` logs it during
+/// session resumption.
+///
+/// Aborting does **not** close the connection: `SplitSink` and `SplitStream` share the
+/// stream through a `BiLock`, and this session keeps the read half, so the socket stays
+/// open until the session itself is dropped. What the bound guarantees is only that
+/// teardown returns to its caller.
+async fn shutdown_writer(
+    close: &Mutex<Option<oneshot::Sender<()>>>,
+    writer: &Mutex<Option<JoinHandle<()>>>,
+    grace: Duration,
+) -> Result<()> {
+    if let Some(signal) = close.lock().await.take() {
+        let _ = signal.send(());
+    }
+
+    // Taken out of the mutex before awaiting: holding a lock across the grace period
+    // would reintroduce, at five seconds, exactly the shape this change removes.
+    let handle = writer.lock().await.take();
+
+    if let Some(mut handle) = handle
+        && tokio::time::timeout(grace, &mut handle).await.is_err()
+    {
+        tracing::warn!(
+            grace_secs = grace.as_secs_f64(),
+            "openai realtime writer did not finish; abandoning it"
+        );
+        handle.abort();
+        return Err(RealtimeError::connection("Close timed out; writer abandoned"));
+    }
+
+    Ok(())
+}
+
 impl OpenAIRealtimeSession {
     /// Connect to OpenAI Realtime API.
     pub async fn connect(url: &str, api_key: &str, config: RealtimeConfig) -> Result<Self> {
@@ -89,13 +202,20 @@ impl OpenAIRealtimeSession {
 
         let (sink, source) = ws_stream.split();
 
+        let connected = Arc::new(AtomicBool::new(true));
+        let (outbound, outbound_rx) = mpsc::channel(OUTBOUND_CAPACITY);
+        let (close, close_rx) = oneshot::channel();
+        let writer = tokio::spawn(writer_loop(sink, outbound_rx, close_rx, Arc::clone(&connected)));
+
         // Generate session ID (will be updated when we receive session.created)
         let session_id = uuid::Uuid::new_v4().to_string();
 
         let session = Self {
             session_id,
-            connected: Arc::new(AtomicBool::new(true)),
-            sender: Arc::new(Mutex::new(sink)),
+            connected,
+            outbound,
+            close: Mutex::new(Some(close)),
+            writer: Mutex::new(Some(writer)),
             receiver: Arc::new(Mutex::new(source)),
         };
 
@@ -120,8 +240,10 @@ impl OpenAITransportLink for OpenAIRealtimeSession {
         let msg = serde_json::to_string(value)
             .map_err(|e| RealtimeError::protocol(format!("JSON serialize error: {}", e)))?;
 
-        let mut sender = self.sender.lock().await;
-        sender
+        // Hands the frame to the writer task and returns. Applies backpressure only
+        // when the queue is genuinely full, and never holds a lock across the network
+        // write, so a slow peer cannot block an unrelated caller or teardown.
+        self.outbound
             .send(Message::Text(msg.into()))
             .await
             .map_err(|e| RealtimeError::connection(format!("Send error: {}", e)))?;
@@ -195,14 +317,25 @@ impl OpenAITransportLink for OpenAIRealtimeSession {
 
     async fn close(&self) -> Result<()> {
         self.connected.store(false, Ordering::SeqCst);
+        shutdown_writer(&self.close, &self.writer, CLOSE_GRACE).await
+    }
+}
 
-        let mut sender = self.sender.lock().await;
-        sender
-            .send(Message::Close(None))
-            .await
-            .map_err(|e| RealtimeError::connection(format!("Close error: {}", e)))?;
-
-        Ok(())
+impl Drop for OpenAIRealtimeSession {
+    /// Stops the writer when the session is dropped without `close()`.
+    ///
+    /// A spawned task outlives the handle that is dropped rather than awaited, and a
+    /// writer parked mid-send on a stalled peer has nothing left to wake it — it would
+    /// hold the sink, the TLS session and the socket for the life of the process.
+    /// Before this change there was no task to leak: dropping the session dropped both
+    /// halves of the stream.
+    ///
+    /// `get_mut` rather than `try_lock`: `Drop` has exclusive access, so this cannot
+    /// lose a race with a concurrent `close()`.
+    fn drop(&mut self) {
+        if let Some(handle) = self.writer.get_mut().take() {
+            handle.abort();
+        }
     }
 }
 
@@ -220,6 +353,190 @@ impl std::fmt::Debug for OpenAIRealtimeSession {
             .field("session_id", &self.session_id)
             .field("connected", &self.connected.load(Ordering::SeqCst))
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod writer_tests {
+    //! Teardown must not be blocked by a peer that stopped reading.
+    //!
+    //! The sink used to sit behind an `Arc<Mutex<SplitSink<..>>>` that both `send_raw`
+    //! and `close` locked *across* their `.await` on the network write. Even with no
+    //! concurrency at all, `close` then hung on its own write against a peer that had
+    //! stopped draining — there was no timeout anywhere on the path. With a concurrent
+    //! sender it was worse: `tokio::sync::Mutex` hands the lock out in order, so `close`
+    //! also had to wait out an in-flight `send_raw` first.
+    //!
+    //! These tests pin what replaced it: teardown terminates and reports, close preempts
+    //! a full queue rather than joining it, and the queue is bounded.
+
+    use super::{CLOSE_GRACE, OUTBOUND_CAPACITY, shutdown_writer, writer_loop};
+    use futures::Sink;
+    use std::pin::Pin;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::task::{Context, Poll};
+    use std::time::{Duration, Instant};
+    use tokio::sync::{Mutex, mpsc, oneshot};
+    use tokio_tungstenite::tungstenite::Message;
+
+    /// A sink whose `send` never resolves — the peer that has stopped reading.
+    ///
+    /// It stalls at `poll_ready` where a real `SplitSink` stalls at `poll_flush`;
+    /// `SinkExt::send` never resolves either way, which is the only property under test.
+    struct StalledSink;
+
+    impl Sink<Message> for StalledSink {
+        type Error = std::io::Error;
+
+        fn poll_ready(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Pending
+        }
+        fn start_send(self: Pin<&mut Self>, _: Message) -> Result<(), Self::Error> {
+            unreachable!("poll_ready never resolves, so start_send is never reached")
+        }
+        fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Pending
+        }
+        fn poll_close(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Pending
+        }
+    }
+
+    /// A peer that accepts everything, recording what it was given.
+    #[derive(Clone, Default)]
+    struct RecordingSink(Arc<std::sync::Mutex<Vec<Message>>>);
+
+    impl Sink<Message> for RecordingSink {
+        type Error = std::io::Error;
+
+        fn poll_ready(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn start_send(self: Pin<&mut Self>, item: Message) -> Result<(), Self::Error> {
+            self.0.lock().unwrap().push(item);
+            Ok(())
+        }
+        fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn poll_close(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    /// Spawns a writer over `sink` and returns the handles `shutdown_writer` needs.
+    #[allow(clippy::type_complexity)]
+    fn spawn_writer<S>(
+        sink: S,
+    ) -> (
+        mpsc::Sender<Message>,
+        Mutex<Option<oneshot::Sender<()>>>,
+        Mutex<Option<tokio::task::JoinHandle<()>>>,
+        Arc<AtomicBool>,
+    )
+    where
+        S: Sink<Message> + Unpin + Send + 'static,
+        S::Error: std::fmt::Display,
+    {
+        let connected = Arc::new(AtomicBool::new(true));
+        let (outbound, outbound_rx) = mpsc::channel(OUTBOUND_CAPACITY);
+        let (close, close_rx) = oneshot::channel();
+        let writer = tokio::spawn(writer_loop(sink, outbound_rx, close_rx, Arc::clone(&connected)));
+        (outbound, Mutex::new(Some(close)), Mutex::new(Some(writer)), connected)
+    }
+
+    /// The regression. Under the old code this call sat on the socket — and, with a
+    /// concurrent sender, on the mutex — and never returned.
+    ///
+    /// Asserts more than "it did not hang": the grace period must actually elapse and
+    /// the failure must be *reported*, so a `shutdown_writer` that silently did nothing
+    /// fails this test.
+    #[tokio::test]
+    async fn teardown_reports_and_terminates_while_the_peer_is_still_stalled() {
+        let (outbound, close, writer, _connected) = spawn_writer(StalledSink);
+
+        // A frame the writer picks up and then blocks on forever.
+        outbound.send(Message::Text("in flight".into())).await.expect("queued");
+        tokio::task::yield_now().await;
+
+        let grace = Duration::from_millis(200);
+        let started = Instant::now();
+        let outcome =
+            tokio::time::timeout(Duration::from_secs(5), shutdown_writer(&close, &writer, grace))
+                .await
+                .expect("teardown must terminate even though the peer never drains");
+
+        assert!(outcome.is_err(), "an abandoned writer must be reported, not swallowed");
+        assert!(started.elapsed() >= grace, "the grace period must actually be honoured");
+        assert!(writer.lock().await.is_none(), "the writer handle must be released");
+    }
+
+    /// Close must *preempt* the backlog, not queue behind it.
+    ///
+    /// A realtime queue is full in the ordinary case of a healthy-but-slow link, so a
+    /// close carried by the outbound queue would be dropped or would wait out the whole
+    /// backlog. The signal is separate, and `biased` select makes it win.
+    #[tokio::test]
+    async fn close_preempts_a_completely_full_queue() {
+        let sink = RecordingSink::default();
+        let (outbound, close, writer, _connected) = spawn_writer(sink.clone());
+
+        // Fill the queue past capacity while the writer is not draining it yet.
+        for frame in 0..OUTBOUND_CAPACITY {
+            outbound
+                .try_send(Message::Text(format!("frame {frame}").into()))
+                .expect("queue accepts up to capacity");
+        }
+        assert!(
+            outbound.try_send(Message::Text("overflow".into())).is_err(),
+            "the queue must be bounded — an unbounded queue would hide the very stall \
+             this design exists to survive"
+        );
+
+        tokio::time::timeout(Duration::from_secs(5), shutdown_writer(&close, &writer, CLOSE_GRACE))
+            .await
+            .expect("teardown must not wait out the backlog")
+            .expect("a healthy peer must close cleanly");
+
+        let written = sink.0.lock().unwrap().clone();
+        assert!(
+            matches!(written.last(), Some(Message::Close(_))),
+            "the close frame must be written: {written:?}"
+        );
+        assert!(
+            written.len() < OUTBOUND_CAPACITY,
+            "close must preempt the backlog rather than drain all {OUTBOUND_CAPACITY} \
+             queued frames first; wrote {}",
+            written.len()
+        );
+    }
+
+    /// The happy path: a healthy peer gets its Close frame, well inside the grace
+    /// period, and the session is marked down.
+    #[tokio::test]
+    async fn a_healthy_peer_receives_the_close_frame_promptly() {
+        let sink = RecordingSink::default();
+        let (outbound, close, writer, connected) = spawn_writer(sink.clone());
+
+        outbound.send(Message::Text("hello".into())).await.expect("queued");
+
+        // Grace far exceeds the assertion window, so passing means teardown was prompt
+        // rather than merely bounded.
+        tokio::time::timeout(
+            Duration::from_millis(500),
+            shutdown_writer(&close, &writer, Duration::from_secs(30)),
+        )
+        .await
+        .expect("a healthy peer must close promptly, not merely within the grace period")
+        .expect("a healthy peer must close cleanly");
+
+        let written = sink.0.lock().unwrap().clone();
+        assert!(
+            matches!(written.last(), Some(Message::Close(_))),
+            "the close frame must reach a peer that is reading: {written:?}"
+        );
+        assert!(!connected.load(Ordering::SeqCst), "the writer marks the session disconnected");
     }
 }
 


### PR DESCRIPTION
## What

Moves the OpenAI realtime session's WebSocket sink into a dedicated writer task behind a bounded `mpsc`, and bounds `close()`.

## Why

Fixes #557.

`adk-realtime/AGENTS.md` §3 already requires this shape — *"one dedicated `writer_task` MUST own the sink … You MUST NOT allow multiple methods to write directly to the sink through a shared mutex"* — and `GeminiRealtimeSession` already follows it. The OpenAI session was the one realtime transport in the crate that did not: it held `Arc<Mutex<WsSink>>` across the `.await` on the network write in both `send_raw` (`:123`) and `close()` (`:199`).

I want to be precise about the failure, because the obvious reviewer question is *"why not just wrap the existing `close()` in a `timeout` and stop there?"*:

1. **Teardown had no bound at all**, even single-threaded — `close()` blocked on its *own* write, and `SplitSink::poll_flush` does not resolve while the peer's receive window is closed. A timeout alone would fix this half.
2. **A concurrent sender made `close()` wait twice** — `tokio::sync::Mutex` is FIFO, so `close()` queued behind an in-flight `send_raw` and only then began its own unbounded write. This half needs the writer task, and it is real rather than theoretical: `send_audio_chunk` (`runner.rs:648`) runs on the audio-pump task while `close()` is called from the event-stream task (`agent.rs:905/961/972`).

This is head-of-line blocking behind a network write — a convoy, not a cycle. I am not claiming a classic deadlock.

## How

- `writer_loop` owns the sink; nothing else can write to it.
- Outbound frames go through `mpsc(64)` — matching Gemini's `WRITER_CHANNEL_CAPACITY`. Sized against audio, not throughput: at 20 ms frames that is ~1.3 s of speech before a producer feels backpressure, past which queued audio is stale by the time it reaches the wire.
- `close()` signals through a **separate `oneshot`**, selected `biased` against the queue. A realtime queue is full whenever the link is merely slow, so a close carried by the outbound queue would routinely be dropped or wait out the entire backlog.
- `shutdown_writer` takes the handle out of the mutex *before* awaiting, then waits `CLOSE_GRACE` (5 s) and aborts. Holding a lock across the grace period would reintroduce, at five seconds, the exact shape this PR removes.

### AGENTS.md §3 amended

As written the rule says `close()` must send the close frame *through that channel* and *await* writer shutdown. Followed literally, both halves are the bug: blocking to enqueue waits for space in a queue the peer is not draining, and an unbounded join waits for a task that cannot exit until that same write completes. Amended to "offer without waiting for queue space, and bound the wait". Flagging this loudly because otherwise this PR reads as violating a MUST.

## Behaviour that changed

Called out rather than buried — none of it is signature-level, so `cargo-semver-checks` cannot see any of it:

| Change | Consequence |
|---|---|
| `send_raw` returns `Ok` once **queued** | A write failing afterwards surfaces on the writer's `warn!`, not to the caller. `connect()` can return `Ok` if the first `session.update` write fails after the upgrade. |
| `close()` error semantics | Now reports a timed-out writer instead of a per-write error. The signal `runner.rs:602` logs during resumption is preserved. |
| `is_connected()` | Now means "socket healthy **and** writer alive"; can read `false` while `receive_raw` still works. |
| `Drop` added | Aborts the writer. A detached task parked mid-send had nothing to wake it. Before this change there was no task to leak — dropping the session dropped both stream halves. |

**Abort does not close the socket.** `SplitSink` and `SplitStream` share the stream through a `BiLock` and the session keeps the read half, so the connection stays open until the session is dropped. The bound guarantees teardown *returns to its caller* — nothing more. I had this wrong in an earlier draft of the comment.

## Tests

Three new tests in `openai::session::writer_tests`, all named in the run below:

- `teardown_reports_and_terminates_while_the_peer_is_still_stalled` — the regression. Asserts more than "did not hang": the grace must actually elapse **and** the failure must be reported, so a `shutdown_writer` that silently did nothing fails.
- `close_preempts_a_completely_full_queue` — fills the queue to capacity, asserts the next `try_send` is rejected (the queue is genuinely bounded), then asserts close writes its frame after fewer than `OUTBOUND_CAPACITY` writes.
- `a_healthy_peer_receives_the_close_frame_promptly` — grace 30 s, assertion window 500 ms, so passing means *prompt*, not merely *bounded*.

`adk-realtime/openai` added to the `feature-coverage` matrix in `ci.yml`. **The feature is not in `default`**, so `cargo nextest run --workspace` never compiled this file and no CI job ever ran its tests; the nightly `full` build compiles them but executes nothing. Without that matrix line these three tests would merge unexecuted.

## What has NOT been verified

- **No live OpenAI Realtime call.** Everything here is exercised against in-process `Sink` doubles. I have no OpenAI Realtime credentials; my own use of this crate is the Gemini path.
- **The stalled-peer shape is simulated, not a real TCP zero-window.** `StalledSink` stalls at `poll_ready` where `SplitSink` stalls at `poll_flush`; `SinkExt::send` never resolves either way, which is the property under test, but it is not a socket.
- **`CLOSE_GRACE = 5s` and `OUTBOUND_CAPACITY = 64` are reasoned, not measured.** 64 matches Gemini; 5 s is a judgement call. Happy to change both.
- **The `Drop`/leak claim is a code reading**, not a reproduction — I did not observe a leaked task in a running process.
- Only `-p adk-realtime --features openai` was run under test; `cargo check --workspace` covers the rest.

## Diff composition

`+347 / −16` across 3 files. The code change itself is small; most of the diff is tests and the reasoning behind two constants.

| Part | Lines |
|---|---|
| `openai/session.rs` — logic (`writer_loop`, `shutdown_writer`, `Drop`, struct/ctor/`send_raw`/`close`) | ~95 |
| `openai/session.rs` — comments/rustdoc | ~65 |
| `openai/session.rs` — tests | ~185 |
| `AGENTS.md` §3 | +11 / −2 |
| `ci.yml` matrix | +5 |

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — `cargo fmt --all -- --check` → exit 0
- [x] `devenv shell clippy` — `cargo clippy -p adk-realtime --features openai --all-targets -- -D warnings` → exit 0
- [x] `devenv shell test` — `cargo nextest run -p adk-realtime --features openai` → **72 tests run: 72 passed, 0 skipped**
- [x] `devenv shell check` — `cargo check --workspace` → exit 0

```
PASS [0.008s] (1/3) adk-realtime openai::session::writer_tests::a_healthy_peer_receives_the_close_frame_promptly
PASS [0.009s] (2/3) adk-realtime openai::session::writer_tests::close_preempts_a_completely_full_queue
PASS [0.209s] (3/3) adk-realtime openai::session::writer_tests::teardown_reports_and_terminates_while_the_peer_is_still_stalled
Summary [0.210s] 3 tests run: 3 passed, 69 skipped
```

### Code Quality

- [x] New code has tests
- [x] Public APIs have rustdoc comments — no public API added; private items documented
- [x] No `println!`/`eprintln!` in library code
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts
- [x] No unrelated changes mixed in
- [x] Branch naming follows convention (`fix/`)
- [x] Commit messages follow conventional format
- [x] PR targets `main`

### Documentation

- [x] `adk-realtime/AGENTS.md` §3 amended (see above)
- [ ] CHANGELOG.md — happy to add an entry if you want one for a fix at this level.

## Follow-ups I have not sent

`GeminiRealtimeSession::close()` has the same unbounded teardown by a different route — `outbound_tx.send(...).await` on a full 64-slot channel (`gemini/session.rs:1260`) and an unbounded `handle.await` (`:1265`). Its single-writer design is already correct; only the two waits need bounding. I'd rather file that separately than grow this PR — say the word and I'll open it.
