### PR TITLE
Add native MCP 2026 lifecycle, Tasks, and MRTR

### DIFF
--- a/adk-tool/README.md
+++ b/adk-tool/README.md
@@ -266,7 +266,8 @@ let toolset = McpHttpClientBuilder::new("https://mcp.example.com/v1")
 
 ### MCP Task Support (Long-Running Operations)
 
-Enable the negotiated MCP `2025-11-25` task lifecycle for long-running tool operations:
+Enable the negotiated MCP 2026-07-28 SEP-2663 Tasks extension for long-running
+tool operations:
 
 ```rust
 use adk_tool::{McpToolset, McpTaskConfig};
@@ -281,10 +282,39 @@ let toolset = McpToolset::new(client)
     );
 ```
 
-Task mode is used only when the server advertises task support and the selected
-tool declares it. ADK-Rust sends task metadata with `tools/call`, polls
-`tasks/get`, reads `tasks/result`, and requests `tasks/cancel` when the local
-timeout or poll bound is reached.
+Task mode is used only when the client config enables it and the server
+advertises the extension. The server decides per call whether to return a task.
+ADK-Rust polls `tasks/get`, fulfils paused `input_required` requests through the
+configured elicitation handler and `tasks/update`, and requests `tasks/cancel`
+when the local timeout or poll bound is reached.
+
+Managed servers select lifecycle and task policy in `mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "controlled-server": {
+      "command": "controlled-server",
+      "lifecycle": "discover",
+      "taskConfig": {
+        "enableTasks": true,
+        "pollIntervalMs": 500,
+        "timeoutMs": 300000,
+        "maxInputRounds": 10
+      }
+    },
+    "third-party-server": {
+      "command": "third-party-server",
+      "lifecycle": "auto"
+    }
+  }
+}
+```
+
+`discover` requires the stateless 2026 lifecycle. `auto` probes discovery and
+falls back only on `METHOD_NOT_FOUND`. The default remains `initialize` for
+backward compatibility. Stateless MRTR elicitation is driven automatically and
+bounded by `maxInputRounds`; opaque `requestState` is echoed without inspection.
 
 ### MCP Auto-Reconnect (Connection Resilience)
 

--- a/adk-tool/src/mcp/elicitation.rs
+++ b/adk-tool/src/mcp/elicitation.rs
@@ -14,7 +14,8 @@ use std::sync::Arc;
 use futures::FutureExt;
 use rmcp::model::{
     ClientInfo, ElicitRequestParams, ElicitResult, ElicitationAction, ElicitationCapability,
-    ElicitationSchema, FormElicitationCapability, UrlElicitationCapability,
+    ElicitationSchema, FormElicitationCapability, InputRequest, InputRequests, InputResponses,
+    UrlElicitationCapability,
 };
 use rmcp::service::{NotificationContext, RequestContext, RoleClient};
 use serde_json::Value;
@@ -124,6 +125,7 @@ impl ElicitationHandler for AutoDeclineElicitationHandler {
 ///
 /// When the `mcp-sampling` feature is enabled, also accepts an optional
 /// `Arc<dyn SamplingHandler>` to handle `sampling/createMessage` requests.
+#[derive(Clone)]
 pub struct AdkClientHandler {
     handler: Arc<dyn ElicitationHandler>,
     resource_notification_handler: Option<Arc<dyn ResourceNotificationHandler>>,
@@ -153,6 +155,80 @@ impl AdkClientHandler {
     pub fn with_tasks(mut self) -> Self {
         self.tasks = true;
         self
+    }
+
+    async fn handle_elicitation(&self, request: ElicitRequestParams) -> ElicitResult {
+        let result = match &request {
+            ElicitRequestParams::FormElicitationParams {
+                message, requested_schema, meta, ..
+            } => {
+                let metadata_value = meta.as_ref().and_then(|m| serde_json::to_value(m).ok());
+                std::panic::AssertUnwindSafe(self.handler.handle_form_elicitation(
+                    message,
+                    requested_schema,
+                    metadata_value.as_ref(),
+                ))
+                .catch_unwind()
+                .await
+            }
+            ElicitRequestParams::UrlElicitationParams {
+                message,
+                url,
+                elicitation_id,
+                meta,
+                ..
+            } => {
+                let metadata_value = meta.as_ref().and_then(|m| serde_json::to_value(m).ok());
+                std::panic::AssertUnwindSafe(self.handler.handle_url_elicitation(
+                    message,
+                    url,
+                    elicitation_id,
+                    metadata_value.as_ref(),
+                ))
+                .catch_unwind()
+                .await
+            }
+            _ => return ElicitResult::new(ElicitationAction::Decline),
+        };
+
+        match result {
+            Ok(Ok(elicitation_result)) => elicitation_result,
+            Ok(Err(error)) => {
+                tracing::warn!(%error, "elicitation handler returned error, declining");
+                ElicitResult::new(ElicitationAction::Decline)
+            }
+            Err(_) => {
+                tracing::warn!("elicitation handler panicked, declining");
+                ElicitResult::new(ElicitationAction::Decline)
+            }
+        }
+    }
+
+    /// Fulfil stateless MRTR requests through the same policy used for legacy
+    /// server-initiated elicitation. Sampling and roots are intentionally not
+    /// accepted here: both are deprecated in the 2026-07-28 lifecycle.
+    pub(crate) async fn fulfill_input_requests(
+        &self,
+        requests: InputRequests,
+    ) -> Result<InputResponses, String> {
+        let mut responses = InputResponses::new();
+        for (key, request) in requests {
+            let value = match request {
+                InputRequest::Elicitation(request) => {
+                    serde_json::to_value(self.handle_elicitation(request.params).await)
+                        .map_err(|error| error.to_string())?
+                }
+                InputRequest::CreateMessage(_) => {
+                    return Err("MRTR sampling is deprecated and not enabled by ADK".to_string());
+                }
+                InputRequest::ListRoots(_) => {
+                    return Err("MRTR roots are deprecated and not enabled by ADK".to_string());
+                }
+                _ => return Err("unsupported MRTR input request".to_string()),
+            };
+            responses.insert(key, value);
+        }
+        Ok(responses)
     }
 
     /// Set the handler for resource update and resource-list notifications.
@@ -308,55 +384,7 @@ impl rmcp::handler::client::ClientHandler for AdkClientHandler {
         request: ElicitRequestParams,
         _context: RequestContext<RoleClient>,
     ) -> Result<ElicitResult, rmcp::ErrorData> {
-        {
-            let result = match &request {
-                ElicitRequestParams::FormElicitationParams {
-                    message,
-                    requested_schema,
-                    meta,
-                    ..
-                } => {
-                    let metadata_value = meta.as_ref().and_then(|m| serde_json::to_value(m).ok());
-                    std::panic::AssertUnwindSafe(self.handler.handle_form_elicitation(
-                        message,
-                        requested_schema,
-                        metadata_value.as_ref(),
-                    ))
-                    .catch_unwind()
-                    .await
-                }
-                ElicitRequestParams::UrlElicitationParams {
-                    message,
-                    url,
-                    elicitation_id,
-                    meta,
-                    ..
-                } => {
-                    let metadata_value = meta.as_ref().and_then(|m| serde_json::to_value(m).ok());
-                    std::panic::AssertUnwindSafe(self.handler.handle_url_elicitation(
-                        message,
-                        url,
-                        elicitation_id,
-                        metadata_value.as_ref(),
-                    ))
-                    .catch_unwind()
-                    .await
-                }
-                _ => return Ok(ElicitResult::new(ElicitationAction::Decline)),
-            };
-
-            match result {
-                Ok(Ok(elicitation_result)) => Ok(elicitation_result),
-                Ok(Err(e)) => {
-                    tracing::warn!(error = %e, "elicitation handler returned error, declining");
-                    Ok(ElicitResult::new(ElicitationAction::Decline))
-                }
-                Err(_panic) => {
-                    tracing::warn!("elicitation handler panicked, declining");
-                    Ok(ElicitResult::new(ElicitationAction::Decline))
-                }
-            }
-        }
+        Ok(self.handle_elicitation(request).await)
     }
 
     async fn on_resource_updated(

--- a/adk-tool/src/mcp/manager/config.rs
+++ b/adk-tool/src/mcp/manager/config.rs
@@ -6,6 +6,37 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+use crate::mcp::McpTaskConfig;
+
+/// MCP client lifecycle used for a managed server connection.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum McpLifecycleMode {
+    /// Maximum compatibility: use the pre-2026 initialization handshake.
+    #[default]
+    Initialize,
+    /// Probe with `server/discover`, falling back only on method-not-found.
+    Auto,
+    /// Require the stateless 2026-07-28 discovery lifecycle.
+    Discover,
+}
+
+impl McpLifecycleMode {
+    pub(crate) fn to_rmcp(self) -> rmcp::ClientLifecycleMode {
+        use rmcp::model::ProtocolVersion;
+        match self {
+            Self::Initialize => rmcp::ClientLifecycleMode::Initialize,
+            Self::Auto => rmcp::ClientLifecycleMode::Auto {
+                preferred_versions: vec![ProtocolVersion::V_2026_07_28],
+                legacy_version: Some(ProtocolVersion::V_2025_11_25),
+            },
+            Self::Discover => rmcp::ClientLifecycleMode::Discover {
+                preferred_versions: vec![ProtocolVersion::V_2026_07_28],
+            },
+        }
+    }
+}
+
 /// Configuration for a single managed MCP server.
 ///
 /// Deserialized from Kiro's `mcp.json` format with camelCase field names.
@@ -55,6 +86,14 @@ pub struct McpServerConfig {
     /// Optional restart policy controlling auto-restart behavior with exponential backoff.
     #[serde(default)]
     pub restart_policy: Option<RestartPolicy>,
+
+    /// Connection lifecycle. Controlled first-party servers should use `discover`.
+    #[serde(default)]
+    pub lifecycle: McpLifecycleMode,
+
+    /// Negotiated Tasks and MRTR execution policy.
+    #[serde(default)]
+    pub task_config: McpTaskConfig,
 }
 
 /// Controls auto-restart behavior with exponential backoff.
@@ -166,6 +205,8 @@ mod tests {
         assert!(!config.disabled);
         assert!(config.auto_approve.is_empty());
         assert!(config.restart_policy.is_none());
+        assert_eq!(config.lifecycle, McpLifecycleMode::Initialize);
+        assert!(!config.task_config.enable_tasks);
     }
 
     #[test]
@@ -212,6 +253,8 @@ mod tests {
                 backoff_multiplier: 1.5,
                 max_restart_attempts: 3,
             }),
+            lifecycle: McpLifecycleMode::Discover,
+            task_config: McpTaskConfig::enabled(),
         };
         let json = serde_json::to_string(&config).unwrap();
         let deserialized: McpServerConfig = serde_json::from_str(&json).unwrap();

--- a/adk-tool/src/mcp/manager/entry.rs
+++ b/adk-tool/src/mcp/manager/entry.rs
@@ -202,6 +202,8 @@ mod tests {
             disabled: false,
             auto_approve: vec![],
             restart_policy: None,
+            lifecycle: Default::default(),
+            task_config: Default::default(),
         };
         let entry = McpServerEntry {
             backoff: BackoffState::new(&config.restart_policy),

--- a/adk-tool/src/mcp/manager/manager.rs
+++ b/adk-tool/src/mcp/manager/manager.rs
@@ -15,7 +15,9 @@ use adk_core::AdkError;
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 
-use super::super::elicitation::{AutoDeclineElicitationHandler, ElicitationHandler};
+use super::super::elicitation::{
+    AdkClientHandler, AutoDeclineElicitationHandler, ElicitationHandler,
+};
 use super::super::resource_notifications::ResourceNotificationHandler;
 use super::super::toolset::McpToolset;
 use super::super::{GetPromptResult, Prompt, Resource, ResourceContents, ResourceTemplate};
@@ -329,35 +331,34 @@ impl McpServerManager {
             ))
         })?;
 
-        // Connect via McpToolset with the appropriate handler
+        // Build one handler for both lifecycle negotiation and later MRTR/task input.
         let handler: Arc<dyn ElicitationHandler> =
             elicitation_handler.clone().unwrap_or_else(|| Arc::new(AutoDeclineElicitationHandler));
 
+        let mut adk_handler = AdkClientHandler::new(handler);
+        if config.task_config.enable_tasks {
+            adk_handler = adk_handler.with_tasks();
+        }
+        if let Some(resource_handler) = resource_notification_handler {
+            adk_handler =
+                adk_handler.with_resource_notification_handler(Arc::clone(resource_handler));
+        }
         #[cfg(feature = "mcp-sampling")]
-        let toolset_result = if let Some(sampling) = sampling_handler {
-            if let Some(resource_handler) = resource_notification_handler {
-                McpToolset::with_sampling_and_resource_handlers(
-                    transport,
-                    handler,
-                    Arc::clone(sampling),
-                    Arc::clone(resource_handler),
-                )
-                .await
-            } else {
-                McpToolset::with_sampling_handler(transport, handler, Arc::clone(sampling)).await
-            }
-        } else if let Some(resource_handler) = resource_notification_handler {
-            McpToolset::with_handlers(transport, handler, Arc::clone(resource_handler)).await
-        } else {
-            McpToolset::with_elicitation_handler(transport, handler).await
-        };
+        if let Some(sampling) = sampling_handler {
+            adk_handler = adk_handler.with_sampling_handler(Arc::clone(sampling));
+        }
 
-        #[cfg(not(feature = "mcp-sampling"))]
-        let toolset_result = if let Some(resource_handler) = resource_notification_handler {
-            McpToolset::with_handlers(transport, handler, Arc::clone(resource_handler)).await
-        } else {
-            McpToolset::with_elicitation_handler(transport, handler).await
-        };
+        let input_handler = adk_handler.clone();
+        use rmcp::ClientServiceExt;
+        let toolset_result = adk_handler
+            .serve_with_lifecycle(transport, config.lifecycle.to_rmcp())
+            .await
+            .map(|client| {
+                McpToolset::new(client)
+                    .with_task_support(config.task_config.clone())
+                    .with_mrtr_handler(input_handler)
+            })
+            .map_err(|error| AdkError::tool(format!("failed to connect MCP server: {error}")));
 
         let toolset = toolset_result.map_err(|e| {
             entry.status = ServerStatus::FailedToStart;
@@ -1178,6 +1179,8 @@ mod tests {
                 disabled: true,
                 auto_approve: vec![],
                 restart_policy: None,
+                lifecycle: Default::default(),
+                task_config: Default::default(),
             },
         )]);
         let manager = McpServerManager::new(configs);
@@ -1196,6 +1199,8 @@ mod tests {
                 disabled: false,
                 auto_approve: vec![],
                 restart_policy: None,
+                lifecycle: Default::default(),
+                task_config: Default::default(),
             },
         )]);
         let manager = McpServerManager::new(configs);
@@ -1242,6 +1247,8 @@ mod tests {
                 disabled: false,
                 auto_approve: vec![],
                 restart_policy: None,
+                lifecycle: Default::default(),
+                task_config: Default::default(),
             },
         )]);
         let manager = McpServerManager::new(configs);
@@ -1270,6 +1277,8 @@ mod tests {
                     disabled: false,
                     auto_approve: vec![],
                     restart_policy: None,
+                    lifecycle: Default::default(),
+                    task_config: Default::default(),
                 },
             ),
             (
@@ -1281,6 +1290,8 @@ mod tests {
                     disabled: true,
                     auto_approve: vec![],
                     restart_policy: None,
+                    lifecycle: Default::default(),
+                    task_config: Default::default(),
                 },
             ),
         ]);
@@ -1309,6 +1320,8 @@ mod tests {
                 disabled: false,
                 auto_approve: vec![],
                 restart_policy: None,
+                lifecycle: Default::default(),
+                task_config: Default::default(),
             },
         )]);
         let manager = McpServerManager::new(configs);
@@ -1333,6 +1346,8 @@ mod tests {
                     disabled: false,
                     auto_approve: vec![],
                     restart_policy: None,
+                    lifecycle: Default::default(),
+                    task_config: Default::default(),
                 },
             ),
             (
@@ -1344,6 +1359,8 @@ mod tests {
                     disabled: true,
                     auto_approve: vec![],
                     restart_policy: None,
+                    lifecycle: Default::default(),
+                    task_config: Default::default(),
                 },
             ),
         ]);
@@ -1464,6 +1481,8 @@ mod tests {
                     disabled: false,
                     auto_approve: vec![],
                     restart_policy: None,
+                    lifecycle: Default::default(),
+                    task_config: Default::default(),
                 },
             ),
             (
@@ -1475,6 +1494,8 @@ mod tests {
                     disabled: true,
                     auto_approve: vec![],
                     restart_policy: None,
+                    lifecycle: Default::default(),
+                    task_config: Default::default(),
                 },
             ),
             (
@@ -1486,6 +1507,8 @@ mod tests {
                     disabled: false,
                     auto_approve: vec![],
                     restart_policy: None,
+                    lifecycle: Default::default(),
+                    task_config: Default::default(),
                 },
             ),
         ]);
@@ -1506,6 +1529,8 @@ mod tests {
             disabled: false,
             auto_approve: vec![],
             restart_policy: None,
+            lifecycle: Default::default(),
+            task_config: Default::default(),
         };
         let result = manager.add_server("new-server".to_string(), config).await;
         assert!(result.is_ok());
@@ -1525,6 +1550,8 @@ mod tests {
                 disabled: false,
                 auto_approve: vec![],
                 restart_policy: None,
+                lifecycle: Default::default(),
+                task_config: Default::default(),
             },
         )]);
         let manager = McpServerManager::new(configs);
@@ -1536,6 +1563,8 @@ mod tests {
             disabled: false,
             auto_approve: vec![],
             restart_policy: None,
+            lifecycle: Default::default(),
+            task_config: Default::default(),
         };
         let result = manager.add_server("existing".to_string(), config).await;
         assert!(result.is_err());
@@ -1553,6 +1582,8 @@ mod tests {
             disabled: true,
             auto_approve: vec![],
             restart_policy: None,
+            lifecycle: Default::default(),
+            task_config: Default::default(),
         };
         let result = manager.add_server("disabled-server".to_string(), config).await;
         assert!(result.is_ok());
@@ -1634,6 +1665,8 @@ mod tests {
                 disabled: false,
                 auto_approve: vec![],
                 restart_policy: None,
+                lifecycle: Default::default(),
+                task_config: Default::default(),
             },
         )]);
         let manager = McpServerManager::new(configs);
@@ -1672,6 +1705,8 @@ mod tests {
                     disabled: false,
                     auto_approve: vec![],
                     restart_policy: None,
+                    lifecycle: Default::default(),
+                    task_config: Default::default(),
                 },
             ),
             (
@@ -1683,6 +1718,8 @@ mod tests {
                     disabled: true,
                     auto_approve: vec![],
                     restart_policy: None,
+                    lifecycle: Default::default(),
+                    task_config: Default::default(),
                 },
             ),
             (
@@ -1694,6 +1731,8 @@ mod tests {
                     disabled: false,
                     auto_approve: vec![],
                     restart_policy: None,
+                    lifecycle: Default::default(),
+                    task_config: Default::default(),
                 },
             ),
         ]);
@@ -1759,6 +1798,8 @@ mod tests {
                 disabled: false,
                 auto_approve: vec![],
                 restart_policy: None,
+                lifecycle: Default::default(),
+                task_config: Default::default(),
             },
         )]);
         let manager = McpServerManager::new(configs);

--- a/adk-tool/src/mcp/manager/mod.rs
+++ b/adk-tool/src/mcp/manager/mod.rs
@@ -25,7 +25,7 @@ mod manager;
 pub(crate) mod status;
 mod toolset_impl;
 
-pub use config::{McpServerConfig, RestartPolicy};
+pub use config::{McpLifecycleMode, McpServerConfig, RestartPolicy};
 pub use status::ServerStatus;
 
 pub use manager::McpServerManager;

--- a/adk-tool/src/mcp/task.rs
+++ b/adk-tool/src/mcp/task.rs
@@ -3,12 +3,15 @@
 // Implements async task lifecycle for long-running MCP tool operations.
 // Tasks allow tools to be queued and polled rather than blocking.
 
+use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
 pub use rmcp::model::{CreateTaskResult, Task as TaskInfo, TaskStatus};
 
 /// Configuration for MCP task-based execution
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+#[serde(default)]
 pub struct McpTaskConfig {
     /// Allow task mode when a tool and server negotiate MCP task support.
     pub enable_tasks: bool,
@@ -18,6 +21,8 @@ pub struct McpTaskConfig {
     pub timeout_ms: Option<u64>,
     /// Maximum number of poll attempts (None = unlimited)
     pub max_poll_attempts: Option<u32>,
+    /// Maximum stateless MRTR input rounds before rejecting a looping peer.
+    pub max_input_rounds: usize,
 }
 
 impl Default for McpTaskConfig {
@@ -27,6 +32,7 @@ impl Default for McpTaskConfig {
             poll_interval_ms: 1000,
             timeout_ms: Some(300_000), // 5 minutes default
             max_poll_attempts: None,
+            max_input_rounds: 10,
         }
     }
 }
@@ -58,6 +64,12 @@ impl McpTaskConfig {
     /// Set maximum poll attempts
     pub fn max_attempts(mut self, attempts: u32) -> Self {
         self.max_poll_attempts = Some(attempts);
+        self
+    }
+
+    /// Set the maximum number of MRTR input rounds.
+    pub fn max_input_rounds(mut self, rounds: usize) -> Self {
+        self.max_input_rounds = rounds;
         self
     }
 

--- a/adk-tool/src/mcp/toolset.rs
+++ b/adk-tool/src/mcp/toolset.rs
@@ -20,6 +20,7 @@ use rmcp::{
         GetPromptRequestParams, GetPromptResult, GetTaskParams, GetTaskRequest, Prompt,
         ReadResourceRequestParams, Resource, ResourceContents, ResourceTemplate, ServerResult,
         SubscribeRequestParams, TaskPayload, ToolAnnotations, UnsubscribeRequestParams,
+        UpdateTaskParams, UpdateTaskRequest,
     },
     service::RunningService,
 };
@@ -194,6 +195,8 @@ where
     retry_tool_calls: bool,
     /// Resource subscriptions restored after an automatic connection refresh.
     resource_subscriptions: Arc<RwLock<BTreeSet<String>>>,
+    /// Policy bridge used to fulfil stateless MRTR and in-task input requests.
+    mrtr_handler: Option<super::elicitation::AdkClientHandler>,
 }
 
 impl<S> Clone for McpToolset<S>
@@ -210,6 +213,7 @@ where
             refresh_config: self.refresh_config.clone(),
             retry_tool_calls: self.retry_tool_calls,
             resource_subscriptions: Arc::clone(&self.resource_subscriptions),
+            mrtr_handler: self.mrtr_handler.clone(),
         }
     }
 }
@@ -245,6 +249,7 @@ where
             refresh_config: RefreshConfig::default(),
             retry_tool_calls: DEFAULT_RETRY_TOOL_CALLS,
             resource_subscriptions: Arc::new(RwLock::new(BTreeSet::new())),
+            mrtr_handler: None,
         }
     }
 
@@ -287,6 +292,15 @@ where
     /// ```
     pub fn with_task_support(mut self, config: McpTaskConfig) -> Self {
         self.task_config = config;
+        self
+    }
+
+    /// Reuse the connection's client policy for stateless MRTR and task input.
+    pub(crate) fn with_mrtr_handler(
+        mut self,
+        handler: super::elicitation::AdkClientHandler,
+    ) -> Self {
+        self.mrtr_handler = Some(handler);
         self
     }
 
@@ -749,6 +763,7 @@ where
                 annotations: mcp_tool.annotations,
                 server_supports_tasks,
                 task_config: self.task_config.clone(),
+                mrtr_handler: self.mrtr_handler.clone(),
             };
 
             tools.push(Arc::new(adk_tool) as Arc<dyn Tool>);
@@ -942,6 +957,8 @@ where
     server_supports_tasks: bool,
     /// Task configuration
     task_config: McpTaskConfig,
+    /// Policy bridge used to fulfil MRTR input without keeping server state.
+    mrtr_handler: Option<super::elicitation::AdkClientHandler>,
 }
 
 impl<S> McpTool<S>
@@ -972,13 +989,14 @@ where
     /// which would break every server that materializes a task.
     async fn call_tool_with_retry(
         &self,
-        params: CallToolRequestParams,
+        mut params: CallToolRequestParams,
     ) -> Result<CallToolResponse> {
         let has_connection_factory = self.connection_factory.is_some();
         let (_, metadata_allows_replay) = mcp_tool_safety(self.annotations.as_ref());
         let replay_allowed = self.retry_tool_calls || metadata_allows_replay;
         let mut attempt = 0u32;
 
+        let mut input_rounds = 0usize;
         loop {
             let call_result = {
                 let client = self.client.lock().await;
@@ -986,6 +1004,35 @@ where
             };
 
             match call_result {
+                Ok(CallToolResponse::InputRequired(required)) => {
+                    input_rounds += 1;
+                    if input_rounds > self.task_config.max_input_rounds {
+                        return Err(AdkError::tool(format!(
+                            "MCP tool '{}' exceeded {} MRTR input rounds",
+                            self.name, self.task_config.max_input_rounds
+                        )));
+                    }
+                    let handler = self.mrtr_handler.as_ref().ok_or_else(|| {
+                        AdkError::tool(format!(
+                            "MCP tool '{}' requires input but no elicitation handler is configured",
+                            self.name
+                        ))
+                    })?;
+                    let responses = match required.input_requests {
+                        Some(requests) => {
+                            handler.fulfill_input_requests(requests).await.map_err(|error| {
+                                AdkError::tool(format!(
+                                    "MCP tool '{}' input request failed: {error}",
+                                    self.name
+                                ))
+                            })?
+                        }
+                        None => Default::default(),
+                    };
+                    params.input_responses = (!responses.is_empty()).then_some(responses);
+                    params.request_state = required.request_state;
+                    attempt = 0;
+                }
                 Ok(result) => return Ok(result),
                 Err(error) => {
                     if !should_retry_mcp_operation(
@@ -1129,13 +1176,30 @@ where
                 TaskPayload::Cancelled => {
                     return Err(TaskError::Cancelled(task_id));
                 }
-                TaskPayload::InputRequired { .. } => {
-                    return Err(TaskError::InputRequired {
-                        task_id,
-                        message: task.status_message.unwrap_or_else(|| {
-                            "the remote server did not describe the required input".to_string()
-                        }),
-                    });
+                TaskPayload::InputRequired { input_requests } => {
+                    let Some(handler) = self.mrtr_handler.as_ref() else {
+                        return Err(TaskError::InputRequired {
+                            task_id,
+                            message: task.status_message.unwrap_or_else(|| {
+                                "the remote server did not describe the required input".to_string()
+                            }),
+                        });
+                    };
+                    let responses = handler
+                        .fulfill_input_requests(input_requests)
+                        .await
+                        .map_err(TaskError::PollFailed)?;
+                    let request = ClientRequest::UpdateTaskRequest(UpdateTaskRequest::new(
+                        UpdateTaskParams::new(&task_id, responses),
+                    ));
+                    match self.send_task_request(request).await? {
+                        ServerResult::TaskAckResult(_) => {}
+                        response => {
+                            return Err(TaskError::PollFailed(format!(
+                                "tasks/update returned an unexpected response: {response:?}"
+                            )));
+                        }
+                    }
                 }
                 TaskPayload::Working => {
                     debug!(task_id, "MCP task is still working");
@@ -1209,8 +1273,7 @@ where
             }
             CallToolResponse::InputRequired(_) => {
                 return Err(AdkError::tool(format!(
-                    "MCP tool '{}' asked for mid-call input (SEP-2322), which this client does not \
-                     drive yet. Configure the server to complete the call in one round.",
+                    "MCP tool '{}' returned an unresolved MRTR input request",
                     self.name
                 )));
             }

--- a/adk-tool/tests/mcp_server_lifecycle_integration_tests.rs
+++ b/adk-tool/tests/mcp_server_lifecycle_integration_tests.rs
@@ -21,6 +21,7 @@ fn playwright_config() -> McpServerConfig {
         disabled: false,
         auto_approve: vec!["browser_click".to_string(), "browser_wait_for".to_string()],
         restart_policy: None,
+        ..Default::default()
     }
 }
 
@@ -37,6 +38,7 @@ fn computer_use_config() -> McpServerConfig {
         disabled: false,
         auto_approve: vec!["wait".to_string()],
         restart_policy: None,
+        ..Default::default()
     }
 }
 

--- a/examples/mcp_manager/src/main.rs
+++ b/examples/mcp_manager/src/main.rs
@@ -68,6 +68,8 @@ fn fixture_config(disabled: bool) -> anyhow::Result<McpServerConfig> {
         env: HashMap::new(),
         disabled,
         auto_approve: Vec::new(),
+        lifecycle: Default::default(),
+        task_config: Default::default(),
         restart_policy: Some(RestartPolicy {
             initial_delay_ms: 100,
             max_delay_ms: 1_000,


### PR DESCRIPTION
## Summary
- add explicit Initialize, Auto, and Discover lifecycle policies to the ADK MCP manager
- advertise and consume SEP-2663 Tasks, including polling, cancellation, and input-required updates
- handle stateless MRTR elicitation with bounded rounds while echoing opaque requestState
- keep legacy initialization as the safe default and document per-server lifecycle/task configuration
- update the standalone manager example for the expanded configuration

## Verification
- `cargo test -p adk-tool --features mcp` (104 unit tests, 13 protocol compatibility tests, property and doc tests)
- pre-commit workspace clippy passed
- pre-push workspace check and all 104 standalone example builds passed