### PR TITLE
fix(rag): reorder FLEXIBLE after TYPE for surrealdb 3.2, add feature-…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,10 @@ jobs:
           - { package: adk-managed, features: full }
           - { package: adk-audio, features: fx }
           - { package: adk-rag, features: lancedb }
+          # adk-rag's SurrealDB backend: gated behind `surrealdb`, so `--workspace` builds
+          # never compiled it. A surrealdb 3.2 parser change broke create_collection while
+          # every required check stayed green. Tests run on the embedded kv-mem engine.
+          - { package: adk-rag, features: surrealdb }
           # adk-auth's SSO/OAuth surface: gated behind `sso`, so `--workspace` without
           # feature flags never compiled it. It had drifted out of the clippy gate, and a
           # jsonwebtoken major bump broke it while every required check stayed green.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `/api/run_sse`, runs the agent to completion, and returns the collected events as a
   JSON array — parity with Google ADK's `api_server` non-streaming `/run` route.
 
+### Fixed
+
+- **adk-rag: SurrealDB `create_collection` parse error.** The `metadata` field
+  definition used the pre-3.2 modifier order `FLEXIBLE TYPE object`, which
+  surrealdb 3.2 rejects with `FLEXIBLE must be specified after TYPE`. Reordered
+  to `TYPE object FLEXIBLE`, and the `surrealdb` feature now has a PR-tier
+  `feature-coverage` matrix entry so the backend cannot silently break again
+  (#568).
+
 ## [2.0.0] - 2026-08-09
 
 ### Breaking

--- a/adk-rag/src/surrealdb.rs
+++ b/adk-rag/src/surrealdb.rs
@@ -149,7 +149,7 @@ impl VectorStore for SurrealVectorStore {
             "DEFINE TABLE IF NOT EXISTS {table}; \
              DEFINE FIELD IF NOT EXISTS text ON {table} TYPE string; \
              DEFINE FIELD IF NOT EXISTS embedding ON {table} TYPE array<float>; \
-             DEFINE FIELD IF NOT EXISTS metadata ON {table} FLEXIBLE TYPE object; \
+             DEFINE FIELD IF NOT EXISTS metadata ON {table} TYPE object FLEXIBLE; \
              DEFINE FIELD IF NOT EXISTS document_id ON {table} TYPE string; \
              DEFINE INDEX IF NOT EXISTS idx_{table}_hnsw ON {table} \
                  FIELDS embedding HNSW DIMENSION {dimensions} DIST COSINE;"


### PR DESCRIPTION
…coverage entry

## What

Fixes the `adk-rag` SurrealDB backend's `create_collection`, which failed on every
call with `Parse error: FLEXIBLE must be specified after TYPE`, and adds the
`surrealdb` feature to the PR-tier `feature-coverage` matrix so the backend cannot
silently break again.

## Why

Fixes #568

`adk-rag/Cargo.toml` pins `surrealdb = "3.0.1"`, which `Cargo.lock` resolves to
3.2.1. SurrealDB 3.2 requires the `FLEXIBLE` modifier after the type clause, so the
pre-3.2 field definition `FLEXIBLE TYPE object` is rejected before any data
operation runs. Nothing caught this in CI: the `surrealdb` feature had no
`feature-coverage` entry, and default `--workspace` builds skip optional-feature
code entirely.

## How

| File | Change |
|------|--------|
| `adk-rag/src/surrealdb.rs` | Reordered the `metadata` field definition to the 3.2 syntax: `TYPE object FLEXIBLE` |
| `.github/workflows/ci.yml` | Added `{ package: adk-rag, features: surrealdb }` to the PR-tier `feature-coverage` matrix — tests run on the embedded `kv-mem` engine, so no service container is needed |
| `CHANGELOG.md` | `### Fixed` entry under `[Unreleased]` |

Verification:

- `cargo nextest run -p adk-rag --features surrealdb` — 16/16 pass, including the
  6 previously failing `surrealdb_tests` and the SurrealDB entries of the shared
  `VectorStore` contract suite.
- `cargo clippy -p adk-rag --features surrealdb --all-targets -- -D warnings` — clean.
- The fix touches only feature-gated code that default `--workspace` builds never
  compile, plus CI configuration and the changelog.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed
- [x] Examples added or updated for new features
