### PR TITLE
feat(telemetry): export traces and JSON logs to Google Cloud - PR 0.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,8 @@ jobs:
           - { package: adk-server, features: a2a-v1 }
           # Vertex AI sessions use an opt-in Google Cloud transport and wire contract.
           - { package: adk-session, features: vertex-session }
+          # Google Cloud telemetry export is an opt-in transport; no default build compiles it.
+          - { package: adk-telemetry, features: gcp }
           # ACP replay and server transport behavior are gated behind the opt-in server feature.
           - { package: adk-acp, features: server }
           # The Monty Python executors and the MontyPythonCodeTool live path: both gated,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Telemetry to Google Cloud** (`adk-telemetry` feature `gcp`, umbrella
+  `gcp-telemetry`, included in `gemini-agent-platform`). `init_with_gcp`
+  exports traces to `https://telemetry.googleapis.com` with per-request
+  `Authorization: Bearer` headers minted from Application Default Credentials
+  (refreshed in the background) plus `x-goog-user-project`. Resource
+  attributes (`service.name`, `gcp.project_id`,
+  `cloud.platform = gcp.agent_engine`) are detected from `K_SERVICE`,
+  `GOOGLE_CLOUD_PROJECT`, and `GOOGLE_CLOUD_AGENT_ENGINE_ID`.
+  `init_json_logging` emits Cloud Logging structured JSON (severity mapping,
+  `logging.googleapis.com/trace` correlation). A collector-sidecar fallback is
+  documented in `docs/official_docs/observability/gcp.md`.
+
 ## [2.0.0] - 2026-08-09
 
 ### Breaking

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1009,6 +1009,8 @@ dependencies = [
 name = "adk-telemetry"
 version = "2.0.0"
 dependencies = [
+ "google-cloud-auth 1.12.0",
+ "http 1.4.1",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
@@ -1017,6 +1019,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tonic 0.14.6",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -19026,6 +19029,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "webpki-roots 1.0.7",
  "zstd",
 ]
 

--- a/adk-rust/Cargo.toml
+++ b/adk-rust/Cargo.toml
@@ -83,12 +83,12 @@ gemini-agent-platform = [
     "gemini-vertex",  # Vertex model backend (adk-model → adk-gemini/vertex)
     "vertex-session", # managed Sessions (adk-session)
     "gcp-secrets",    # GCP Secret Manager (adk-auth)
+    "gcp-telemetry",  # Cloud Trace/Logging transport (adk-telemetry)
     # target end-state — appended by the PR that introduces each flag:
     # "agent-engine",           class-method runtime contract (adk-server)
     # "vertex-memory",          Memory Bank (adk-memory)
     # "example-store",          Example Store (adk-tool)
     # "gcs-artifacts",          GCS artifact backend (adk-artifact)
-    # "gcp-telemetry",          Cloud Trace/Logging transport (adk-telemetry)
     # "vertex-sandbox",         managed code-execution sandbox (adk-code)
     # "vertex-eval",            Gen AI Evaluation bridge (adk-eval)
     # "vertex-rag",             RAG Engine retrieval (adk-rag)
@@ -129,6 +129,7 @@ server = ["dep:adk-server", "adk-server/a2a-v1"]
 telemetry = ["dep:adk-telemetry"]
 telemetry-otlp = ["telemetry", "adk-telemetry/otlp"]
 telemetry-sqlite = ["telemetry", "adk-telemetry/sqlite"]
+gcp-telemetry = ["telemetry", "adk-telemetry/gcp"]
 graph = ["dep:adk-graph"]
 code = ["dep:adk-code"]
 sandbox = ["dep:adk-sandbox"]

--- a/adk-telemetry/Cargo.toml
+++ b/adk-telemetry/Cargo.toml
@@ -22,6 +22,10 @@ opentelemetry-otlp = { version = "0.32", features = ["metrics", "grpc-tonic"], o
 tracing-opentelemetry = { version = "0.33", optional = true }
 serde_json = { workspace = true, optional = true }
 rusqlite = { version = "0.32", features = ["bundled"], optional = true }
+google-cloud-auth = { version = "1.8", optional = true, default-features = false, features = ["default-rustls-provider"] }
+http = { version = "1", optional = true }
+tokio = { workspace = true, optional = true, features = ["rt", "time"] }
+tonic = { version = "0.14", optional = true, default-features = false, features = ["channel", "tls-aws-lc", "tls-webpki-roots"] }
 
 [features]
 default = ["genai-semconv"]
@@ -29,12 +33,27 @@ genai-semconv = []
 otlp = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp", "dep:tracing-opentelemetry"]
 metrics = ["otlp"]
 json = ["tracing-subscriber/json"]
+# Telemetry to Google Cloud: OTLP trace export to telemetry.googleapis.com with
+# ADC-minted auth headers, GCP resource detection, and Cloud Logging JSON output.
+# The TLS features are required because the Google endpoint is HTTPS-only;
+# tls-aws-lc keeps the workspace-wide aws-lc-rs rustls provider.
+gcp = [
+    "otlp",
+    "json",
+    "google-cloud-auth",
+    "http",
+    "tokio",
+    "tonic",
+    "dep:serde_json",
+    "opentelemetry-otlp/tls-aws-lc",
+    "opentelemetry-otlp/tls-webpki-roots",
+]
 # Direct span export to a local SQLite file — zero-infrastructure tracing
 # (no collector or backend to deploy). rusqlite is pinned to the release that
 # shares libsqlite3-sys with the workspace's sqlx crates (`links` allows one).
 sqlite = ["dep:rusqlite", "dep:serde_json"]
 
 [dev-dependencies]
-tokio = { version = "1.0", features = ["rt", "macros", "time"] }
+tokio = { workspace = true, features = ["rt", "macros", "time"] }
 proptest = "1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "registry"] }

--- a/adk-telemetry/README.md
+++ b/adk-telemetry/README.md
@@ -121,6 +121,41 @@ for session in reader.sessions()? {
 }
 ```
 
+## Telemetry to Google Cloud (`gcp` feature)
+
+Export traces straight to Google Cloud Observability and emit Cloud
+Logging-parseable JSON logs. `adk-rust` forwards it as `gcp-telemetry`,
+and the `gemini-agent-platform` meta-feature includes it:
+
+```toml
+adk-telemetry = { version = "2.0.0", features = ["gcp"] }
+```
+
+```rust
+use adk_telemetry::init_with_gcp;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Requires GOOGLE_CLOUD_PROJECT and Application Default Credentials.
+    init_with_gcp("my-agent").await?;
+
+    // Your agent code here...
+
+    adk_telemetry::shutdown_telemetry();
+    Ok(())
+}
+```
+
+Spans go to `https://telemetry.googleapis.com` with per-request
+`Authorization: Bearer` headers minted from ADC (refreshed in the
+background), plus `x-goog-user-project`. Resource attributes
+(`service.name`, `gcp.project_id`, `cloud.platform = gcp.agent_engine`) are
+detected from `K_SERVICE`, `GOOGLE_CLOUD_PROJECT`, and
+`GOOGLE_CLOUD_AGENT_ENGINE_ID`. `init_json_logging()` installs the Cloud
+Logging JSON format standalone. See
+[docs/official_docs/observability/gcp.md](../docs/official_docs/observability/gcp.md)
+for the collector-sidecar fallback.
+
 ## Available Functions
 
 | Function | Description |
@@ -129,6 +164,8 @@ for session in reader.sessions()? {
 | `init_with_otlp(service_name, endpoint)` | OTLP export to collectors |
 | `init_with_adk_exporter(service_name)` | ADK-style span exporter |
 | `init_with_sqlite(service_name, db_path)` | Direct SQLite span export (`sqlite` feature) |
+| `init_with_gcp(service_name)` | OTLP trace export to Google Cloud with ADC auth (`gcp` feature) |
+| `init_json_logging()` | Cloud Logging structured JSON on stdout (`gcp` feature) |
 | `shutdown_telemetry()` | Flush and shutdown |
 
 ## Span Helpers

--- a/adk-telemetry/src/gcp.rs
+++ b/adk-telemetry/src/gcp.rs
@@ -1,0 +1,812 @@
+//! Telemetry to Google Cloud.
+//!
+//! Three integration points, composable or standalone:
+//!
+//! - [`init_with_gcp`] — OTLP trace export straight to
+//!   `https://telemetry.googleapis.com` with `Authorization: Bearer` headers
+//!   minted from Application Default Credentials, plus Cloud Logging JSON
+//!   output on stdout.
+//! - [`init_json_logging`] — Cloud Logging structured JSON on stdout only
+//!   (severity mapping and trace correlation, no exporter).
+//! - [`gcp_resource_attributes`] — GCP resource detection from the environment
+//!   variables the platform sets in deployed containers.
+//!
+//! For environments without direct API access, export to a collector sidecar
+//! instead: `init_with_otlp("my-agent", "http://localhost:4317")` — see
+//! `docs/official_docs/observability/gcp.md`.
+
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+
+use google_cloud_auth::credentials::{self, CacheableResource, Credentials};
+use opentelemetry::KeyValue;
+use tonic::metadata::{AsciiMetadataKey, AsciiMetadataValue};
+use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
+
+use crate::init::{INIT, TelemetryError, otlp_pipeline};
+
+/// Google Cloud OTLP ingest endpoint (Telemetry API, gRPC over HTTPS).
+pub const GCP_OTLP_ENDPOINT: &str = "https://telemetry.googleapis.com";
+
+const CLOUD_PLATFORM_SCOPE: &str = "https://www.googleapis.com/auth/cloud-platform";
+const USER_PROJECT_HEADER: &str = "x-goog-user-project";
+
+/// Refresh cadence for the auth headers injected into exporter requests.
+/// `google-cloud-auth` caches tokens internally and only re-mints near expiry,
+/// so a short cadence costs nothing between refreshes.
+const HEADER_REFRESH_INTERVAL: Duration = Duration::from_secs(300);
+
+/// Project ID of the Google Cloud project receiving telemetry.
+const ENV_PROJECT: &str = "GOOGLE_CLOUD_PROJECT";
+/// Service name set by Cloud Run and other Knative-shaped runtimes.
+const ENV_K_SERVICE: &str = "K_SERVICE";
+/// Bare numeric engine ID set by Vertex AI Agent Engine in deployed containers.
+const ENV_AGENT_ENGINE_ID: &str = "GOOGLE_CLOUD_AGENT_ENGINE_ID";
+
+/// Cloud Logging structured-log field parsed for trace correlation.
+const LOG_TRACE_KEY: &str = "logging.googleapis.com/trace";
+const LOG_SPAN_ID_KEY: &str = "logging.googleapis.com/spanId";
+const LOG_TRACE_SAMPLED_KEY: &str = "logging.googleapis.com/trace_sampled";
+
+/// Supplies Google Cloud authorization headers for the OTLP exporter.
+///
+/// Wraps [`google_cloud_auth`] credentials and appends the
+/// `x-goog-user-project` header naming the project that receives (and is
+/// billed for) the telemetry.
+///
+/// # Example
+/// ```no_run
+/// use adk_telemetry::GcpHeaderSupplier;
+///
+/// # async fn example() -> Result<(), adk_telemetry::TelemetryError> {
+/// let supplier = GcpHeaderSupplier::new_with_adc("my-project")?;
+/// let headers = supplier.headers().await?;
+/// assert!(headers.iter().any(|(name, _)| name == "authorization"));
+/// # Ok(())
+/// # }
+/// ```
+pub struct GcpHeaderSupplier {
+    credentials: Credentials,
+    user_project: String,
+}
+
+impl GcpHeaderSupplier {
+    /// Creates a supplier using Application Default Credentials (ADC).
+    ///
+    /// # Errors
+    /// Returns [`TelemetryError::Init`] when ADC cannot be constructed — for
+    /// example when no credential source is available. Run
+    /// `gcloud auth application-default login` locally, or attach a service
+    /// account in deployed environments.
+    pub fn new_with_adc(user_project: impl Into<String>) -> Result<Self, TelemetryError> {
+        let credentials = credentials::Builder::default()
+            .with_scopes([CLOUD_PLATFORM_SCOPE])
+            .build()
+            .map_err(|e| {
+                TelemetryError::Init(format!(
+                    "failed to build application default credentials for gcp telemetry: {e}. \
+                     Run `gcloud auth application-default login` or attach a service account."
+                ))
+            })?;
+        Ok(Self::with_credentials(credentials, user_project))
+    }
+
+    /// Creates a supplier with explicit credentials.
+    pub fn with_credentials(credentials: Credentials, user_project: impl Into<String>) -> Self {
+        Self { credentials, user_project: user_project.into() }
+    }
+
+    /// Mints the current header set: the credential headers (typically
+    /// `authorization: Bearer …`) plus `x-goog-user-project`.
+    ///
+    /// # Errors
+    /// Returns [`TelemetryError::Init`] when the credential provider fails or
+    /// returns a non-printable header value.
+    pub async fn headers(&self) -> Result<Vec<(String, String)>, TelemetryError> {
+        let cacheable = self.credentials.headers(http::Extensions::new()).await.map_err(|e| {
+            TelemetryError::Init(format!("failed to mint gcp telemetry auth headers: {e}"))
+        })?;
+
+        let header_map = match cacheable {
+            CacheableResource::New { data, .. } => data,
+            // Unreachable with empty extensions (no entity tag was offered),
+            // kept as an error instead of a panic in case that changes upstream.
+            CacheableResource::NotModified => {
+                return Err(TelemetryError::Init(
+                    "gcp credentials returned NotModified without a prior cached header set"
+                        .to_string(),
+                ));
+            }
+        };
+
+        let mut headers = Vec::with_capacity(header_map.len() + 1);
+        for (name, value) in &header_map {
+            let value = value.to_str().map_err(|e| {
+                TelemetryError::Init(format!(
+                    "gcp credential header `{name}` is not printable ascii: {e}"
+                ))
+            })?;
+            headers.push((name.as_str().to_string(), value.to_string()));
+        }
+        headers.push((USER_PROJECT_HEADER.to_string(), self.user_project.clone()));
+        Ok(headers)
+    }
+}
+
+/// Per-request header injection for the tonic OTLP exporter.
+///
+/// The exporter's interceptor hook is synchronous, so headers are read from a
+/// shared slot that a background task refreshes via [`GcpHeaderSupplier`].
+#[derive(Clone)]
+struct AuthHeaderInterceptor {
+    headers: Arc<RwLock<Vec<(AsciiMetadataKey, AsciiMetadataValue)>>>,
+}
+
+impl AuthHeaderInterceptor {
+    fn new(headers: Vec<(AsciiMetadataKey, AsciiMetadataValue)>) -> Self {
+        Self { headers: Arc::new(RwLock::new(headers)) }
+    }
+
+    /// Spawns the token-refresh loop keeping the header slot current.
+    fn spawn_refresh(&self, supplier: GcpHeaderSupplier) {
+        let slot = self.headers.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(HEADER_REFRESH_INTERVAL);
+            interval.tick().await; // consume the immediate first tick
+            loop {
+                interval.tick().await;
+                match supplier.headers().await {
+                    Ok(headers) => match to_metadata_pairs(&headers) {
+                        Ok(pairs) => {
+                            *slot.write().unwrap_or_else(|p| p.into_inner()) = pairs;
+                            tracing::debug!("gcp otlp auth headers refreshed");
+                        }
+                        Err(e) => {
+                            tracing::warn!(error = %e, "gcp otlp auth header conversion failed");
+                        }
+                    },
+                    Err(e) => {
+                        tracing::warn!(error = %e, "gcp otlp auth header refresh failed");
+                    }
+                }
+            }
+        });
+    }
+}
+
+impl tonic::service::Interceptor for AuthHeaderInterceptor {
+    fn call(
+        &mut self,
+        mut request: tonic::Request<()>,
+    ) -> Result<tonic::Request<()>, tonic::Status> {
+        let headers = self.headers.read().unwrap_or_else(|p| p.into_inner());
+        for (key, value) in headers.iter() {
+            request.metadata_mut().insert(key.clone(), value.clone());
+        }
+        Ok(request)
+    }
+}
+
+/// Converts string header pairs into pre-parsed tonic metadata so the
+/// per-request interceptor never parses on the hot path.
+fn to_metadata_pairs(
+    headers: &[(String, String)],
+) -> Result<Vec<(AsciiMetadataKey, AsciiMetadataValue)>, TelemetryError> {
+    headers
+        .iter()
+        .map(|(name, value)| {
+            let key = name.parse::<AsciiMetadataKey>().map_err(|e| {
+                TelemetryError::Init(format!("invalid gcp telemetry header name `{name}`: {e}"))
+            })?;
+            let value = value.parse::<AsciiMetadataValue>().map_err(|e| {
+                TelemetryError::Init(format!(
+                    "invalid gcp telemetry header value for `{name}`: {e}"
+                ))
+            })?;
+            Ok((key, value))
+        })
+        .collect()
+}
+
+/// Exporter hook injecting TLS roots and the auth interceptor.
+struct GcpExporterHook {
+    interceptor: AuthHeaderInterceptor,
+}
+
+impl otlp_pipeline::ExporterHook for GcpExporterHook {
+    fn configure<B: opentelemetry_otlp::WithTonicConfig>(&self, builder: B) -> B {
+        builder
+            .with_tls_config(tonic::transport::ClientTlsConfig::new().with_enabled_roots())
+            .with_interceptor(self.interceptor.clone())
+    }
+}
+
+/// Detects GCP resource attributes from the environment.
+///
+/// | Attribute | Source |
+/// |-----------|--------|
+/// | `service.name` | `K_SERVICE`, else `GOOGLE_CLOUD_AGENT_ENGINE_ID`, else `fallback_service_name` |
+/// | `gcp.project_id` | `GOOGLE_CLOUD_PROJECT` (omitted when unset) |
+/// | `cloud.platform` | `gcp.agent_engine` when `GOOGLE_CLOUD_AGENT_ENGINE_ID` is set |
+///
+/// `GOOGLE_CLOUD_AGENT_ENGINE_ID` is the bare numeric engine ID that Vertex AI
+/// Agent Engine sets in deployed containers.
+///
+/// # Example
+/// ```
+/// use adk_telemetry::gcp_resource_attributes;
+///
+/// let attributes = gcp_resource_attributes("my-agent");
+/// assert!(attributes.iter().any(|kv| kv.key.as_str() == "service.name"));
+/// ```
+pub fn gcp_resource_attributes(fallback_service_name: &str) -> Vec<KeyValue> {
+    let non_empty = |name: &str| std::env::var(name).ok().filter(|v| !v.is_empty());
+    let k_service = non_empty(ENV_K_SERVICE);
+    let engine_id = non_empty(ENV_AGENT_ENGINE_ID);
+    let project_id = non_empty(ENV_PROJECT);
+
+    let service_name = k_service
+        .or_else(|| engine_id.clone())
+        .unwrap_or_else(|| fallback_service_name.to_string());
+
+    let mut attributes = vec![KeyValue::new("service.name", service_name)];
+    if let Some(project_id) = project_id {
+        attributes.push(KeyValue::new("gcp.project_id", project_id));
+    }
+    if engine_id.is_some() {
+        // `gcp.agent_engine` is the canonical OpenTelemetry semconv value for
+        // Vertex AI Agent Engine, added upstream in
+        // open-telemetry/semantic-conventions#2957 (Oct 2025).
+        attributes.push(KeyValue::new("cloud.platform", "gcp.agent_engine"));
+    }
+    attributes
+}
+
+/// Initialize telemetry with OTLP trace export to Google Cloud.
+///
+/// Exports spans to [`GCP_OTLP_ENDPOINT`] with `Authorization: Bearer` headers
+/// minted from Application Default Credentials and an `x-goog-user-project`
+/// header, and writes Cloud Logging structured JSON to stdout (see
+/// [`init_json_logging`] for the log format). Resource attributes come from
+/// [`gcp_resource_attributes`].
+///
+/// Headers are injected per request through a tonic interceptor; a background
+/// task re-mints them every five minutes, so exports keep authenticating
+/// across token expiry in long-running processes.
+///
+/// Requires `GOOGLE_CLOUD_PROJECT` to name the project that receives the
+/// telemetry. Metrics are not exported on this path — route them through a
+/// collector sidecar with [`init_with_otlp`](crate::init_with_otlp) instead.
+///
+/// # Errors
+/// Returns [`TelemetryError::Init`] when `GOOGLE_CLOUD_PROJECT` is unset, ADC
+/// is unavailable, the initial token mint fails, or the exporter cannot be
+/// built.
+///
+/// # Example
+/// ```no_run
+/// # #[tokio::main]
+/// # async fn main() -> Result<(), adk_telemetry::TelemetryError> {
+/// adk_telemetry::init_with_gcp("my-agent").await?;
+/// // ... run the agent ...
+/// adk_telemetry::shutdown_telemetry();
+/// # Ok(())
+/// # }
+/// ```
+pub async fn init_with_gcp(service_name: &str) -> Result<(), TelemetryError> {
+    let project_id =
+        std::env::var(ENV_PROJECT).ok().filter(|v| !v.is_empty()).ok_or_else(|| {
+            TelemetryError::Init(format!(
+                "{ENV_PROJECT} must be set to the project that receives telemetry"
+            ))
+        })?;
+
+    let supplier = GcpHeaderSupplier::new_with_adc(&project_id)?;
+    // Fail fast at init when no token can be minted at all.
+    let initial = supplier.headers().await?;
+    let interceptor = AuthHeaderInterceptor::new(to_metadata_pairs(&initial)?);
+    interceptor.spawn_refresh(supplier);
+
+    let resource = opentelemetry_sdk::Resource::builder_empty()
+        .with_attributes(gcp_resource_attributes(service_name))
+        .build();
+    let tracer =
+        otlp_pipeline::build_tracer(resource, GCP_OTLP_ENDPOINT, &GcpExporterHook { interceptor })?;
+
+    let service_name = service_name.to_string();
+    INIT.call_once(move || {
+        let filter = EnvFilter::try_from_default_env()
+            .or_else(|_| EnvFilter::try_new("info"))
+            .unwrap_or_else(|_| EnvFilter::new("info"));
+
+        tracing_subscriber::registry()
+            .with(filter)
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .json()
+                    .event_format(CloudLoggingJsonFormat::new(Some(project_id))),
+            )
+            .with(tracing_opentelemetry::OpenTelemetryLayer::new(tracer))
+            .init();
+
+        tracing::info!(
+            service.name = service_name,
+            otlp.endpoint = GCP_OTLP_ENDPOINT,
+            "telemetry initialized with google cloud otlp export"
+        );
+    });
+
+    Ok(())
+}
+
+/// Initialize structured JSON logging for Cloud Logging.
+///
+/// Writes one JSON object per line to stdout using
+/// [`CloudLoggingJsonFormat`], so Cloud Logging parses severity, message, and
+/// trace correlation fields instead of showing opaque text payloads. The trace
+/// resource name uses `GOOGLE_CLOUD_PROJECT` when set.
+///
+/// Trace correlation fields are emitted when an OpenTelemetry layer is active
+/// in the subscriber — [`init_with_gcp`] installs both; this function installs
+/// logging only.
+///
+/// # Errors
+/// Currently infallible; returns `Result` for signature stability with the
+/// other `init_*` functions.
+///
+/// # Example
+/// ```
+/// use adk_telemetry::init_json_logging;
+///
+/// init_json_logging().expect("failed to initialize json logging");
+/// tracing::info!(user.id = "u1", "request handled");
+/// ```
+pub fn init_json_logging() -> Result<(), TelemetryError> {
+    let project_id = std::env::var(ENV_PROJECT).ok().filter(|v| !v.is_empty());
+    INIT.call_once(move || {
+        let filter = EnvFilter::try_from_default_env()
+            .or_else(|_| EnvFilter::try_new("info"))
+            .unwrap_or_else(|_| EnvFilter::new("info"));
+
+        tracing_subscriber::registry()
+            .with(filter)
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .json()
+                    .event_format(CloudLoggingJsonFormat::new(project_id)),
+            )
+            .init();
+
+        tracing::info!("telemetry initialized with cloud logging json output");
+    });
+    Ok(())
+}
+
+/// Maps a tracing level to its Cloud Logging severity name.
+///
+/// Cloud Logging has no `TRACE` severity and spells warnings `WARNING`;
+/// everything else matches the tracing name.
+fn cloud_severity(level: tracing::Level) -> &'static str {
+    // `tracing::Level` is not pattern-matchable (associated constants on an
+    // opaque struct), so this is an equality chain rather than a `match`.
+    if level == tracing::Level::ERROR {
+        "ERROR"
+    } else if level == tracing::Level::WARN {
+        "WARNING"
+    } else if level == tracing::Level::INFO {
+        "INFO"
+    } else {
+        "DEBUG"
+    }
+}
+
+/// Formats the Cloud Logging trace resource name for a trace ID.
+fn cloud_trace_resource(project_id: &str, trace_id: &opentelemetry::trace::TraceId) -> String {
+    format!("projects/{project_id}/traces/{trace_id}")
+}
+
+/// Event formatter emitting Cloud Logging structured JSON.
+///
+/// One JSON object per line with:
+///
+/// | Field | Content |
+/// |-------|---------|
+/// | `timestamp` | RFC 3339 event time |
+/// | `severity` | Cloud Logging severity mapped from the tracing level |
+/// | `message` | The event message |
+/// | `target` | The tracing target |
+/// | `logging.googleapis.com/trace` | `projects/{project}/traces/{trace_id}` from the active OpenTelemetry span |
+/// | `logging.googleapis.com/spanId` | Span ID from the active OpenTelemetry span |
+/// | `logging.googleapis.com/trace_sampled` | Sampling decision |
+/// | *(event fields)* | Each field as a typed JSON value |
+/// | *(span fields)* | Fields of in-scope spans (innermost wins, never overrides event fields) |
+///
+/// Trace fields are only present when a `tracing-opentelemetry` layer is
+/// registered in the same subscriber and the event fires inside a span.
+///
+/// # Example
+/// ```
+/// use adk_telemetry::CloudLoggingJsonFormat;
+/// use tracing_subscriber::layer::SubscriberExt;
+///
+/// let subscriber = tracing_subscriber::registry().with(
+///     tracing_subscriber::fmt::layer()
+///         .json()
+///         .event_format(CloudLoggingJsonFormat::new(Some("my-project".to_string()))),
+/// );
+/// ```
+pub struct CloudLoggingJsonFormat {
+    project_id: Option<String>,
+}
+
+impl CloudLoggingJsonFormat {
+    /// Creates a formatter. `project_id` is required for the
+    /// `logging.googleapis.com/trace` resource name; without it, only the
+    /// span ID and sampling fields are emitted.
+    pub fn new(project_id: Option<String>) -> Self {
+        Self { project_id }
+    }
+}
+
+impl<S, N> tracing_subscriber::fmt::FormatEvent<S, N> for CloudLoggingJsonFormat
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+    N: for<'a> tracing_subscriber::fmt::FormatFields<'a> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &tracing_subscriber::fmt::FmtContext<'_, S, N>,
+        mut writer: tracing_subscriber::fmt::format::Writer<'_>,
+        event: &tracing::Event<'_>,
+    ) -> std::fmt::Result {
+        use tracing_subscriber::fmt::time::FormatTime;
+
+        let mut fields = serde_json::Map::new();
+
+        let mut timestamp = String::new();
+        if tracing_subscriber::fmt::time::SystemTime
+            .format_time(&mut tracing_subscriber::fmt::format::Writer::new(&mut timestamp))
+            .is_ok()
+        {
+            fields.insert("timestamp".to_string(), serde_json::Value::String(timestamp));
+        }
+
+        let metadata = event.metadata();
+        fields.insert(
+            "severity".to_string(),
+            serde_json::Value::String(cloud_severity(*metadata.level()).to_string()),
+        );
+        fields
+            .insert("target".to_string(), serde_json::Value::String(metadata.target().to_string()));
+
+        let mut visitor = JsonFieldVisitor::default();
+        event.record(&mut visitor);
+        if let Some(message) = visitor.message {
+            fields.insert("message".to_string(), message);
+        }
+        for (name, value) in visitor.fields {
+            fields.insert(name, value);
+        }
+
+        // Trace correlation from the active OpenTelemetry span, when a
+        // tracing-opentelemetry layer is registered in this subscriber.
+        let otel_context =
+            tracing_opentelemetry::OpenTelemetrySpanExt::context(&tracing::Span::current());
+        let otel_span = opentelemetry::trace::TraceContextExt::span(&otel_context);
+        let span_context = otel_span.span_context();
+        if span_context.is_valid() {
+            if let Some(project_id) = &self.project_id {
+                fields.insert(
+                    LOG_TRACE_KEY.to_string(),
+                    serde_json::Value::String(cloud_trace_resource(
+                        project_id,
+                        &span_context.trace_id(),
+                    )),
+                );
+            }
+            fields.insert(
+                LOG_SPAN_ID_KEY.to_string(),
+                serde_json::Value::String(span_context.span_id().to_string()),
+            );
+            fields.insert(
+                LOG_TRACE_SAMPLED_KEY.to_string(),
+                serde_json::Value::Bool(span_context.is_sampled()),
+            );
+        }
+
+        // Span fields recorded by the fmt layer's JSON field formatter.
+        // Innermost span first; existing keys (event fields) are never overridden.
+        if let Some(scope) = ctx.event_scope() {
+            for span in scope {
+                let extensions = span.extensions();
+                let Some(formatted) =
+                    extensions.get::<tracing_subscriber::fmt::FormattedFields<N>>()
+                else {
+                    continue;
+                };
+                let Ok(span_fields) = serde_json::from_str::<
+                    serde_json::Map<String, serde_json::Value>,
+                >(&formatted.fields) else {
+                    continue;
+                };
+                for (name, value) in span_fields {
+                    fields.entry(name).or_insert(value);
+                }
+            }
+        }
+
+        writeln!(writer, "{}", serde_json::Value::Object(fields))
+    }
+}
+
+/// Collects event fields into typed JSON values, separating `message`.
+#[derive(Default)]
+struct JsonFieldVisitor {
+    message: Option<serde_json::Value>,
+    fields: Vec<(String, serde_json::Value)>,
+}
+
+impl JsonFieldVisitor {
+    fn record(&mut self, field: &tracing::field::Field, value: serde_json::Value) {
+        if field.name() == "message" {
+            self.message = Some(value);
+        } else {
+            self.fields.push((field.name().to_string(), value));
+        }
+    }
+}
+
+impl tracing::field::Visit for JsonFieldVisitor {
+    fn record_f64(&mut self, field: &tracing::field::Field, value: f64) {
+        self.record(field, serde_json::json!(value));
+    }
+
+    fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
+        self.record(field, serde_json::json!(value));
+    }
+
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        self.record(field, serde_json::json!(value));
+    }
+
+    fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
+        self.record(field, serde_json::json!(value));
+    }
+
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        self.record(field, serde_json::Value::String(value.to_string()));
+    }
+
+    fn record_error(
+        &mut self,
+        field: &tracing::field::Field,
+        value: &(dyn std::error::Error + 'static),
+    ) {
+        self.record(field, serde_json::Value::String(value.to_string()));
+    }
+
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        self.record(field, serde_json::Value::String(format!("{value:?}")));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use google_cloud_auth::credentials::{CredentialsProvider, EntityTag};
+    use std::sync::Mutex;
+
+    /// Serializes env-var mutation across tests. `cargo nextest` isolates each
+    /// test in its own process, but plain `cargo test` shares one.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_env(vars: &[(&str, Option<&str>)], f: impl FnOnce()) {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let saved: Vec<(&str, Option<String>)> =
+            vars.iter().map(|(name, _)| (*name, std::env::var(name).ok())).collect();
+        // SAFETY: mutation is serialized by ENV_LOCK and scoped to this helper.
+        for (name, value) in vars {
+            match value {
+                Some(value) => unsafe { std::env::set_var(name, value) },
+                None => unsafe { std::env::remove_var(name) },
+            }
+        }
+        f();
+        for (name, value) in saved {
+            match value {
+                Some(value) => unsafe { std::env::set_var(name, value) },
+                None => unsafe { std::env::remove_var(name) },
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    struct FakeCredentials;
+
+    impl CredentialsProvider for FakeCredentials {
+        fn headers(
+            &self,
+            _extensions: http::Extensions,
+        ) -> impl std::future::Future<
+            Output = std::result::Result<
+                CacheableResource<http::HeaderMap>,
+                google_cloud_auth::errors::CredentialsError,
+            >,
+        > + Send {
+            let mut data = http::HeaderMap::new();
+            data.insert(
+                http::header::AUTHORIZATION,
+                http::HeaderValue::from_static("Bearer fake-token"),
+            );
+            std::future::ready(Ok(CacheableResource::New { entity_tag: EntityTag::new(), data }))
+        }
+
+        fn universe_domain(&self) -> impl std::future::Future<Output = Option<String>> + Send {
+            std::future::ready(None)
+        }
+    }
+
+    #[tokio::test]
+    async fn header_supplier_mints_authorization_and_user_project() {
+        let supplier =
+            GcpHeaderSupplier::with_credentials(Credentials::from(FakeCredentials), "test-project");
+        let headers = supplier.headers().await.expect("mint headers");
+        assert_eq!(
+            headers,
+            vec![
+                ("authorization".to_string(), "Bearer fake-token".to_string()),
+                ("x-goog-user-project".to_string(), "test-project".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn interceptor_injects_headers_per_request() {
+        use tonic::service::Interceptor;
+
+        let pairs = to_metadata_pairs(&[
+            ("authorization".to_string(), "Bearer fake-token".to_string()),
+            ("x-goog-user-project".to_string(), "test-project".to_string()),
+        ])
+        .expect("convert headers");
+        let mut interceptor = AuthHeaderInterceptor::new(pairs);
+
+        let request = interceptor.call(tonic::Request::new(())).expect("intercept");
+        let metadata = request.metadata();
+        assert_eq!(
+            metadata.get("authorization").and_then(|v| v.to_str().ok()),
+            Some("Bearer fake-token")
+        );
+        assert_eq!(
+            metadata.get("x-goog-user-project").and_then(|v| v.to_str().ok()),
+            Some("test-project")
+        );
+    }
+
+    #[test]
+    fn metadata_conversion_rejects_invalid_header_names() {
+        let result = to_metadata_pairs(&[("not a header".to_string(), "value".to_string())]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn resource_attributes_prefer_k_service_and_detect_agent_engine() {
+        with_env(
+            &[
+                (ENV_PROJECT, Some("my-project")),
+                (ENV_K_SERVICE, Some("my-run-service")),
+                (ENV_AGENT_ENGINE_ID, Some("1234567890")),
+            ],
+            || {
+                assert_eq!(
+                    gcp_resource_attributes("fallback"),
+                    vec![
+                        KeyValue::new("service.name", "my-run-service"),
+                        KeyValue::new("gcp.project_id", "my-project"),
+                        KeyValue::new("cloud.platform", "gcp.agent_engine"),
+                    ]
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn resource_attributes_fall_back_to_engine_id_then_argument() {
+        with_env(
+            &[
+                (ENV_PROJECT, None),
+                (ENV_K_SERVICE, None),
+                (ENV_AGENT_ENGINE_ID, Some("1234567890")),
+            ],
+            || {
+                assert_eq!(
+                    gcp_resource_attributes("fallback"),
+                    vec![
+                        KeyValue::new("service.name", "1234567890"),
+                        KeyValue::new("cloud.platform", "gcp.agent_engine"),
+                    ]
+                );
+            },
+        );
+        with_env(
+            &[(ENV_PROJECT, None), (ENV_K_SERVICE, None), (ENV_AGENT_ENGINE_ID, None)],
+            || {
+                assert_eq!(
+                    gcp_resource_attributes("fallback"),
+                    vec![KeyValue::new("service.name", "fallback")]
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn severity_mapping_matches_cloud_logging_names() {
+        assert_eq!(cloud_severity(tracing::Level::TRACE), "DEBUG");
+        assert_eq!(cloud_severity(tracing::Level::DEBUG), "DEBUG");
+        assert_eq!(cloud_severity(tracing::Level::INFO), "INFO");
+        assert_eq!(cloud_severity(tracing::Level::WARN), "WARNING");
+        assert_eq!(cloud_severity(tracing::Level::ERROR), "ERROR");
+    }
+
+    #[test]
+    fn trace_resource_name_uses_project_and_trace_id() {
+        let trace_id = opentelemetry::trace::TraceId::from_hex("0123456789abcdef0123456789abcdef")
+            .expect("valid trace id");
+        assert_eq!(
+            cloud_trace_resource("my-project", &trace_id),
+            "projects/my-project/traces/0123456789abcdef0123456789abcdef"
+        );
+    }
+
+    #[derive(Clone, Default)]
+    struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+
+    impl std::io::Write for SharedBuf {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap_or_else(|p| p.into_inner()).extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for SharedBuf {
+        type Writer = SharedBuf;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    #[test]
+    fn json_format_emits_cloud_logging_fields() {
+        let buf = SharedBuf::default();
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_subscriber::fmt::layer()
+                .json()
+                .event_format(CloudLoggingJsonFormat::new(Some("my-project".to_string())))
+                .with_writer(buf.clone()),
+        );
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!("request", request.id = "r1");
+            let _enter = span.enter();
+            tracing::warn!(status.code = 429, "rate limited");
+        });
+
+        let output = String::from_utf8(buf.0.lock().unwrap_or_else(|p| p.into_inner()).clone())
+            .expect("utf8 output");
+        let line = output.lines().next().expect("one log line");
+        let value: serde_json::Value = serde_json::from_str(line).expect("valid json");
+
+        assert_eq!(value["severity"], "WARNING");
+        assert_eq!(value["message"], "rate limited");
+        assert_eq!(value["status.code"], 429);
+        assert_eq!(value["request.id"], "r1");
+        assert!(value["timestamp"].is_string());
+        // No OpenTelemetry layer registered, so no trace correlation fields.
+        assert!(value.get(LOG_TRACE_KEY).is_none());
+    }
+}

--- a/adk-telemetry/src/init.rs
+++ b/adk-telemetry/src/init.rs
@@ -5,7 +5,7 @@ use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitEx
 
 use crate::span_exporter::{AdkSpanExporter, AdkSpanLayer};
 
-static INIT: Once = Once::new();
+pub(crate) static INIT: Once = Once::new();
 
 /// Error returned by telemetry initialization functions.
 #[derive(Debug, thiserror::Error)]
@@ -152,6 +152,59 @@ pub fn init_with_otlp(service_name: &str, endpoint: &str) -> Result<(), Telemetr
     Ok(())
 }
 
+/// The tonic OTLP pipeline with a configuration hook on each exporter builder.
+///
+/// The hook is the seam that lets the `gcp` module inject TLS settings and a
+/// per-request auth interceptor without duplicating the exporter/provider
+/// plumbing shared with [`build_otlp_layer`].
+#[cfg(feature = "otlp")]
+pub(crate) mod otlp_pipeline {
+    use super::TelemetryError;
+    use opentelemetry::trace::TracerProvider;
+    use opentelemetry_otlp::{WithExportConfig, WithTonicConfig};
+
+    /// Configures a tonic exporter builder before it is built.
+    pub(crate) trait ExporterHook {
+        /// Returns the builder with hook-specific configuration applied.
+        fn configure<B: WithTonicConfig>(&self, builder: B) -> B;
+    }
+
+    /// Hook that leaves the builder unchanged — the plain-collector path.
+    pub(crate) struct NoopHook;
+
+    impl ExporterHook for NoopHook {
+        fn configure<B: WithTonicConfig>(&self, builder: B) -> B {
+            builder
+        }
+    }
+
+    /// Builds the OTLP span pipeline (exporter → batch tracer provider →
+    /// global registration) and returns a tracer for layer construction.
+    pub(crate) fn build_tracer<H: ExporterHook>(
+        resource: opentelemetry_sdk::Resource,
+        endpoint: &str,
+        hook: &H,
+    ) -> Result<opentelemetry_sdk::trace::SdkTracer, TelemetryError> {
+        let span_exporter = hook
+            .configure(
+                opentelemetry_otlp::SpanExporter::builder().with_tonic().with_endpoint(endpoint),
+            )
+            .build()
+            .map_err(|e| {
+                TelemetryError::Init(format!("failed to build OTLP span exporter: {e}"))
+            })?;
+
+        let tracer_provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+            .with_batch_exporter(span_exporter)
+            .with_resource(resource)
+            .build();
+
+        let tracer = tracer_provider.tracer("adk-telemetry");
+        opentelemetry::global::set_tracer_provider(tracer_provider);
+        Ok(tracer)
+    }
+}
+
 /// Build an OTLP tracing layer without initializing a global subscriber.
 ///
 /// Returns a boxed [`tracing_subscriber::Layer`] that can be composed with any
@@ -197,7 +250,6 @@ where
         + Send
         + Sync,
 {
-    use opentelemetry::trace::TracerProvider;
     use opentelemetry_otlp::WithExportConfig;
     use tracing_opentelemetry::OpenTelemetryLayer;
 
@@ -205,21 +257,7 @@ where
         .with_attributes([opentelemetry::KeyValue::new("service.name", service_name.to_string())])
         .build();
 
-    // Build OTLP span exporter
-    let span_exporter = opentelemetry_otlp::SpanExporter::builder()
-        .with_tonic()
-        .with_endpoint(endpoint)
-        .build()
-        .map_err(|e| TelemetryError::Init(format!("failed to build OTLP span exporter: {e}")))?;
-
-    // Build tracer provider with batch exporter
-    let tracer_provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
-        .with_batch_exporter(span_exporter)
-        .with_resource(resource.clone())
-        .build();
-
-    let tracer = tracer_provider.tracer("adk-telemetry");
-    opentelemetry::global::set_tracer_provider(tracer_provider);
+    let tracer = otlp_pipeline::build_tracer(resource.clone(), endpoint, &otlp_pipeline::NoopHook)?;
 
     // Build OTLP metric exporter
     let metric_exporter = opentelemetry_otlp::MetricExporter::builder()

--- a/adk-telemetry/src/lib.rs
+++ b/adk-telemetry/src/lib.rs
@@ -35,6 +35,10 @@ pub mod spans;
 #[cfg(feature = "sqlite")]
 pub mod sqlite;
 
+// Telemetry to Google Cloud (feature-gated)
+#[cfg(feature = "gcp")]
+pub mod gcp;
+
 // GenAI Semantic Conventions module (feature-gated)
 #[cfg(feature = "genai-semconv")]
 pub mod semconv;
@@ -57,6 +61,11 @@ pub use spans::*;
 pub use span_exporter::*;
 
 // Re-export init functions and error type
+#[cfg(feature = "gcp")]
+pub use gcp::{
+    CloudLoggingJsonFormat, GCP_OTLP_ENDPOINT, GcpHeaderSupplier, gcp_resource_attributes,
+    init_json_logging, init_with_gcp,
+};
 #[cfg(feature = "sqlite")]
 pub use init::init_with_sqlite;
 pub use init::{TelemetryError, init_telemetry, init_with_adk_exporter, shutdown_telemetry};

--- a/docs/official_docs/observability/gcp.md
+++ b/docs/official_docs/observability/gcp.md
@@ -1,0 +1,168 @@
+# Telemetry to Google Cloud
+
+The `gcp` feature of `adk-telemetry` exports traces directly to Google Cloud Observability (Cloud Trace) and writes structured JSON logs that Cloud Logging parses natively — severity, message, and trace correlation included.
+
+## Enable the Feature
+
+```toml
+[dependencies]
+adk-telemetry = { version = "2.0.0", features = ["gcp"] }
+```
+
+Or through the umbrella crate (`gcp-telemetry` is also part of the `gemini-agent-platform` meta-feature):
+
+```toml
+[dependencies]
+adk-rust = { version = "2.0.0", features = ["minimal", "gcp-telemetry"] }
+```
+
+## Direct Export to Google Cloud
+
+`init_with_gcp` exports spans to `https://telemetry.googleapis.com` over gRPC, authenticating each request with a Bearer token minted from Application Default Credentials (ADC) plus an `x-goog-user-project` header. A background task re-mints the token every five minutes, so long-running agents keep exporting across token expiry.
+
+```rust
+use adk_telemetry::init_with_gcp;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Requires GOOGLE_CLOUD_PROJECT and Application Default Credentials.
+    init_with_gcp("my-agent").await?;
+
+    // Your agent code here
+
+    adk_telemetry::shutdown_telemetry();
+    Ok(())
+}
+```
+
+Requirements:
+
+| Requirement | How |
+|-------------|-----|
+| `GOOGLE_CLOUD_PROJECT` | Set to the project that receives (and is billed for) the telemetry |
+| Credentials | `gcloud auth application-default login` locally, or an attached service account when deployed |
+| API | Enable the Telemetry API (`telemetry.googleapis.com`) on the project |
+| IAM | The principal needs the `telemetry.traces.write` permission (`roles/telemetry.tracesWriter`) |
+
+> **Note:** This path exports traces only. Route metrics through the collector sidecar below.
+
+## GCP Resource Detection
+
+`init_with_gcp` derives OpenTelemetry resource attributes from the environment variables the platform sets in deployed containers:
+
+| Attribute | Source |
+|-----------|--------|
+| `service.name` | `K_SERVICE`, else `GOOGLE_CLOUD_AGENT_ENGINE_ID`, else the `service_name` argument |
+| `gcp.project_id` | `GOOGLE_CLOUD_PROJECT` (omitted when unset) |
+| `cloud.platform` | `gcp.agent_engine` when `GOOGLE_CLOUD_AGENT_ENGINE_ID` is set |
+
+`GOOGLE_CLOUD_AGENT_ENGINE_ID` is the bare numeric engine ID that Vertex AI Agent Engine sets in deployed containers. `gcp.agent_engine` is the canonical `cloud.platform` value from the OpenTelemetry semantic conventions (added upstream in October 2025).
+
+The same detection is available standalone for composing your own pipeline:
+
+```rust
+use adk_telemetry::gcp_resource_attributes;
+
+let attributes = gcp_resource_attributes("my-agent");
+```
+
+## Structured JSON Logging for Cloud Logging
+
+`init_json_logging` writes one JSON object per line to stdout, so Cloud Logging parses severity and trace fields instead of showing opaque text payloads. `init_with_gcp` installs the same format automatically.
+
+```rust
+use adk_telemetry::init_json_logging;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    init_json_logging()?;
+
+    tracing::info!(user.id = "u1", "request handled");
+    Ok(())
+}
+```
+
+Emitted fields:
+
+| Field | Content |
+|-------|---------|
+| `timestamp` | RFC 3339 event time |
+| `severity` | `DEBUG` / `INFO` / `WARNING` / `ERROR` (tracing `trace` and `debug` both map to `DEBUG`, `warn` maps to `WARNING`) |
+| `message` | The event message |
+| `target` | The tracing target |
+| `logging.googleapis.com/trace` | `projects/{project}/traces/{trace_id}` from the active OpenTelemetry span |
+| `logging.googleapis.com/spanId` | Span ID from the active OpenTelemetry span |
+| `logging.googleapis.com/trace_sampled` | Sampling decision |
+| *(event and span fields)* | Each field as a typed JSON value |
+
+Trace correlation fields require an OpenTelemetry layer in the same subscriber and `GOOGLE_CLOUD_PROJECT` — `init_with_gcp` provides both, which makes log entries appear inline in the Cloud Trace panel.
+
+## Fallback: OTLP to a Collector Sidecar
+
+When direct API access is unavailable — or when you also need metrics — run an OpenTelemetry Collector as a sidecar and point the standard OTLP exporter at it:
+
+```rust
+use adk_telemetry::init_with_otlp;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    init_with_otlp("my-agent", "http://localhost:4317")?;
+
+    // Your agent code here
+
+    adk_telemetry::shutdown_telemetry();
+    Ok(())
+}
+```
+
+Collector configuration forwarding to Google Cloud (`otel-collector-config.yaml`, using the [googlecloud exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlecloudexporter) from the contrib distribution):
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+processors:
+  batch:
+    send_batch_size: 200
+    timeout: 5s
+  resourcedetection:
+    detectors: [env, gcp]
+
+exporters:
+  googlecloud:
+    project: my-project
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [resourcedetection, batch]
+      exporters: [googlecloud]
+    metrics:
+      receivers: [otlp]
+      processors: [resourcedetection, batch]
+      exporters: [googlecloud]
+```
+
+Run it locally for development:
+
+```bash
+docker run --rm -p 4317:4317 \
+  -v ./otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml \
+  -v ~/.config/gcloud:/root/.config/gcloud \
+  otel/opentelemetry-collector-contrib:latest
+```
+
+## Choosing a Path
+
+| Path | Signals | Extra infrastructure | Auth |
+|------|---------|---------------------|------|
+| `init_with_gcp` | Traces + JSON logs on stdout | None | ADC in-process |
+| Collector sidecar | Traces + metrics (+ logs via collector) | Collector container | ADC in the collector |
+
+## Related
+
+- [Telemetry](telemetry.md) - Core telemetry setup and span helpers
+- [Deployment](../deployment/server.md) - Production telemetry setup

--- a/docs/official_docs/observability/telemetry.md
+++ b/docs/official_docs/observability/telemetry.md
@@ -551,6 +551,7 @@ export RUST_LOG=warn,my_app=info
 
 ## Related
 
+- [Telemetry to Google Cloud](gcp.md) - Direct Cloud Trace export and Cloud Logging JSON
 - [Callbacks](../callbacks/callbacks.md) - Add telemetry to callbacks
 - [Tools](../tools/function-tools.md) - Instrument custom tools
 - [Deployment](../deployment/server.md) - Production telemetry setup


### PR DESCRIPTION
New gcp feature: init_with_gcp (OTLP to telemetry.googleapis.com with per-request ADC bearer headers), gcp.agent_engine resource detection, init_json_logging with Cloud Logging severity/trace correlation, and a documented collector-sidecar fallback. Umbrella gcp-telemetry forwarding appended to gemini-agent-platform; CI feature-coverage entry added.

## What

Telemetry to Google Cloud: a new `gcp` feature on `adk-telemetry`.

- `init_with_gcp(service_name)` — OTLP trace export to `https://telemetry.googleapis.com` with per-request `Authorization: Bearer` headers minted from Application Default Credentials plus `x-goog-user-project`, and Cloud Logging JSON on stdout.
- GCP resource detection — `service.name`, `gcp.project_id`, and `cloud.platform = gcp.agent_engine` (canonical semconv value, open-telemetry/semantic-conventions#2957) derived from `K_SERVICE`, `GOOGLE_CLOUD_PROJECT`, and `GOOGLE_CLOUD_AGENT_ENGINE_ID`.
- `init_json_logging()` — Cloud Logging structured JSON: tracing levels mapped to Cloud severity names, `logging.googleapis.com/trace` correlation from the active OpenTelemetry span.
- Documented fallback: OTLP to a collector sidecar at `http://localhost:4317`, with a full collector config in `docs/official_docs/observability/gcp.md`.
- Umbrella forwarding `gcp-telemetry`, appended to the `gemini-agent-platform` meta-feature per its growth rule.

## Why

Part of #438

Agents deployed on Vertex AI Agent Engine and Cloud Run need traces in Cloud Trace and parseable structured logs in Cloud Logging without a collector deployment. The direct path authenticates in-process via ADC; the sidecar path covers metrics and restricted-egress environments.

## How

- The existing tonic span pipeline in `init.rs` moves into `otlp_pipeline::build_tracer` with an `ExporterHook` seam; `build_otlp_layer` keeps its exact signature and behavior via a `NoopHook`.
- The `gcp` hook injects TLS roots and a per-request tonic interceptor. Headers come from a shared slot refreshed every five minutes by a background task wrapping `GcpHeaderSupplier`, because the interceptor is synchronous and credential minting is async. The exporter's `with_interceptor` API makes per-request injection possible, so no static-at-init token-lifetime limitation applies.
- `CloudLoggingJsonFormat` builds on the `json` feature's `fmt::layer().json()` field plumbing via `event_format`, adding severity mapping and trace-resource-name formatting.
- Tests: header supplier with a fake `CredentialsProvider` (no network), interceptor metadata injection, resource-attribute assembly under a mutex-serialized env guard, severity mapping, trace resource name, and a full formatter round-trip through an in-memory writer.
- CI: one `feature-coverage` matrix line (`adk-telemetry, gcp`); the `gemini-agent-platform` PR-tier build now compiles the forwarding.
- Traces only on the direct path — metrics route through the documented collector sidecar; the metric pipeline in `build_otlp_layer` is untouched. `TelemetryError` gains no new variants (semver-relevant enum on a Stable-tier crate).

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (`adk-telemetry --features gcp`)
- [x] `devenv shell test` — `cargo nextest run -p adk-telemetry --features gcp`: 24/24; 25 doctests pass
- [x] `devenv shell check` — `cargo check -p adk-rust --no-default-features --features minimal,gemini-agent-platform` passes

### Code Quality

- [x] New code has tests (9 new unit tests, no network)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts
- [x] No unrelated changes mixed in
- [x] Branch naming follows convention (`feat/`)
- [x] Commit messages follow conventional format
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated
- [x] `adk-telemetry/README.md` — new "Telemetry to Google Cloud" section
- [x] New docs page `observability/gcp.md`; `scripts/check-doc-examples.sh` passes (98 files)
