### PR TITLE
feat(artifact): add GCS artifact backend with adk-python blob parity - PR 0.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,8 @@ jobs:
           - { package: adk-server, features: a2a-v1 }
           # Vertex AI sessions use an opt-in Google Cloud transport and wire contract.
           - { package: adk-session, features: vertex-session }
+          # The GCS artifact backend is opt-in and must keep blob-name parity with adk-python.
+          - { package: adk-artifact, features: gcs }
           # ACP replay and server transport behavior are gated behind the opt-in server feature.
           - { package: adk-acp, features: server }
           # The Monty Python executors and the MontyPythonCodeTool live path: both gated,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **GCS artifact backend** (`adk-artifact`, feature `gcs`): `GcsArtifactService`
+  stores artifacts in a Google Cloud Storage bucket over the GCS JSON API with
+  ADC authentication, keeping byte-for-byte blob-name parity with adk-python's
+  `GcsArtifactService` (session-scoped and `user:`-namespaced layouts, `adkDisplayName`/
+  `adkIsText`/`adkFileUri`/`adkFileMimeType` object metadata, versions starting at 0).
+  Umbrella feature `gcs-artifacts`, included in the `gemini-agent-platform` meta-feature.
+
 ## [2.0.0] - 2026-08-09
 
 ### Breaking

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,9 +155,14 @@ version = "2.0.0"
 dependencies = [
  "adk-core",
  "async-trait",
+ "axum 0.8.9",
+ "google-cloud-auth 1.12.0",
+ "reqwest 0.12.28",
+ "serde",
  "serde_json",
  "tempfile",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/adk-artifact/Cargo.toml
+++ b/adk-artifact/Cargo.toml
@@ -15,9 +15,18 @@ readme = "README.md"
 [dependencies]
 adk-core.workspace = true
 async-trait.workspace = true
+serde = { workspace = true, optional = true }
 serde_json.workspace = true
 tokio = { workspace = true, features = ["fs"] }
+google-cloud-auth = { version = "1.8", optional = true, default-features = false, features = ["default-rustls-provider"] }
+reqwest = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = "3"
-tokio = { workspace = true, features = ["fs", "rt", "macros"] }
+tokio = { workspace = true, features = ["fs", "rt", "macros", "net"] }
+axum = "0.8"
+
+[features]
+default = []
+gcs = ["google-cloud-auth", "reqwest", "serde", "tracing", "tokio/sync", "tokio/time"]

--- a/adk-artifact/README.md
+++ b/adk-artifact/README.md
@@ -10,14 +10,40 @@ Binary artifact storage for Rust Agent Development Kit (ADK-Rust) agents.
 
 `adk-artifact` provides versioned binary data storage for the Rust Agent Development Kit ([ADK-Rust](https://github.com/zavora-ai/adk-rust)). Artifacts are useful for storing images, documents, audio, and other binary data that agents produce or consume.
 
-Two storage backends are included:
+Three storage backends are included:
 
 | Backend | Type | Persistence | Use case |
 |---------|------|-------------|----------|
 | `InMemoryArtifactService` | In-memory `HashMap` | Process lifetime only | Development, testing |
 | `FileArtifactService` | Local filesystem | Durable | Single-node production, local dev |
+| `GcsArtifactService` (feature `gcs`) | Google Cloud Storage | Durable | Deployed agents, Gemini Enterprise |
 
-Both implement the `ArtifactService` trait, so you can swap backends without changing application code.
+All implement the `ArtifactService` trait, so you can swap backends without changing application code.
+
+The GCS backend keeps byte-for-byte blob-name parity with adk-python's `GcsArtifactService`, so Rust agents, Python agents, and the Gemini Enterprise console read the same objects:
+
+- Session-scoped: `{app_name}/{user_id}/{session_id}/{filename}/{version}`
+- User-namespaced (filename starts with `user:`): `{app_name}/{user_id}/user/{filename}/{version}`
+
+Auto-assigned versions start at `0` (matching adk-python; the in-memory and file backends start at `1`). Authentication uses Application Default Credentials via `google-cloud-auth`.
+
+> **Important:** save and load must resolve the same `app_name` — the engine ID when deployed. adk-python had a save/load path mismatch (googleapis/python-aiplatform#6521); this implementation takes `app_name` verbatim from each request and never rewrites it.
+
+```toml
+[dependencies]
+adk-artifact = { version = "2.0.0", features = ["gcs"] }
+# or via the umbrella crate:
+adk-rust = { version = "2.0.0", features = ["minimal", "gcs-artifacts"] }
+```
+
+```rust,no_run
+use adk_artifact::GcsArtifactService;
+
+fn main() -> adk_core::Result<()> {
+    let service = GcsArtifactService::new_with_adc("my-artifact-bucket")?;
+    Ok(())
+}
+```
 
 ## Installation
 

--- a/adk-artifact/src/gcs.rs
+++ b/adk-artifact/src/gcs.rs
@@ -1,0 +1,873 @@
+//! Google Cloud Storage (GCS) artifact backend.
+//!
+//! Blob-name layout, version numbering, and object metadata keys are
+//! transcribed from adk-python's `GcsArtifactService`
+//! (google/adk-python, `src/google/adk/artifacts/gcs_artifact_service.py`,
+//! transcribed from google-adk 2.6.3) so that a Rust agent, a Python agent,
+//! and the Gemini Enterprise console all read the same objects.
+//!
+//! # Dependency choice
+//!
+//! This module talks to the GCS JSON API directly with `reqwest` and obtains
+//! Application Default Credentials via `google-cloud-auth` — the same pair
+//! already used by `adk-session`'s `vertex-session` backend. The official
+//! `google-cloud-storage` crate would add a substantially heavier dependency
+//! tree (gRPC, prost, tower) for the five plain-HTTP calls this service needs.
+
+use crate::service::{
+    ArtifactService, DeleteRequest, ListRequest, ListResponse, LoadRequest, LoadResponse,
+    SaveRequest, SaveResponse, VersionsRequest, VersionsResponse,
+};
+use adk_core::{AdkError, ErrorComponent, Part, Result};
+use async_trait::async_trait;
+use google_cloud_auth::credentials::{self, CacheableResource, Credentials};
+use reqwest::{Client, RequestBuilder, StatusCode};
+use serde::Deserialize;
+use serde_json::{Value, json};
+use std::collections::{BTreeSet, HashMap};
+use std::fmt::Write as _;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::RwLock;
+
+const DEFAULT_ENDPOINT: &str = "https://storage.googleapis.com";
+const CLOUD_PLATFORM_SCOPE: &str = "https://www.googleapis.com/auth/cloud-platform";
+const HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+
+// GCS object metadata keys shared with adk-python's GcsArtifactService.
+const GCS_DISPLAY_NAME_METADATA_KEY: &str = "adkDisplayName";
+const GCS_IS_TEXT_METADATA_KEY: &str = "adkIsText";
+const GCS_FILE_URI_METADATA_KEY: &str = "adkFileUri";
+const GCS_FILE_MIME_TYPE_METADATA_KEY: &str = "adkFileMimeType";
+
+/// Artifact storage backed by a Google Cloud Storage bucket.
+///
+/// Blob names match adk-python's `GcsArtifactService` byte for byte
+/// (transcribed from google-adk 2.6.3):
+///
+/// - Session-scoped: `{app_name}/{user_id}/{session_id}/{filename}/{version}`
+/// - User-namespaced (filename starts with `user:`):
+///   `{app_name}/{user_id}/user/{filename}/{version}`
+///
+/// Auto-assigned versions start at `0` and increment by one, matching
+/// adk-python. This differs from [`InMemoryArtifactService`](crate::InMemoryArtifactService),
+/// which starts at `1`.
+///
+/// # `app_name` consistency
+///
+/// The `app_name` is the leading blob-name segment, so **save and load must
+/// resolve the same `app_name`** — when deployed to Agent Engine that is the
+/// engine ID. adk-python has a live save/load path-mismatch bug where the two
+/// operations resolved different app names and artifacts silently vanished
+/// (googleapis/python-aiplatform#6521). This implementation takes `app_name`
+/// verbatim from each request and never rewrites it; callers own keeping it
+/// stable across operations.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use adk_artifact::{ArtifactService, GcsArtifactService, SaveRequest};
+/// use adk_core::Part;
+///
+/// #[tokio::main]
+/// async fn main() -> adk_core::Result<()> {
+///     // Uses Application Default Credentials.
+///     let service = GcsArtifactService::new_with_adc("my-artifact-bucket")?;
+///
+///     let saved = service
+///         .save(SaveRequest {
+///             app_name: "my_app".to_string(),
+///             user_id: "user_123".to_string(),
+///             session_id: "session_456".to_string(),
+///             file_name: "report.pdf".to_string(),
+///             part: Part::InlineData {
+///                 mime_type: "application/pdf".to_string(),
+///                 data: vec![0x25, 0x50, 0x44, 0x46],
+///                 uri: None,
+///                 annotations: None,
+///             },
+///             version: None,
+///         })
+///         .await?;
+///     assert_eq!(saved.version, 0); // versions start at 0, like adk-python
+///     Ok(())
+/// }
+/// ```
+pub struct GcsArtifactService {
+    http_client: Client,
+    bucket: String,
+    endpoint: String,
+    credentials: Credentials,
+    auth_headers: Arc<RwLock<Option<reqwest::header::HeaderMap>>>,
+}
+
+/// One object returned by the GCS JSON API.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ObjectResource {
+    name: String,
+    #[serde(default)]
+    content_type: Option<String>,
+    #[serde(default)]
+    metadata: Option<HashMap<String, String>>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ListObjectsResponse {
+    #[serde(default)]
+    items: Option<Vec<ObjectResource>>,
+    #[serde(default)]
+    next_page_token: Option<String>,
+}
+
+impl GcsArtifactService {
+    /// Creates a service using Application Default Credentials (ADC).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when ADC cannot be constructed or the HTTP client
+    /// cannot be built.
+    pub fn new_with_adc(bucket: impl Into<String>) -> Result<Self> {
+        let credentials =
+            credentials::Builder::default().with_scopes([CLOUD_PLATFORM_SCOPE]).build().map_err(
+                |error| Self::auth_error(format!("failed to build gcs ADC credentials: {error}")),
+            )?;
+        Self::with_credentials(bucket, credentials)
+    }
+
+    /// Creates a service with explicit credentials.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the HTTP client cannot be built.
+    pub fn with_credentials(bucket: impl Into<String>, credentials: Credentials) -> Result<Self> {
+        let http_client = Client::builder()
+            .connect_timeout(HTTP_CONNECT_TIMEOUT)
+            .timeout(HTTP_REQUEST_TIMEOUT)
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .map_err(|error| {
+                Self::internal_error(format!(
+                    "failed to build gcs artifact HTTP client: {}",
+                    error.without_url()
+                ))
+            })?;
+        Ok(Self {
+            http_client,
+            bucket: bucket.into(),
+            endpoint: DEFAULT_ENDPOINT.to_string(),
+            credentials,
+            auth_headers: Arc::new(RwLock::new(None)),
+        })
+    }
+
+    /// Overrides the GCS API origin, e.g. for a local emulator or test server.
+    ///
+    /// Both the JSON API path (`/storage/v1/...`) and the upload path
+    /// (`/upload/storage/v1/...`) are resolved against this origin.
+    #[must_use]
+    pub fn with_endpoint(mut self, endpoint: impl Into<String>) -> Self {
+        self.endpoint = endpoint.into().trim_end_matches('/').to_string();
+        self
+    }
+
+    fn internal_error(message: impl Into<String>) -> AdkError {
+        AdkError::internal(ErrorComponent::Artifact, "artifact.gcs.internal", message)
+            .with_provider("gcs")
+    }
+
+    fn invalid_input(message: impl Into<String>) -> AdkError {
+        AdkError::new(
+            ErrorComponent::Artifact,
+            adk_core::ErrorCategory::InvalidInput,
+            "artifact.gcs.invalid_input",
+            message,
+        )
+        .with_provider("gcs")
+    }
+
+    fn not_found_error(message: impl Into<String>) -> AdkError {
+        AdkError::not_found(ErrorComponent::Artifact, "artifact.gcs.not_found", message)
+            .with_provider("gcs")
+    }
+
+    fn auth_error(message: impl Into<String>) -> AdkError {
+        AdkError::unauthorized(ErrorComponent::Artifact, "artifact.gcs.unauthorized", message)
+            .with_provider("gcs")
+    }
+
+    fn http_error(status: StatusCode, context: &str, body: &str) -> AdkError {
+        let body: String = body.chars().take(512).collect();
+        let message = format!("gcs {context} failed with status {status}: {body}");
+        let error = match status {
+            StatusCode::NOT_FOUND => Self::not_found_error(message),
+            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => Self::auth_error(message),
+            StatusCode::TOO_MANY_REQUESTS => AdkError::rate_limited(
+                ErrorComponent::Artifact,
+                "artifact.gcs.rate_limited",
+                message,
+            )
+            .with_provider("gcs"),
+            status if status.is_server_error() => {
+                AdkError::unavailable(ErrorComponent::Artifact, "artifact.gcs.unavailable", message)
+                    .with_provider("gcs")
+            }
+            _ => Self::internal_error(message),
+        };
+        error.with_upstream_status(status.as_u16())
+    }
+
+    async fn auth_headers(&self) -> Result<reqwest::header::HeaderMap> {
+        let cacheable_headers =
+            self.credentials.headers(Default::default()).await.map_err(|error| {
+                Self::auth_error(format!("failed to obtain google cloud auth headers: {error}"))
+            })?;
+        match cacheable_headers {
+            CacheableResource::New { data, .. } => {
+                *self.auth_headers.write().await = Some(data.clone());
+                Ok(data)
+            }
+            CacheableResource::NotModified => {
+                self.auth_headers.read().await.clone().ok_or_else(|| {
+                    Self::auth_error(
+                        "google cloud credentials returned NotModified before any cached auth headers were available",
+                    )
+                })
+            }
+        }
+    }
+
+    async fn apply_auth(&self, request: RequestBuilder) -> Result<RequestBuilder> {
+        let headers = self.auth_headers().await?;
+        Ok(request.headers(headers))
+    }
+
+    fn objects_url(&self) -> String {
+        format!("{}/storage/v1/b/{}/o", self.endpoint, percent_encode(&self.bucket))
+    }
+
+    fn object_url(&self, blob_name: &str) -> String {
+        format!("{}/{}", self.objects_url(), percent_encode(blob_name))
+    }
+
+    fn upload_url(&self) -> String {
+        format!("{}/upload/storage/v1/b/{}/o", self.endpoint, percent_encode(&self.bucket))
+    }
+
+    /// Returns the blob-name prefix (without the trailing `/{version}`).
+    ///
+    /// Matches `GcsArtifactService._get_blob_prefix` in adk-python 2.6.3.
+    fn blob_prefix(
+        app_name: &str,
+        user_id: &str,
+        session_id: &str,
+        file_name: &str,
+    ) -> Result<String> {
+        validate_path_segment(app_name, "app_name")?;
+        validate_path_segment(user_id, "user_id")?;
+        validate_file_name(file_name)?;
+        if file_has_user_namespace(file_name) {
+            return Ok(format!("{app_name}/{user_id}/user/{file_name}"));
+        }
+        validate_path_segment(session_id, "session_id")?;
+        Ok(format!("{app_name}/{user_id}/{session_id}/{file_name}"))
+    }
+
+    /// Returns the full blob name including the version segment.
+    ///
+    /// Matches `GcsArtifactService._get_blob_name` in adk-python 2.6.3.
+    fn blob_name(
+        app_name: &str,
+        user_id: &str,
+        session_id: &str,
+        file_name: &str,
+        version: i64,
+    ) -> Result<String> {
+        Ok(format!("{}/{version}", Self::blob_prefix(app_name, user_id, session_id, file_name)?))
+    }
+
+    async fn list_objects(&self, prefix: &str) -> Result<Vec<ObjectResource>> {
+        let mut items = Vec::new();
+        let mut page_token: Option<String> = None;
+        loop {
+            let mut query: Vec<(&str, &str)> = vec![("prefix", prefix)];
+            if let Some(token) = page_token.as_deref() {
+                query.push(("pageToken", token));
+            }
+            let request =
+                self.apply_auth(self.http_client.get(self.objects_url()).query(&query)).await?;
+            let response = request.send().await.map_err(|error| {
+                Self::internal_error(format!(
+                    "gcs list objects request failed: {}",
+                    error.without_url()
+                ))
+            })?;
+            let status = response.status();
+            if !status.is_success() {
+                let body = response.text().await.unwrap_or_default();
+                return Err(Self::http_error(status, "list objects", &body));
+            }
+            let page: ListObjectsResponse = response.json().await.map_err(|error| {
+                Self::internal_error(format!(
+                    "gcs list objects response was not valid JSON: {}",
+                    error.without_url()
+                ))
+            })?;
+            items.extend(page.items.unwrap_or_default());
+            match page.next_page_token {
+                Some(token) if !token.is_empty() => page_token = Some(token),
+                _ => break,
+            }
+        }
+        Ok(items)
+    }
+
+    /// Lists available versions for an artifact, in ascending order.
+    async fn list_versions(
+        &self,
+        app_name: &str,
+        user_id: &str,
+        session_id: &str,
+        file_name: &str,
+    ) -> Result<Vec<i64>> {
+        let prefix = format!("{}/", Self::blob_prefix(app_name, user_id, session_id, file_name)?);
+        let mut versions: Vec<i64> = self
+            .list_objects(&prefix)
+            .await?
+            .iter()
+            .filter_map(|object| parse_version(&object.name, &prefix))
+            .collect();
+        versions.sort_unstable();
+        Ok(versions)
+    }
+
+    async fn get_object(&self, blob_name: &str) -> Result<Option<ObjectResource>> {
+        let request = self.apply_auth(self.http_client.get(self.object_url(blob_name))).await?;
+        let response = request.send().await.map_err(|error| {
+            Self::internal_error(format!("gcs get object request failed: {}", error.without_url()))
+        })?;
+        let status = response.status();
+        if status == StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(Self::http_error(status, "get object", &body));
+        }
+        let object: ObjectResource = response.json().await.map_err(|error| {
+            Self::internal_error(format!(
+                "gcs object resource was not valid JSON: {}",
+                error.without_url()
+            ))
+        })?;
+        Ok(Some(object))
+    }
+
+    async fn download_object(&self, blob_name: &str) -> Result<Vec<u8>> {
+        let request = self
+            .apply_auth(self.http_client.get(self.object_url(blob_name)).query(&[("alt", "media")]))
+            .await?;
+        let response = request.send().await.map_err(|error| {
+            Self::internal_error(format!("gcs download request failed: {}", error.without_url()))
+        })?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(Self::http_error(status, "download object", &body));
+        }
+        let bytes = response.bytes().await.map_err(|error| {
+            Self::internal_error(format!("gcs download body read failed: {}", error.without_url()))
+        })?;
+        Ok(bytes.to_vec())
+    }
+
+    async fn upload_object(
+        &self,
+        blob_name: &str,
+        content_type: Option<&str>,
+        metadata: &HashMap<String, String>,
+        data: &[u8],
+    ) -> Result<()> {
+        let mut resource = json!({ "name": blob_name });
+        if let Some(content_type) = content_type {
+            resource["contentType"] = Value::String(content_type.to_string());
+        }
+        if !metadata.is_empty() {
+            resource["metadata"] = json!(metadata);
+        }
+        let (boundary, body) = multipart_related_body(&resource, content_type, data)?;
+        let request = self
+            .apply_auth(
+                self.http_client
+                    .post(self.upload_url())
+                    .query(&[("uploadType", "multipart")])
+                    .header(
+                        reqwest::header::CONTENT_TYPE,
+                        format!("multipart/related; boundary={boundary}"),
+                    )
+                    .body(body),
+            )
+            .await?;
+        let response = request.send().await.map_err(|error| {
+            Self::internal_error(format!("gcs upload request failed: {}", error.without_url()))
+        })?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(Self::http_error(status, "upload object", &body));
+        }
+        Ok(())
+    }
+
+    async fn delete_object(&self, blob_name: &str) -> Result<()> {
+        let request = self.apply_auth(self.http_client.delete(self.object_url(blob_name))).await?;
+        let response = request.send().await.map_err(|error| {
+            Self::internal_error(format!("gcs delete request failed: {}", error.without_url()))
+        })?;
+        let status = response.status();
+        // Deleting an already-absent version is not an error, matching the
+        // idempotent delete semantics of the other backends in this crate.
+        if status == StatusCode::NOT_FOUND || status.is_success() {
+            return Ok(());
+        }
+        let body = response.text().await.unwrap_or_default();
+        Err(Self::http_error(status, "delete object", &body))
+    }
+}
+
+fn file_has_user_namespace(file_name: &str) -> bool {
+    file_name.starts_with("user:")
+}
+
+fn validate_path_segment(segment: &str, field: &str) -> Result<()> {
+    if segment.is_empty() || segment.contains('/') || segment == "." || segment == ".." {
+        return Err(GcsArtifactService::invalid_input(format!(
+            "invalid {field} '{segment}': must be a non-empty path segment without '/'"
+        )));
+    }
+    Ok(())
+}
+
+// Filenames may contain '/' (adk-python allows nested artifact names), but no
+// component may be a traversal pattern and the name may not start or end with '/'.
+fn validate_file_name(file_name: &str) -> Result<()> {
+    let valid = !file_name.is_empty()
+        && !file_name.starts_with('/')
+        && !file_name.ends_with('/')
+        && !file_name.contains('\\')
+        && file_name
+            .split('/')
+            .all(|component| !component.is_empty() && component != "." && component != "..");
+    if !valid {
+        return Err(GcsArtifactService::invalid_input(format!(
+            "invalid artifact file name '{file_name}': empty components, traversal patterns, and backslashes are not allowed"
+        )));
+    }
+    Ok(())
+}
+
+/// Extracts the version number from a blob name under `prefix`.
+///
+/// GCS has a flat namespace, so listing by `prefix` also returns artifacts
+/// nested under this one (filenames may contain `/`). A blob holds a version
+/// of this artifact only when its name is exactly `{prefix}{version}`.
+/// Matches `_parse_version` in adk-python 2.6.3.
+fn parse_version(blob_name: &str, prefix: &str) -> Option<i64> {
+    let suffix = blob_name.strip_prefix(prefix)?;
+    if suffix.contains('/') {
+        // Belongs to a distinct artifact nested under this one.
+        return None;
+    }
+    if suffix.is_empty() || !suffix.bytes().all(|byte| byte.is_ascii_digit()) {
+        tracing::warn!(
+            gcs.blob_name = blob_name,
+            "skipping blob because it does not end with a version number"
+        );
+        return None;
+    }
+    suffix.parse().ok()
+}
+
+/// Percent-encodes every byte outside the RFC 3986 unreserved set, so blob
+/// names containing `/` become a single URL path segment.
+fn percent_encode(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for byte in input.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                out.push(byte as char)
+            }
+            _ => {
+                let _ = write!(out, "%{byte:02X}");
+            }
+        }
+    }
+    out
+}
+
+/// Builds a `multipart/related` body for a GCS multipart upload: a JSON
+/// object-resource part followed by the media part.
+fn multipart_related_body(
+    resource: &Value,
+    content_type: Option<&str>,
+    data: &[u8],
+) -> Result<(String, Vec<u8>)> {
+    let resource_json = serde_json::to_vec(resource).map_err(|error| {
+        GcsArtifactService::internal_error(format!(
+            "failed to encode gcs object resource JSON: {error}"
+        ))
+    })?;
+    // The boundary must not occur in either part's payload.
+    let mut boundary = String::from("adk_gcs_artifact_boundary");
+    while contains_subslice(data, boundary.as_bytes())
+        || contains_subslice(&resource_json, boundary.as_bytes())
+    {
+        boundary.push('x');
+    }
+    let media_content_type = content_type.unwrap_or("application/octet-stream");
+    let mut body = Vec::with_capacity(data.len() + resource_json.len() + 256);
+    body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+    body.extend_from_slice(b"Content-Type: application/json; charset=UTF-8\r\n\r\n");
+    body.extend_from_slice(&resource_json);
+    body.extend_from_slice(format!("\r\n--{boundary}\r\n").as_bytes());
+    body.extend_from_slice(format!("Content-Type: {media_content_type}\r\n\r\n").as_bytes());
+    body.extend_from_slice(data);
+    body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+    Ok((boundary, body))
+}
+
+fn contains_subslice(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack.windows(needle.len()).any(|window| window == needle)
+}
+
+/// The upload payload derived from a [`Part`].
+struct UploadPlan {
+    content_type: Option<String>,
+    metadata: HashMap<String, String>,
+    data: Vec<u8>,
+}
+
+fn plan_upload(part: &Part) -> Result<UploadPlan> {
+    match part {
+        Part::InlineData { mime_type, data, annotations, .. } => {
+            let mut metadata = HashMap::new();
+            // adk-core's Part has no display-name field; a "displayName"
+            // annotation round-trips through the adkDisplayName metadata key.
+            if let Some(Value::Object(map)) = annotations
+                && let Some(Value::String(display_name)) = map.get("displayName")
+            {
+                metadata.insert(GCS_DISPLAY_NAME_METADATA_KEY.to_string(), display_name.clone());
+            }
+            Ok(UploadPlan { content_type: Some(mime_type.clone()), metadata, data: data.clone() })
+        }
+        Part::Text { text } => {
+            // Flagged so load reconstructs Part::Text instead of inline data,
+            // matching adk-python.
+            let metadata =
+                HashMap::from([(GCS_IS_TEXT_METADATA_KEY.to_string(), "true".to_string())]);
+            Ok(UploadPlan {
+                content_type: Some("text/plain".to_string()),
+                metadata,
+                data: text.clone().into_bytes(),
+            })
+        }
+        Part::FileData { mime_type, file_uri, .. } => {
+            if file_uri.is_empty() {
+                return Err(GcsArtifactService::invalid_input(
+                    "artifact file_data must have a file_uri",
+                ));
+            }
+            // URI reference only: metadata carries the URI, the object body is empty.
+            let mut metadata =
+                HashMap::from([(GCS_FILE_URI_METADATA_KEY.to_string(), file_uri.clone())]);
+            let content_type = if mime_type.is_empty() {
+                None
+            } else {
+                metadata.insert(GCS_FILE_MIME_TYPE_METADATA_KEY.to_string(), mime_type.clone());
+                Some(mime_type.clone())
+            };
+            Ok(UploadPlan { content_type, metadata, data: Vec::new() })
+        }
+        Part::Thinking { .. }
+        | Part::FunctionCall { .. }
+        | Part::FunctionResponse { .. }
+        | Part::ServerToolCall { .. }
+        | Part::ServerToolResponse { .. }
+        | Part::EmbeddedResource { .. } => Err(GcsArtifactService::invalid_input(
+            "artifact must be text, inline data, or file data",
+        )),
+    }
+}
+
+fn reconstruct_part(object: &ObjectResource, data: Option<Vec<u8>>) -> Result<Part> {
+    let metadata = object.metadata.clone().unwrap_or_default();
+    // "file_uri" is the legacy key some older adk-python versions wrote.
+    let file_uri = metadata
+        .get(GCS_FILE_URI_METADATA_KEY)
+        .or_else(|| metadata.get("file_uri"))
+        .filter(|uri| !uri.is_empty());
+    if let Some(file_uri) = file_uri {
+        let mime_type = metadata
+            .get(GCS_FILE_MIME_TYPE_METADATA_KEY)
+            .cloned()
+            .or_else(|| object.content_type.clone())
+            .unwrap_or_default();
+        return Ok(Part::FileData { mime_type, file_uri: file_uri.clone(), annotations: None });
+    }
+    let data = data.unwrap_or_default();
+    if metadata.get(GCS_IS_TEXT_METADATA_KEY).is_some_and(|value| value == "true") {
+        let text = String::from_utf8(data).map_err(|error| {
+            GcsArtifactService::internal_error(format!(
+                "gcs text artifact is not valid UTF-8: {error}"
+            ))
+        })?;
+        return Ok(Part::Text { text });
+    }
+    let annotations = metadata
+        .get(GCS_DISPLAY_NAME_METADATA_KEY)
+        .map(|display_name| json!({ "displayName": display_name }));
+    Ok(Part::InlineData {
+        mime_type: object
+            .content_type
+            .clone()
+            .unwrap_or_else(|| "application/octet-stream".to_string()),
+        data,
+        uri: None,
+        annotations,
+    })
+}
+
+#[async_trait]
+impl ArtifactService for GcsArtifactService {
+    #[tracing::instrument(skip_all, fields(artifact.file_name = %req.file_name))]
+    async fn save(&self, req: SaveRequest) -> Result<SaveResponse> {
+        let version = match req.version {
+            Some(version) => version,
+            // First auto-assigned version is 0, matching adk-python.
+            None => self
+                .list_versions(&req.app_name, &req.user_id, &req.session_id, &req.file_name)
+                .await?
+                .last()
+                .map_or(0, |latest| latest + 1),
+        };
+        let blob_name =
+            Self::blob_name(&req.app_name, &req.user_id, &req.session_id, &req.file_name, version)?;
+        let plan = plan_upload(&req.part)?;
+        self.upload_object(&blob_name, plan.content_type.as_deref(), &plan.metadata, &plan.data)
+            .await?;
+        tracing::debug!(gcs.blob_name = blob_name, artifact.version = version, "artifact saved");
+        Ok(SaveResponse { version })
+    }
+
+    #[tracing::instrument(skip_all, fields(artifact.file_name = %req.file_name))]
+    async fn load(&self, req: LoadRequest) -> Result<LoadResponse> {
+        let version = match req.version {
+            Some(version) => version,
+            None => *self
+                .list_versions(&req.app_name, &req.user_id, &req.session_id, &req.file_name)
+                .await?
+                .last()
+                .ok_or_else(|| Self::not_found_error("artifact not found"))?,
+        };
+        let blob_name =
+            Self::blob_name(&req.app_name, &req.user_id, &req.session_id, &req.file_name, version)?;
+        let object = self
+            .get_object(&blob_name)
+            .await?
+            .ok_or_else(|| Self::not_found_error("artifact not found"))?;
+        let is_uri_reference = object.metadata.as_ref().is_some_and(|metadata| {
+            metadata.contains_key(GCS_FILE_URI_METADATA_KEY) || metadata.contains_key("file_uri")
+        });
+        let data =
+            if is_uri_reference { None } else { Some(self.download_object(&blob_name).await?) };
+        Ok(LoadResponse { part: reconstruct_part(&object, data)? })
+    }
+
+    #[tracing::instrument(skip_all, fields(artifact.file_name = %req.file_name))]
+    async fn delete(&self, req: DeleteRequest) -> Result<()> {
+        let versions = match req.version {
+            Some(version) => vec![version],
+            None => {
+                self.list_versions(&req.app_name, &req.user_id, &req.session_id, &req.file_name)
+                    .await?
+            }
+        };
+        for version in versions {
+            let blob_name = Self::blob_name(
+                &req.app_name,
+                &req.user_id,
+                &req.session_id,
+                &req.file_name,
+                version,
+            )?;
+            self.delete_object(&blob_name).await?;
+        }
+        Ok(())
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn list(&self, req: ListRequest) -> Result<ListResponse> {
+        validate_path_segment(&req.app_name, "app_name")?;
+        validate_path_segment(&req.user_id, "user_id")?;
+        validate_path_segment(&req.session_id, "session_id")?;
+        let mut file_names = BTreeSet::new();
+        let session_prefix = format!("{}/{}/{}/", req.app_name, req.user_id, req.session_id);
+        let user_prefix = format!("{}/{}/user/", req.app_name, req.user_id);
+        for prefix in [&session_prefix, &user_prefix] {
+            for object in self.list_objects(prefix).await? {
+                // Blob names are `{prefix}{filename}/{version}`; the filename
+                // itself may contain '/', so only the final segment is dropped.
+                let Some(suffix) = object.name.strip_prefix(prefix.as_str()) else {
+                    continue;
+                };
+                if let Some((file_name, _version)) = suffix.rsplit_once('/') {
+                    file_names.insert(file_name.to_string());
+                }
+            }
+        }
+        Ok(ListResponse { file_names: file_names.into_iter().collect() })
+    }
+
+    #[tracing::instrument(skip_all, fields(artifact.file_name = %req.file_name))]
+    async fn versions(&self, req: VersionsRequest) -> Result<VersionsResponse> {
+        let versions = self
+            .list_versions(&req.app_name, &req.user_id, &req.session_id, &req.file_name)
+            .await?;
+        if versions.is_empty() {
+            return Err(Self::not_found_error("artifact not found"));
+        }
+        Ok(VersionsResponse { versions })
+    }
+
+    async fn health_check(&self) -> Result<()> {
+        let url = format!("{}/storage/v1/b/{}", self.endpoint, percent_encode(&self.bucket));
+        let request = self.apply_auth(self.http_client.get(url)).await?;
+        let response = request.send().await.map_err(|error| {
+            Self::internal_error(format!(
+                "gcs health check request failed: {}",
+                error.without_url()
+            ))
+        })?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(Self::http_error(status, "health check", &body));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Golden blob names transcribed from adk-python's GcsArtifactService
+    // (google-adk 2.6.3): {app_name}/{user_id}/{session_id}/{filename}/{version}
+    #[test]
+    fn test_blob_name_session_scoped_matches_adk_python() {
+        let name =
+            GcsArtifactService::blob_name("my-app", "user123", "session456", "report.pdf", 0)
+                .unwrap();
+        assert_eq!(name, "my-app/user123/session456/report.pdf/0");
+    }
+
+    // User-namespaced filenames keep the `user:` prefix in the blob name and
+    // replace the session segment with the literal string "user".
+    #[test]
+    fn test_blob_name_user_namespace_matches_adk_python() {
+        let name =
+            GcsArtifactService::blob_name("my-app", "user123", "session456", "user:profile.png", 3)
+                .unwrap();
+        assert_eq!(name, "my-app/user123/user/user:profile.png/3");
+    }
+
+    // The engine ID is the app_name when deployed; save and load must build
+    // identical names from it (googleapis/python-aiplatform#6521).
+    #[test]
+    fn test_blob_name_engine_id_app_name() {
+        let name = GcsArtifactService::blob_name(
+            "1234567890123456789",
+            "user123",
+            "session456",
+            "chart.png",
+            7,
+        )
+        .unwrap();
+        assert_eq!(name, "1234567890123456789/user123/session456/chart.png/7");
+    }
+
+    #[test]
+    fn test_blob_name_allows_nested_filenames() {
+        let name =
+            GcsArtifactService::blob_name("app", "user", "session", "reports/q1.pdf", 2).unwrap();
+        assert_eq!(name, "app/user/session/reports/q1.pdf/2");
+    }
+
+    #[test]
+    fn test_blob_name_rejects_invalid_segments() {
+        for (app, user, session, file) in [
+            ("", "user", "session", "file"),
+            ("app/x", "user", "session", "file"),
+            ("app", "..", "session", "file"),
+            ("app", "user", "a/b", "file"),
+            ("app", "user", "session", ""),
+            ("app", "user", "session", "../etc/passwd"),
+            ("app", "user", "session", "a//b"),
+            ("app", "user", "session", "/leading"),
+            ("app", "user", "session", "trailing/"),
+            ("app", "user", "session", "back\\slash"),
+        ] {
+            assert!(
+                GcsArtifactService::blob_name(app, user, session, file, 0).is_err(),
+                "expected rejection for {app}/{user}/{session}/{file}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_version_matches_adk_python() {
+        let prefix = "app/user/session/a/";
+        assert_eq!(parse_version("app/user/session/a/3", prefix), Some(3));
+        assert_eq!(parse_version("app/user/session/a/0", prefix), Some(0));
+        // Version 3 of the distinct nested artifact "a/b", not of "a".
+        assert_eq!(parse_version("app/user/session/a/b/3", prefix), None);
+        // Non-numeric suffixes are skipped.
+        assert_eq!(parse_version("app/user/session/a/latest", prefix), None);
+        assert_eq!(parse_version("app/user/session/a/ 3", prefix), None);
+        assert_eq!(parse_version("app/user/session/a/1_0", prefix), None);
+        // Different prefix entirely.
+        assert_eq!(parse_version("other/user/session/a/3", prefix), None);
+    }
+
+    #[test]
+    fn test_percent_encode_escapes_slashes_and_colons() {
+        assert_eq!(
+            percent_encode("app/user/user/user:profile.png/0"),
+            "app%2Fuser%2Fuser%2Fuser%3Aprofile.png%2F0"
+        );
+        assert_eq!(percent_encode("simple-name_1.bin~"), "simple-name_1.bin~");
+    }
+
+    #[test]
+    fn test_multipart_body_boundary_never_collides() {
+        let data = b"payload with adk_gcs_artifact_boundary embedded".to_vec();
+        let (boundary, body) =
+            multipart_related_body(&json!({"name": "n"}), Some("text/plain"), &data).unwrap();
+        assert!(boundary.starts_with("adk_gcs_artifact_boundary"));
+        assert_ne!(boundary, "adk_gcs_artifact_boundary");
+        assert!(contains_subslice(&body, format!("--{boundary}--\r\n").as_bytes()));
+    }
+
+    #[test]
+    fn test_plan_upload_rejects_non_data_parts() {
+        let part = Part::FunctionCall {
+            name: "f".to_string(),
+            args: json!({}),
+            id: None,
+            thought_signature: None,
+        };
+        assert!(plan_upload(&part).is_err());
+    }
+}

--- a/adk-artifact/src/lib.rs
+++ b/adk-artifact/src/lib.rs
@@ -10,6 +10,8 @@
 //! - [`InMemoryArtifactService`] - Simple in-memory storage
 //! - [`ArtifactService`] - Trait for custom backends
 //! - [`ScopedArtifacts`] - Session-scoped artifact access
+//! - `GcsArtifactService` - Google Cloud Storage backend (feature `gcs`),
+//!   blob-name compatible with adk-python
 //!
 //! ## Quick Start
 //!
@@ -29,11 +31,15 @@
 //! - Share binary data between agent turns
 
 pub mod file;
+#[cfg(feature = "gcs")]
+pub mod gcs;
 pub mod inmemory;
 pub mod scoped;
 pub mod service;
 
 pub use file::FileArtifactService;
+#[cfg(feature = "gcs")]
+pub use gcs::GcsArtifactService;
 pub use inmemory::InMemoryArtifactService;
 pub use scoped::ScopedArtifacts;
 pub use service::{

--- a/adk-artifact/tests/gcs_tests.rs
+++ b/adk-artifact/tests/gcs_tests.rs
@@ -1,0 +1,348 @@
+//! Contract tests for the GCS artifact backend against a mock GCS JSON API,
+//! plus an ignored live test against a real bucket.
+
+#![cfg(feature = "gcs")]
+
+use adk_artifact::{
+    ArtifactService, DeleteRequest, GcsArtifactService, ListRequest, LoadRequest, SaveRequest,
+    VersionsRequest,
+};
+use adk_core::Part;
+use axum::body::Bytes;
+use axum::extract::{Path, Query, State};
+use axum::http::{HeaderMap, StatusCode, header};
+use axum::response::{IntoResponse, Response};
+use axum::routing::{delete, get, post};
+use google_cloud_auth::credentials::api_key_credentials;
+use serde_json::{Value, json};
+use std::collections::{BTreeMap, HashMap};
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug, Clone)]
+struct StoredObject {
+    data: Vec<u8>,
+    content_type: Option<String>,
+    metadata: HashMap<String, String>,
+}
+
+type Store = Arc<Mutex<BTreeMap<String, StoredObject>>>;
+
+fn object_resource(name: &str, object: &StoredObject) -> Value {
+    let mut resource = json!({ "name": name });
+    if let Some(content_type) = &object.content_type {
+        resource["contentType"] = json!(content_type);
+    }
+    if !object.metadata.is_empty() {
+        resource["metadata"] = json!(object.metadata);
+    }
+    resource
+}
+
+async fn list_objects(
+    State(store): State<Store>,
+    Query(params): Query<HashMap<String, String>>,
+) -> Response {
+    let prefix = params.get("prefix").cloned().unwrap_or_default();
+    let store = store.lock().unwrap();
+    let items: Vec<Value> = store
+        .iter()
+        .filter(|(name, _)| name.starts_with(&prefix))
+        .map(|(name, object)| object_resource(name, object))
+        .collect();
+    axum::Json(json!({ "items": items })).into_response()
+}
+
+async fn get_object(
+    State(store): State<Store>,
+    Path((_bucket, object_name)): Path<(String, String)>,
+    Query(params): Query<HashMap<String, String>>,
+) -> Response {
+    let store = store.lock().unwrap();
+    let Some(object) = store.get(&object_name) else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    if params.get("alt").is_some_and(|alt| alt == "media") {
+        let content_type =
+            object.content_type.clone().unwrap_or_else(|| "application/octet-stream".to_string());
+        return ([(header::CONTENT_TYPE, content_type)], object.data.clone()).into_response();
+    }
+    axum::Json(object_resource(&object_name, object)).into_response()
+}
+
+async fn delete_object(
+    State(store): State<Store>,
+    Path((_bucket, object_name)): Path<(String, String)>,
+) -> Response {
+    let mut store = store.lock().unwrap();
+    if store.remove(&object_name).is_some() {
+        StatusCode::NO_CONTENT.into_response()
+    } else {
+        StatusCode::NOT_FOUND.into_response()
+    }
+}
+
+/// Parses the `multipart/related` upload body: a JSON object-resource part
+/// followed by a media part.
+fn parse_multipart_related(headers: &HeaderMap, body: &[u8]) -> (Value, Vec<u8>) {
+    let content_type = headers[header::CONTENT_TYPE].to_str().unwrap();
+    let boundary = content_type.split("boundary=").nth(1).unwrap().trim();
+    let delimiter = format!("--{boundary}");
+    let mut parts = Vec::new();
+    let mut rest = body;
+    while let Some(start) = find_subslice(rest, delimiter.as_bytes()) {
+        rest = &rest[start + delimiter.len()..];
+        if rest.starts_with(b"--") {
+            break;
+        }
+        let Some(end) = find_subslice(rest, delimiter.as_bytes()) else {
+            break;
+        };
+        let segment = &rest[..end];
+        // Each part is `\r\nheaders\r\n\r\ncontent\r\n`.
+        let content_start = find_subslice(segment, b"\r\n\r\n").unwrap() + 4;
+        let content = &segment[content_start..segment.len() - 2];
+        parts.push(content.to_vec());
+    }
+    assert_eq!(parts.len(), 2, "expected metadata + media parts");
+    let resource: Value = serde_json::from_slice(&parts[0]).unwrap();
+    (resource, parts[1].clone())
+}
+
+async fn upload_object(State(store): State<Store>, headers: HeaderMap, body: Bytes) -> Response {
+    let (resource, data) = parse_multipart_related(&headers, &body);
+    let name = resource["name"].as_str().unwrap().to_string();
+    let content_type = resource["contentType"].as_str().map(str::to_string);
+    let metadata: HashMap<String, String> = resource
+        .get("metadata")
+        .and_then(Value::as_object)
+        .map(|map| map.iter().map(|(k, v)| (k.clone(), v.as_str().unwrap().to_string())).collect())
+        .unwrap_or_default();
+    let object = StoredObject { data, content_type, metadata };
+    let response = object_resource(&name, &object);
+    store.lock().unwrap().insert(name, object);
+    axum::Json(response).into_response()
+}
+
+async fn spawn_mock_gcs() -> (String, Store) {
+    let store: Store = Arc::new(Mutex::new(BTreeMap::new()));
+    let app = axum::Router::new()
+        .route("/storage/v1/b/{bucket}/o", get(list_objects))
+        .route("/storage/v1/b/{bucket}/o/{object}", get(get_object))
+        .route("/storage/v1/b/{bucket}/o/{object}", delete(delete_object))
+        .route("/upload/storage/v1/b/{bucket}/o", post(upload_object))
+        .with_state(store.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    (format!("http://{addr}"), store)
+}
+
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack.windows(needle.len()).position(|window| window == needle)
+}
+
+fn mock_service(endpoint: &str) -> GcsArtifactService {
+    GcsArtifactService::with_credentials(
+        "test-bucket",
+        api_key_credentials::Builder::new("test-key").build(),
+    )
+    .unwrap()
+    .with_endpoint(endpoint)
+}
+
+fn save_request(app_name: &str, file_name: &str, part: Part) -> SaveRequest {
+    SaveRequest {
+        app_name: app_name.to_string(),
+        user_id: "user123".to_string(),
+        session_id: "session456".to_string(),
+        file_name: file_name.to_string(),
+        part,
+        version: None,
+    }
+}
+
+fn load_request(app_name: &str, file_name: &str, version: Option<i64>) -> LoadRequest {
+    LoadRequest {
+        app_name: app_name.to_string(),
+        user_id: "user123".to_string(),
+        session_id: "session456".to_string(),
+        file_name: file_name.to_string(),
+        version,
+    }
+}
+
+fn inline_part(data: &[u8]) -> Part {
+    Part::InlineData {
+        mime_type: "image/png".to_string(),
+        data: data.to_vec(),
+        uri: None,
+        annotations: None,
+    }
+}
+
+#[tokio::test]
+async fn test_mock_round_trip_save_load_list_versions_delete() {
+    let (endpoint, store) = spawn_mock_gcs().await;
+    let service = mock_service(&endpoint);
+
+    // Two versions of a session-scoped artifact: auto-versioning starts at 0.
+    let v0 = service.save(save_request("my-app", "chart.png", inline_part(b"v0"))).await.unwrap();
+    assert_eq!(v0.version, 0);
+    let v1 = service.save(save_request("my-app", "chart.png", inline_part(b"v1"))).await.unwrap();
+    assert_eq!(v1.version, 1);
+
+    // One user-namespaced artifact.
+    let user_v0 =
+        service.save(save_request("my-app", "user:profile.png", inline_part(b"me"))).await.unwrap();
+    assert_eq!(user_v0.version, 0);
+
+    // The mock recorded the exact adk-python blob names on the wire.
+    {
+        let store = store.lock().unwrap();
+        let names: Vec<&String> = store.keys().collect();
+        assert_eq!(
+            names,
+            vec![
+                "my-app/user123/session456/chart.png/0",
+                "my-app/user123/session456/chart.png/1",
+                "my-app/user123/user/user:profile.png/0",
+            ]
+        );
+    }
+
+    // Load: latest, pinned version, and user namespace.
+    let latest = service.load(load_request("my-app", "chart.png", None)).await.unwrap();
+    assert_eq!(latest.part, inline_part(b"v1"));
+    let pinned = service.load(load_request("my-app", "chart.png", Some(0))).await.unwrap();
+    assert_eq!(pinned.part, inline_part(b"v0"));
+    let user = service.load(load_request("my-app", "user:profile.png", None)).await.unwrap();
+    assert_eq!(user.part, inline_part(b"me"));
+
+    // List includes both session-scoped and user-namespaced filenames.
+    let listed = service
+        .list(ListRequest {
+            app_name: "my-app".to_string(),
+            user_id: "user123".to_string(),
+            session_id: "session456".to_string(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(listed.file_names, vec!["chart.png".to_string(), "user:profile.png".to_string()]);
+
+    // Versions come back ascending, matching adk-python.
+    let versions = service
+        .versions(VersionsRequest {
+            app_name: "my-app".to_string(),
+            user_id: "user123".to_string(),
+            session_id: "session456".to_string(),
+            file_name: "chart.png".to_string(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(versions.versions, vec![0, 1]);
+
+    // Delete all versions removes every blob of the artifact and nothing else.
+    service
+        .delete(DeleteRequest {
+            app_name: "my-app".to_string(),
+            user_id: "user123".to_string(),
+            session_id: "session456".to_string(),
+            file_name: "chart.png".to_string(),
+            version: None,
+        })
+        .await
+        .unwrap();
+    {
+        let store = store.lock().unwrap();
+        let names: Vec<&String> = store.keys().collect();
+        assert_eq!(names, vec!["my-app/user123/user/user:profile.png/0"]);
+    }
+    let missing = service.load(load_request("my-app", "chart.png", None)).await;
+    assert!(missing.is_err_and(|error| error.is_not_found()));
+}
+
+#[tokio::test]
+async fn test_mock_text_and_file_data_metadata_keys() {
+    let (endpoint, store) = spawn_mock_gcs().await;
+    let service = mock_service(&endpoint);
+
+    // Text artifacts are flagged adkIsText and reconstruct as Part::Text.
+    let text_part = Part::Text { text: "hello artifact".to_string() };
+    service.save(save_request("my-app", "notes.txt", text_part.clone())).await.unwrap();
+    let loaded = service.load(load_request("my-app", "notes.txt", None)).await.unwrap();
+    assert_eq!(loaded.part, text_part);
+
+    // File-data artifacts store only metadata (adkFileUri/adkFileMimeType).
+    let file_part = Part::FileData {
+        mime_type: "video/mp4".to_string(),
+        file_uri: "gs://other-bucket/video.mp4".to_string(),
+        annotations: None,
+    };
+    service.save(save_request("my-app", "video.mp4", file_part.clone())).await.unwrap();
+    let loaded = service.load(load_request("my-app", "video.mp4", None)).await.unwrap();
+    assert_eq!(loaded.part, file_part);
+
+    let store = store.lock().unwrap();
+    let text_object = &store["my-app/user123/session456/notes.txt/0"];
+    assert_eq!(text_object.metadata["adkIsText"], "true");
+    assert_eq!(text_object.content_type.as_deref(), Some("text/plain"));
+    let file_object = &store["my-app/user123/session456/video.mp4/0"];
+    assert_eq!(file_object.metadata["adkFileUri"], "gs://other-bucket/video.mp4");
+    assert_eq!(file_object.metadata["adkFileMimeType"], "video/mp4");
+    assert!(file_object.data.is_empty());
+}
+
+// Regression for googleapis/python-aiplatform#6521: when deployed, the
+// app_name is the engine ID. Save and load must build the same blob name
+// from it, or artifacts silently vanish between the two operations.
+#[tokio::test]
+async fn test_engine_id_app_name_round_trips() {
+    let (endpoint, store) = spawn_mock_gcs().await;
+    let service = mock_service(&endpoint);
+    let engine_id = "1234567890123456789";
+
+    let part = inline_part(b"engine artifact");
+    let saved = service.save(save_request(engine_id, "output.png", part.clone())).await.unwrap();
+    assert_eq!(saved.version, 0);
+
+    let loaded =
+        service.load(load_request(engine_id, "output.png", Some(saved.version))).await.unwrap();
+    assert_eq!(loaded.part, part);
+
+    let store = store.lock().unwrap();
+    assert!(store.contains_key("1234567890123456789/user123/session456/output.png/0"));
+}
+
+/// Live round-trip against a real bucket. Requires ADC plus
+/// `GOOGLE_CLOUD_PROJECT` and `ADK_ARTIFACT_BUCKET`.
+#[tokio::test]
+#[ignore = "requires GOOGLE_CLOUD_PROJECT, ADK_ARTIFACT_BUCKET, and ADC"]
+async fn test_live_gcs_round_trip() {
+    let _project =
+        std::env::var("GOOGLE_CLOUD_PROJECT").expect("set GOOGLE_CLOUD_PROJECT to run this test");
+    let bucket =
+        std::env::var("ADK_ARTIFACT_BUCKET").expect("set ADK_ARTIFACT_BUCKET to run this test");
+    let service = GcsArtifactService::new_with_adc(bucket).unwrap();
+
+    let file_name = format!("live-test-{}.bin", std::process::id());
+    let part = inline_part(b"live round trip");
+    let saved = service.save(save_request("adk-rust-live-test", &file_name, part.clone())).await;
+    let saved = saved.unwrap();
+    let loaded = service
+        .load(load_request("adk-rust-live-test", &file_name, Some(saved.version)))
+        .await
+        .unwrap();
+    assert_eq!(loaded.part, part);
+    service
+        .delete(DeleteRequest {
+            app_name: "adk-rust-live-test".to_string(),
+            user_id: "user123".to_string(),
+            session_id: "session456".to_string(),
+            file_name,
+            version: None,
+        })
+        .await
+        .unwrap();
+}

--- a/adk-rust/Cargo.toml
+++ b/adk-rust/Cargo.toml
@@ -83,11 +83,11 @@ gemini-agent-platform = [
     "gemini-vertex",  # Vertex model backend (adk-model → adk-gemini/vertex)
     "vertex-session", # managed Sessions (adk-session)
     "gcp-secrets",    # GCP Secret Manager (adk-auth)
+    "gcs-artifacts",  # GCS artifact backend (adk-artifact)
     # target end-state — appended by the PR that introduces each flag:
     # "agent-engine",           class-method runtime contract (adk-server)
     # "vertex-memory",          Memory Bank (adk-memory)
     # "example-store",          Example Store (adk-tool)
-    # "gcs-artifacts",          GCS artifact backend (adk-artifact)
     # "gcp-telemetry",          Cloud Trace/Logging transport (adk-telemetry)
     # "vertex-sandbox",         managed code-execution sandbox (adk-code)
     # "vertex-eval",            Gen AI Evaluation bridge (adk-eval)
@@ -123,6 +123,8 @@ tools = ["dep:adk-tool"]
 skills = ["dep:adk-skill"]
 sessions = ["dep:adk-session"]
 artifacts = ["dep:adk-artifact"]
+# GCS artifact backend, blob-name compatible with adk-python (forwarded to adk-artifact)
+gcs-artifacts = ["artifacts", "adk-artifact/gcs"]
 memory = ["dep:adk-memory"]
 runner = ["dep:adk-runner"]
 server = ["dep:adk-server", "adk-server/a2a-v1"]


### PR DESCRIPTION
GcsArtifactService (feature gcs) over the GCS JSON API + ADC. Blob names, version-0 numbering, and adk* metadata keys transcribed from google-adk 2.6.3 so the Gemini Enterprise console and Python agents read the same objects. Regression test pins app_name save/load consistency (googleapis/python-aiplatform#6521). Umbrella gcs-artifacts forwarding appended to gemini-agent-platform.

## What

- `GcsArtifactService` in `adk-artifact` behind a new `gcs` feature, implementing `ArtifactService` (save/load/delete/list/versions/health_check) against the GCS JSON API with ADC authentication.
- Umbrella feature `gcs-artifacts = ["artifacts", "adk-artifact/gcs"]`, appended to the `gemini-agent-platform` meta-feature.
- CI `feature-coverage` matrix entry `{ package: adk-artifact, features: gcs }`.

## Why

Part of #438

Deployed Python agents default to GCS artifact storage and the Gemini Enterprise console renders artifacts from those GCS paths. A Rust agent needs byte-for-byte blob-name parity so the console and Python agents read the same objects.

## How

- Blob names, version numbering (starting at 0), version parsing, and object metadata keys (`adkDisplayName`, `adkIsText`, `adkFileUri`, `adkFileMimeType`) are transcribed from adk-python's `GcsArtifactService` (google-adk 2.6.3):
  - Session-scoped: `{app_name}/{user_id}/{session_id}/{filename}/{version}`
  - User-namespaced (`user:` prefix): `{app_name}/{user_id}/user/{filename}/{version}`
- Transport is plain `reqwest` against `https://storage.googleapis.com/storage/v1/...` and the `/upload/storage/v1/...` multipart endpoint; auth is ADC via `google-cloud-auth`, the same pair `adk-session`'s `vertex-session` uses — a lighter tree than the `google-cloud-storage` crate.
- `app_name` is taken verbatim from every request and never rewritten, so save and load always resolve the same path. adk-python has a live save/load path mismatch here (googleapis/python-aiplatform#6521); a regression test asserts round-trip under an engine-ID app name.
- Tests: golden blob-name tests (exact string equality, including the `user:` namespace), a mock axum GCS JSON API proving the save/load/list/versions/delete round-trip with wire-level blob-name assertions, and an `#[ignore]` live test gated on `GOOGLE_CLOUD_PROJECT` + `ADK_ARTIFACT_BUCKET`.

> **Note:** the GCS backend intentionally starts auto-assigned versions at 0 (Python parity) while `InMemoryArtifactService` starts at 1 — documented in the rustdoc, README, and CHANGELOG.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (`adk-artifact --features gcs`)
- [x] `devenv shell test` — `cargo nextest run -p adk-artifact --features gcs`: 22/22, 1 skipped (live); 3 doctests pass
- [x] `devenv shell check` — `cargo check -p adk-rust --no-default-features --features minimal,gemini-agent-platform` passes

### Code Quality

- [x] New code has tests (golden blob-name, mock contract, live `#[ignore]`)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts
- [x] No unrelated changes mixed in
- [x] Branch naming follows convention (`feat/`)
- [x] Commit messages follow conventional format
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated
- [x] `adk-artifact/README.md` — GCS backend row, blob-name layout, version-0 note, #6521 caveat
- [ ] Examples — deferred to Wave 1 PR 1.2 (`AgentEngineOptions::artifact_service` wiring docs, per plan)
