### PR TITLE
feat(server): add plain-JSON POST /api/run runtime endpoint - PR 0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`POST /api/run` plain-JSON endpoint in `adk-server`.** Accepts the same body as
+  `/api/run_sse`, runs the agent to completion, and returns the collected events as a
+  JSON array — parity with Google ADK's `api_server` non-streaming `/run` route.
+
 ## [2.0.0] - 2026-08-09
 
 ### Breaking

--- a/adk-server/src/rest/controllers/runtime.rs
+++ b/adk-server/src/rest/controllers/runtime.rs
@@ -1423,3 +1423,135 @@ pub async fn run_sse_compat(
 
     Ok(Sse::new(sse_stream).keep_alive(KeepAlive::default()))
 }
+
+/// POST /run - plain-JSON, non-streaming endpoint (Google ADK api_server parity)
+///
+/// Accepts the same JSON body as `POST /run_sse`, runs the agent to
+/// completion, and returns every produced event as a JSON array instead of
+/// an SSE stream. The `streaming` body field is ignored — the run always
+/// uses `StreamingMode::None`.
+pub async fn run_collect(
+    State(controller): State<RuntimeController>,
+    headers: HeaderMap,
+    Json(req): Json<RunSseRequest>,
+) -> Result<Json<Vec<adk_core::Event>>, RuntimeError> {
+    let app_name = req.app_name.clone();
+    let user_id = req.user_id.clone();
+    let session_id = req.session_id.clone();
+
+    info!(
+        app_name = %app_name,
+        user_id = %user_id,
+        session_id = %session_id,
+        "POST /run request received"
+    );
+
+    // Extract request context from auth middleware bridge if configured.
+    // This returns Err (401/500) when the extractor is present but auth
+    // fails, ensuring authorization checks are never bypassed.
+    let request_context =
+        extract_request_context(controller.config.request_context_extractor.as_deref(), &headers)
+            .await?;
+
+    // Explicit authenticated user override: when an auth extractor is
+    // configured and succeeds, the authenticated user_id takes precedence
+    // over the request body value. This prevents callers from impersonating
+    // other users via the JSON payload while keeping the body param as a
+    // fallback for unauthenticated deployments (no extractor configured).
+    let effective_user_id = request_context.as_ref().map_or(user_id, |rc| rc.user_id.clone());
+
+    let new_message = req
+        .new_message
+        .as_ref()
+        .ok_or_else(|| (StatusCode::BAD_REQUEST, "newMessage is required".to_string()))?;
+
+    // Build content from message parts (includes both text and inline_data)
+    let content = build_content_from_parts(&new_message.parts)?;
+
+    let state_delta = body_state_delta(req.state_delta.as_ref())?;
+
+    // Validate session exists or create it (same behavior as /run_sse)
+    let session_result = controller
+        .config
+        .session_service
+        .get(adk_session::GetRequest {
+            app_name: app_name.clone(),
+            user_id: effective_user_id.clone(),
+            session_id: session_id.clone(),
+            num_recent_events: None,
+            after: None,
+        })
+        .await;
+
+    if session_result.is_err() {
+        controller
+            .config
+            .session_service
+            .create(adk_session::CreateRequest {
+                app_name: app_name.clone(),
+                user_id: effective_user_id.clone(),
+                session_id: Some(session_id.clone()),
+                state: state_delta.clone(),
+            })
+            .await
+            .map_err(adk_err_to_runtime)?;
+    } else {
+        apply_state_delta_to_session(
+            &controller.config.session_service,
+            &app_name,
+            &effective_user_id,
+            &session_id,
+            state_delta,
+        )
+        .await?;
+    }
+
+    // Load agent
+    let agent =
+        controller.config.agent_loader.load_agent(&app_name).await.map_err(adk_err_to_runtime)?;
+
+    // Create runner — always non-streaming for the plain-JSON endpoint
+    let mut runner_builder = adk_runner::Runner::builder()
+        .app_name(app_name)
+        .agent(agent)
+        .session_service(controller.config.session_service.clone())
+        .run_config(
+            adk_core::RunConfig::builder().streaming_mode(adk_core::StreamingMode::None).build(),
+        );
+    if let Some(ref artifact_service) = controller.config.artifact_service {
+        runner_builder = runner_builder.artifact_service(artifact_service.clone());
+    }
+    if let Some(ref memory_service) = controller.config.memory_service {
+        runner_builder = runner_builder.memory_service(memory_service.clone());
+    }
+    if let Some(ref compaction_config) = controller.config.compaction_config {
+        runner_builder = runner_builder.compaction_config(compaction_config.clone());
+    }
+    if let Some(ref context_cache_config) = controller.config.context_cache_config {
+        runner_builder = runner_builder.context_cache_config(context_cache_config.clone());
+    }
+    if let Some(ref cache_capable) = controller.config.cache_capable {
+        runner_builder = runner_builder.cache_capable(cache_capable.clone());
+    }
+    if let Some(request_context) = request_context {
+        runner_builder = runner_builder.request_context(request_context);
+    }
+    let runner = runner_builder.build().map_err(adk_err_to_runtime)?;
+
+    // Run agent to completion, collecting every event
+    let typed_user_id =
+        UserId::new(effective_user_id).map_err(|err| adk_err_to_runtime(err.into()))?;
+    let typed_session_id =
+        SessionId::new(session_id).map_err(|err| adk_err_to_runtime(err.into()))?;
+    let mut event_stream =
+        runner.run(typed_user_id, typed_session_id, content).await.map_err(adk_err_to_runtime)?;
+
+    let mut events = Vec::new();
+    while let Some(event) = event_stream.next().await {
+        events.push(event.map_err(adk_err_to_runtime)?);
+    }
+
+    info!(event_count = events.len(), "POST /run completed");
+
+    Ok(Json(events))
+}

--- a/adk-server/src/rest/mod.rs
+++ b/adk-server/src/rest/mod.rs
@@ -387,6 +387,7 @@ pub fn create_app_with_a2a(config: ServerConfig, a2a_base_url: Option<&str>) -> 
         .layer(auth_layer.clone());
 
     let runtime_router = Router::new()
+        .route("/run", post(controllers::runtime::run_collect))
         .route("/run/{app_name}/{user_id}/{session_id}", post(controllers::runtime::run_sse))
         .route("/run_sse", post(controllers::runtime::run_sse_compat))
         .with_state(runtime_controller);
@@ -710,6 +711,7 @@ impl ServerBuilder {
             .layer(auth_layer.clone());
 
         let runtime_router = Router::new()
+            .route("/run", post(controllers::runtime::run_collect))
             .route("/run/{app_name}/{user_id}/{session_id}", post(controllers::runtime::run_sse))
             .route("/run_sse", post(controllers::runtime::run_sse_compat))
             .with_state(runtime_controller);

--- a/adk-server/tests/runtime_run_collect_tests.rs
+++ b/adk-server/tests/runtime_run_collect_tests.rs
@@ -1,0 +1,232 @@
+//! Integration tests for the plain-JSON `POST /api/run` endpoint
+
+use adk_server::create_app;
+use adk_session::{
+    CreateRequest, DeleteRequest, Event, GetRequest, ListRequest, Session, SessionService,
+};
+use async_stream::stream;
+use async_trait::async_trait;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use std::sync::Arc;
+use tower::ServiceExt;
+
+const FIXED_EVENT_ID: &str = "run-collect-event";
+const FIXED_INVOCATION_ID: &str = "test-invocation";
+
+/// Builds the exact event the mock agent emits, so tests can assert
+/// whole-object equality against the response payload.
+fn expected_agent_event() -> adk_core::Event {
+    let mut event = adk_core::Event::with_id(FIXED_EVENT_ID, FIXED_INVOCATION_ID);
+    event.author = "test-agent".to_string();
+    event.llm_response.content =
+        Some(adk_core::Content::new("model").with_text("Hello from the test agent"));
+    event
+}
+
+// Mock implementations
+struct MockAgentLoader;
+
+#[async_trait]
+impl adk_core::AgentLoader for MockAgentLoader {
+    async fn load_agent(&self, _app_name: &str) -> adk_core::Result<Arc<dyn adk_core::Agent>> {
+        Ok(Arc::new(MockAgent))
+    }
+
+    fn list_agents(&self) -> Vec<String> {
+        vec!["test-app".to_string()]
+    }
+
+    fn root_agent(&self) -> Arc<dyn adk_core::Agent> {
+        Arc::new(MockAgent)
+    }
+}
+
+struct MockAgent;
+
+#[async_trait]
+impl adk_core::Agent for MockAgent {
+    fn name(&self) -> &str {
+        "test-agent"
+    }
+
+    fn description(&self) -> &str {
+        "Test agent for the plain-JSON run endpoint"
+    }
+
+    fn sub_agents(&self) -> &[Arc<dyn adk_core::Agent>] {
+        &[]
+    }
+
+    async fn run(
+        &self,
+        _ctx: Arc<dyn adk_core::InvocationContext>,
+    ) -> adk_core::Result<adk_core::EventStream> {
+        let s = stream! {
+            yield Ok(expected_agent_event());
+        };
+        Ok(Box::pin(s))
+    }
+}
+
+struct MockSessionService;
+
+#[async_trait]
+impl SessionService for MockSessionService {
+    async fn create(&self, req: CreateRequest) -> adk_core::Result<Box<dyn Session>> {
+        Ok(Box::new(MockSession {
+            id: req.session_id.unwrap_or_else(|| "generated-id".to_string()),
+            app_name: req.app_name,
+            user_id: req.user_id,
+        }))
+    }
+
+    async fn get(&self, req: GetRequest) -> adk_core::Result<Box<dyn Session>> {
+        Ok(Box::new(MockSession {
+            id: req.session_id,
+            app_name: req.app_name,
+            user_id: req.user_id,
+        }))
+    }
+
+    async fn list(&self, _req: ListRequest) -> adk_core::Result<Vec<Box<dyn Session>>> {
+        Ok(vec![])
+    }
+
+    async fn delete(&self, _req: DeleteRequest) -> adk_core::Result<()> {
+        Ok(())
+    }
+
+    async fn append_event(&self, _session_id: &str, _event: Event) -> adk_core::Result<()> {
+        Ok(())
+    }
+}
+
+struct MockSession {
+    id: String,
+    app_name: String,
+    user_id: String,
+}
+
+impl Session for MockSession {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn app_name(&self) -> &str {
+        &self.app_name
+    }
+
+    fn user_id(&self) -> &str {
+        &self.user_id
+    }
+
+    fn state(&self) -> &dyn adk_session::State {
+        &MockState
+    }
+
+    fn events(&self) -> &dyn adk_session::Events {
+        &MockEvents
+    }
+
+    fn last_update_time(&self) -> chrono::DateTime<chrono::Utc> {
+        chrono::Utc::now()
+    }
+}
+
+struct MockState;
+impl adk_session::State for MockState {
+    fn get(&self, _key: &str) -> Option<serde_json::Value> {
+        None
+    }
+    fn set(&mut self, _key: String, _value: serde_json::Value) {}
+    fn all(&self) -> std::collections::HashMap<String, serde_json::Value> {
+        std::collections::HashMap::new()
+    }
+}
+
+struct MockEvents;
+impl adk_session::Events for MockEvents {
+    fn all(&self) -> Vec<Event> {
+        vec![]
+    }
+    fn len(&self) -> usize {
+        0
+    }
+    fn at(&self, _index: usize) -> Option<&Event> {
+        None
+    }
+}
+
+fn create_test_app() -> axum::Router {
+    let config =
+        adk_server::ServerConfig::new(Arc::new(MockAgentLoader), Arc::new(MockSessionService));
+    create_app(config)
+}
+
+async fn post_run(app: axum::Router, body: serde_json::Value) -> axum::response::Response {
+    app.oneshot(
+        Request::builder()
+            .method("POST")
+            .uri("/api/run")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_string(&body).unwrap()))
+            .unwrap(),
+    )
+    .await
+    .unwrap()
+}
+
+#[tokio::test]
+async fn test_run_returns_json_array_of_events() {
+    let app = create_test_app();
+
+    let body = serde_json::json!({
+        "appName": "test-app",
+        "userId": "user123",
+        "sessionId": "session456",
+        "newMessage": {
+            "role": "user",
+            "parts": [
+                {"text": "Hello, world!"}
+            ]
+        }
+    });
+
+    let response = post_run(app, body).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let content_type = response
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+    assert!(content_type.starts_with("application/json"), "content-type was {content_type}");
+
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let events: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+
+    let array = events.as_array().expect("response body must be a JSON array");
+    assert_eq!(array.len(), 1);
+
+    // Whole-object equality: the response event must match the mock agent's
+    // event exactly, modulo the runner-assigned timestamp.
+    let mut expected = serde_json::to_value(expected_agent_event()).unwrap();
+    expected["timestamp"] = array[0]["timestamp"].clone();
+    assert_eq!(array[0], expected);
+}
+
+#[tokio::test]
+async fn test_run_without_new_message_is_bad_request() {
+    let app = create_test_app();
+
+    let body = serde_json::json!({
+        "appName": "test-app",
+        "userId": "user123",
+        "sessionId": "session456"
+    });
+
+    let response = post_run(app, body).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}

--- a/docs/official_docs/deployment/server.md
+++ b/docs/official_docs/deployment/server.md
@@ -126,6 +126,37 @@ POST /api/run_sse
 }
 ```
 
+### Run Agent (Non-Streaming)
+
+Execute an agent to completion and receive all events in a single JSON response:
+
+```
+POST /api/run
+```
+
+**Request Body:** same shape as `POST /api/run_sse` (the `streaming` field is ignored):
+```json
+{
+  "appName": "my_agent",
+  "userId": "user123",
+  "sessionId": "session456",
+  "newMessage": {
+    "role": "user",
+    "parts": [
+      {
+        "text": "What is the capital of France?"
+      }
+    ]
+  }
+}
+```
+
+**Response:**
+- Content-Type: `application/json`
+- A JSON array containing every event produced by the run, in order, using the same event format as `/api/run_sse`
+
+This endpoint mirrors Google ADK's `api_server` non-streaming `/run` route.
+
 ### Session Management
 
 #### Create Session


### PR DESCRIPTION
Non-streaming run-to-completion route returning Vec<Event> as a JSON array, for Google ADK api_server parity. Reuses RunSseRequest as the body type; existing /api/run_sse and /api/run/{...} are unchanged.

## What

- Adds `POST /api/run` — a plain-JSON, non-streaming runtime endpoint that runs the agent to completion and returns all produced events as a JSON array, for parity with Google ADK's `api_server` `/run` route.
- The request body reuses the existing `RunSseRequest` shape (`appName`, `userId`, `sessionId`, `newMessage`, `stateDelta`); the `streaming` field is ignored — the run always uses `StreamingMode::None`.
- Registers the route on both runtime router mounts (`create_app` and `ServerBuilder`), next to `/run/{app}/{user}/{session}` and `/run_sse`.
- Adds `adk-server/tests/runtime_run_collect_tests.rs` covering the success path (whole-event equality against the mock agent's output) and the missing-`newMessage` 400 path.
- Documents the endpoint in `docs/official_docs/deployment/server.md` and adds a `CHANGELOG.md` entry under Unreleased.

## Why

Google ADK's `api_server` exposes both a streaming `/run_sse` and a non-streaming `/run`; ADK-Rust previously exposed only the SSE variants. Clients that want a single JSON response — CLIs, batch jobs, simple integrations — no longer need to parse an SSE stream.

Part of #438

## How

- `run_collect` in `adk-server/src/rest/controllers/runtime.rs` follows the same flow as `run_sse_compat` — auth-bridge context extraction with authenticated-user override, session get-or-create, `stateDelta` application, runner construction with all optional services — then collects the event stream into `Vec<adk_core::Event>` and returns `Json(events)`.
- Errors use the existing `RuntimeError` pattern (`adk_err_to_runtime` → `AdkError::http_status_code()` + problem JSON).
- The existing `/api/run_sse` and `/api/run/{…}` handlers are unchanged.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass (`cargo nextest run -p adk-server`: 116 passed, 0 failed)
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (integration tests in `adk-server/tests/runtime_run_collect_tests.rs`)
- [x] Public APIs have rustdoc comments
- [x] No `println!`/`eprintln!` in library code
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts
- [x] No unrelated changes mixed in
- [x] Branch naming follows convention (`feat/`)
- [x] Commit messages follow conventional format
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated
- [x] `docs/official_docs/deployment/server.md` updated
- [ ] Examples — not applicable (existing server examples cover the runtime surface)