### PR TITLE
feat(session): complete VertexAiSessionService for managed deployments - PR 0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`VertexAiSessionConfig::from_env()`** builds the config from
+  `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`, and
+  `GOOGLE_CLOUD_AGENT_ENGINE_ID` (the bare numeric engine ID) — the variables
+  the Vertex AI Agent Engine platform sets inside deployed containers. Missing
+  or blank variables produce an actionable invalid-input error naming each one.
+- **Vertex session expiration**: `VertexAiSessionConfig::with_ttl()` and
+  `with_expire_time()` send the `Session.expiration` oneof (`ttl` /
+  `expireTime` from `google/cloud/aiplatform/v1beta1/session.proto`) on
+  session create. Setting both members, or a TTL below the 24-hour minimum,
+  fails at service construction.
+
 ## [2.0.0] - 2026-08-09
 
 ### Breaking

--- a/adk-session/README.md
+++ b/adk-session/README.md
@@ -108,6 +108,14 @@ let config = VertexAiSessionConfig::new("my-project", "us-central1")
 let service = VertexAiSessionService::new_with_adc(config)?;
 ```
 
+Inside a deployed Vertex AI Agent Engine container,
+`VertexAiSessionConfig::from_env()` reads `GOOGLE_CLOUD_PROJECT`,
+`GOOGLE_CLOUD_LOCATION`, and `GOOGLE_CLOUD_AGENT_ENGINE_ID` (the bare numeric
+engine ID) directly from the platform-provided environment.
+`with_ttl()`/`with_expire_time()` set the `Session.expiration` oneof sent on
+session create; `ttl` has a 24-hour minimum and both members are mutually
+exclusive.
+
 Caller-facing session IDs remain unchanged. The backend derives a deterministic
 remote ID from the complete `(app_name, user_id, session_id)` identity and stores
 a protected identity marker in Vertex session state. The marker is removed from

--- a/adk-session/src/vertex.rs
+++ b/adk-session/src/vertex.rs
@@ -51,6 +51,12 @@ const VERTEX_MAX_PAGE_TOKEN_BYTES: usize = 64 * 1024;
 const VERTEX_SESSION_SCOPE_CACHE_CAPACITY: usize = 1024;
 const RUST_RAW_EVENT_ENVELOPE_KEY: &str = "_adkRust";
 const VERTEX_IDENTITY_STATE_KEY: &str = "__adk_vertex_identity_v1";
+const ENV_GOOGLE_CLOUD_PROJECT: &str = "GOOGLE_CLOUD_PROJECT";
+const ENV_GOOGLE_CLOUD_LOCATION: &str = "GOOGLE_CLOUD_LOCATION";
+const ENV_GOOGLE_CLOUD_AGENT_ENGINE_ID: &str = "GOOGLE_CLOUD_AGENT_ENGINE_ID";
+// google/cloud/aiplatform/v1beta1/session.proto documents a 24-hour minimum
+// for the input-only `ttl` member of the Session `expiration` oneof.
+const MIN_SESSION_TTL: Duration = Duration::from_secs(24 * 60 * 60);
 
 /// Configuration for the Vertex AI Session API backend.
 #[derive(Debug, Clone)]
@@ -66,6 +72,19 @@ pub struct VertexAiSessionConfig {
     /// The origin receives Google authorization headers plus session and event
     /// data. It must not contain userinfo, a path, a query, or a fragment.
     pub endpoint: Option<String>,
+    /// Optional session time-to-live sent on session create.
+    ///
+    /// `ttl` is a member of the `Session` `expiration` oneof in
+    /// `google/cloud/aiplatform/v1beta1/session.proto`: input-only, serialized
+    /// as a JSON duration string (e.g. `"86400s"`), minimum 24 hours. Mutually
+    /// exclusive with [`expire_time`](Self::expire_time).
+    pub ttl: Option<Duration>,
+    /// Optional absolute session expiration timestamp sent on session create.
+    ///
+    /// `expireTime` is the other `Session` `expiration` oneof member,
+    /// serialized as an RFC 3339 timestamp. Mutually exclusive with
+    /// [`ttl`](Self::ttl).
+    pub expire_time: Option<DateTime<Utc>>,
 }
 
 impl VertexAiSessionConfig {
@@ -76,6 +95,68 @@ impl VertexAiSessionConfig {
             location: location.into(),
             reasoning_engine: None,
             endpoint: None,
+            ttl: None,
+            expire_time: None,
+        }
+    }
+
+    /// Builds a config from the environment variables the Vertex AI Agent
+    /// Engine platform sets inside deployed containers.
+    ///
+    /// Reads `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`, and
+    /// `GOOGLE_CLOUD_AGENT_ENGINE_ID` (the bare numeric agent engine ID, not a
+    /// full resource name). Values are trimmed; blank values count as missing.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use adk_session::{VertexAiSessionConfig, VertexAiSessionService};
+    ///
+    /// # fn main() -> adk_core::Result<()> {
+    /// let config = VertexAiSessionConfig::from_env()?;
+    /// let service = VertexAiSessionService::new_with_adc(config)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an invalid-input error naming every missing or blank variable.
+    pub fn from_env() -> Result<Self> {
+        let read = |key: &str| {
+            std::env::var(key)
+                .ok()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+        };
+        let project_id = read(ENV_GOOGLE_CLOUD_PROJECT);
+        let location = read(ENV_GOOGLE_CLOUD_LOCATION);
+        let agent_engine_id = read(ENV_GOOGLE_CLOUD_AGENT_ENGINE_ID);
+
+        match (project_id, location, agent_engine_id) {
+            (Some(project_id), Some(location), Some(agent_engine_id)) => {
+                Ok(Self::new(project_id, location).with_reasoning_engine(agent_engine_id))
+            }
+            (project_id, location, agent_engine_id) => {
+                let missing = [
+                    (ENV_GOOGLE_CLOUD_PROJECT, project_id.is_none()),
+                    (ENV_GOOGLE_CLOUD_LOCATION, location.is_none()),
+                    (ENV_GOOGLE_CLOUD_AGENT_ENGINE_ID, agent_engine_id.is_none()),
+                ]
+                .into_iter()
+                .filter_map(|(key, is_missing)| is_missing.then_some(key))
+                .collect::<Vec<_>>()
+                .join(", ");
+                Err(AdkError::new(
+                    ErrorComponent::Session,
+                    ErrorCategory::InvalidInput,
+                    "session.vertex.missing_env",
+                    format!(
+                        "missing or blank environment variable(s): {missing}. The Vertex AI Agent Engine platform sets these inside deployed containers (GOOGLE_CLOUD_AGENT_ENGINE_ID is the bare numeric engine ID); set them explicitly elsewhere, or construct the config with VertexAiSessionConfig::new",
+                    ),
+                )
+                .with_provider("vertex_ai"))
+            }
         }
     }
 
@@ -92,6 +173,45 @@ impl VertexAiSessionConfig {
     /// Userinfo, paths, queries, and fragments are rejected before transport.
     pub fn with_endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
+        self
+    }
+
+    /// Sets the session time-to-live sent on session create.
+    ///
+    /// `ttl` is input-only with a 24-hour minimum and is mutually exclusive
+    /// with [`with_expire_time`](Self::with_expire_time); both constraints are
+    /// enforced at service construction.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use adk_session::VertexAiSessionConfig;
+    /// use std::time::Duration;
+    ///
+    /// let config = VertexAiSessionConfig::new("my-project", "us-central1")
+    ///     .with_ttl(Duration::from_secs(86_400)); // sent as "86400s"
+    /// ```
+    pub fn with_ttl(mut self, ttl: Duration) -> Self {
+        self.ttl = Some(ttl);
+        self
+    }
+
+    /// Sets the absolute session expiration timestamp sent on session create.
+    ///
+    /// Mutually exclusive with [`with_ttl`](Self::with_ttl); the constraint is
+    /// enforced at service construction.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use adk_session::VertexAiSessionConfig;
+    /// use chrono::{Duration, Utc};
+    ///
+    /// let config = VertexAiSessionConfig::new("my-project", "us-central1")
+    ///     .with_expire_time(Utc::now() + Duration::days(7));
+    /// ```
+    pub fn with_expire_time(mut self, expire_time: DateTime<Utc>) -> Self {
+        self.expire_time = Some(expire_time);
         self
     }
 
@@ -208,6 +328,8 @@ pub struct VertexAiSessionService {
     max_response_bytes: usize,
     max_request_bytes: usize,
     pagination_timeout: Duration,
+    session_ttl: Option<String>,
+    session_expire_time: Option<String>,
     credentials: Credentials,
     auth_headers: Arc<RwLock<Option<reqwest::header::HeaderMap>>>,
     session_scopes: Arc<RwLock<VecDeque<(String, SessionScope)>>>,
@@ -237,12 +359,30 @@ impl VertexAiSessionService {
     ///
     /// # Errors
     ///
-    /// Returns an error when the endpoint is not a valid secure origin or the
-    /// bounded, redirect-disabled HTTP client cannot be constructed.
+    /// Returns an error when the endpoint is not a valid secure origin, the
+    /// session expiration config is invalid (both `ttl` and `expire_time`
+    /// set, or a TTL below the 24-hour minimum), or the bounded,
+    /// redirect-disabled HTTP client cannot be constructed.
     pub fn with_credentials(
         config: VertexAiSessionConfig,
         credentials: Credentials,
     ) -> Result<Self> {
+        // `ttl` and `expireTime` form the Session `expiration` oneof in
+        // google/cloud/aiplatform/v1beta1/session.proto, so at most one may
+        // be sent; `ttl` is input-only with a documented 24-hour minimum.
+        if config.ttl.is_some() && config.expire_time.is_some() {
+            return Err(Self::invalid_input(
+                "session ttl and expire_time are mutually exclusive Session.expiration oneof members; configure at most one of with_ttl and with_expire_time",
+            ));
+        }
+        if let Some(ttl) = config.ttl
+            && ttl < MIN_SESSION_TTL
+        {
+            return Err(Self::invalid_input(format!(
+                "session ttl of {}s is below the Vertex AI minimum of 24 hours (86400s)",
+                ttl.as_secs(),
+            )));
+        }
         let http_client = Client::builder()
             .connect_timeout(HTTP_CONNECT_TIMEOUT)
             .timeout(HTTP_REQUEST_TIMEOUT)
@@ -264,6 +404,10 @@ impl VertexAiSessionService {
             max_response_bytes: DEFAULT_MAX_RESPONSE_BYTES,
             max_request_bytes: DEFAULT_MAX_REQUEST_BYTES,
             pagination_timeout: PAGINATION_TIMEOUT,
+            session_ttl: config.ttl.map(proto_duration_string),
+            session_expire_time: config.expire_time.map(|expire_time| {
+                expire_time.to_rfc3339_opts(chrono::SecondsFormat::AutoSi, true)
+            }),
             credentials,
             auth_headers: Arc::new(RwLock::new(None)),
             session_scopes: Arc::new(RwLock::new(VecDeque::new())),
@@ -1188,8 +1332,12 @@ impl SessionService for VertexAiSessionService {
         insert_vertex_session_identity(&mut stored_state, &identity)?;
         validate_vertex_struct_map(&stored_state, "sessionState")?;
         let parent = self.session_parent(&req.app_name)?;
-        let body =
-            VertexCreateSession { user_id: req.user_id.clone(), session_state: Some(stored_state) };
+        let body = VertexCreateSession {
+            user_id: req.user_id.clone(),
+            session_state: Some(stored_state),
+            ttl: self.session_ttl.clone(),
+            expire_time: self.session_expire_time.clone(),
+        };
         let body = self.encode_request_body(&body, "create-session request")?;
 
         if self.allows_unmarked_sessions_for_app(&req.app_name)
@@ -1834,6 +1982,14 @@ struct VertexCreateSession {
     user_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     session_state: Option<HashMap<String, Value>>,
+    // `ttl` and `expireTime` are the Session `expiration` oneof members in
+    // google/cloud/aiplatform/v1beta1/session.proto. `ttl` is an input-only
+    // JSON duration string (e.g. "86400s") with a 24-hour minimum;
+    // `expireTime` is an RFC 3339 timestamp. At most one is ever set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ttl: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    expire_time: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -2819,6 +2975,19 @@ fn validate_vertex_operation_name(
         )));
     }
     Ok(())
+}
+
+// JSON representation of google.protobuf.Duration: decimal seconds with an
+// "s" suffix (e.g. "86400s"), fractional digits only when nonzero.
+fn proto_duration_string(duration: Duration) -> String {
+    let nanos = duration.subsec_nanos();
+    if nanos == 0 {
+        format!("{}s", duration.as_secs())
+    } else {
+        let fraction = format!("{nanos:09}");
+        let fraction = fraction.trim_end_matches('0');
+        format!("{}.{fraction}s", duration.as_secs())
+    }
 }
 
 fn proto3_optional_string(value: Option<&str>) -> Option<&str> {
@@ -4790,6 +4959,18 @@ fn bounded_field_names(extra: &Map<String, Value>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_proto_duration_string_matches_protobuf_json_format() {
+        for (duration, expected) in [
+            (Duration::from_secs(86_400), "86400s"),
+            (Duration::from_secs(172_800), "172800s"),
+            (Duration::new(86_400, 500_000_000), "86400.5s"),
+            (Duration::new(86_400, 1), "86400.000000001s"),
+        ] {
+            assert_eq!(proto_duration_string(duration), expected);
+        }
+    }
 
     #[test]
     fn test_vertex_endpoint_routes_global_and_multi_regions() {

--- a/adk-session/tests/session_contract_vertex.rs
+++ b/adk-session/tests/session_contract_vertex.rs
@@ -3,8 +3,8 @@
 mod common;
 
 use adk_core::{
-    AdkIdentity, AppName, Content, FileDataPart, FunctionResponseData, InlineDataPart, Part,
-    SessionId, UserId,
+    AdkIdentity, AppName, Content, ErrorCategory, FileDataPart, FunctionResponseData,
+    InlineDataPart, Part, SessionId, UserId,
 };
 use adk_session::{
     AppendEventRequest, CreateRequest, DeleteRequest, Event, GetRequest, ListRequest,
@@ -21,7 +21,7 @@ use chrono::{DateTime, Utc};
 use google_cloud_auth::credentials::api_key_credentials;
 use serde::Deserialize;
 use serde_json::{Map, Value, json};
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 use tokio::sync::Mutex;
 
 const VERTEX_IDENTITY_STATE_KEY: &str = "__adk_vertex_identity_v1";
@@ -76,6 +76,10 @@ struct CreateSessionBody {
     user_id: String,
     #[serde(default)]
     session_state: HashMap<String, Value>,
+    // `ttl` and `expireTime` are the Session `expiration` oneof members in
+    // google/cloud/aiplatform/v1beta1/session.proto.
+    ttl: Option<String>,
+    expire_time: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -207,6 +211,31 @@ async fn create_session(
             );
         }
     };
+
+    if session.ttl.is_some() && session.expire_time.is_some() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(
+                json!({ "error": { "message": "ttl and expireTime are expiration oneof members" } }),
+            ),
+        );
+    }
+    if let Some(ttl) = session.ttl.as_deref()
+        && ttl.strip_suffix('s').is_none_or(|seconds| seconds.parse::<f64>().is_err())
+    {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": { "message": "ttl must be a JSON duration string" } })),
+        );
+    }
+    if let Some(expire_time) = session.expire_time.as_deref()
+        && DateTime::parse_from_rfc3339(expire_time).is_err()
+    {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": { "message": "expireTime must be an RFC 3339 timestamp" } })),
+        );
+    }
 
     let mut db = state.db.lock().await;
     db.create_bodies.push(raw);
@@ -794,6 +823,18 @@ async fn test_service() -> (MockVertexState, VertexAiSessionService, tokio::task
 async fn test_service_with_reasoning_engine(
     reasoning_engine: Option<&str>,
 ) -> (MockVertexState, VertexAiSessionService, tokio::task::JoinHandle<()>) {
+    test_service_configured(|mut config| {
+        if let Some(reasoning_engine) = reasoning_engine {
+            config = config.with_reasoning_engine(reasoning_engine);
+        }
+        config
+    })
+    .await
+}
+
+async fn test_service_configured(
+    configure: impl FnOnce(VertexAiSessionConfig) -> VertexAiSessionConfig,
+) -> (MockVertexState, VertexAiSessionService, tokio::task::JoinHandle<()>) {
     let state = MockVertexState::default();
     let app = Router::new()
         .route(
@@ -816,11 +857,10 @@ async fn test_service_with_reasoning_engine(
         axum::serve(listener, app).await.expect("mock vertex server should run");
     });
 
-    let mut config = VertexAiSessionConfig::new("test-project", "us-central1")
-        .with_endpoint(format!("http://{addr}"));
-    if let Some(reasoning_engine) = reasoning_engine {
-        config = config.with_reasoning_engine(reasoning_engine);
-    }
+    let config = configure(
+        VertexAiSessionConfig::new("test-project", "us-central1")
+            .with_endpoint(format!("http://{addr}")),
+    );
     let credentials = api_key_credentials::Builder::new("test-api-key").build();
     let service =
         VertexAiSessionService::with_credentials(config, credentials).expect("build test service");
@@ -2450,6 +2490,235 @@ async fn test_vertex_rejects_invalid_base64_in_stored_content() {
     drop(db);
 
     server.abort();
+}
+
+#[tokio::test]
+async fn test_vertex_multi_turn_tool_conversation_round_trips_whole_objects() {
+    let (state, service, server) = test_service().await;
+    let created = service
+        .create(CreateRequest {
+            app_name: "1001".to_string(),
+            user_id: "user1".to_string(),
+            session_id: Some("golden-session".to_string()),
+            state: HashMap::new(),
+        })
+        .await
+        .expect("create golden session");
+
+    let mut user_turn = Event::new("inv-golden");
+    user_turn.author = "user".to_string();
+    user_turn.llm_response.content = Some(Content {
+        role: "user".to_string(),
+        parts: vec![Part::Text { text: "chart the weather in Paris".to_string() }],
+    });
+
+    let mut tool_call_turn = Event::new("inv-golden");
+    tool_call_turn.author = "model".to_string();
+    tool_call_turn.llm_response.content = Some(Content {
+        role: "model".to_string(),
+        parts: vec![
+            Part::Text { text: "Looking that up.".to_string() },
+            Part::FunctionCall {
+                name: "get_weather".to_string(),
+                args: json!({ "city": "Paris", "units": "metric" }),
+                id: None,
+                thought_signature: None,
+            },
+        ],
+    });
+
+    let mut tool_response_turn = Event::new("inv-golden");
+    tool_response_turn.author = "tool".to_string();
+    tool_response_turn.llm_response.content = Some(Content {
+        role: "tool".to_string(),
+        parts: vec![Part::FunctionResponse {
+            function_response: FunctionResponseData {
+                name: "get_weather".to_string(),
+                response: json!({ "tempC": 21, "condition": "sunny" }),
+                inline_data: vec![],
+                file_data: vec![],
+            },
+            id: None,
+            annotations: None,
+        }],
+    });
+    tool_response_turn.actions.state_delta.insert("lastCity".to_string(), json!("Paris"));
+
+    let mut answer_turn = Event::new("inv-golden");
+    answer_turn.author = "model".to_string();
+    answer_turn.llm_response.content = Some(Content {
+        role: "model".to_string(),
+        parts: vec![
+            Part::Text { text: "It is 21°C and sunny in Paris.".to_string() },
+            Part::InlineData {
+                mime_type: "image/png".to_string(),
+                data: vec![137, 80, 78, 71, 0, 255],
+                uri: None,
+                annotations: None,
+            },
+        ],
+    });
+
+    let turns = vec![user_turn, tool_call_turn, tool_response_turn, answer_turn];
+    let expected = turns
+        .iter()
+        .map(|event| serde_json::to_value(event).expect("serialize expected turn"))
+        .collect::<Vec<_>>();
+    for turn in turns {
+        service.append_event(created.id(), turn).await.expect("append golden turn");
+    }
+
+    {
+        let db = state.db.lock().await;
+        assert_eq!(db.append_bodies.len(), 4);
+        for body in &db.append_bodies {
+            assert_eq!(
+                body["rawEvent"]["_adkRust"]["contentSource"], "canonical",
+                "text, function call, function response, and inlineData parts must persist canonically",
+            );
+        }
+    }
+
+    let fetched = service
+        .get(GetRequest {
+            app_name: "1001".to_string(),
+            user_id: "user1".to_string(),
+            session_id: created.id().to_string(),
+            num_recent_events: None,
+            after: None,
+        })
+        .await
+        .expect("fetch golden session");
+    let restored = fetched
+        .events()
+        .all()
+        .iter()
+        .map(|event| serde_json::to_value(event).expect("serialize restored turn"))
+        .collect::<Vec<_>>();
+    assert_eq!(restored, expected, "reconstructed conversation must equal the appended events");
+    assert_eq!(fetched.state().get("lastCity"), Some(json!("Paris")));
+
+    server.abort();
+}
+
+#[test]
+fn test_vertex_config_from_env_reads_platform_variables() {
+    // Env mutation is process-isolated under nextest; keep every mutation of
+    // these variables inside this single test to avoid intra-process races.
+    unsafe {
+        std::env::remove_var("GOOGLE_CLOUD_PROJECT");
+        std::env::remove_var("GOOGLE_CLOUD_LOCATION");
+        std::env::remove_var("GOOGLE_CLOUD_AGENT_ENGINE_ID");
+    }
+    let error = VertexAiSessionConfig::from_env().expect_err("missing env vars must fail");
+    assert_eq!(error.category, ErrorCategory::InvalidInput);
+    assert_eq!(error.code, "session.vertex.missing_env");
+    assert!(
+        error
+            .message
+            .contains("GOOGLE_CLOUD_PROJECT, GOOGLE_CLOUD_LOCATION, GOOGLE_CLOUD_AGENT_ENGINE_ID."),
+        "error must name every missing variable: {}",
+        error.message,
+    );
+
+    unsafe {
+        std::env::set_var("GOOGLE_CLOUD_PROJECT", " test-project ");
+        std::env::set_var("GOOGLE_CLOUD_LOCATION", "us-central1");
+        std::env::set_var("GOOGLE_CLOUD_AGENT_ENGINE_ID", "   ");
+    }
+    let error = VertexAiSessionConfig::from_env().expect_err("blank engine ID counts as missing");
+    assert_eq!(error.category, ErrorCategory::InvalidInput);
+    assert!(
+        error.message.contains("variable(s): GOOGLE_CLOUD_AGENT_ENGINE_ID."),
+        "error must name only the blank variable: {}",
+        error.message,
+    );
+
+    unsafe {
+        std::env::set_var("GOOGLE_CLOUD_AGENT_ENGINE_ID", " 1234567890 ");
+    }
+    let config = VertexAiSessionConfig::from_env().expect("complete platform environment");
+    assert_eq!(config.project_id, "test-project");
+    assert_eq!(config.location, "us-central1");
+    assert_eq!(config.reasoning_engine.as_deref(), Some("1234567890"));
+    assert_eq!(config.ttl, None);
+    assert_eq!(config.expire_time, None);
+
+    unsafe {
+        std::env::remove_var("GOOGLE_CLOUD_PROJECT");
+        std::env::remove_var("GOOGLE_CLOUD_LOCATION");
+        std::env::remove_var("GOOGLE_CLOUD_AGENT_ENGINE_ID");
+    }
+}
+
+#[tokio::test]
+async fn test_vertex_create_sends_expiration_oneof_member() {
+    let (state, service, server) =
+        test_service_configured(|config| config.with_ttl(Duration::from_secs(86_400))).await;
+    service
+        .create(CreateRequest {
+            app_name: "1001".to_string(),
+            user_id: "user1".to_string(),
+            session_id: Some("ttl-session".to_string()),
+            state: HashMap::new(),
+        })
+        .await
+        .expect("create session with ttl");
+    {
+        let db = state.db.lock().await;
+        let body = db.create_bodies.last().expect("captured ttl create body");
+        assert_eq!(body["ttl"], "86400s");
+        assert!(body.get("expireTime").is_none());
+    }
+    server.abort();
+
+    let expire_time = DateTime::parse_from_rfc3339("2027-01-01T00:00:00Z")
+        .expect("parse expire time")
+        .with_timezone(&Utc);
+    let (state, service, server) =
+        test_service_configured(|config| config.with_expire_time(expire_time)).await;
+    service
+        .create(CreateRequest {
+            app_name: "1001".to_string(),
+            user_id: "user1".to_string(),
+            session_id: Some("expire-session".to_string()),
+            state: HashMap::new(),
+        })
+        .await
+        .expect("create session with expire time");
+    {
+        let db = state.db.lock().await;
+        let body = db.create_bodies.last().expect("captured expire-time create body");
+        assert_eq!(body["expireTime"], "2027-01-01T00:00:00Z");
+        assert!(body.get("ttl").is_none());
+    }
+    server.abort();
+}
+
+#[tokio::test]
+async fn test_vertex_expiration_config_enforces_oneof_and_minimum_ttl() {
+    let config = VertexAiSessionConfig::new("test-project", "us-central1")
+        .with_ttl(Duration::from_secs(86_400))
+        .with_expire_time(Utc::now());
+    let error = VertexAiSessionService::with_credentials(
+        config,
+        api_key_credentials::Builder::new("test-api-key").build(),
+    )
+    .err()
+    .expect("setting both expiration oneof members must fail");
+    assert_eq!(error.category, ErrorCategory::InvalidInput);
+    assert!(error.message.contains("mutually exclusive"), "unexpected message: {}", error.message);
+
+    let config = VertexAiSessionConfig::new("test-project", "us-central1")
+        .with_ttl(Duration::from_secs(3_600));
+    let error = VertexAiSessionService::with_credentials(
+        config,
+        api_key_credentials::Builder::new("test-api-key").build(),
+    )
+    .err()
+    .expect("a TTL below 24 hours must fail");
+    assert_eq!(error.category, ErrorCategory::InvalidInput);
+    assert!(error.message.contains("86400s"), "unexpected message: {}", error.message);
 }
 
 #[tokio::test]

--- a/adk-session/tests/session_contract_vertex_live.rs
+++ b/adk-session/tests/session_contract_vertex_live.rs
@@ -2,7 +2,14 @@
 
 mod common;
 
-use adk_session::{VertexAiSessionConfig, VertexAiSessionService};
+use adk_core::{Content, FunctionResponseData, Part};
+use adk_session::{
+    CreateRequest, DeleteRequest, Event, GetRequest, SessionService, VertexAiSessionConfig,
+    VertexAiSessionService,
+};
+use serde_json::{Value, json};
+use std::collections::HashMap;
+use std::time::Duration;
 use uuid::Uuid;
 
 const ENV_PROJECT_ID_KEYS: [&str; 2] = ["GOOGLE_PROJECT_ID", "GOOGLE_CLOUD_PROJECT"];
@@ -48,4 +55,131 @@ async fn test_vertex_service_live_contract() {
         &user_2,
     )
     .await;
+}
+
+#[tokio::test]
+#[ignore = "requires live Vertex Session Service resources + ADC; run with --ignored"]
+async fn test_vertex_live_from_env_ttl_multi_turn_round_trip() {
+    let config = VertexAiSessionConfig::from_env()
+        .expect("GOOGLE_CLOUD_PROJECT, GOOGLE_CLOUD_LOCATION, and GOOGLE_CLOUD_AGENT_ENGINE_ID are required")
+        .with_ttl(Duration::from_secs(86_400));
+    let service =
+        VertexAiSessionService::new_with_adc(config).expect("build vertex session service");
+
+    let run_id = Uuid::new_v4().simple().to_string();
+    let app_name = format!("adk-rust-live-ttl-{run_id}");
+    let user_id = format!("adk-rust-live-ttl-user-{run_id}");
+    let session_id = format!("live-ttl-{run_id}");
+
+    service
+        .create(CreateRequest {
+            app_name: app_name.clone(),
+            user_id: user_id.clone(),
+            session_id: Some(session_id.clone()),
+            state: HashMap::new(),
+        })
+        .await
+        .expect("create session with ttl");
+
+    let verification: Result<(), String> = async {
+        let mut user_turn = Event::new("inv-live-ttl");
+        user_turn.author = "user".to_string();
+        user_turn.llm_response.content = Some(Content {
+            role: "user".to_string(),
+            parts: vec![Part::Text { text: "what is the weather in Paris?".to_string() }],
+        });
+
+        let mut tool_call_turn = Event::new("inv-live-ttl");
+        tool_call_turn.author = "model".to_string();
+        tool_call_turn.llm_response.content = Some(Content {
+            role: "model".to_string(),
+            parts: vec![Part::FunctionCall {
+                name: "get_weather".to_string(),
+                args: json!({ "city": "Paris" }),
+                id: None,
+                thought_signature: None,
+            }],
+        });
+
+        let mut tool_response_turn = Event::new("inv-live-ttl");
+        tool_response_turn.author = "tool".to_string();
+        tool_response_turn.llm_response.content = Some(Content {
+            role: "tool".to_string(),
+            parts: vec![Part::FunctionResponse {
+                function_response: FunctionResponseData {
+                    name: "get_weather".to_string(),
+                    response: json!({ "tempC": 21, "condition": "sunny" }),
+                    inline_data: vec![],
+                    file_data: vec![],
+                },
+                id: None,
+                annotations: None,
+            }],
+        });
+
+        let mut answer_turn = Event::new("inv-live-ttl");
+        answer_turn.author = "model".to_string();
+        answer_turn.llm_response.content = Some(Content {
+            role: "model".to_string(),
+            parts: vec![
+                Part::Text { text: "It is 21°C and sunny in Paris.".to_string() },
+                Part::InlineData {
+                    mime_type: "image/png".to_string(),
+                    data: vec![137, 80, 78, 71, 0, 255],
+                    uri: None,
+                    annotations: None,
+                },
+            ],
+        });
+
+        let turns = vec![user_turn, tool_call_turn, tool_response_turn, answer_turn];
+        let expected = turns
+            .iter()
+            .map(|event| serde_json::to_value(event).map_err(|error| error.to_string()))
+            .collect::<Result<Vec<Value>, String>>()?;
+        for turn in turns {
+            service
+                .append_event(&session_id, turn)
+                .await
+                .map_err(|error| format!("append turn: {error}"))?;
+        }
+
+        let fetched = service
+            .get(GetRequest {
+                app_name: app_name.clone(),
+                user_id: user_id.clone(),
+                session_id: session_id.clone(),
+                num_recent_events: None,
+                after: None,
+            })
+            .await
+            .map_err(|error| format!("get session: {error}"))?;
+        let restored = fetched
+            .events()
+            .all()
+            .iter()
+            .map(|event| serde_json::to_value(event).map_err(|error| error.to_string()))
+            .collect::<Result<Vec<Value>, String>>()?;
+        if restored != expected {
+            return Err("reconstructed conversation does not equal the appended events".to_string());
+        }
+        Ok(())
+    }
+    .await;
+
+    let cleanup = service
+        .delete(DeleteRequest {
+            app_name: app_name.clone(),
+            user_id: user_id.clone(),
+            session_id: session_id.clone(),
+        })
+        .await;
+    match (verification, cleanup) {
+        (Err(verification), Err(cleanup)) => {
+            panic!("live ttl round trip failed: {verification}; cleanup also failed: {cleanup}")
+        }
+        (Err(verification), Ok(())) => panic!("live ttl round trip failed: {verification}"),
+        (Ok(()), Err(cleanup)) => panic!("live ttl round trip cleanup failed: {cleanup}"),
+        (Ok(()), Ok(())) => {}
+    }
 }

--- a/docs/official_docs/sessions/sessions.md
+++ b/docs/official_docs/sessions/sessions.md
@@ -178,6 +178,43 @@ let config = VertexAiSessionConfig::new("my-project", "us-central1")
 let service = VertexAiSessionService::new_with_adc(config)?;
 ```
 
+Inside a deployed Vertex AI Agent Engine container the platform provides the
+configuration as environment variables, and `VertexAiSessionConfig::from_env()`
+reads them:
+
+| Variable | Meaning |
+|----------|---------|
+| `GOOGLE_CLOUD_PROJECT` | Google Cloud project ID |
+| `GOOGLE_CLOUD_LOCATION` | GCP region |
+| `GOOGLE_CLOUD_AGENT_ENGINE_ID` | Bare numeric agent engine ID (not a full resource name) |
+
+```rust
+use adk_session::{VertexAiSessionConfig, VertexAiSessionService};
+
+let config = VertexAiSessionConfig::from_env()?;
+let service = VertexAiSessionService::new_with_adc(config)?;
+```
+
+Missing or blank variables produce an invalid-input error naming each one.
+
+#### Session expiration
+
+`ttl` and `expireTime` are the `Session.expiration` oneof members
+(`google/cloud/aiplatform/v1beta1/session.proto`). The config sends at most
+one on session create: `ttl` is input-only, serialized as a JSON duration
+string (e.g. `"86400s"`), with a 24-hour minimum; `expireTime` is an RFC 3339
+timestamp. Setting both members, or a TTL below 24 hours, fails at service
+construction.
+
+```rust
+use adk_session::VertexAiSessionConfig;
+use std::time::Duration;
+
+let config = VertexAiSessionConfig::new("my-project", "us-central1")
+    .with_reasoning_engine("1234567890")
+    .with_ttl(Duration::from_secs(86_400)); // sent as "86400s"
+```
+
 #### Identity isolation
 
 The public session ID is always the ID supplied to `CreateRequest`, or a locally


### PR DESCRIPTION
- Golden round-trip contract test: multi-turn tool conversation reconstructed equal through get (whole-object equality)
- VertexAiSessionConfig::from_env() from platform container env vars
- Session expiration: ttl / expireTime oneof on create, per google/cloud/aiplatform/v1beta1/session.proto

## What

Completes `VertexAiSessionService` as a lossless source of truth (`adk-session`, feature `vertex-session`):

- **Round-trip verification** — a golden mock contract test appends a four-turn conversation (text, function call, function response, inlineData) and asserts the reconstruction through `get` equals the appended events by whole-object equality. Every turn persists with `contentSource: "canonical"`; no canonical-representation gap surfaced, so `canonical_content_for_append` is unchanged.
- **`VertexAiSessionConfig::from_env()`** — reads `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`, and `GOOGLE_CLOUD_AGENT_ENGINE_ID` (the bare numeric engine ID the platform sets inside deployed containers). Missing or blank variables return an invalid-input `AdkError` naming each one.
- **TTL support** — `with_ttl()` and `with_expire_time()` send the `Session.expiration` oneof (`ttl` as a JSON duration string, `expireTime` as RFC 3339) on session create, per `google/cloud/aiplatform/v1beta1/session.proto`. Setting both members, or a TTL below the 24-hour minimum, fails at service construction.

## Why

Part of #438

Managed Vertex AI Sessions serve as the durable session store for deployed agents. Deployed containers need zero-config construction from platform environment variables, session lifecycle needs expiration control, and the persistence path needs proof that multi-turn tool conversations survive a full append/get cycle without loss.

## How

- `from_env()` trims values, treats blank as missing, and returns `session.vertex.missing_env` (`InvalidInput`) listing every missing variable.
- Expiration config is validated once in `with_credentials()` and preformatted (`proto_duration_string`, RFC 3339); `VertexCreateSession` gains `ttl`/`expireTime` fields with `skip_serializing_if`, so existing create bodies are unchanged when unset.
- The mock server enforces the oneof and wire formats via `deny_unknown_fields` plus explicit duration/timestamp validation.
- Tests: golden multi-turn round trip, `from_env` (all-missing, one-blank, complete), create-body `ttl`/`expireTime` assertions, construction-time oneof/minimum rejection, an `#[ignore]` live test (`from_env` + 24h TTL + multi-turn round trip with cleanup), and a `proto_duration_string` unit test.
- Docs: `docs/official_docs/sessions/sessions.md`, `adk-session/README.md`, and `CHANGELOG.md` updated.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (`adk-session --features vertex-session`)
- [x] `devenv shell test` — `cargo nextest run -p adk-session --features vertex-session`: 101 passed, 3 skipped (`#[ignore]` live); 5 doctests pass
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (mock contract, live `#[ignore]`, unit)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts
- [x] No unrelated changes mixed in
- [x] Branch naming follows convention (`feat/`)
- [x] Commit messages follow conventional format
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated
- [x] `adk-session/README.md` updated
- [x] `docs/official_docs/sessions/sessions.md` updated
