### PR TITLE
feat(gemini): implement cached-content operations on VertexBackend - PR 0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **adk-gemini: cached content on Vertex AI.** `VertexBackend` implements the five
+  cached-content operations (create, get, update, list, delete) against the Vertex
+  REST endpoint `…/v1/projects/{project}/locations/{location}/cachedContents`,
+  including TTL refresh via `updateCachedContent` so the runner's cache-refresh
+  path works on Vertex. Studio-style model names (`models/{model}`) in create
+  payloads are normalized to full Vertex resource names. The Files API, batch
+  operations, and the Interactions API remain Studio-only on the Vertex backend.
+
 ## [2.0.0] - 2026-08-09
 
 ### Breaking

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,6 +529,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "wiremock",
 ]
 
 [[package]]

--- a/adk-gemini/Cargo.toml
+++ b/adk-gemini/Cargo.toml
@@ -339,8 +339,15 @@ path = "tests/schema_property_tests.rs"
 name = "interactions_tests"
 path = "tests/interactions_tests.rs"
 
+[[test]]
+name = "vertex_cache_live_tests"
+path = "tests/vertex_cache_live_tests.rs"
+
 [dev-dependencies.display-error-chain]
 version = "0.2"
+
+[dev-dependencies.futures]
+version = "^0.3.1"
 
 [dev-dependencies.proptest]
 version = "1"
@@ -352,3 +359,6 @@ features = ["full"]
 [dev-dependencies.tracing-subscriber]
 version = "0.3.20"
 features = ["env-filter"]
+
+[dev-dependencies.wiremock]
+version = "0.6"

--- a/adk-gemini/README.md
+++ b/adk-gemini/README.md
@@ -464,6 +464,8 @@ let response = client
 
 The `GeminiBackend` trait defines `send_request()` and `send_streaming_request()` methods. All `Gemini::new()` / `Gemini::with_model()` constructors use `StudioBackend` by default. Vertex AI constructors (`with_google_cloud`, `with_google_cloud_adc`, etc.) use `VertexBackend`.
 
+**Backend capabilities.** `StudioBackend` supports the full API surface. `VertexBackend` supports generation, streaming, embeddings, and cached content (create, get, update, list, delete). The Files API, batch operations, and the Interactions API are Studio-only and return `GoogleCloudUnsupported` on Vertex.
+
 ```rust
 use adk_gemini::{Gemini, GeminiBuilder};
 

--- a/adk-gemini/src/backend/vertex.rs
+++ b/adk-gemini/src/backend/vertex.rs
@@ -6,17 +6,30 @@
 //! API key), the gRPC SDK for non-streaming requests (with REST fallback on
 //! transport errors), and REST SSE for streaming.
 //!
+//! Cached-content operations (create, get, update, list, delete) go through the
+//! Vertex REST endpoint
+//! `{endpoint}/v1/projects/{project}/locations/{location}/cachedContents`.
+//! The Files API, batch operations, and the Interactions API remain
+//! [`GoogleCloudUnsupported`](crate::client::Error::GoogleCloudUnsupported) on
+//! this backend — a deliberate exclusion: Vertex AI has no Files API
+//! equivalent, batch prediction uses a different resource model (BigQuery/GCS
+//! jobs), and the Interactions API is Studio-only while in Beta.
+//!
 //! Streaming support inspired by [PR #74](https://github.com/zavora-ai/adk-rust/pull/74)
 //! by @mikefaille.
 
 use super::{BackendStream, GeminiBackend};
 use crate::{
+    cache::model::{
+        CacheExpirationRequest, CachedContent, CreateCachedContentRequest,
+        ListCachedContentsResponse,
+    },
     client::{
         BadResponseSnafu, DecodeResponseSnafu, DeserializeSnafu, Error,
         GoogleCloudCredentialHeadersSnafu, GoogleCloudCredentialHeadersUnavailableSnafu,
         GoogleCloudRequestDeserializeSnafu, GoogleCloudRequestNotObjectSnafu,
         GoogleCloudRequestSerializeSnafu, GoogleCloudResponseDeserializeSnafu,
-        GoogleCloudResponseSerializeSnafu, Model, UrlParseSnafu,
+        GoogleCloudResponseSerializeSnafu, Model, UrlParseSnafu, ValidationSnafu,
     },
     embedding::{ContentEmbeddingResponse, EmbedContentRequest},
     generation::{GenerateContentRequest, GenerationResponse},
@@ -27,10 +40,16 @@ use futures::TryStreamExt;
 use google_cloud_aiplatform_v1::client::PredictionService;
 use google_cloud_auth::credentials::Credentials;
 use reqwest::Client;
+use serde_json::json;
 use snafu::{OptionExt, ResultExt};
+use tracing::{debug, instrument};
 use url::Url;
 
 /// Vertex AI backend.
+///
+/// Supports content generation, streaming, embeddings, and cached-content
+/// management. The Files API, batch operations, and the Interactions API are
+/// deliberately left unsupported (see the module documentation).
 #[derive(Debug)]
 pub struct VertexBackend {
     pub(crate) prediction: PredictionService,
@@ -127,6 +146,87 @@ impl VertexBackend {
         let value =
             serde_json::to_value(&vertex_resp).context(GoogleCloudResponseSerializeSnafu)?;
         serde_json::from_value(value).context(GoogleCloudResponseDeserializeSnafu)
+    }
+
+    // ── Cached-content plumbing ──────────────────────────────────
+
+    /// Extract `(project, location)` from the model resource path.
+    ///
+    /// The backend's model is always a full Vertex resource name of the form
+    /// `projects/{project}/locations/{location}/...` (see
+    /// [`Model::vertex_model_path`]), so the cachedContents parent is derived
+    /// from it rather than stored separately.
+    fn project_and_location(&self) -> Result<(String, String), Error> {
+        let model = self.model.to_string();
+        let mut segments = model.split('/');
+        match (segments.next(), segments.next(), segments.next(), segments.next()) {
+            (Some("projects"), Some(project), Some("locations"), Some(location))
+                if !project.is_empty() && !location.is_empty() =>
+            {
+                Ok((project.to_string(), location.to_string()))
+            }
+            _ => ValidationSnafu {
+                message: format!(
+                    "vertex model path '{model}' does not start with \
+                     'projects/{{project}}/locations/{{location}}'; cached content on Vertex AI \
+                     requires the full model resource name — build the client with \
+                     GeminiBuilder::with_google_cloud"
+                ),
+            }
+            .fail(),
+        }
+    }
+
+    /// Build a cachedContents URL.
+    ///
+    /// `None` yields the collection URL (create/list). `Some(name)` accepts a
+    /// full resource name (`projects/…/cachedContents/{id}`), a Studio-style
+    /// name (`cachedContents/{id}`), or a bare id, and resolves all three to
+    /// the full Vertex resource URL.
+    fn cache_url(&self, name: Option<&str>) -> Result<Url, Error> {
+        let (project, location) = self.project_and_location()?;
+        let parent = format!("projects/{project}/locations/{location}");
+        let suffix = match name {
+            None => format!("{parent}/cachedContents"),
+            Some(n) if n.starts_with("projects/") => n.to_string(),
+            Some(n) => {
+                let id = n.strip_prefix("cachedContents/").unwrap_or(n);
+                format!("{parent}/cachedContents/{id}")
+            }
+        };
+        Url::parse(&format!("{}/v1/{suffix}", self.endpoint.trim_end_matches('/')))
+            .context(UrlParseSnafu)
+    }
+
+    /// GET a JSON resource with auth headers.
+    async fn get_json<T: serde::de::DeserializeOwned>(&self, url: Url) -> Result<T, Error> {
+        let auth_headers = self.auth_headers().await?;
+        let response = Client::new()
+            .get(url.clone())
+            .headers(auth_headers)
+            .send()
+            .await
+            .map_err(|source| Error::PerformRequest { source, url })?;
+        let response = Self::check_response(response).await?;
+        response.json().await.context(DecodeResponseSnafu)
+    }
+
+    /// POST a JSON body with auth headers and decode the JSON response.
+    async fn post_json<Req: serde::Serialize, Res: serde::de::DeserializeOwned>(
+        &self,
+        url: Url,
+        body: &Req,
+    ) -> Result<Res, Error> {
+        let auth_headers = self.auth_headers().await?;
+        let response = Client::new()
+            .post(url.clone())
+            .headers(auth_headers)
+            .json(body)
+            .send()
+            .await
+            .map_err(|source| Error::PerformRequest { source, url })?;
+        let response = Self::check_response(response).await?;
+        response.json().await.context(DecodeResponseSnafu)
     }
 }
 
@@ -265,5 +365,306 @@ impl GeminiBackend for VertexBackend {
         let value =
             serde_json::to_value(&vertex_resp).context(GoogleCloudResponseSerializeSnafu)?;
         serde_json::from_value(value).context(GoogleCloudResponseDeserializeSnafu)
+    }
+
+    // ── Cache operations ────────────────────────────────────────
+
+    #[instrument(skip_all, fields(
+        display.name = request.display_name,
+        contents.count = request.contents.as_ref().map(Vec::len),
+        tools.present = request.tools.is_some(),
+        system.instruction.present = request.system_instruction.is_some(),
+    ))]
+    async fn create_cached_content(
+        &self,
+        request: CreateCachedContentRequest,
+    ) -> Result<CachedContent, Error> {
+        let (project, location) = self.project_and_location()?;
+        // Vertex requires the full model resource name in the payload, unlike
+        // Studio's `models/{model}` form.
+        let mut request = request;
+        request.model = Model::Custom(request.model.vertex_model_path(&project, &location));
+
+        let url = self.cache_url(None)?;
+        debug!(cache.model = %request.model, "creating cached content");
+        self.post_json(url, &request).await
+    }
+
+    #[instrument(skip_all, fields(cache.name = name))]
+    async fn get_cached_content(&self, name: &str) -> Result<CachedContent, Error> {
+        let url = self.cache_url(Some(name))?;
+        self.get_json(url).await
+    }
+
+    #[instrument(skip_all, fields(
+        page.size = page_size,
+        page.token.present = page_token.is_some(),
+    ))]
+    async fn list_cached_contents(
+        &self,
+        page_size: Option<i32>,
+        page_token: Option<String>,
+    ) -> Result<ListCachedContentsResponse, Error> {
+        let mut url = self.cache_url(None)?;
+        if let Some(size) = page_size {
+            url.query_pairs_mut().append_pair("pageSize", &size.to_string());
+        }
+        if let Some(token) = page_token {
+            url.query_pairs_mut().append_pair("pageToken", &token);
+        }
+        self.get_json(url).await
+    }
+
+    #[instrument(skip_all, fields(cache.name = name))]
+    async fn update_cached_content(
+        &self,
+        name: &str,
+        expiration: CacheExpirationRequest,
+    ) -> Result<CachedContent, Error> {
+        let mut url = self.cache_url(Some(name))?;
+        // Only `ttl` and `expireTime` are mutable; scope the PATCH accordingly.
+        let (update_mask, update_payload) = match expiration {
+            CacheExpirationRequest::Ttl { ttl } => ("ttl", json!({ "ttl": ttl })),
+            CacheExpirationRequest::ExpireTime { expire_time } => (
+                "expireTime",
+                json!({
+                    "expireTime": expire_time
+                        .format(&time::format_description::well_known::Rfc3339)
+                        .unwrap()
+                }),
+            ),
+        };
+        url.query_pairs_mut().append_pair("updateMask", update_mask);
+        debug!(cache.update_mask = update_mask, "updating cached content expiration");
+
+        let auth_headers = self.auth_headers().await?;
+        let response = Client::new()
+            .patch(url.clone())
+            .headers(auth_headers)
+            .json(&update_payload)
+            .send()
+            .await
+            .map_err(|source| Error::PerformRequest { source, url })?;
+        let response = Self::check_response(response).await?;
+        response.json().await.context(DecodeResponseSnafu)
+    }
+
+    #[instrument(skip_all, fields(cache.name = name))]
+    async fn delete_cached_content(&self, name: &str) -> Result<(), Error> {
+        let url = self.cache_url(Some(name))?;
+        let auth_headers = self.auth_headers().await?;
+        let response = Client::new()
+            .delete(url.clone())
+            .headers(auth_headers)
+            .send()
+            .await
+            .map_err(|source| Error::PerformRequest { source, url })?;
+        Self::check_response(response).await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::Content;
+    use serde_json::{Value, json};
+    use wiremock::matchers::{body_partial_json, method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    const PARENT: &str = "projects/test-project/locations/us-central1";
+
+    async fn backend_with_model(endpoint: &str, model: Model) -> VertexBackend {
+        let credentials =
+            google_cloud_auth::credentials::api_key_credentials::Builder::new("test-key").build();
+        let prediction = PredictionService::builder()
+            .with_endpoint(endpoint)
+            .with_credentials(credentials.clone())
+            .build()
+            .await
+            .expect("prediction service should build offline");
+        VertexBackend::new(model, prediction, credentials, endpoint.to_string())
+    }
+
+    async fn backend(endpoint: &str) -> VertexBackend {
+        backend_with_model(
+            endpoint,
+            Model::Custom(format!("{PARENT}/publishers/google/models/gemini-2.5-flash")),
+        )
+        .await
+    }
+
+    fn cached_content_json(name: &str) -> Value {
+        json!({
+            "name": name,
+            "model": format!("{PARENT}/publishers/google/models/gemini-2.5-flash"),
+            "createTime": "2026-01-01T00:00:00Z",
+            "updateTime": "2026-01-01T00:10:00Z",
+            "expireTime": "2026-01-01T01:00:00Z",
+            "usageMetadata": { "totalTokenCount": 2048 }
+        })
+    }
+
+    #[tokio::test]
+    async fn create_cached_content_posts_to_collection_and_normalizes_model() {
+        let server = MockServer::start().await;
+        let cache_name = format!("{PARENT}/cachedContents/cache-123");
+        Mock::given(method("POST"))
+            .and(path(format!("/v1/{PARENT}/cachedContents")))
+            .and(body_partial_json(json!({
+                "model": format!("{PARENT}/publishers/google/models/gemini-2.5-flash"),
+                "displayName": "test-cache",
+                "ttl": "3600s",
+            })))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(cached_content_json(&cache_name)),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let backend = backend(&server.uri()).await;
+        // A Studio-style model (`models/gemini-2.5-flash`) must be normalized
+        // to the full Vertex resource name in the payload.
+        let request = CreateCachedContentRequest {
+            display_name: Some("test-cache".to_string()),
+            model: Model::Gemini25Flash,
+            contents: Some(vec![Content::text("context to cache")]),
+            tools: None,
+            system_instruction: None,
+            tool_config: None,
+            expiration: CacheExpirationRequest::Ttl { ttl: "3600s".to_string() },
+        };
+
+        let created = backend.create_cached_content(request).await.expect("create should succeed");
+        assert_eq!(created.name, cache_name);
+        assert_eq!(created.usage_metadata.total_token_count, 2048);
+        assert!(created.expiration.expire_time.is_some());
+    }
+
+    #[tokio::test]
+    async fn get_cached_content_resolves_bare_prefixed_and_full_names() {
+        let server = MockServer::start().await;
+        let cache_name = format!("{PARENT}/cachedContents/cache-123");
+        Mock::given(method("GET"))
+            .and(path(format!("/v1/{cache_name}")))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(cached_content_json(&cache_name)),
+            )
+            .expect(3)
+            .mount(&server)
+            .await;
+
+        let backend = backend(&server.uri()).await;
+        for name in ["cache-123", "cachedContents/cache-123", cache_name.as_str()] {
+            let cached = backend.get_cached_content(name).await.expect("get should succeed");
+            assert_eq!(cached.name, cache_name);
+        }
+    }
+
+    #[tokio::test]
+    async fn list_cached_contents_sends_pagination_query() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(format!("/v1/{PARENT}/cachedContents")))
+            .and(query_param("pageSize", "5"))
+            .and(query_param("pageToken", "tok-1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "cachedContents": [cached_content_json(&format!("{PARENT}/cachedContents/cache-1"))],
+                "nextPageToken": "tok-2",
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let backend = backend(&server.uri()).await;
+        let response = backend
+            .list_cached_contents(Some(5), Some("tok-1".to_string()))
+            .await
+            .expect("list should succeed");
+        assert_eq!(response.cached_contents.len(), 1);
+        assert_eq!(response.cached_contents[0].name, format!("{PARENT}/cachedContents/cache-1"));
+        assert_eq!(response.next_page_token.as_deref(), Some("tok-2"));
+    }
+
+    #[tokio::test]
+    async fn update_cached_content_patches_ttl_with_update_mask() {
+        let server = MockServer::start().await;
+        let cache_name = format!("{PARENT}/cachedContents/cache-123");
+        Mock::given(method("PATCH"))
+            .and(path(format!("/v1/{cache_name}")))
+            .and(query_param("updateMask", "ttl"))
+            .and(body_partial_json(json!({ "ttl": "600s" })))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(cached_content_json(&cache_name)),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let backend = backend(&server.uri()).await;
+        let updated = backend
+            .update_cached_content(
+                &cache_name,
+                CacheExpirationRequest::Ttl { ttl: "600s".to_string() },
+            )
+            .await
+            .expect("update should succeed");
+        assert_eq!(updated.name, cache_name);
+    }
+
+    #[tokio::test]
+    async fn update_cached_content_patches_expire_time_with_update_mask() {
+        let server = MockServer::start().await;
+        let cache_name = format!("{PARENT}/cachedContents/cache-123");
+        Mock::given(method("PATCH"))
+            .and(path(format!("/v1/{cache_name}")))
+            .and(query_param("updateMask", "expireTime"))
+            .and(body_partial_json(json!({ "expireTime": "2026-01-01T01:00:00Z" })))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(cached_content_json(&cache_name)),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let expire_time = time::OffsetDateTime::parse(
+            "2026-01-01T01:00:00Z",
+            &time::format_description::well_known::Rfc3339,
+        )
+        .unwrap();
+        let backend = backend(&server.uri()).await;
+        let updated = backend
+            .update_cached_content(&cache_name, CacheExpirationRequest::ExpireTime { expire_time })
+            .await
+            .expect("update should succeed");
+        assert_eq!(updated.name, cache_name);
+    }
+
+    #[tokio::test]
+    async fn delete_cached_content_issues_delete() {
+        let server = MockServer::start().await;
+        let cache_name = format!("{PARENT}/cachedContents/cache-123");
+        Mock::given(method("DELETE"))
+            .and(path(format!("/v1/{cache_name}")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let backend = backend(&server.uri()).await;
+        backend.delete_cached_content("cache-123").await.expect("delete should succeed");
+    }
+
+    #[tokio::test]
+    async fn cache_ops_require_parent_in_model_path() {
+        // A backend constructed with a bare model name has no project/location
+        // to derive the cachedContents parent from.
+        let backend = backend_with_model("https://example.invalid", Model::Gemini25Flash).await;
+        let err =
+            backend.get_cached_content("cache-123").await.expect_err("bare model path should fail");
+        assert!(
+            matches!(err, Error::Validation { ref message } if message.contains("models/gemini-2.5-flash"))
+        );
     }
 }

--- a/adk-gemini/src/client.rs
+++ b/adk-gemini/src/client.rs
@@ -439,7 +439,7 @@ pub enum Error {
 
     /// The requested operation is not supported by the Vertex AI backend.
     #[snafu(display(
-        "operation '{operation}' is not supported with the google cloud sdk backend (PredictionService currently exposes generateContent/embedContent only)"
+        "operation '{operation}' is not supported with the google cloud vertex backend (files, batch, and interactions APIs are Studio-only)"
     ))]
     GoogleCloudUnsupported {
         /// The unsupported operation name.

--- a/adk-gemini/tests/vertex_cache_live_tests.rs
+++ b/adk-gemini/tests/vertex_cache_live_tests.rs
@@ -1,0 +1,85 @@
+//! Live integration test for cached content on the Vertex AI backend.
+//!
+//! Exercises the full cache lifecycle (create with TTL, get, update TTL,
+//! list, delete) against a real Vertex AI project. Requires real Google
+//! Cloud credentials, so the test is marked `#[ignore]` and must be run
+//! manually.
+//!
+//! # Required Environment Variables
+//!
+//! - `GOOGLE_CLOUD_PROJECT` — GCP project ID with Vertex AI API enabled
+//! - `GOOGLE_CLOUD_LOCATION` — GCP location (defaults to `us-central1`)
+//! - Application Default Credentials must be configured:
+//!   `gcloud auth application-default login`
+//!
+//! # Running
+//!
+//! ```bash
+//! cargo test -p adk-gemini --features vertex \
+//!     --test vertex_cache_live_tests -- --ignored
+//! ```
+
+#![cfg(feature = "vertex")]
+
+use adk_gemini::{CacheExpirationRequest, Gemini, Model};
+use futures::TryStreamExt;
+use std::time::Duration;
+
+/// Cache lifecycle on live Vertex AI: create with a TTL, get, update the TTL,
+/// verify the cache appears in list, then delete.
+#[tokio::test]
+#[ignore]
+async fn vertex_cached_content_lifecycle() {
+    let project_id =
+        std::env::var("GOOGLE_CLOUD_PROJECT").expect("GOOGLE_CLOUD_PROJECT env var is required");
+    let location =
+        std::env::var("GOOGLE_CLOUD_LOCATION").unwrap_or_else(|_| "us-central1".to_string());
+
+    let gemini = Gemini::with_google_cloud_adc_model(&project_id, &location, Model::Gemini25Flash)
+        .expect("failed to build Vertex client with ADC");
+
+    // Vertex enforces a minimum cached token count (1024 for 2.5 Flash), so
+    // the cached context must be large enough.
+    let large_context = "The quick brown fox jumps over the lazy dog. ".repeat(400);
+
+    // Create with a TTL.
+    let cache = gemini
+        .create_cache()
+        .with_display_name("adk-gemini vertex live test cache")
+        .expect("display name within limit")
+        .with_system_instruction("You are a test fixture. Answer briefly.")
+        .with_user_message(large_context)
+        .with_ttl(Duration::from_secs(600))
+        .execute()
+        .await
+        .expect("cache creation should succeed");
+    let cache_name = cache.name().to_string();
+    assert!(cache_name.contains("cachedContents/"), "unexpected cache name: {cache_name}");
+
+    // Get.
+    let fetched = cache.get().await.expect("get should succeed");
+    assert_eq!(fetched.name, cache_name);
+    let first_expiry = fetched.expiration.expire_time.expect("expire_time should be set");
+
+    // Update TTL (the runner's cache-refresh path).
+    let updated = cache
+        .update(CacheExpirationRequest::from_ttl(Duration::from_secs(3600)))
+        .await
+        .expect("ttl update should succeed");
+    let refreshed_expiry = updated.expiration.expire_time.expect("expire_time should be set");
+    assert!(
+        refreshed_expiry > first_expiry,
+        "TTL refresh should push expiry later: {first_expiry} -> {refreshed_expiry}"
+    );
+
+    // List contains it.
+    let summaries: Vec<_> =
+        gemini.list_cached_contents(50).try_collect().await.expect("list should succeed");
+    assert!(
+        summaries.iter().any(|summary| summary.name == cache_name),
+        "created cache '{cache_name}' should appear in list"
+    );
+
+    // Delete.
+    cache.delete().await.map_err(|(_, e)| e).expect("delete should succeed");
+}


### PR DESCRIPTION
All five cachedContents ops (create/get/update/list/delete) against the Vertex REST endpoint, with Studio-style model-name normalization and updateMask on PATCH. update is included so the runner's cache TTL refresh works on Vertex. Files/batch/Interactions remain unsupported by design (rustdoc notes the exclusion).

## What

`VertexBackend` implements the five cached-content operations — `create_cached_content`, `get_cached_content`, `update_cached_content`, `list_cached_contents`, `delete_cached_content` — against the Vertex REST endpoint `…/v1/projects/{project}/locations/{location}/cachedContents`. The Files API, batch operations, and the Interactions API remain `GoogleCloudUnsupported` on Vertex; the backend rustdoc records the deliberate exclusion.

## Why

Part of #438

Explicit context caching previously worked only on the Studio backend; every cache op on Vertex returned `GoogleCloudUnsupported`. `update_cached_content` is included because TTL refresh on a live cache goes through update — leaving it unsupported would strand the runner's cache-refresh path on Vertex.

## How

- The cachedContents parent (`projects/{p}/locations/{l}`) is derived from the backend's model resource path, which `GeminiBuilder` always sets via `Model::vertex_model_path`. The existing endpoint string handles global vs regional hosts.
- Create payloads normalize Studio-style model names (`models/{id}`) to full Vertex resource names, mirroring the generate-content path.
- Update sends `PATCH {name}?updateMask=ttl|expireTime` with the partial body, matching Studio's body shape plus the field mask Vertex expects.
- Cache names resolve from bare id, `cachedContents/{id}`, or full resource name.
- Seven wiremock contract tests cover URL shape, request bodies (model normalization, TTL/expireTime), response parsing, and the missing-parent error. An `#[ignore]`d live test (`tests/vertex_cache_live_tests.rs`, gated on `GOOGLE_CLOUD_PROJECT` with ADC) exercises the full lifecycle: create with TTL, get, update TTL, list, delete.
- A model without the full Vertex resource prefix fails with the existing `Error::Validation` rather than a new enum variant — `adk-gemini` is a Stable-tier crate with an exhaustive `Error` enum, so adding a variant would trip the strict semver gate.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (default and `vertex` feature)
- [x] `devenv shell test` — `cargo nextest run -p adk-gemini --features vertex`: 189 passed, 1 skipped (live); 7 doctests pass; `cargo doc` clean under `-D warnings`
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (7 wiremock contract tests + `#[ignore]` live lifecycle test)
- [x] Public APIs have rustdoc comments
- [x] No `println!`/`eprintln!` in library code (adk-gemini AGENTS.md tracing conventions followed)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts
- [x] No unrelated changes mixed in
- [x] Branch naming follows convention (`feat/`)
- [x] Commit messages follow conventional format
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated
- [x] `adk-gemini/README.md` — "Backend capabilities" paragraph added
- [ ] Examples — not applicable (cache usage covered by existing runner cache docs)
