### PR TITLE
feat(model): drive Vertex backend selection from GOOGLE_GENAI_USE_* env - PR 0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`provider_from_env()` now consults the Vertex opt-in flags before any API
+  key.** A truthy `GOOGLE_GENAI_USE_ENTERPRISE` or `GOOGLE_GENAI_USE_VERTEXAI`
+  (`1` or a case-insensitive `true`) selects Gemini on Vertex AI — via
+  Application Default Credentials with `GOOGLE_CLOUD_PROJECT` and
+  `GOOGLE_CLOUD_LOCATION` — even when `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or
+  `GOOGLE_API_KEY` is set. Previously these flags were ignored and API-key
+  sniffing alone decided the provider. If you already set a `GOOGLE_GENAI_USE_*`
+  variable for another SDK (e.g. adk-python) and rely on `provider_from_env()`
+  picking Anthropic or OpenAI from an API key, unset the flag or set it to a
+  falsy value. `GOOGLE_GENAI_USE_ENTERPRISE` takes precedence when both flags
+  are set. When a flag is truthy but the `gemini-vertex` feature is not
+  compiled, `provider_from_env()` emits a `tracing` warning and falls through
+  to API-key detection; a truthy flag with `GOOGLE_CLOUD_PROJECT` /
+  `GOOGLE_CLOUD_LOCATION` missing is an error, not a Studio fallback.
+
+### Added
+
+- **`GeminiModel::from_env(model)`** — environment-driven construction: Vertex
+  AI via ADC when `GOOGLE_GENAI_USE_ENTERPRISE` / `GOOGLE_GENAI_USE_VERTEXAI`
+  is truthy (requires the `gemini-vertex` feature; errors when the feature is
+  missing or the Vertex target is incomplete), otherwise the Gemini API via
+  `GOOGLE_API_KEY` or `GEMINI_API_KEY`.
+- **`adk_model::gemini::vertex_env_requested()`** — reports whether the
+  environment opts in to the Vertex AI backend.
+- New docs page
+  [Vertex-Only Deployments](docs/official_docs/compliance/vertex-only-deployments.md)
+  — guaranteeing no `generativelanguage.googleapis.com` traffic for HIPAA and
+  data-residency workloads.
+
 ## [2.0.0] - 2026-08-09
 
 ### Breaking

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,6 +872,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/adk-model/README.md
+++ b/adk-model/README.md
@@ -74,6 +74,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+`GeminiModel::from_env(model)` builds the client from the environment: a truthy
+`GOOGLE_GENAI_USE_ENTERPRISE` or `GOOGLE_GENAI_USE_VERTEXAI` (`1` or a
+case-insensitive `true`) selects Vertex AI via Application Default Credentials
+using `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION` (requires the
+`gemini-vertex` feature); otherwise the Gemini API via `GOOGLE_API_KEY` or
+`GEMINI_API_KEY`.
+
 ### OpenAI
 
 ```rust

--- a/adk-model/src/gemini/client.rs
+++ b/adk-model/src/gemini/client.rs
@@ -209,6 +209,71 @@ fn interaction_terminal_error(code: &'static str, message: &str) -> adk_core::Ad
     .with_provider("gemini")
 }
 
+/// Returns the value of the environment variable `name` when it is set and
+/// non-empty (after trimming whitespace).
+fn env_non_empty(name: &str) -> Option<String> {
+    std::env::var(name).ok().filter(|v| !v.trim().is_empty())
+}
+
+/// Returns `true` when an opt-in flag value selects the Vertex AI backend:
+/// `1` or a case-insensitive `true`.
+fn env_flag_truthy(value: &str) -> bool {
+    let v = value.trim();
+    v == "1" || v.eq_ignore_ascii_case("true")
+}
+
+/// Reports whether the environment opts in to the Vertex AI backend.
+///
+/// Consults `GOOGLE_GENAI_USE_ENTERPRISE` first and, when that variable is
+/// unset or empty, the deprecated `GOOGLE_GENAI_USE_VERTEXAI`. A flag is
+/// truthy when its value is `1` or a case-insensitive `true`.
+/// `GOOGLE_GENAI_USE_ENTERPRISE` takes precedence when both are set.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// if adk_model::gemini::vertex_env_requested() {
+///     // route Gemini traffic through Vertex AI
+/// }
+/// ```
+pub fn vertex_env_requested() -> bool {
+    // `GOOGLE_GENAI_USE_VERTEXAI` is the deprecated name adk-python still
+    // honors. Deliberately no deprecation warning for it —
+    // google/adk-python#6168 documents the churn such a warning caused.
+    if let Some(v) = env_non_empty("GOOGLE_GENAI_USE_ENTERPRISE") {
+        return env_flag_truthy(&v);
+    }
+    env_non_empty("GOOGLE_GENAI_USE_VERTEXAI").is_some_and(|v| env_flag_truthy(&v))
+}
+
+/// Reads `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION`, erroring with a
+/// message that names whichever variable is missing.
+#[cfg(feature = "gemini-vertex")]
+fn vertex_target_from_env() -> Result<(String, String)> {
+    let project = env_non_empty("GOOGLE_CLOUD_PROJECT");
+    let location = env_non_empty("GOOGLE_CLOUD_LOCATION");
+    if let (Some(project), Some(location)) = (&project, &location) {
+        return Ok((project.clone(), location.clone()));
+    }
+    let mut missing = Vec::new();
+    if project.is_none() {
+        missing.push("GOOGLE_CLOUD_PROJECT");
+    }
+    if location.is_none() {
+        missing.push("GOOGLE_CLOUD_LOCATION");
+    }
+    Err(adk_core::AdkError::new(
+        ErrorComponent::Model,
+        ErrorCategory::InvalidInput,
+        "model.gemini.vertex_env_incomplete",
+        format!(
+            "Vertex AI backend selected via GOOGLE_GENAI_USE_ENTERPRISE/GOOGLE_GENAI_USE_VERTEXAI, but {} not set. Set the missing variable(s) to your Google Cloud project ID and region (e.g. us-central1).",
+            missing.join(" and ")
+        ),
+    )
+    .with_provider("gemini"))
+}
+
 impl GeminiModel {
     fn gemini_part_thought_signature(value: &serde_json::Value) -> Option<String> {
         value.get("thoughtSignature").and_then(serde_json::Value::as_str).map(str::to_string)
@@ -327,6 +392,74 @@ impl GeminiModel {
         .map_err(|e| adk_core::AdkError::model(e.to_string()))?;
 
         Ok(Self::from_client(client, model_name))
+    }
+
+    /// Create a Gemini model from environment variables.
+    ///
+    /// When `GOOGLE_GENAI_USE_ENTERPRISE` or `GOOGLE_GENAI_USE_VERTEXAI` is
+    /// truthy (`1` or a case-insensitive `true`), builds a Vertex AI client
+    /// with Application Default Credentials from `GOOGLE_CLOUD_PROJECT` and
+    /// `GOOGLE_CLOUD_LOCATION` — this path requires the `gemini-vertex`
+    /// feature. Otherwise builds a Gemini API (AI Studio) client from
+    /// `GOOGLE_API_KEY` or `GEMINI_API_KEY`.
+    ///
+    /// `GOOGLE_GENAI_USE_ENTERPRISE` takes precedence when both flags are set.
+    ///
+    /// The Vertex path builds Application Default Credentials, which requires
+    /// a Tokio runtime to be current — call from async code or under
+    /// `#[tokio::main]`.
+    ///
+    /// # Errors
+    ///
+    /// - A Vertex flag is truthy but `GOOGLE_CLOUD_PROJECT` or
+    ///   `GOOGLE_CLOUD_LOCATION` is not set.
+    /// - A Vertex flag is truthy but the `gemini-vertex` feature is not
+    ///   compiled.
+    /// - No Vertex flag is truthy and neither `GOOGLE_API_KEY` nor
+    ///   `GEMINI_API_KEY` is set.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use adk_model::gemini::GeminiModel;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() -> adk_core::Result<()> {
+    /// let model = GeminiModel::from_env("gemini-2.5-flash")?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn from_env(model: &str) -> Result<Self> {
+        if vertex_env_requested() {
+            #[cfg(feature = "gemini-vertex")]
+            {
+                let (project, location) = vertex_target_from_env()?;
+                return Self::new_google_cloud_adc(project, location, model);
+            }
+            #[cfg(not(feature = "gemini-vertex"))]
+            {
+                return Err(adk_core::AdkError::new(
+                    ErrorComponent::Model,
+                    ErrorCategory::Unsupported,
+                    "model.gemini.vertex_feature_missing",
+                    "Vertex AI backend selected via GOOGLE_GENAI_USE_ENTERPRISE/GOOGLE_GENAI_USE_VERTEXAI, but the `gemini-vertex` feature is not compiled. Enable the `gemini-vertex` feature (or `gemini-agent-platform` on the adk-rust umbrella crate) to route Gemini traffic through Vertex AI.",
+                )
+                .with_provider("gemini"));
+            }
+        }
+
+        let Some(api_key) =
+            env_non_empty("GOOGLE_API_KEY").or_else(|| env_non_empty("GEMINI_API_KEY"))
+        else {
+            return Err(adk_core::AdkError::new(
+                ErrorComponent::Model,
+                ErrorCategory::InvalidInput,
+                "model.gemini.api_key_missing",
+                "No Gemini API key found. Set GOOGLE_API_KEY or GEMINI_API_KEY, or set GOOGLE_GENAI_USE_ENTERPRISE=true with GOOGLE_CLOUD_PROJECT/GOOGLE_CLOUD_LOCATION for Vertex AI.",
+            )
+            .with_provider("gemini"));
+        };
+        Self::new(api_key, model)
     }
 
     /// Set the retry configuration (builder pattern).
@@ -1720,6 +1853,16 @@ mod tests {
         },
         time::Duration,
     };
+
+    #[test]
+    fn env_flag_truthy_accepts_one_and_case_insensitive_true() {
+        for truthy in ["1", "true", "TRUE", "True", " true ", "tRuE"] {
+            assert!(env_flag_truthy(truthy), "expected {truthy:?} to be truthy");
+        }
+        for falsy in ["0", "false", "FALSE", "yes", "on", "", "2", "vertex"] {
+            assert!(!env_flag_truthy(falsy), "expected {falsy:?} to be falsy");
+        }
+    }
 
     #[test]
     fn constructor_is_backward_compatible_and_sync() {

--- a/adk-model/src/gemini/mod.rs
+++ b/adk-model/src/gemini/mod.rs
@@ -10,7 +10,7 @@ pub mod interactions_target;
 pub mod streaming;
 
 pub use crate::retry::RetryConfig;
-pub use client::GeminiModel;
+pub use client::{GeminiModel, vertex_env_requested};
 
 // Re-export the Interactions transport surface (Beta) so consumers can configure
 // the toggle through `adk_model::gemini::{...}` without reaching into submodules.

--- a/adk-model/tests/gemini_from_env_tests.rs
+++ b/adk-model/tests/gemini_from_env_tests.rs
@@ -1,0 +1,212 @@
+//! Environment-driven construction tests for `GeminiModel::from_env` and
+//! `vertex_env_requested`.
+//!
+//! Environment variables are process-global, so every test takes `ENV_LOCK`
+//! through [`EnvGuard`], which clears the relevant variables, applies the
+//! test's values, and restores the previous state on drop. This keeps the
+//! suite correct under `cargo test` (threads share one process); `cargo
+//! nextest` isolates each test in its own process anyway.
+#![cfg(feature = "gemini")]
+
+use adk_model::gemini::{GeminiModel, vertex_env_requested};
+use std::sync::{Mutex, MutexGuard};
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// Every variable `from_env` (or the ADC credential builder) consults.
+const VARS: &[&str] = &[
+    "GOOGLE_GENAI_USE_ENTERPRISE",
+    "GOOGLE_GENAI_USE_VERTEXAI",
+    "GOOGLE_CLOUD_PROJECT",
+    "GOOGLE_CLOUD_LOCATION",
+    "GOOGLE_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+];
+
+/// Serializes env access, applies `vars` on a clean slate, restores on drop.
+struct EnvGuard {
+    _lock: MutexGuard<'static, ()>,
+    saved: Vec<(&'static str, Option<String>)>,
+}
+
+impl EnvGuard {
+    fn new(vars: &[(&str, &str)]) -> Self {
+        let lock = ENV_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let saved = VARS.iter().map(|&name| (name, std::env::var(name).ok())).collect();
+        for &name in VARS {
+            // SAFETY: serialized by ENV_LOCK; test-only.
+            unsafe { std::env::remove_var(name) };
+        }
+        for &(name, value) in vars {
+            // SAFETY: serialized by ENV_LOCK; test-only.
+            unsafe { std::env::set_var(name, value) };
+        }
+        Self { _lock: lock, saved }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (name, value) in &self.saved {
+            match value {
+                // SAFETY: serialized by ENV_LOCK; test-only.
+                Some(v) => unsafe { std::env::set_var(name, v) },
+                None => unsafe { std::env::remove_var(name) },
+            }
+        }
+    }
+}
+
+#[test]
+fn enterprise_flag_alone_requests_vertex() {
+    let _guard = EnvGuard::new(&[("GOOGLE_GENAI_USE_ENTERPRISE", "1")]);
+    assert!(vertex_env_requested());
+}
+
+#[test]
+fn vertexai_flag_alone_requests_vertex() {
+    let _guard = EnvGuard::new(&[("GOOGLE_GENAI_USE_VERTEXAI", "true")]);
+    assert!(vertex_env_requested());
+}
+
+#[test]
+fn flag_values_are_one_or_case_insensitive_true() {
+    for (value, expected) in
+        [("1", true), ("true", true), ("TRUE", true), ("True", true), ("0", false), ("yes", false)]
+    {
+        let _guard = EnvGuard::new(&[("GOOGLE_GENAI_USE_ENTERPRISE", value)]);
+        assert_eq!(vertex_env_requested(), expected, "value {value:?}");
+    }
+}
+
+#[test]
+fn enterprise_wins_when_both_flags_set() {
+    // Truthy enterprise + falsy vertexai → vertex.
+    let guard = EnvGuard::new(&[
+        ("GOOGLE_GENAI_USE_ENTERPRISE", "true"),
+        ("GOOGLE_GENAI_USE_VERTEXAI", "false"),
+    ]);
+    assert!(vertex_env_requested());
+    drop(guard);
+
+    // Falsy enterprise overrides truthy vertexai — enterprise takes precedence.
+    let _guard = EnvGuard::new(&[
+        ("GOOGLE_GENAI_USE_ENTERPRISE", "0"),
+        ("GOOGLE_GENAI_USE_VERTEXAI", "true"),
+    ]);
+    assert!(!vertex_env_requested());
+}
+
+#[test]
+fn no_flags_means_studio() {
+    let _guard = EnvGuard::new(&[]);
+    assert!(!vertex_env_requested());
+}
+
+#[test]
+fn no_flags_uses_google_api_key() {
+    let _guard = EnvGuard::new(&[("GOOGLE_API_KEY", "test-key")]);
+    let result = GeminiModel::from_env("gemini-2.5-flash");
+    assert!(result.is_ok(), "expected studio construction to succeed: {:?}", result.err());
+}
+
+#[test]
+fn no_flags_falls_back_to_gemini_api_key() {
+    let _guard = EnvGuard::new(&[("GEMINI_API_KEY", "test-key")]);
+    let result = GeminiModel::from_env("gemini-2.5-flash");
+    assert!(result.is_ok(), "expected studio construction to succeed: {:?}", result.err());
+}
+
+#[test]
+fn no_flags_no_keys_errors_naming_the_variables() {
+    let _guard = EnvGuard::new(&[]);
+    let err = GeminiModel::from_env("gemini-2.5-flash").err().expect("expected an error");
+    let msg = err.to_string();
+    assert!(msg.contains("GOOGLE_API_KEY"), "message should name GOOGLE_API_KEY: {msg}");
+    assert!(msg.contains("GEMINI_API_KEY"), "message should name GEMINI_API_KEY: {msg}");
+}
+
+#[cfg(feature = "gemini-vertex")]
+mod vertex_enabled {
+    use super::*;
+
+    // The ADC credential builder registers a token-cache task, so a Tokio
+    // runtime must be current when the Vertex client is constructed.
+    #[tokio::test]
+    async fn enterprise_flag_builds_vertex_client_via_adc() {
+        let _guard = EnvGuard::new(&[
+            ("GOOGLE_GENAI_USE_ENTERPRISE", "1"),
+            ("GOOGLE_CLOUD_PROJECT", "test-project"),
+            ("GOOGLE_CLOUD_LOCATION", "us-central1"),
+        ]);
+        let result = GeminiModel::from_env("gemini-2.5-flash");
+        assert!(result.is_ok(), "expected vertex construction to succeed: {:?}", result.err());
+    }
+
+    #[tokio::test]
+    async fn vertexai_flag_builds_vertex_client_via_adc() {
+        let _guard = EnvGuard::new(&[
+            ("GOOGLE_GENAI_USE_VERTEXAI", "TRUE"),
+            ("GOOGLE_CLOUD_PROJECT", "test-project"),
+            ("GOOGLE_CLOUD_LOCATION", "us-central1"),
+        ]);
+        let result = GeminiModel::from_env("gemini-2.5-flash");
+        assert!(result.is_ok(), "expected vertex construction to succeed: {:?}", result.err());
+    }
+
+    #[test]
+    fn missing_project_and_location_errors_naming_both() {
+        let _guard = EnvGuard::new(&[("GOOGLE_GENAI_USE_ENTERPRISE", "true")]);
+        let err = GeminiModel::from_env("gemini-2.5-flash").err().expect("expected an error");
+        let msg = err.to_string();
+        assert!(msg.contains("GOOGLE_CLOUD_PROJECT"), "should name GOOGLE_CLOUD_PROJECT: {msg}");
+        assert!(msg.contains("GOOGLE_CLOUD_LOCATION"), "should name GOOGLE_CLOUD_LOCATION: {msg}");
+    }
+
+    #[test]
+    fn missing_location_errors_naming_only_location() {
+        let _guard = EnvGuard::new(&[
+            ("GOOGLE_GENAI_USE_ENTERPRISE", "true"),
+            ("GOOGLE_CLOUD_PROJECT", "test-project"),
+        ]);
+        let err = GeminiModel::from_env("gemini-2.5-flash").err().expect("expected an error");
+        let msg = err.to_string();
+        assert!(msg.contains("GOOGLE_CLOUD_LOCATION"), "should name GOOGLE_CLOUD_LOCATION: {msg}");
+        assert!(
+            !msg.contains("GOOGLE_CLOUD_PROJECT not set")
+                && !msg.contains("GOOGLE_CLOUD_PROJECT and"),
+            "should not report GOOGLE_CLOUD_PROJECT as missing: {msg}"
+        );
+    }
+
+    #[test]
+    fn flag_takes_precedence_over_api_key() {
+        // A truthy flag with incomplete Vertex config errors instead of
+        // silently falling back to the Studio endpoint the API key would reach.
+        let _guard = EnvGuard::new(&[
+            ("GOOGLE_GENAI_USE_ENTERPRISE", "true"),
+            ("GOOGLE_API_KEY", "test-key"),
+        ]);
+        assert!(GeminiModel::from_env("gemini-2.5-flash").is_err());
+    }
+}
+
+#[cfg(not(feature = "gemini-vertex"))]
+mod vertex_disabled {
+    use super::*;
+
+    #[test]
+    fn flag_without_feature_errors_pointing_at_the_feature() {
+        let _guard = EnvGuard::new(&[
+            ("GOOGLE_GENAI_USE_ENTERPRISE", "1"),
+            ("GOOGLE_CLOUD_PROJECT", "test-project"),
+            ("GOOGLE_CLOUD_LOCATION", "us-central1"),
+            // The API key must not rescue the call — no silent Studio fallback.
+            ("GOOGLE_API_KEY", "test-key"),
+        ]);
+        let err = GeminiModel::from_env("gemini-2.5-flash").err().expect("expected an error");
+        let msg = err.to_string();
+        assert!(msg.contains("gemini-vertex"), "should point at the gemini-vertex feature: {msg}");
+    }
+}

--- a/adk-rust/Cargo.toml
+++ b/adk-rust/Cargo.toml
@@ -329,6 +329,7 @@ futures = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "sync", "time", "macros", "net", "signal", "fs", "process", "io-util", "test-util"] }

--- a/adk-rust/src/lib.rs
+++ b/adk-rust/src/lib.rs
@@ -1071,13 +1071,25 @@ pub use adk_enterprise;
 /// `minimal` tier detects Gemini via `GOOGLE_API_KEY`; add `openai` or
 /// `anthropic` to widen detection.
 ///
-/// 1. `ANTHROPIC_API_KEY` → Anthropic (Claude)
-/// 2. `OPENAI_API_KEY` → OpenAI
-/// 3. `GOOGLE_API_KEY` → Gemini
+/// 1. `GOOGLE_GENAI_USE_ENTERPRISE` / `GOOGLE_GENAI_USE_VERTEXAI` truthy
+///    (`1` or case-insensitive `true`) → Gemini on Vertex AI via Application
+///    Default Credentials, using `GOOGLE_CLOUD_PROJECT` and
+///    `GOOGLE_CLOUD_LOCATION` (requires the `gemini-vertex` feature;
+///    `GOOGLE_GENAI_USE_ENTERPRISE` takes precedence when both are set)
+/// 2. `ANTHROPIC_API_KEY` → Anthropic (Claude)
+/// 3. `OPENAI_API_KEY` → OpenAI
+/// 4. `GOOGLE_API_KEY` → Gemini
+///
+/// When a Vertex flag is truthy but the `gemini-vertex` feature is not
+/// compiled, a `tracing` warning is emitted and detection falls through to
+/// the API-key steps, which may select the Gemini Studio endpoint
+/// (`generativelanguage.googleapis.com`).
 ///
 /// # Errors
 ///
-/// Returns [`AdkError`] when no supported environment variable is set.
+/// Returns [`AdkError`] when no supported environment variable is set, or
+/// when a Vertex flag is truthy but `GOOGLE_CLOUD_PROJECT` /
+/// `GOOGLE_CLOUD_LOCATION` is missing.
 ///
 /// # Example
 ///
@@ -1088,6 +1100,24 @@ pub use adk_enterprise;
 /// let model: Arc<dyn adk_rust::Llm> = provider_from_env()?;
 /// ```
 pub fn provider_from_env() -> Result<std::sync::Arc<dyn Llm>> {
+    // The Vertex opt-in flags come before any API-key sniffing so a
+    // deployment pinned to Vertex AI can never be diverted to the Studio
+    // endpoint by a stray API key.
+    #[cfg(feature = "gemini")]
+    {
+        if model::gemini::vertex_env_requested() {
+            #[cfg(feature = "gemini-vertex")]
+            {
+                return Ok(std::sync::Arc::new(model::GeminiModel::from_env("gemini-2.5-flash")?));
+            }
+            #[cfg(not(feature = "gemini-vertex"))]
+            tracing::warn!(
+                env.flags = "GOOGLE_GENAI_USE_ENTERPRISE/GOOGLE_GENAI_USE_VERTEXAI",
+                "vertex backend requested via environment but the gemini-vertex feature is not compiled; api-key detection may select the gemini studio endpoint (generativelanguage.googleapis.com)"
+            );
+        }
+    }
+
     #[cfg(feature = "anthropic")]
     {
         if let Ok(key) = std::env::var("ANTHROPIC_API_KEY") {

--- a/adk-rust/tests/provider_from_env_tests.rs
+++ b/adk-rust/tests/provider_from_env_tests.rs
@@ -1,0 +1,143 @@
+//! Precedence tests for `provider_from_env` — the Vertex opt-in flags
+//! (`GOOGLE_GENAI_USE_ENTERPRISE` / `GOOGLE_GENAI_USE_VERTEXAI`) come before
+//! API-key sniffing.
+//!
+//! Environment variables are process-global, so every test takes `ENV_LOCK`
+//! through [`EnvGuard`], which clears the relevant variables, applies the
+//! test's values, and restores the previous state on drop.
+#![cfg(feature = "gemini")]
+
+use adk_rust::provider_from_env;
+use std::sync::{Mutex, MutexGuard};
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// Every variable provider detection (or the ADC credential builder) consults.
+const VARS: &[&str] = &[
+    "GOOGLE_GENAI_USE_ENTERPRISE",
+    "GOOGLE_GENAI_USE_VERTEXAI",
+    "GOOGLE_CLOUD_PROJECT",
+    "GOOGLE_CLOUD_LOCATION",
+    "GOOGLE_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+];
+
+/// Serializes env access, applies `vars` on a clean slate, restores on drop.
+struct EnvGuard {
+    _lock: MutexGuard<'static, ()>,
+    saved: Vec<(&'static str, Option<String>)>,
+}
+
+impl EnvGuard {
+    fn new(vars: &[(&str, &str)]) -> Self {
+        let lock = ENV_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let saved = VARS.iter().map(|&name| (name, std::env::var(name).ok())).collect();
+        for &name in VARS {
+            // SAFETY: serialized by ENV_LOCK; test-only.
+            unsafe { std::env::remove_var(name) };
+        }
+        for &(name, value) in vars {
+            // SAFETY: serialized by ENV_LOCK; test-only.
+            unsafe { std::env::set_var(name, value) };
+        }
+        Self { _lock: lock, saved }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (name, value) in &self.saved {
+            match value {
+                // SAFETY: serialized by ENV_LOCK; test-only.
+                Some(v) => unsafe { std::env::set_var(name, v) },
+                None => unsafe { std::env::remove_var(name) },
+            }
+        }
+    }
+}
+
+#[test]
+fn no_flags_no_keys_errors() {
+    let _guard = EnvGuard::new(&[]);
+    assert!(provider_from_env().is_err());
+}
+
+#[test]
+fn no_flags_google_api_key_selects_gemini() {
+    let _guard = EnvGuard::new(&[("GOOGLE_API_KEY", "test-key")]);
+    let model = provider_from_env().expect("expected the gemini studio provider");
+    assert_eq!(model.name(), "gemini-2.5-flash");
+}
+
+#[cfg(feature = "gemini-vertex")]
+mod vertex_enabled {
+    use super::*;
+
+    // The ADC credential builder registers a token-cache task, so a Tokio
+    // runtime must be current when the Vertex client is constructed.
+    #[tokio::test]
+    async fn vertex_flag_selects_vertex_without_any_api_key() {
+        // No API key set: only the Vertex path can construct a provider, so an
+        // Ok result proves the flag routed detection to Vertex AI.
+        let _guard = EnvGuard::new(&[
+            ("GOOGLE_GENAI_USE_ENTERPRISE", "true"),
+            ("GOOGLE_CLOUD_PROJECT", "test-project"),
+            ("GOOGLE_CLOUD_LOCATION", "us-central1"),
+        ]);
+        let model = provider_from_env().expect("expected the vertex provider");
+        assert_eq!(model.name(), "gemini-2.5-flash");
+    }
+
+    #[test]
+    fn vertex_flag_beats_api_keys_and_incomplete_config_errors() {
+        // A truthy flag with missing project/location errors even though
+        // GOOGLE_API_KEY (and, when compiled, ANTHROPIC_API_KEY /
+        // OPENAI_API_KEY) would have produced a provider — proof the flags are
+        // consulted first and never silently fall back to Studio.
+        let _guard = EnvGuard::new(&[
+            ("GOOGLE_GENAI_USE_VERTEXAI", "1"),
+            ("GOOGLE_API_KEY", "test-key"),
+            ("ANTHROPIC_API_KEY", "test-key"),
+            ("OPENAI_API_KEY", "test-key"),
+        ]);
+        assert!(provider_from_env().is_err());
+    }
+
+    #[test]
+    fn falsy_enterprise_flag_overrides_truthy_vertexai_flag() {
+        // GOOGLE_GENAI_USE_ENTERPRISE takes precedence when both are set.
+        let _guard = EnvGuard::new(&[
+            ("GOOGLE_GENAI_USE_ENTERPRISE", "0"),
+            ("GOOGLE_GENAI_USE_VERTEXAI", "true"),
+            ("GOOGLE_API_KEY", "test-key"),
+        ]);
+        let model = provider_from_env().expect("expected the gemini studio provider");
+        assert_eq!(model.name(), "gemini-2.5-flash");
+    }
+}
+
+#[cfg(not(feature = "gemini-vertex"))]
+mod vertex_disabled {
+    use super::*;
+
+    #[test]
+    fn vertex_flag_without_feature_warns_and_falls_back_to_api_keys() {
+        let _guard = EnvGuard::new(&[
+            ("GOOGLE_GENAI_USE_ENTERPRISE", "true"),
+            ("GOOGLE_API_KEY", "test-key"),
+        ]);
+        // The residual Studio path: flag set, feature missing → warn + fall
+        // through to API-key detection.
+        let model = provider_from_env().expect("expected the api-key fallback provider");
+        assert_eq!(model.name(), "gemini-2.5-flash");
+    }
+
+    #[test]
+    fn vertex_flag_without_feature_and_no_keys_errors() {
+        let _guard = EnvGuard::new(&[("GOOGLE_GENAI_USE_ENTERPRISE", "true")]);
+        assert!(provider_from_env().is_err());
+    }
+}

--- a/docs/official_docs/compliance/vertex-only-deployments.md
+++ b/docs/official_docs/compliance/vertex-only-deployments.md
@@ -1,0 +1,117 @@
+# Vertex-Only Deployments
+
+Guarantee that Gemini traffic reaches only Vertex AI (`{location}-aiplatform.googleapis.com`) and never the Gemini API Studio endpoint (`generativelanguage.googleapis.com`). Regulated workloads — HIPAA, data-residency, VPC Service Controls — require this: the Studio endpoint is not covered by a Google Cloud BAA, while Vertex AI is.
+
+## Endpoint Decision
+
+`GeminiModel::from_env` and `provider_from_env` consult two environment flags before any API key. A flag is truthy when its value is `1` or a case-insensitive `true`.
+
+| Flag | Status | Notes |
+|------|--------|-------|
+| `GOOGLE_GENAI_USE_ENTERPRISE` | Current | Takes precedence when both are set |
+| `GOOGLE_GENAI_USE_VERTEXAI` | Deprecated | Still honored for adk-python parity; no deprecation warning is emitted |
+
+| Vertex flag | `gemini-vertex` feature | Result |
+|-------------|-------------------------|--------|
+| Truthy | Compiled | Vertex AI via Application Default Credentials (`GOOGLE_CLOUD_PROJECT` + `GOOGLE_CLOUD_LOCATION`) |
+| Truthy, project or location missing | Compiled | Error naming the missing variable — no Studio fallback |
+| Truthy | Not compiled | `GeminiModel::from_env` errors; `provider_from_env` emits a `tracing` warning and falls through to API-key detection, which may select Studio |
+| Not truthy | — | Gemini API (Studio) via `GOOGLE_API_KEY` or `GEMINI_API_KEY` |
+
+> **Important:** the flags take precedence over every API key, including `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` in `provider_from_env`. A stray API key cannot divert a Vertex-pinned deployment to Studio.
+
+## Setup
+
+### 1. Enable the `gemini-vertex` feature
+
+Compile the Vertex backend in — without it, the flag cannot be honored:
+
+```toml
+[dependencies]
+adk-rust = { version = "2.0.0", features = ["minimal", "gemini-vertex"] }
+```
+
+Or use the platform preset, which includes it:
+
+```toml
+[dependencies]
+adk-rust = { version = "2.0.0", features = ["minimal", "gemini-agent-platform"] }
+```
+
+### 2. Set the environment flags
+
+```bash
+export GOOGLE_GENAI_USE_ENTERPRISE=true
+export GOOGLE_CLOUD_PROJECT=my-project
+export GOOGLE_CLOUD_LOCATION=us-central1
+```
+
+Unset `GOOGLE_API_KEY` and `GEMINI_API_KEY` in the deployment environment for defense in depth — with the flag truthy they are never consulted, but removing them eliminates the residual path entirely.
+
+### 3. Configure Application Default Credentials
+
+The Vertex path authenticates with ADC, not an API key:
+
+```bash
+# Local development
+gcloud auth application-default login
+
+# Service accounts (CI, containers)
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+```
+
+On GKE and Cloud Run, Workload Identity provides ADC without a key file.
+
+### 4. Construct the model from the environment
+
+```rust
+use adk_model::gemini::GeminiModel;
+
+// The Vertex path builds Application Default Credentials, which requires a
+// current Tokio runtime.
+#[tokio::main]
+async fn main() -> adk_core::Result<()> {
+    // Vertex AI when a flag is truthy; errors instead of falling back to
+    // Studio when the Vertex configuration is incomplete.
+    let model = GeminiModel::from_env("gemini-2.5-flash")?;
+    Ok(())
+}
+```
+
+Or via provider auto-detection on the umbrella crate:
+
+```rust
+use adk_rust::provider_from_env;
+
+#[tokio::main]
+async fn main() -> adk_rust::Result<()> {
+    let model = provider_from_env()?;
+    Ok(())
+}
+```
+
+## Verifying No Studio Traffic
+
+**Build-time** — the flag errors instead of silently degrading:
+
+- `GeminiModel::from_env` with a truthy flag and no `gemini-vertex` feature returns an error naming the feature.
+- A truthy flag with `GOOGLE_CLOUD_PROJECT` or `GOOGLE_CLOUD_LOCATION` missing returns an error naming the missing variable.
+
+**Runtime** — watch for the guard-rail warning. `provider_from_env` emits it whenever a Vertex flag is truthy but the `gemini-vertex` feature is not compiled and detection falls through to API keys:
+
+```text
+WARN vertex backend requested via environment but the gemini-vertex feature is not compiled; api-key detection may select the gemini studio endpoint (generativelanguage.googleapis.com)
+```
+
+A Vertex-only deployment must treat this warning as a deployment error: it means the binary was built without the `gemini-vertex` feature. Alert on it in log aggregation.
+
+**Network** — for VPC Service Controls perimeters, block egress to `generativelanguage.googleapis.com`. With the flag truthy and the feature compiled, no code path constructs a Studio client, so the block never fires for ADK traffic.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Error naming `GOOGLE_CLOUD_PROJECT` / `GOOGLE_CLOUD_LOCATION` | Flag truthy, Vertex target incomplete | Set both variables |
+| Error naming the `gemini-vertex` feature | Flag truthy, feature not compiled | Add `gemini-vertex` (or `gemini-agent-platform`) to the `adk-rust` features |
+| The guard-rail warning appears | `provider_from_env` fell back to API keys | Rebuild with `gemini-vertex`; remove Studio API keys from the environment |
+| Authentication errors at request time | ADC not configured | Run `gcloud auth application-default login` or set `GOOGLE_APPLICATION_CREDENTIALS` |

--- a/docs/official_docs/index.md
+++ b/docs/official_docs/index.md
@@ -134,6 +134,10 @@ Long-term memory that outlives a session — the persistent counterpart to sessi
 - [Memory](security/memory.md) - Long-term semantic memory for agents
 - [Payments and Commerce](security/payments.md) - Agentic commerce journeys, protocol support, and validation paths
 
+## Compliance
+
+- [Vertex-Only Deployments](compliance/vertex-only-deployments.md) - Guarantee no Gemini Studio (`generativelanguage.googleapis.com`) traffic for HIPAA and data-residency workloads
+
 ## Studio
 
 - [ADK Studio](studio/studio.md) - Visual development environment for building agents

--- a/examples/a2a_quickstart/Cargo.lock
+++ b/examples/a2a_quickstart/Cargo.lock
@@ -294,6 +294,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -974,7 +975,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2451,7 +2452,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3423,7 +3424,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/examples/acp_kiro/Cargo.lock
+++ b/examples/acp_kiro/Cargo.lock
@@ -142,6 +142,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/examples/anthropic_server_tools/Cargo.lock
+++ b/examples/anthropic_server_tools/Cargo.lock
@@ -284,6 +284,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -981,7 +982,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2481,7 +2482,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3453,7 +3454,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/examples/bedrock_test/Cargo.lock
+++ b/examples/bedrock_test/Cargo.lock
@@ -117,6 +117,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/examples/competitive_ergonomics/Cargo.lock
+++ b/examples/competitive_ergonomics/Cargo.lock
@@ -284,6 +284,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1027,7 +1028,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2573,7 +2574,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3555,7 +3556,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/examples/crate_adoption_feedback/Cargo.lock
+++ b/examples/crate_adoption_feedback/Cargo.lock
@@ -286,6 +286,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1085,7 +1086,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2944,7 +2945,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4271,7 +4272,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/examples/developer_ergonomics/Cargo.lock
+++ b/examples/developer_ergonomics/Cargo.lock
@@ -284,6 +284,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -986,7 +987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2474,7 +2475,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3446,7 +3447,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/examples/gemini3_builtin_tools/Cargo.lock
+++ b/examples/gemini3_builtin_tools/Cargo.lock
@@ -284,6 +284,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -964,7 +965,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2481,7 +2482,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3453,7 +3454,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/examples/gemini_audio/Cargo.lock
+++ b/examples/gemini_audio/Cargo.lock
@@ -306,6 +306,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1006,7 +1007,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2512,7 +2513,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3536,7 +3537,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/examples/mcp_elicitation/Cargo.lock
+++ b/examples/mcp_elicitation/Cargo.lock
@@ -355,6 +355,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1331,7 +1332,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1427,7 +1428,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2457,7 +2458,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2815,7 +2816,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3228,7 +3229,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3286,7 +3287,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3791,7 +3792,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4478,7 +4479,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/examples/mcp_resources/Cargo.lock
+++ b/examples/mcp_resources/Cargo.lock
@@ -355,6 +355,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -546,7 +547,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -557,7 +558,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1365,7 +1366,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1461,7 +1462,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2448,7 +2449,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2783,7 +2784,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3188,7 +3189,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3246,7 +3247,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3651,7 +3652,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3762,7 +3763,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4130,7 +4131,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4399,7 +4400,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/examples/mcp_sampling/Cargo.lock
+++ b/examples/mcp_sampling/Cargo.lock
@@ -355,6 +355,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1331,7 +1332,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1427,7 +1428,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2450,7 +2451,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2802,7 +2803,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3215,7 +3216,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3273,7 +3274,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3778,7 +3779,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4465,7 +4466,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/examples/multi_perspective_analysis/Cargo.lock
+++ b/examples/multi_perspective_analysis/Cargo.lock
@@ -284,6 +284,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -998,7 +999,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2054,7 +2055,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2453,7 +2454,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3387,7 +3388,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/examples/multimodal_function_response/Cargo.lock
+++ b/examples/multimodal_function_response/Cargo.lock
@@ -284,6 +284,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -964,7 +965,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2468,7 +2469,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3440,7 +3441,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/examples/ollama_qwen/Cargo.lock
+++ b/examples/ollama_qwen/Cargo.lock
@@ -286,6 +286,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -960,7 +961,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2482,7 +2483,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3461,7 +3462,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/examples/openai_background/Cargo.lock
+++ b/examples/openai_background/Cargo.lock
@@ -116,6 +116,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/examples/openai_builtin_tools/Cargo.lock
+++ b/examples/openai_builtin_tools/Cargo.lock
@@ -116,6 +116,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/examples/openai_conversations/Cargo.lock
+++ b/examples/openai_conversations/Cargo.lock
@@ -116,6 +116,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/examples/openai_deep_research/Cargo.lock
+++ b/examples/openai_deep_research/Cargo.lock
@@ -116,6 +116,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/examples/openai_open_responses/Cargo.lock
+++ b/examples/openai_open_responses/Cargo.lock
@@ -116,6 +116,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/examples/openai_responses/Cargo.lock
+++ b/examples/openai_responses/Cargo.lock
@@ -116,6 +116,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/examples/openai_server_tools/Cargo.lock
+++ b/examples/openai_server_tools/Cargo.lock
@@ -284,6 +284,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -964,7 +965,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2481,7 +2482,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3453,7 +3454,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/examples/openai_ws_minimal/Cargo.lock
+++ b/examples/openai_ws_minimal/Cargo.lock
@@ -117,6 +117,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/examples/openrouter/Cargo.lock
+++ b/examples/openrouter/Cargo.lock
@@ -115,6 +115,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/examples/skills_multilingual/Cargo.lock
+++ b/examples/skills_multilingual/Cargo.lock
@@ -124,6 +124,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/examples/tier_examples/Cargo.lock
+++ b/examples/tier_examples/Cargo.lock
@@ -429,6 +429,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]


### PR DESCRIPTION
- GeminiModel::from_env: Vertex via ADC when GOOGLE_GENAI_USE_ENTERPRISE or GOOGLE_GENAI_USE_VERTEXAI is truthy; Studio API-key path otherwise
- provider_from_env() consults the flags before API-key sniffing (intended behavioral change, CHANGELOG'd prominently)
- warn! guard rail + compliance/vertex-only-deployments.md docs page

## What

Environment-driven Vertex configuration:

- `GeminiModel::from_env(model)` — builds a Vertex AI client via Application Default Credentials when `GOOGLE_GENAI_USE_ENTERPRISE` or `GOOGLE_GENAI_USE_VERTEXAI` is truthy (`1` or case-insensitive `true`), using `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION`; otherwise a Gemini API client from `GOOGLE_API_KEY` / `GEMINI_API_KEY`.
- `adk_model::gemini::vertex_env_requested()` — reports the flag decision; `GOOGLE_GENAI_USE_ENTERPRISE` takes precedence when both are set.
- **Behavioral change:** `provider_from_env()` consults the Vertex flags **before** any API-key sniffing. A truthy flag selects Gemini on Vertex AI even when `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `GOOGLE_API_KEY` is set. Behavior is unchanged when neither flag is set.
- Guard rail: `provider_from_env()` emits a `tracing` warning when a Vertex flag is truthy but the `gemini-vertex` feature is not compiled and detection falls through to API keys (the only path where Studio can be selected with a flag set).
- New docs page `docs/official_docs/compliance/vertex-only-deployments.md`: guaranteeing no `generativelanguage.googleapis.com` traffic (flag, feature, ADC, verification via the warn log), registered in the docs index.

## Why

Part of #438

Regulated workloads (HIPAA, data residency) must route Gemini traffic through Vertex AI only — the Studio endpoint is not covered by a Google Cloud BAA. adk-python already honors these flags; this brings ADK-Rust to parity and makes the opt-in authoritative over stray API keys. `GOOGLE_GENAI_USE_VERTEXAI` stays honored without a deprecation warning — google/adk-python#6168 documents the churn such a warning caused.

## How

- Flag parsing treats `1` and case-insensitive `true` as truthy, empty values as unset; `GOOGLE_GENAI_USE_ENTERPRISE` wins when both flags are set.
- The Vertex path uses the existing `new_google_cloud_adc` constructor. A truthy flag with an incomplete Vertex target (`GOOGLE_CLOUD_PROJECT` / `GOOGLE_CLOUD_LOCATION`) is an `InvalidInput` error naming the missing variables — never a silent Studio fallback. A truthy flag without the `gemini-vertex` feature is an `Unsupported` error naming the feature.
- Tests serialize process-global env mutation with a shared `Mutex` and a save/clear/restore guard; cfg-gated modules cover both feature configurations. 12 new tests in `adk-model`, 6 in `adk-rust`.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings in all four configurations (adk-model/adk-rust × default/`gemini-vertex`)
- [x] `devenv shell test` — `adk-model`: 99 + 103 passed; `adk-rust`: 5 + 6 passed; 6 doctests pass
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (18 new env-scoped tests, mutex-serialized)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts
- [x] No unrelated changes mixed in
- [x] Branch naming follows convention (`feat/`)
- [x] Commit messages follow conventional format
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md — prominent `### Changed` entry for the precedence change
- [x] `adk-model/README.md` updated
- [x] New docs page `compliance/vertex-only-deployments.md`, registered in the docs index; `scripts/check-doc-examples.sh` passes (98 files)
