### PR TITLE
feat(server): add Agent Engine dispatch core - envelope, operations, router - PR 1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,10 @@ jobs:
           # default --workspace build skips their tests entirely. Nothing compiled them
           # when durable run records were added.
           - { package: adk-server, features: background }
+          # The Agent Engine dispatch surface (Gemini Enterprise Agent Platform runtime
+          # contract) is behind `agent-engine`; its wire-fixture and dispatch tests only
+          # run with the feature on. Umbrella forwarding follows in the entrypoint PR.
+          - { package: adk-server, features: agent-engine }
           # sandbox-linux is Linux-only *and* feature-gated, so nothing built it until a
           # container run found the bubblewrap probe could never succeed and that its
           # property tests did not compile.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Agent Engine dispatch surface** (`adk-server`, feature `agent-engine`): the
+  container-side runtime contract that makes an adk-rust agent drivable by the
+  Gemini Enterprise Agent Platform (`reasoningEngines.query` /
+  `streamQuery`, console Playground, platform SDKs). `agent_engine_router`
+  mounts `POST /api/reasoning_engine` (unary, `{"output": ...}`) and
+  `POST /api/stream_reasoning_engine` (newline-delimited JSON events), dispatching
+  the exact `AdkApp` operation set — session CRUD in sync/async pairs,
+  `stream_query` / `async_stream_query`, `streaming_agent_run_with_events`,
+  `async_add_session_to_memory` / `async_search_memory` (Unsupported until a
+  memory service is configured), and `register_operations`. A shared wire
+  fixture (`adk-server/tests/fixtures/agent_engine_wire.json`) pins the
+  envelope and streamed-event framing for the future remote-engine client.
+
 - **adk-rag: shared `VectorStore` contract test suite.** A new
   `adk-rag/tests/common/vector_store_contract.rs` holds the behavioral contract
   every vector store backend must satisfy — idempotent collection creation,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,6 +928,7 @@ dependencies = [
  "adk-agent",
  "adk-artifact",
  "adk-core",
+ "adk-memory",
  "adk-runner",
  "adk-session",
  "adk-skill",

--- a/adk-server/Cargo.toml
+++ b/adk-server/Cargo.toml
@@ -20,6 +20,8 @@ adk-runner = { workspace = true, features = ["artifacts", "plugins", "skills"] }
 adk-session.workspace = true
 adk-skill.workspace = true
 adk-artifact.workspace = true
+# Optional: Agent Engine dispatch surface (memory class methods)
+adk-memory = { workspace = true, optional = true }
 adk-telemetry.workspace = true
 tokio = { workspace = true, features = ["sync", "signal", "macros", "rt", "time"] }
 tokio-stream.workspace = true
@@ -69,6 +71,8 @@ a2a-interceptors = []
 openai-webhooks = ["dep:hmac", "dep:sha2", "dep:hex"]
 # Enable background run endpoints and cron job management
 background = ["dep:cron"]
+# Enable the Gemini Enterprise Agent Platform (ReasoningEngine) dispatch surface
+agent-engine = ["dep:adk-memory"]
 
 [dev-dependencies]
 async-stream.workspace = true

--- a/adk-server/src/agent_engine/envelope.rs
+++ b/adk-server/src/agent_engine/envelope.rs
@@ -1,0 +1,43 @@
+//! Wire envelope for the Agent Engine dispatch protocol.
+//!
+//! # Casing exception
+//!
+//! This envelope is **snake_case**, not the workspace's usual camelCase for
+//! REST payloads. The platform's container contract dispatches
+//! `{"class_method": ..., "input": ...}` because adk-python resolves the
+//! method with `getattr` — the field names are Python identifiers on the
+//! wire (confirmed by verification task V14). Do not "fix" this to
+//! camelCase; it would break every host-side caller.
+
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+/// A dispatch request as delivered by the Agent Engine host to the container.
+///
+/// Sent to both `POST /api/reasoning_engine` (unary) and
+/// `POST /api/stream_reasoning_engine` (streaming).
+///
+/// # Example
+///
+/// ```rust
+/// use adk_server::agent_engine::DispatchRequest;
+///
+/// let req: DispatchRequest = serde_json::from_str(
+///     r#"{"class_method": "async_stream_query", "input": {"user_id": "u", "message": "hi"}}"#,
+/// )
+/// .unwrap();
+/// assert_eq!(req.class_method, "async_stream_query");
+/// ```
+#[derive(Debug, Clone, Deserialize)]
+pub struct DispatchRequest {
+    /// The operation name, matched against [`ClassMethod`](super::ClassMethod).
+    pub class_method: String,
+    /// Operation arguments; each class method deserializes this into its
+    /// typed input struct at the dispatch boundary.
+    pub input: Option<Value>,
+}
+
+/// Wraps a unary handler result in the platform's `{"output": ...}` envelope.
+pub(crate) fn unary_response(output: Value) -> Value {
+    json!({ "output": output })
+}

--- a/adk-server/src/agent_engine/mod.rs
+++ b/adk-server/src/agent_engine/mod.rs
@@ -1,0 +1,358 @@
+//! Agent Engine dispatch surface for the Gemini Enterprise Agent Platform.
+//!
+//! Makes an adk-rust agent in a BYOC container drivable by
+//! `reasoningEngines.query`, `reasoningEngines.streamQuery`, the console
+//! Playground, and the platform SDKs. The host POSTs a
+//! [`DispatchRequest`] envelope naming a [`ClassMethod`]; this module routes
+//! it to the session service, memory service, or [`Runner`].
+//!
+//! - `POST /api/reasoning_engine` — unary operations, responding
+//!   `{"output": ...}`.
+//! - `POST /api/stream_reasoning_engine` — streaming operations, responding
+//!   newline-delimited JSON events with `Content-Type: application/json`
+//!   (no SSE framing).
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use adk_server::agent_engine::{AgentEngineState, agent_engine_router};
+//! use adk_runner::Runner;
+//! use std::sync::Arc;
+//!
+//! # fn build(runner: Arc<Runner>) -> axum::Router {
+//! let state = AgentEngineState::new(runner);
+//! agent_engine_router(state)
+//! # }
+//! ```
+
+mod envelope;
+mod operations;
+
+pub use envelope::DispatchRequest;
+pub use operations::{
+    AddSessionToMemoryInput, AgentRunRequest, ApiMode, ClassMethod, CreateSessionInput,
+    DeleteSessionInput, GetSessionInput, ListSessionsInput, SearchMemoryInput, StreamQueryInput,
+    StreamingAgentRunWithEventsInput,
+};
+
+use adk_core::{AdkError, Content, ErrorCategory, ErrorComponent, Result};
+use adk_runner::Runner;
+use axum::{
+    Json, Router,
+    body::Body,
+    http::{StatusCode, header},
+    response::{IntoResponse, Response},
+    routing::post,
+};
+use futures::StreamExt;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::str::FromStr;
+use std::sync::Arc;
+use tracing::{error, info};
+
+/// Shared state for the Agent Engine dispatch handlers.
+///
+/// The session service and app name are taken from the [`Runner`] so the
+/// dispatch surface and the runner can never disagree about session scoping.
+/// The memory and artifact services are optional from day one: filling them
+/// in later is additive, mirroring adk-python `AdkApp`'s
+/// `memory_service_builder` / `artifact_service_builder`.
+#[derive(Clone)]
+pub struct AgentEngineState {
+    runner: Arc<Runner>,
+    session_service: Arc<dyn adk_session::SessionService>,
+    memory_service: Option<Arc<dyn adk_memory::MemoryService>>,
+    artifact_service: Option<Arc<dyn adk_artifact::ArtifactService>>,
+    app_name: String,
+}
+
+impl AgentEngineState {
+    /// Creates dispatch state around a prebuilt runner.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use adk_server::agent_engine::AgentEngineState;
+    /// use adk_runner::Runner;
+    /// use std::sync::Arc;
+    ///
+    /// # fn build(runner: Arc<Runner>) {
+    /// let state = AgentEngineState::new(runner);
+    /// # }
+    /// ```
+    pub fn new(runner: Arc<Runner>) -> Self {
+        let session_service = runner.session_service().clone();
+        let app_name = runner.app_name().to_string();
+        Self { runner, session_service, memory_service: None, artifact_service: None, app_name }
+    }
+
+    /// Configures the memory service backing `async_add_session_to_memory`
+    /// and `async_search_memory`. Without one, both return an
+    /// [`Unsupported`](adk_core::ErrorCategory::Unsupported) error.
+    pub fn with_memory_service(
+        mut self,
+        memory_service: Arc<dyn adk_memory::MemoryService>,
+    ) -> Self {
+        self.memory_service = Some(memory_service);
+        self
+    }
+
+    /// Configures the artifact service. No class method consumes it yet; it
+    /// is carried here so wiring `GcsArtifactService` later is additive.
+    pub fn with_artifact_service(
+        mut self,
+        artifact_service: Arc<dyn adk_artifact::ArtifactService>,
+    ) -> Self {
+        self.artifact_service = Some(artifact_service);
+        self
+    }
+
+    /// The runner executing `stream_query` operations.
+    pub fn runner(&self) -> &Arc<Runner> {
+        &self.runner
+    }
+
+    /// The session service backing the session class methods.
+    pub fn session_service(&self) -> &Arc<dyn adk_session::SessionService> {
+        &self.session_service
+    }
+
+    /// The memory service, when configured.
+    pub fn memory_service(&self) -> Option<&Arc<dyn adk_memory::MemoryService>> {
+        self.memory_service.as_ref()
+    }
+
+    /// The artifact service, when configured.
+    pub fn artifact_service(&self) -> Option<&Arc<dyn adk_artifact::ArtifactService>> {
+        self.artifact_service.as_ref()
+    }
+
+    /// The resolved application name used for session scoping.
+    pub fn app_name(&self) -> &str {
+        &self.app_name
+    }
+}
+
+/// Builds the Agent Engine dispatch router.
+///
+/// Mounts `POST /api/reasoning_engine` (unary) and
+/// `POST /api/stream_reasoning_engine` (streaming). Merge it into a server
+/// app or serve it standalone in a BYOC container.
+pub fn agent_engine_router(state: AgentEngineState) -> Router {
+    Router::new()
+        .route("/api/reasoning_engine", post(dispatch_unary))
+        .route("/api/stream_reasoning_engine", post(dispatch_stream))
+        .with_state(state)
+}
+
+/// Renders an [`AdkError`] as its problem-JSON response.
+fn problem_response(err: &AdkError) -> Response {
+    let status =
+        StatusCode::from_u16(err.http_status_code()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+    (status, Json(err.to_problem_json())).into_response()
+}
+
+/// The error for a method POSTed to the wrong endpoint (streaming method on
+/// the unary route or vice versa).
+fn wrong_endpoint(method: ClassMethod, expected: &str) -> AdkError {
+    AdkError::new(
+        ErrorComponent::Server,
+        ErrorCategory::InvalidInput,
+        "agent_engine.wrong_endpoint",
+        format!("class_method '{}' must be POSTed to {expected}", method.as_str()),
+    )
+}
+
+/// Unary dispatch: `POST /api/reasoning_engine`.
+async fn dispatch_unary(
+    axum::extract::State(state): axum::extract::State<AgentEngineState>,
+    Json(request): Json<DispatchRequest>,
+) -> Response {
+    info!(class_method = %request.class_method, "agent engine unary dispatch");
+    let method = match ClassMethod::from_str(&request.class_method) {
+        Ok(method) => method,
+        Err(err) => return problem_response(&err),
+    };
+    if method.api_mode().is_streaming() {
+        return problem_response(&wrong_endpoint(method, "/api/stream_reasoning_engine"));
+    }
+    let output = run_unary(&state, method, request.input).await;
+    match output {
+        Ok(output) => Json(envelope::unary_response(output)).into_response(),
+        Err(err) => {
+            error!(class_method = %request.class_method, error = %err, "unary dispatch failed");
+            problem_response(&err)
+        }
+    }
+}
+
+/// Executes a unary class method against the state.
+///
+/// The match is exhaustive — streaming variants are rejected before this is
+/// called, and returning an error for them here keeps the compiler enforcing
+/// that every future variant picks an endpoint.
+async fn run_unary(
+    state: &AgentEngineState,
+    method: ClassMethod,
+    input: Option<Value>,
+) -> Result<Value> {
+    match method {
+        ClassMethod::CreateSession | ClassMethod::AsyncCreateSession => {
+            operations::handle_create_session(state, operations::typed_input(input)?).await
+        }
+        ClassMethod::GetSession | ClassMethod::AsyncGetSession => {
+            operations::handle_get_session(state, operations::typed_input(input)?).await
+        }
+        ClassMethod::ListSessions | ClassMethod::AsyncListSessions => {
+            operations::handle_list_sessions(state, operations::typed_input(input)?).await
+        }
+        ClassMethod::DeleteSession | ClassMethod::AsyncDeleteSession => {
+            operations::handle_delete_session(state, operations::typed_input(input)?).await
+        }
+        ClassMethod::AsyncAddSessionToMemory => {
+            operations::handle_add_session_to_memory(state, operations::typed_input(input)?).await
+        }
+        ClassMethod::AsyncSearchMemory => {
+            operations::handle_search_memory(state, operations::typed_input(input)?).await
+        }
+        ClassMethod::RegisterOperations => Ok(operations::handle_register_operations()),
+        ClassMethod::StreamQuery
+        | ClassMethod::AsyncStreamQuery
+        | ClassMethod::StreamingAgentRunWithEvents => {
+            Err(wrong_endpoint(method, "/api/stream_reasoning_engine"))
+        }
+    }
+}
+
+/// Streaming dispatch: `POST /api/stream_reasoning_engine`.
+async fn dispatch_stream(
+    axum::extract::State(state): axum::extract::State<AgentEngineState>,
+    Json(request): Json<DispatchRequest>,
+) -> Response {
+    info!(class_method = %request.class_method, "agent engine streaming dispatch");
+    let method = match ClassMethod::from_str(&request.class_method) {
+        Ok(method) => method,
+        Err(err) => return problem_response(&err),
+    };
+    let prepared = match method {
+        ClassMethod::StreamQuery | ClassMethod::AsyncStreamQuery => {
+            prepare_stream_query(&state, request.input).await
+        }
+        ClassMethod::StreamingAgentRunWithEvents => {
+            prepare_agent_run_with_events(&state, request.input).await
+        }
+        ClassMethod::CreateSession
+        | ClassMethod::AsyncCreateSession
+        | ClassMethod::GetSession
+        | ClassMethod::AsyncGetSession
+        | ClassMethod::ListSessions
+        | ClassMethod::AsyncListSessions
+        | ClassMethod::DeleteSession
+        | ClassMethod::AsyncDeleteSession
+        | ClassMethod::AsyncAddSessionToMemory
+        | ClassMethod::AsyncSearchMemory
+        | ClassMethod::RegisterOperations => Err(wrong_endpoint(method, "/api/reasoning_engine")),
+    };
+    let (user_id, session_id, content) = match prepared {
+        Ok(prepared) => prepared,
+        Err(err) => {
+            error!(class_method = %request.class_method, error = %err, "streaming dispatch failed");
+            return problem_response(&err);
+        }
+    };
+
+    let (typed_user_id, typed_session_id) = match operations::typed_identity(&user_id, &session_id)
+    {
+        Ok(identity) => identity,
+        Err(err) => return problem_response(&err),
+    };
+    let event_stream = match state.runner().run(typed_user_id, typed_session_id, content).await {
+        Ok(stream) => stream,
+        Err(err) => {
+            error!(error = %err, "runner failed to start");
+            return problem_response(&err);
+        }
+    };
+
+    // One JSON object per line. An error after the first event cannot change
+    // the already-sent 200 status, so it is emitted as a problem-JSON line
+    // and the stream ends — the same contract as adk-python's template
+    // server, whose callers parse each line independently.
+    let body_stream = event_stream.map(|item| {
+        let line = match item {
+            Ok(event) => serde_json::to_string(&event).unwrap_or_else(|err| {
+                error_line(&AdkError::new(
+                    ErrorComponent::Server,
+                    ErrorCategory::Internal,
+                    "agent_engine.event_serialization",
+                    format!("failed to serialize event: {err}"),
+                ))
+            }),
+            Err(err) => {
+                error!(error = %err, "agent event stream failed");
+                error_line(&err)
+            }
+        };
+        Ok::<_, std::convert::Infallible>(format!("{line}\n"))
+    });
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from_stream(body_stream))
+        .unwrap_or_else(|err| {
+            error!(error = %err, "failed to build streaming response");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        })
+}
+
+/// Serializes an error as a single NDJSON problem line.
+fn error_line(err: &AdkError) -> String {
+    err.to_problem_json().to_string()
+}
+
+/// Validates a `stream_query` input and resolves its session.
+async fn prepare_stream_query(
+    state: &AgentEngineState,
+    input: Option<Value>,
+) -> Result<(String, String, Content)> {
+    let input: StreamQueryInput = operations::typed_input(input)?;
+    let content = operations::message_to_content(input.message)?;
+    let (session_id, _created) =
+        operations::resolve_session(state, &input.user_id, input.session_id, HashMap::new())
+            .await?;
+    Ok((input.user_id, session_id, content))
+}
+
+/// Validates a `streaming_agent_run_with_events` input and resolves its
+/// session, applying the request's state delta.
+async fn prepare_agent_run_with_events(
+    state: &AgentEngineState,
+    input: Option<Value>,
+) -> Result<(String, String, Content)> {
+    let input: StreamingAgentRunWithEventsInput = operations::typed_input(input)?;
+    let request: AgentRunRequest = serde_json::from_str(&input.request_json).map_err(|err| {
+        AdkError::new(
+            ErrorComponent::Server,
+            ErrorCategory::InvalidInput,
+            "agent_engine.invalid_agent_run_request",
+            format!("request_json is not a valid AgentRunRequest: {err}"),
+        )
+    })?;
+    let state_delta: HashMap<String, Value> =
+        request.state_delta.unwrap_or_default().into_iter().collect();
+    // A created session takes the delta as its initial state; an existing one
+    // gets it as an appended state-delta event, matching the REST runtime.
+    let (session_id, created) = operations::resolve_session(
+        state,
+        &request.user_id,
+        Some(request.session_id),
+        state_delta.clone(),
+    )
+    .await?;
+    if !created {
+        operations::apply_state_delta(state, &request.user_id, &session_id, state_delta).await?;
+    }
+    Ok((request.user_id, session_id, request.new_message))
+}

--- a/adk-server/src/agent_engine/operations.rs
+++ b/adk-server/src/agent_engine/operations.rs
@@ -1,0 +1,696 @@
+//! Class-method dispatch for the Agent Engine runtime contract.
+//!
+//! # Anti-corruption layer
+//!
+//! This module deliberately contains a Python-reflection-shaped protocol: the
+//! platform dispatches on method-name strings because adk-python resolves
+//! operations with `getattr`. The foreignness stays here — typed request
+//! structs are produced at the boundary and nothing string-dispatched leaks
+//! into `adk-core` or `adk-runner`.
+//!
+//! # Sync/async name pairs
+//!
+//! `create_session` / `async_create_session` (and the other session CRUD
+//! pairs) are wire-parity aliases mapping to the same handler. adk-rust is
+//! async throughout; the [`ApiMode`] split exists only because adk-python
+//! exposes both sync and async Python methods and the platform routes them
+//! through different API modes.
+//!
+//! # asyncQuery (durable query jobs)
+//!
+//! The platform also exposes `reasoningEngines:asyncQuery`
+//! (`AsyncQueryReasoningEngine`). It is **not** registered here: the
+//! capability must be declared at engine create time and cannot be added to
+//! an engine post-create (google/adk-python#6220), and adk-python's `AdkApp`
+//! does not register it either — strict parity excludes it. Deployments that
+//! need durable query jobs must front the engine with their own job store.
+
+use super::AgentEngineState;
+use adk_core::{AdkError, Content, ErrorCategory, ErrorComponent, Result, SessionId, UserId};
+use serde::Deserialize;
+use serde_json::{Map, Value, json};
+use std::collections::HashMap;
+use std::str::FromStr;
+
+/// Maximum number of events serialized into a session dump, mirroring the
+/// cap used by the REST session controller.
+const MAX_EVENTS: usize = 10_000;
+
+/// The platform API mode an operation is registered under.
+///
+/// Wire values are the keys of the `register_operations` map: `""`, `async`,
+/// `stream`, and `async_stream`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApiMode {
+    /// Default (unary) mode, registered under `""`.
+    Sync,
+    /// Async unary mode, registered under `"async"`.
+    Async,
+    /// Streaming mode, registered under `"stream"`.
+    Stream,
+    /// Async streaming mode, registered under `"async_stream"`.
+    AsyncStream,
+}
+
+impl ApiMode {
+    /// Returns the wire key for this mode in the `register_operations` map.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ApiMode::Sync => "",
+            ApiMode::Async => "async",
+            ApiMode::Stream => "stream",
+            ApiMode::AsyncStream => "async_stream",
+        }
+    }
+
+    /// Whether operations in this mode stream newline-delimited JSON.
+    pub fn is_streaming(&self) -> bool {
+        match self {
+            ApiMode::Sync | ApiMode::Async => false,
+            ApiMode::Stream | ApiMode::AsyncStream => true,
+        }
+    }
+}
+
+/// One dispatchable operation of the Agent Engine contract.
+///
+/// The variant set is the exact operation set adk-python's `AdkApp` registers
+/// (verification task V2, `google-cloud-aiplatform` 1.112 / `google-adk`
+/// 2.6.3), plus `register_operations` itself.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClassMethod {
+    /// `create_session` — session CRUD, default mode.
+    CreateSession,
+    /// `async_create_session` — wire-parity alias of [`Self::CreateSession`].
+    AsyncCreateSession,
+    /// `get_session` — session CRUD, default mode.
+    GetSession,
+    /// `async_get_session` — wire-parity alias of [`Self::GetSession`].
+    AsyncGetSession,
+    /// `list_sessions` — session CRUD, default mode.
+    ListSessions,
+    /// `async_list_sessions` — wire-parity alias of [`Self::ListSessions`].
+    AsyncListSessions,
+    /// `delete_session` — session CRUD, default mode.
+    DeleteSession,
+    /// `async_delete_session` — wire-parity alias of [`Self::DeleteSession`].
+    AsyncDeleteSession,
+    /// `stream_query` — run the agent, streaming ADK events.
+    StreamQuery,
+    /// `async_stream_query` — wire-parity alias of [`Self::StreamQuery`].
+    AsyncStreamQuery,
+    /// `streaming_agent_run_with_events` — run the agent from an ADK
+    /// `AgentRunRequest` JSON string (console Playground path).
+    StreamingAgentRunWithEvents,
+    /// `async_add_session_to_memory` — extract a session's events into the
+    /// configured memory service.
+    AsyncAddSessionToMemory,
+    /// `async_search_memory` — search the configured memory service.
+    AsyncSearchMemory,
+    /// `register_operations` — advertise the operation map to the host.
+    RegisterOperations,
+}
+
+impl ClassMethod {
+    /// Every dispatchable operation, in registration order.
+    ///
+    /// The `register_operations` output is derived from this list, so the
+    /// advertised operation set and the dispatcher cannot drift.
+    pub const ALL: [ClassMethod; 14] = [
+        ClassMethod::CreateSession,
+        ClassMethod::AsyncCreateSession,
+        ClassMethod::GetSession,
+        ClassMethod::AsyncGetSession,
+        ClassMethod::ListSessions,
+        ClassMethod::AsyncListSessions,
+        ClassMethod::DeleteSession,
+        ClassMethod::AsyncDeleteSession,
+        ClassMethod::StreamQuery,
+        ClassMethod::AsyncStreamQuery,
+        ClassMethod::StreamingAgentRunWithEvents,
+        ClassMethod::AsyncAddSessionToMemory,
+        ClassMethod::AsyncSearchMemory,
+        ClassMethod::RegisterOperations,
+    ];
+
+    /// Returns the wire name of this operation.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ClassMethod::CreateSession => "create_session",
+            ClassMethod::AsyncCreateSession => "async_create_session",
+            ClassMethod::GetSession => "get_session",
+            ClassMethod::AsyncGetSession => "async_get_session",
+            ClassMethod::ListSessions => "list_sessions",
+            ClassMethod::AsyncListSessions => "async_list_sessions",
+            ClassMethod::DeleteSession => "delete_session",
+            ClassMethod::AsyncDeleteSession => "async_delete_session",
+            ClassMethod::StreamQuery => "stream_query",
+            ClassMethod::AsyncStreamQuery => "async_stream_query",
+            ClassMethod::StreamingAgentRunWithEvents => "streaming_agent_run_with_events",
+            ClassMethod::AsyncAddSessionToMemory => "async_add_session_to_memory",
+            ClassMethod::AsyncSearchMemory => "async_search_memory",
+            ClassMethod::RegisterOperations => "register_operations",
+        }
+    }
+
+    /// Returns the platform API mode this operation is registered under.
+    pub fn api_mode(&self) -> ApiMode {
+        match self {
+            ClassMethod::CreateSession
+            | ClassMethod::GetSession
+            | ClassMethod::ListSessions
+            | ClassMethod::DeleteSession
+            | ClassMethod::RegisterOperations => ApiMode::Sync,
+            ClassMethod::AsyncCreateSession
+            | ClassMethod::AsyncGetSession
+            | ClassMethod::AsyncListSessions
+            | ClassMethod::AsyncDeleteSession
+            | ClassMethod::AsyncAddSessionToMemory
+            | ClassMethod::AsyncSearchMemory => ApiMode::Async,
+            ClassMethod::StreamQuery => ApiMode::Stream,
+            ClassMethod::AsyncStreamQuery | ClassMethod::StreamingAgentRunWithEvents => {
+                ApiMode::AsyncStream
+            }
+        }
+    }
+}
+
+impl FromStr for ClassMethod {
+    type Err = AdkError;
+
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "create_session" => Ok(ClassMethod::CreateSession),
+            "async_create_session" => Ok(ClassMethod::AsyncCreateSession),
+            "get_session" => Ok(ClassMethod::GetSession),
+            "async_get_session" => Ok(ClassMethod::AsyncGetSession),
+            "list_sessions" => Ok(ClassMethod::ListSessions),
+            "async_list_sessions" => Ok(ClassMethod::AsyncListSessions),
+            "delete_session" => Ok(ClassMethod::DeleteSession),
+            "async_delete_session" => Ok(ClassMethod::AsyncDeleteSession),
+            "stream_query" => Ok(ClassMethod::StreamQuery),
+            "async_stream_query" => Ok(ClassMethod::AsyncStreamQuery),
+            "streaming_agent_run_with_events" => Ok(ClassMethod::StreamingAgentRunWithEvents),
+            "async_add_session_to_memory" => Ok(ClassMethod::AsyncAddSessionToMemory),
+            "async_search_memory" => Ok(ClassMethod::AsyncSearchMemory),
+            "register_operations" => Ok(ClassMethod::RegisterOperations),
+            unknown => Err(AdkError::new(
+                ErrorComponent::Server,
+                ErrorCategory::InvalidInput,
+                "agent_engine.unknown_class_method",
+                format!(
+                    "unknown class_method '{unknown}'; call register_operations for the \
+                     supported operation set"
+                ),
+            )),
+        }
+    }
+}
+
+// ── Typed inputs ─────────────────────────────────────────────────────────
+//
+// Each operation deserializes its `input` value into one of these structs
+// immediately at the dispatch boundary; handlers never see raw JSON.
+
+/// Input for `create_session` / `async_create_session`.
+#[derive(Debug, Deserialize)]
+pub struct CreateSessionInput {
+    /// Session owner.
+    pub user_id: String,
+    /// Optional caller-chosen session ID; generated when absent.
+    pub session_id: Option<String>,
+    /// Optional initial session state.
+    pub state: Option<Map<String, Value>>,
+}
+
+/// Input for `get_session` / `async_get_session`.
+#[derive(Debug, Deserialize)]
+pub struct GetSessionInput {
+    /// Session owner.
+    pub user_id: String,
+    /// Session to retrieve.
+    pub session_id: String,
+}
+
+/// Input for `list_sessions` / `async_list_sessions`.
+#[derive(Debug, Deserialize)]
+pub struct ListSessionsInput {
+    /// User whose sessions are listed.
+    pub user_id: String,
+}
+
+/// Input for `delete_session` / `async_delete_session`.
+#[derive(Debug, Deserialize)]
+pub struct DeleteSessionInput {
+    /// Session owner.
+    pub user_id: String,
+    /// Session to delete.
+    pub session_id: String,
+}
+
+/// Input for `stream_query` / `async_stream_query`.
+#[derive(Debug, Deserialize)]
+pub struct StreamQueryInput {
+    /// Session owner.
+    pub user_id: String,
+    /// Optional session to continue; a new session is created when absent.
+    pub session_id: Option<String>,
+    /// The user message: either a plain string or a `Content` object,
+    /// matching adk-python's `str | dict` parameter.
+    pub message: Value,
+}
+
+/// Input for `streaming_agent_run_with_events`.
+#[derive(Debug, Deserialize)]
+pub struct StreamingAgentRunWithEventsInput {
+    /// An ADK `AgentRunRequest` as a JSON **string** — the console Playground
+    /// sends the request pre-serialized, matching adk-python's
+    /// `streaming_agent_run_with_events(request_json: str)`.
+    pub request_json: String,
+}
+
+/// The ADK `AgentRunRequest` carried inside
+/// [`StreamingAgentRunWithEventsInput::request_json`].
+///
+/// google-adk's model accepts both snake_case field names and camelCase
+/// aliases (`populate_by_name=True`); the serde aliases mirror that.
+#[derive(Debug, Deserialize)]
+pub struct AgentRunRequest {
+    /// Application name; accepted for wire parity. The runner's own app name
+    /// governs session scoping, so a mismatched value is not an error.
+    #[serde(default, alias = "appName")]
+    pub app_name: Option<String>,
+    /// Session owner.
+    #[serde(alias = "userId")]
+    pub user_id: String,
+    /// Session to run in; created when it does not exist.
+    #[serde(alias = "sessionId")]
+    pub session_id: String,
+    /// The user message.
+    #[serde(alias = "newMessage")]
+    pub new_message: Content,
+    /// Accepted for wire parity; HTTP framing (unary vs streaming endpoint)
+    /// decides the response shape, not this flag.
+    #[serde(default)]
+    pub streaming: bool,
+    /// Optional state delta applied to the session before the run.
+    #[serde(default, alias = "stateDelta")]
+    pub state_delta: Option<Map<String, Value>>,
+}
+
+/// Input for `async_add_session_to_memory`.
+#[derive(Debug, Deserialize)]
+pub struct AddSessionToMemoryInput {
+    /// Session owner.
+    pub user_id: String,
+    /// Session whose events are extracted into memory.
+    pub session_id: String,
+}
+
+/// Input for `async_search_memory`.
+#[derive(Debug, Deserialize)]
+pub struct SearchMemoryInput {
+    /// User whose memory is searched.
+    pub user_id: String,
+    /// Search query.
+    pub query: String,
+}
+
+/// Deserializes an operation's `input` into its typed request struct.
+///
+/// A missing `input` is treated as `{}` so operations whose fields are all
+/// optional (and `register_operations`, which takes none) accept an absent
+/// field.
+pub(crate) fn typed_input<T: serde::de::DeserializeOwned>(input: Option<Value>) -> Result<T> {
+    let value = input.unwrap_or_else(|| Value::Object(Map::new()));
+    serde_json::from_value(value).map_err(|err| {
+        AdkError::new(
+            ErrorComponent::Server,
+            ErrorCategory::InvalidInput,
+            "agent_engine.invalid_input",
+            format!("input does not match the class_method's schema: {err}"),
+        )
+    })
+}
+
+// ── Handlers ─────────────────────────────────────────────────────────────
+
+/// Serializes a session in the `AdkApp` dump shape: snake_case keys, events
+/// inline, `last_update_time` as float seconds (Python parity).
+pub(crate) fn session_to_value(session: &dyn adk_session::Session) -> Value {
+    let events: Vec<Value> = session
+        .events()
+        .all()
+        .into_iter()
+        .take(MAX_EVENTS)
+        .map(|event| serde_json::to_value(event).unwrap_or(Value::Null))
+        .collect();
+    json!({
+        "id": session.id(),
+        "app_name": session.app_name(),
+        "user_id": session.user_id(),
+        "state": session.state().all(),
+        "events": events,
+        "last_update_time": session.last_update_time().timestamp_millis() as f64 / 1000.0,
+    })
+}
+
+/// Handles `create_session` / `async_create_session`.
+pub(crate) async fn handle_create_session(
+    state: &AgentEngineState,
+    input: CreateSessionInput,
+) -> Result<Value> {
+    let initial_state: HashMap<String, Value> =
+        input.state.unwrap_or_default().into_iter().collect();
+    let session = state
+        .session_service()
+        .create(adk_session::CreateRequest {
+            app_name: state.app_name().to_string(),
+            user_id: input.user_id,
+            session_id: input.session_id,
+            state: initial_state,
+        })
+        .await?;
+    Ok(session_to_value(session.as_ref()))
+}
+
+/// Handles `get_session` / `async_get_session`.
+pub(crate) async fn handle_get_session(
+    state: &AgentEngineState,
+    input: GetSessionInput,
+) -> Result<Value> {
+    let session = state
+        .session_service()
+        .get(adk_session::GetRequest {
+            app_name: state.app_name().to_string(),
+            user_id: input.user_id,
+            session_id: input.session_id,
+            num_recent_events: None,
+            after: None,
+        })
+        .await?;
+    Ok(session_to_value(session.as_ref()))
+}
+
+/// Handles `list_sessions` / `async_list_sessions`.
+pub(crate) async fn handle_list_sessions(
+    state: &AgentEngineState,
+    input: ListSessionsInput,
+) -> Result<Value> {
+    let sessions = state
+        .session_service()
+        .list(adk_session::ListRequest {
+            app_name: state.app_name().to_string(),
+            user_id: input.user_id,
+            limit: None,
+            offset: None,
+        })
+        .await?;
+    let sessions: Vec<Value> =
+        sessions.iter().map(|session| session_to_value(session.as_ref())).collect();
+    Ok(json!({ "sessions": sessions }))
+}
+
+/// Handles `delete_session` / `async_delete_session`.
+pub(crate) async fn handle_delete_session(
+    state: &AgentEngineState,
+    input: DeleteSessionInput,
+) -> Result<Value> {
+    state
+        .session_service()
+        .delete(adk_session::DeleteRequest {
+            app_name: state.app_name().to_string(),
+            user_id: input.user_id,
+            session_id: input.session_id,
+        })
+        .await?;
+    Ok(Value::Null)
+}
+
+/// Handles `register_operations`.
+///
+/// The map is derived from [`ClassMethod::ALL`] grouped by
+/// [`ClassMethod::api_mode`], so it cannot drift from the dispatcher.
+pub(crate) fn handle_register_operations() -> Value {
+    let mut map = Map::new();
+    for mode in [ApiMode::Sync, ApiMode::Async, ApiMode::Stream, ApiMode::AsyncStream] {
+        let names: Vec<Value> = ClassMethod::ALL
+            .iter()
+            .filter(|method| method.api_mode() == mode)
+            .map(|method| Value::String(method.as_str().to_string()))
+            .collect();
+        map.insert(mode.as_str().to_string(), Value::Array(names));
+    }
+    Value::Object(map)
+}
+
+/// The error returned by the memory class methods when no memory service is
+/// configured — every deployment until the Memory Bank backend lands.
+fn memory_unavailable() -> AdkError {
+    AdkError::new(
+        ErrorComponent::Server,
+        ErrorCategory::Unsupported,
+        "agent_engine.memory_unavailable",
+        "no memory service is configured on this engine; configure one via \
+         AgentEngineState::with_memory_service (Memory Bank support arrives with the \
+         vertex memory backend)",
+    )
+}
+
+/// Handles `async_add_session_to_memory`.
+///
+/// Fetches the session, converts its content-bearing events into
+/// [`adk_memory::MemoryEntry`] items, and adds them to the memory service —
+/// the trait takes pre-extracted entries, not a session.
+pub(crate) async fn handle_add_session_to_memory(
+    state: &AgentEngineState,
+    input: AddSessionToMemoryInput,
+) -> Result<Value> {
+    let Some(memory_service) = state.memory_service() else {
+        return Err(memory_unavailable());
+    };
+    let session = state
+        .session_service()
+        .get(adk_session::GetRequest {
+            app_name: state.app_name().to_string(),
+            user_id: input.user_id.clone(),
+            session_id: input.session_id.clone(),
+            num_recent_events: None,
+            after: None,
+        })
+        .await?;
+    let entries: Vec<adk_memory::MemoryEntry> = session
+        .events()
+        .all()
+        .into_iter()
+        .filter_map(|event| {
+            event.llm_response.content.clone().map(|content| adk_memory::MemoryEntry {
+                content,
+                author: event.author.clone(),
+                timestamp: event.timestamp,
+            })
+        })
+        .collect();
+    memory_service
+        .add_session(state.app_name(), &input.user_id, &input.session_id, entries)
+        .await?;
+    Ok(Value::Null)
+}
+
+/// Handles `async_search_memory`.
+pub(crate) async fn handle_search_memory(
+    state: &AgentEngineState,
+    input: SearchMemoryInput,
+) -> Result<Value> {
+    let Some(memory_service) = state.memory_service() else {
+        return Err(memory_unavailable());
+    };
+    let response = memory_service
+        .search(adk_memory::SearchRequest {
+            query: input.query,
+            user_id: input.user_id,
+            app_name: state.app_name().to_string(),
+            limit: None,
+            min_score: None,
+            project_id: None,
+        })
+        .await?;
+    let memories: Vec<Value> = response
+        .memories
+        .into_iter()
+        .map(|entry| {
+            json!({
+                "content": entry.content,
+                "author": entry.author,
+                "timestamp": entry.timestamp,
+            })
+        })
+        .collect();
+    Ok(json!({ "memories": memories }))
+}
+
+/// Resolves the message value of `stream_query` into a [`Content`].
+///
+/// A JSON string becomes a single-part user message; an object is
+/// deserialized as a full `Content`, matching adk-python's `str | dict`.
+pub(crate) fn message_to_content(message: Value) -> Result<Content> {
+    match message {
+        Value::String(text) => Ok(Content::new("user").with_text(text)),
+        Value::Object(_) => serde_json::from_value(message).map_err(|err| {
+            AdkError::new(
+                ErrorComponent::Server,
+                ErrorCategory::InvalidInput,
+                "agent_engine.invalid_message",
+                format!("message object is not a valid Content: {err}"),
+            )
+        }),
+        other => Err(AdkError::new(
+            ErrorComponent::Server,
+            ErrorCategory::InvalidInput,
+            "agent_engine.invalid_message",
+            format!("message must be a string or a Content object, got {other}"),
+        )),
+    }
+}
+
+/// Returns the session ID to run in, creating the session when it does not
+/// exist (or when no ID was supplied), and whether it was created.
+///
+/// Matches `AdkApp.stream_query`: a supplied ID that has no session record is
+/// created with that ID rather than rejected.
+pub(crate) async fn resolve_session(
+    state: &AgentEngineState,
+    user_id: &str,
+    session_id: Option<String>,
+    initial_state: HashMap<String, Value>,
+) -> Result<(String, bool)> {
+    let session_id = match session_id {
+        Some(id) => id,
+        None => uuid::Uuid::new_v4().to_string(),
+    };
+    let existing = state
+        .session_service()
+        .get(adk_session::GetRequest {
+            app_name: state.app_name().to_string(),
+            user_id: user_id.to_string(),
+            session_id: session_id.clone(),
+            num_recent_events: None,
+            after: None,
+        })
+        .await;
+    match existing {
+        Ok(_) => Ok((session_id, false)),
+        Err(err) if err.is_not_found() => {
+            state
+                .session_service()
+                .create(adk_session::CreateRequest {
+                    app_name: state.app_name().to_string(),
+                    user_id: user_id.to_string(),
+                    session_id: Some(session_id.clone()),
+                    state: initial_state,
+                })
+                .await?;
+            Ok((session_id, true))
+        }
+        Err(err) => Err(err),
+    }
+}
+
+/// Applies a state delta to an existing session by appending a
+/// state-delta-only event, mirroring the REST runtime's behavior.
+pub(crate) async fn apply_state_delta(
+    state: &AgentEngineState,
+    user_id: &str,
+    session_id: &str,
+    state_delta: HashMap<String, Value>,
+) -> Result<()> {
+    if state_delta.is_empty() {
+        return Ok(());
+    }
+    let identity = adk_core::AdkIdentity {
+        app_name: adk_core::AppName::try_from(state.app_name())?,
+        user_id: adk_core::UserId::try_from(user_id)?,
+        session_id: adk_core::SessionId::try_from(session_id)?,
+    };
+    let mut event = adk_core::Event::new(format!("agent-engine-input-{}", uuid::Uuid::new_v4()));
+    event.author = "agent_engine_dispatch".to_string();
+    event.actions.state_delta = state_delta;
+    state
+        .session_service()
+        .append_event_for_identity(adk_session::AppendEventRequest { identity, event })
+        .await
+}
+
+/// Validates and types the identity pair for a runner invocation.
+pub(crate) fn typed_identity(user_id: &str, session_id: &str) -> Result<(UserId, SessionId)> {
+    let user_id = UserId::try_from(user_id)?;
+    let session_id = SessionId::try_from(session_id)?;
+    Ok((user_id, session_id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn class_method_round_trips_through_from_str() {
+        for method in ClassMethod::ALL {
+            assert_eq!(ClassMethod::from_str(method.as_str()).unwrap(), method);
+        }
+    }
+
+    #[test]
+    fn unknown_class_method_is_invalid_input() {
+        let err = ClassMethod::from_str("does_not_exist").unwrap_err();
+        assert_eq!(err.http_status_code(), 400);
+    }
+
+    #[test]
+    fn register_operations_covers_every_variant_exactly_once() {
+        let map = handle_register_operations();
+        let advertised: Vec<&str> = map
+            .as_object()
+            .unwrap()
+            .values()
+            .flat_map(|names| names.as_array().unwrap())
+            .map(|name| name.as_str().unwrap())
+            .collect();
+        let expected: Vec<&str> = ClassMethod::ALL.iter().map(ClassMethod::as_str).collect();
+        // Same multiset: every variant advertised exactly once.
+        assert_eq!(advertised.len(), expected.len());
+        for name in expected {
+            assert_eq!(advertised.iter().filter(|n| **n == name).count(), 1, "{name}");
+        }
+    }
+
+    #[test]
+    fn api_modes_partition_the_streaming_endpoints() {
+        for method in ClassMethod::ALL {
+            let streaming = matches!(
+                method,
+                ClassMethod::StreamQuery
+                    | ClassMethod::AsyncStreamQuery
+                    | ClassMethod::StreamingAgentRunWithEvents
+            );
+            assert_eq!(method.api_mode().is_streaming(), streaming, "{}", method.as_str());
+        }
+    }
+
+    #[test]
+    fn agent_run_request_accepts_both_casings() {
+        let camel: AgentRunRequest = serde_json::from_str(
+            r#"{"appName":"a","userId":"u","sessionId":"s","newMessage":{"role":"user","parts":[{"text":"hi"}]}}"#,
+        )
+        .unwrap();
+        let snake: AgentRunRequest = serde_json::from_str(
+            r#"{"app_name":"a","user_id":"u","session_id":"s","new_message":{"role":"user","parts":[{"text":"hi"}]}}"#,
+        )
+        .unwrap();
+        assert_eq!(camel.user_id, snake.user_id);
+        assert_eq!(camel.session_id, snake.session_id);
+        assert_eq!(
+            serde_json::to_value(&camel.new_message).unwrap(),
+            serde_json::to_value(&snake.new_message).unwrap()
+        );
+    }
+}

--- a/adk-server/src/lib.rs
+++ b/adk-server/src/lib.rs
@@ -79,6 +79,12 @@ pub mod webhooks;
 #[cfg(feature = "background")]
 pub mod background;
 
+#[cfg(feature = "agent-engine")]
+pub mod agent_engine;
+
+#[cfg(feature = "agent-engine")]
+pub use agent_engine::{AgentEngineState, agent_engine_router};
+
 // Background runs and cron scheduling re-exports
 #[cfg(feature = "background")]
 pub use background::{

--- a/adk-server/tests/agent_engine_dispatch.rs
+++ b/adk-server/tests/agent_engine_dispatch.rs
@@ -1,0 +1,371 @@
+//! Integration tests for the Agent Engine dispatch surface.
+//!
+//! Exercises the two dispatch endpoints against an in-memory `SessionService`
+//! and a deterministic echo agent, asserting against the shared wire fixture
+//! (`tests/fixtures/agent_engine_wire.json`) that the future
+//! `RemoteReasoningEngineAgent` client round-trips against.
+
+#![cfg(feature = "agent-engine")]
+
+use adk_server::agent_engine::{AgentEngineState, agent_engine_router};
+use async_stream::stream;
+use async_trait::async_trait;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use std::sync::Arc;
+use tower::ServiceExt;
+
+const FIXTURE: &str = include_str!("fixtures/agent_engine_wire.json");
+const APP_NAME: &str = "test-app";
+
+fn fixture() -> serde_json::Value {
+    serde_json::from_str(FIXTURE).expect("fixture file is valid JSON")
+}
+
+fn fixture_request(name: &str) -> serde_json::Value {
+    fixture()["requests"][name].clone()
+}
+
+/// The deterministic event the echo agent emits — identical to the fixture's
+/// `streamed_events[0]` except for the runner-visible timestamp, which tests
+/// normalize.
+fn fixture_event() -> adk_core::Event {
+    let mut event =
+        adk_core::Event::with_id("agent-engine-fixture-event", "agent-engine-fixture-invocation");
+    event.timestamp = chrono::DateTime::parse_from_rfc3339("2025-01-01T00:00:00Z")
+        .unwrap()
+        .with_timezone(&chrono::Utc);
+    event.author = "echo-agent".to_string();
+    event.llm_response.content = Some(adk_core::Content::new("model").with_text("echo: hi"));
+    event
+}
+
+struct EchoAgent;
+
+#[async_trait]
+impl adk_core::Agent for EchoAgent {
+    fn name(&self) -> &str {
+        "echo-agent"
+    }
+
+    fn description(&self) -> &str {
+        "Deterministic echo agent for dispatch tests"
+    }
+
+    fn sub_agents(&self) -> &[Arc<dyn adk_core::Agent>] {
+        &[]
+    }
+
+    async fn run(
+        &self,
+        _ctx: Arc<dyn adk_core::InvocationContext>,
+    ) -> adk_core::Result<adk_core::EventStream> {
+        let s = stream! {
+            yield Ok(fixture_event());
+        };
+        Ok(Box::pin(s))
+    }
+}
+
+fn build_state(memory: bool) -> AgentEngineState {
+    let session_service = Arc::new(adk_session::InMemorySessionService::new());
+    let runner = Arc::new(
+        adk_runner::Runner::builder()
+            .app_name(APP_NAME)
+            .agent(Arc::new(EchoAgent))
+            .session_service(session_service)
+            .build()
+            .expect("runner builds"),
+    );
+    let state = AgentEngineState::new(runner);
+    if memory {
+        state.with_memory_service(Arc::new(adk_memory::InMemoryMemoryService::new()))
+    } else {
+        state
+    }
+}
+
+fn build_router(memory: bool) -> axum::Router {
+    agent_engine_router(build_state(memory))
+}
+
+async fn post(app: &axum::Router, uri: &str, body: serde_json::Value) -> axum::response::Response {
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(uri)
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+async fn post_unary(app: &axum::Router, body: serde_json::Value) -> axum::response::Response {
+    post(app, "/api/reasoning_engine", body).await
+}
+
+async fn post_stream(app: &axum::Router, body: serde_json::Value) -> axum::response::Response {
+    post(app, "/api/stream_reasoning_engine", body).await
+}
+
+async fn body_json(response: axum::response::Response) -> serde_json::Value {
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+/// Collects a streaming response into parsed NDJSON lines, asserting the
+/// framing contract (200, `application/json`, one JSON object per line).
+async fn stream_lines(response: axum::response::Response) -> Vec<serde_json::Value> {
+    assert_eq!(response.status(), StatusCode::OK);
+    let content_type =
+        response.headers().get("content-type").and_then(|v| v.to_str().ok()).unwrap().to_string();
+    assert!(content_type.starts_with("application/json"), "content-type was {content_type}");
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let text = String::from_utf8(bytes.to_vec()).unwrap();
+    assert!(text.ends_with('\n'), "stream must be newline-terminated");
+    text.lines().map(|line| serde_json::from_str(line).expect("each line is JSON")).collect()
+}
+
+/// The expected `AdkApp`-shaped session dump, with volatile fields copied
+/// from the actual value so whole-object equality stays meaningful.
+fn expected_session(
+    actual: &serde_json::Value,
+    id: &str,
+    state: serde_json::Value,
+) -> serde_json::Value {
+    serde_json::json!({
+        "id": id,
+        "app_name": APP_NAME,
+        "user_id": "u",
+        "state": state,
+        "events": [],
+        "last_update_time": actual["last_update_time"].clone(),
+    })
+}
+
+// ── (a) unary class methods round-trip ───────────────────────────────────
+
+#[tokio::test]
+async fn session_crud_round_trips() {
+    let app = build_router(false);
+
+    // create_session with explicit ID and initial state
+    let response = post_unary(&app, fixture_request("create_session")).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let created = body_json(response).await;
+    let expected =
+        expected_session(&created["output"], "s-fixture", serde_json::json!({"kind": "fixture"}));
+    assert_eq!(created, serde_json::json!({"output": expected}));
+
+    // async_create_session is a wire-parity alias of create_session
+    let response = post_unary(&app, fixture_request("async_create_session")).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let created_async = body_json(response).await;
+    let expected =
+        expected_session(&created_async["output"], "s-fixture-async", serde_json::json!({}));
+    assert_eq!(created_async, serde_json::json!({"output": expected}));
+
+    // get_session / async_get_session return the same dump
+    for name in ["get_session", "async_get_session"] {
+        let response = post_unary(&app, fixture_request(name)).await;
+        assert_eq!(response.status(), StatusCode::OK, "{name}");
+        let got = body_json(response).await;
+        let expected =
+            expected_session(&got["output"], "s-fixture", serde_json::json!({"kind": "fixture"}));
+        assert_eq!(got, serde_json::json!({"output": expected}), "{name}");
+    }
+
+    // list_sessions / async_list_sessions wrap the dumps in {"sessions": [...]}
+    for name in ["list_sessions", "async_list_sessions"] {
+        let response = post_unary(&app, fixture_request(name)).await;
+        assert_eq!(response.status(), StatusCode::OK, "{name}");
+        let listed = body_json(response).await;
+        let sessions = listed["output"]["sessions"].as_array().unwrap();
+        assert_eq!(sessions.len(), 2, "{name}");
+        let mut ids: Vec<&str> = sessions.iter().map(|s| s["id"].as_str().unwrap()).collect();
+        ids.sort_unstable();
+        assert_eq!(ids, ["s-fixture", "s-fixture-async"], "{name}");
+    }
+
+    // delete_session / async_delete_session return null output
+    let response = post_unary(&app, fixture_request("delete_session")).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(body_json(response).await, serde_json::json!({"output": null}));
+
+    let response = post_unary(&app, fixture_request("async_delete_session")).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(body_json(response).await, serde_json::json!({"output": null}));
+
+    // Both sessions are gone
+    let response = post_unary(&app, fixture_request("get_session")).await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+// ── (b) streaming returns newline-delimited JSON ─────────────────────────
+
+#[tokio::test]
+async fn stream_query_streams_fixture_events() {
+    let app = build_router(false);
+
+    // The codelab payload: async_stream_query with no session_id (auto-create).
+    let lines = stream_lines(post_stream(&app, fixture_request("async_stream_query")).await).await;
+
+    let mut expected: Vec<serde_json::Value> =
+        fixture()["streamed_events"].as_array().unwrap().clone();
+    assert_eq!(lines.len(), expected.len());
+    for (line, expected) in lines.iter().zip(expected.iter_mut()) {
+        // The event timestamp is assigned at emission time; everything else
+        // must match the fixture exactly.
+        expected["timestamp"] = line["timestamp"].clone();
+        assert_eq!(line, expected);
+    }
+}
+
+#[tokio::test]
+async fn stream_query_with_explicit_session_persists_events() {
+    let state = build_state(false);
+    let app = agent_engine_router(state.clone());
+
+    let lines = stream_lines(post_stream(&app, fixture_request("stream_query")).await).await;
+    assert_eq!(lines.len(), 1);
+
+    // The auto-created session recorded the exchange: user message + echo.
+    let session = state
+        .session_service()
+        .get(adk_session::GetRequest {
+            app_name: APP_NAME.to_string(),
+            user_id: "u".to_string(),
+            session_id: "s-stream".to_string(),
+            num_recent_events: None,
+            after: None,
+        })
+        .await
+        .expect("session was auto-created");
+    assert!(!session.events().is_empty());
+}
+
+#[tokio::test]
+async fn streaming_agent_run_with_events_drives_the_runner() {
+    let app = build_router(false);
+
+    let lines =
+        stream_lines(post_stream(&app, fixture_request("streaming_agent_run_with_events")).await)
+            .await;
+    assert_eq!(lines.len(), 1);
+    assert_eq!(lines[0]["author"], "echo-agent");
+}
+
+// ── (c) unknown method → 400 problem+json ────────────────────────────────
+
+#[tokio::test]
+async fn unknown_class_method_is_400_problem_json() {
+    let app = build_router(false);
+
+    for uri in ["/api/reasoning_engine", "/api/stream_reasoning_engine"] {
+        let response = post(&app, uri, serde_json::json!({"class_method": "does_not_exist"})).await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{uri}");
+        let body = body_json(response).await;
+        assert_eq!(body["error"]["code"], "agent_engine.unknown_class_method", "{uri}");
+    }
+}
+
+#[tokio::test]
+async fn wrong_endpoint_is_400() {
+    let app = build_router(false);
+
+    // Streaming method on the unary endpoint
+    let response = post_unary(&app, fixture_request("async_stream_query")).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = body_json(response).await;
+    assert_eq!(body["error"]["code"], "agent_engine.wrong_endpoint");
+
+    // Unary method on the streaming endpoint
+    let response = post_stream(&app, fixture_request("create_session")).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = body_json(response).await;
+    assert_eq!(body["error"]["code"], "agent_engine.wrong_endpoint");
+}
+
+// ── (d) register_operations matches the contract table ───────────────────
+
+#[tokio::test]
+async fn register_operations_matches_fixture() {
+    let app = build_router(false);
+
+    let response = post_unary(&app, fixture_request("register_operations")).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = body_json(response).await;
+    assert_eq!(body, serde_json::json!({"output": fixture()["register_operations_output"]}));
+}
+
+// ── memory class methods ─────────────────────────────────────────────────
+
+#[tokio::test]
+async fn memory_methods_are_unsupported_without_memory_service() {
+    let app = build_router(false);
+
+    for name in ["async_add_session_to_memory", "async_search_memory"] {
+        let response = post_unary(&app, fixture_request(name)).await;
+        assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED, "{name}");
+        let body = body_json(response).await;
+        assert_eq!(body["error"]["code"], "agent_engine.memory_unavailable", "{name}");
+    }
+}
+
+#[tokio::test]
+async fn memory_methods_round_trip_with_memory_service() {
+    let app = build_router(true);
+
+    // Populate a session via stream_query, then extract it into memory.
+    stream_lines(post_stream(&app, fixture_request("stream_query")).await).await;
+
+    let response = post_unary(&app, fixture_request("async_add_session_to_memory")).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(body_json(response).await, serde_json::json!({"output": null}));
+
+    let response = post_unary(&app, fixture_request("async_search_memory")).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = body_json(response).await;
+    // Looser than whole-object equality: the in-memory backend's ranking is
+    // not this contract's subject; shape and provenance are.
+    let memories = body["output"]["memories"].as_array().unwrap();
+    assert!(!memories.is_empty());
+    assert!(memories.iter().any(|m| m["author"] == "echo-agent"));
+    for memory in memories {
+        assert!(memory["content"].is_object());
+        assert!(memory["timestamp"].is_string());
+    }
+}
+
+// ── shared wire fixture round-trip (prep for the remote client) ──────────
+
+#[tokio::test]
+async fn fixture_streamed_events_round_trip_as_adk_events() {
+    for value in fixture()["streamed_events"].as_array().unwrap() {
+        let event: adk_core::Event =
+            serde_json::from_value(value.clone()).expect("fixture event parses as adk_core::Event");
+        let reserialized = serde_json::to_value(&event).unwrap();
+        assert_eq!(&reserialized, value, "fixture event must round-trip byte-for-byte");
+    }
+}
+
+#[tokio::test]
+async fn fixture_requests_parse_as_dispatch_requests() {
+    use adk_server::agent_engine::DispatchRequest;
+    use std::str::FromStr;
+
+    let fixture = fixture();
+    let requests = fixture["requests"].as_object().unwrap();
+    // Every operation of the contract has a canonical fixture request.
+    assert_eq!(requests.len(), 14);
+    for (name, value) in requests {
+        let request: DispatchRequest =
+            serde_json::from_value(value.clone()).expect("fixture request parses");
+        assert_eq!(&request.class_method, name);
+        adk_server::agent_engine::ClassMethod::from_str(&request.class_method)
+            .expect("fixture request names a known class method");
+    }
+}

--- a/adk-server/tests/agent_engine_property_tests.rs
+++ b/adk-server/tests/agent_engine_property_tests.rs
@@ -1,0 +1,131 @@
+//! Property tests for the Agent Engine dispatcher: arbitrary `class_method`
+//! strings and arbitrary JSON `input` values must produce an HTTP response,
+//! never a panic.
+
+#![cfg(feature = "agent-engine")]
+
+use adk_server::agent_engine::{AgentEngineState, agent_engine_router};
+use async_stream::stream;
+use async_trait::async_trait;
+use axum::body::Body;
+use axum::http::Request;
+use proptest::prelude::*;
+use std::sync::Arc;
+use tower::ServiceExt;
+
+struct EchoAgent;
+
+#[async_trait]
+impl adk_core::Agent for EchoAgent {
+    fn name(&self) -> &str {
+        "echo-agent"
+    }
+
+    fn description(&self) -> &str {
+        "Echo agent for dispatcher property tests"
+    }
+
+    fn sub_agents(&self) -> &[Arc<dyn adk_core::Agent>] {
+        &[]
+    }
+
+    async fn run(
+        &self,
+        _ctx: Arc<dyn adk_core::InvocationContext>,
+    ) -> adk_core::Result<adk_core::EventStream> {
+        let s = stream! {
+            yield Ok(adk_core::Event::new("prop-invocation"));
+        };
+        Ok(Box::pin(s))
+    }
+}
+
+fn build_router() -> axum::Router {
+    let session_service = Arc::new(adk_session::InMemorySessionService::new());
+    let runner = Arc::new(
+        adk_runner::Runner::builder()
+            .app_name("prop-app")
+            .agent(Arc::new(EchoAgent))
+            .session_service(session_service)
+            .build()
+            .expect("runner builds"),
+    );
+    agent_engine_router(AgentEngineState::new(runner))
+}
+
+/// Shallow arbitrary JSON: enough shape variety to hit every deserialization
+/// branch without generating megabyte documents.
+fn arb_json() -> impl Strategy<Value = serde_json::Value> {
+    let leaf = prop_oneof![
+        Just(serde_json::Value::Null),
+        any::<bool>().prop_map(serde_json::Value::from),
+        any::<i64>().prop_map(serde_json::Value::from),
+        "[a-zA-Z0-9_ -]{0,20}".prop_map(serde_json::Value::from),
+    ];
+    leaf.prop_recursive(3, 32, 8, |inner| {
+        prop_oneof![
+            prop::collection::vec(inner.clone(), 0..4).prop_map(serde_json::Value::Array),
+            prop::collection::hash_map("[a-z_]{1,12}", inner, 0..6)
+                .prop_map(|map| { serde_json::Value::Object(map.into_iter().collect()) }),
+        ]
+    })
+}
+
+/// Class-method names: mostly valid contract names, sometimes garbage.
+fn arb_class_method() -> impl Strategy<Value = String> {
+    prop_oneof![
+        4 => prop::sample::select(vec![
+            "create_session",
+            "async_create_session",
+            "get_session",
+            "async_get_session",
+            "list_sessions",
+            "async_list_sessions",
+            "delete_session",
+            "async_delete_session",
+            "stream_query",
+            "async_stream_query",
+            "streaming_agent_run_with_events",
+            "async_add_session_to_memory",
+            "async_search_memory",
+            "register_operations",
+        ])
+        .prop_map(str::to_string),
+        1 => "[a-zA-Z0-9_.:-]{0,32}",
+    ]
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(128))]
+
+    #[test]
+    fn dispatcher_never_panics(class_method in arb_class_method(), input in arb_json()) {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            let app = build_router();
+            let body = serde_json::json!({
+                "class_method": class_method,
+                "input": input,
+            });
+            for uri in ["/api/reasoning_engine", "/api/stream_reasoning_engine"] {
+                let response = app
+                    .clone()
+                    .oneshot(
+                        Request::builder()
+                            .method("POST")
+                            .uri(uri)
+                            .header("content-type", "application/json")
+                            .body(Body::from(serde_json::to_string(&body).unwrap()))
+                            .unwrap(),
+                    )
+                    .await
+                    .expect("dispatcher always responds");
+                // Streams must also drain without panicking.
+                let _ = axum::body::to_bytes(response.into_body(), usize::MAX).await;
+            }
+        });
+    }
+}

--- a/adk-server/tests/fixtures/agent_engine_wire.json
+++ b/adk-server/tests/fixtures/agent_engine_wire.json
@@ -1,0 +1,50 @@
+{
+  "comment": "Canonical Agent Engine wire fixtures. Shared by the agent_engine dispatch tests (server side) and, later, the RemoteReasoningEngineAgent round-trip tests (client side) so the two modules stay wire-compatible. The envelope is snake_case per the platform contract (V14).",
+  "requests": {
+    "create_session": { "class_method": "create_session", "input": { "user_id": "u", "session_id": "s-fixture", "state": { "kind": "fixture" } } },
+    "async_create_session": { "class_method": "async_create_session", "input": { "user_id": "u", "session_id": "s-fixture-async" } },
+    "get_session": { "class_method": "get_session", "input": { "user_id": "u", "session_id": "s-fixture" } },
+    "async_get_session": { "class_method": "async_get_session", "input": { "user_id": "u", "session_id": "s-fixture" } },
+    "list_sessions": { "class_method": "list_sessions", "input": { "user_id": "u" } },
+    "async_list_sessions": { "class_method": "async_list_sessions", "input": { "user_id": "u" } },
+    "delete_session": { "class_method": "delete_session", "input": { "user_id": "u", "session_id": "s-fixture" } },
+    "async_delete_session": { "class_method": "async_delete_session", "input": { "user_id": "u", "session_id": "s-fixture-async" } },
+    "stream_query": { "class_method": "stream_query", "input": { "user_id": "u", "session_id": "s-stream", "message": "hi" } },
+    "async_stream_query": { "class_method": "async_stream_query", "input": { "user_id": "u", "message": "hi" } },
+    "streaming_agent_run_with_events": { "class_method": "streaming_agent_run_with_events", "input": { "request_json": "{\"appName\":\"test-app\",\"userId\":\"u\",\"sessionId\":\"s-playground\",\"newMessage\":{\"role\":\"user\",\"parts\":[{\"text\":\"hi\"}]},\"streaming\":true}" } },
+    "async_add_session_to_memory": { "class_method": "async_add_session_to_memory", "input": { "user_id": "u", "session_id": "s-stream" } },
+    "async_search_memory": { "class_method": "async_search_memory", "input": { "user_id": "u", "query": "hi" } },
+    "register_operations": { "class_method": "register_operations" }
+  },
+  "register_operations_output": {
+    "": ["create_session", "get_session", "list_sessions", "delete_session", "register_operations"],
+    "async": ["async_create_session", "async_get_session", "async_list_sessions", "async_delete_session", "async_add_session_to_memory", "async_search_memory"],
+    "stream": ["stream_query"],
+    "async_stream": ["async_stream_query", "streaming_agent_run_with_events"]
+  },
+  "streamed_events": [
+    {
+      "id": "agent-engine-fixture-event",
+      "timestamp": "2025-01-01T00:00:00Z",
+      "invocation_id": "agent-engine-fixture-invocation",
+      "branch": "",
+      "author": "echo-agent",
+      "content": { "role": "model", "parts": [{ "text": "echo: hi" }] },
+      "usage_metadata": null,
+      "finish_reason": null,
+      "partial": false,
+      "turn_complete": false,
+      "interrupted": false,
+      "error_code": null,
+      "error_message": null,
+      "actions": {
+        "state_delta": {},
+        "artifact_delta": {},
+        "skip_summarization": false,
+        "transfer_to_agent": null,
+        "escalate": false
+      },
+      "long_running_tool_ids": []
+    }
+  ]
+}


### PR DESCRIPTION
## What

The Agent Engine dispatch core: a new feature-gated `adk-server/src/agent_engine/` module (feature `agent-engine`) implementing the container-side runtime contract of the Gemini Enterprise Agent Platform — the dispatch envelope, the full `AdkApp` class-method set, and the two-endpoint router.

- `agent_engine_router(state)` mounts `POST /api/reasoning_engine` (unary, `{"output": ...}`) and `POST /api/stream_reasoning_engine` (newline-delimited JSON events, `Content-Type: application/json`, no SSE framing).
- `AgentEngineState` wraps a prebuilt `Runner` (session service and app name are taken from it, so the two can never disagree) with optional memory and artifact services — defined now so filling them in later is additive.
- A shared wire fixture, `adk-server/tests/fixtures/agent_engine_wire.json`, pins the canonical dispatch requests and streamed-event output that the Wave 4 `RemoteReasoningEngineAgent` will round-trip against.

## Why

Part of #438 (Wave 1, PR 1.1 — WP1.1–1.3). This is the blocking runtime contract: everything in Waves 2–4 that talks to a deployed engine builds on the envelope and dispatch surface defined here.

## How

**Envelope** (`envelope.rs`): `DispatchRequest { class_method, input }`. The envelope is snake_case — a documented exception to the workspace's camelCase convention, because the platform dispatches on Python identifiers (`getattr`), confirmed by verification task V14.

**Operations** (`operations.rs`): a deliberate anti-corruption layer for the Python-reflection-shaped protocol.

| `class_method` | `api_mode` | Maps to |
|---|---|---|
| `create_session`, `async_create_session` | `""` / `async` | `SessionService::create` |
| `get_session`, `async_get_session` | `""` / `async` | `SessionService::get` |
| `list_sessions`, `async_list_sessions` | `""` / `async` | `SessionService::list` |
| `delete_session`, `async_delete_session` | `""` / `async` | `SessionService::delete` |
| `stream_query` / `async_stream_query` | `stream` / `async_stream` | `Runner::run`, auto-creating the session |
| `streaming_agent_run_with_events` | `async_stream` | `Runner::run` from an ADK `AgentRunRequest` JSON string (Playground path) |
| `async_add_session_to_memory` | `async` | session events → `MemoryEntry` items → `MemoryService::add_session` |
| `async_search_memory` | `async` | `MemoryService::search` |
| `register_operations` | `""` | the operations map |

- `ClassMethod` enum with `FromStr` (unknown name → 400 problem+json) and `api_mode()`; dispatch is an exhaustive `match` with no wildcard arm.
- Each variant deserializes `input` into a typed request struct at the boundary; handlers never see raw `Value`.
- Sync/async name pairs are wire-parity aliases to the same handler (Rust is async-throughout); documented in module rustdoc.
- `register_operations` output is derived from `ClassMethod::ALL` grouped by `api_mode()`, so the advertised set and the dispatcher cannot drift.
- The memory class methods return an `Unsupported` (501) error until a memory service is configured — graceful degradation until Memory Bank lands (Wave 2, PR 2.1).
- **asyncQuery (V12):** not registered. The capability must be declared at engine create time and cannot be added post-create (google/adk-python#6220), and `AdkApp` does not register it either — strict parity excludes it. Documented in module rustdoc.

**Dependencies:** one new *optional* dependency, `adk-memory`, enabled only by the `agent-engine` feature — the default workspace build is unchanged (and example lockfiles are untouched, since optional deps do not enter them).

**CI:** one `feature-coverage` matrix line (`adk-server, agent-engine`) so the module's clippy and tests run in the PR tier. Umbrella forwarding and the `gemini-agent-platform` append follow in PR 1.2 with the turnkey entrypoint, per the wave plan.

**Tests** (`agent_engine_dispatch.rs`, `agent_engine_property_tests.rs`):
- Every class method round-trips against the fixture requests with whole-JSON-value assertions (session dumps normalized only on `last_update_time`).
- Streaming returns newline-delimited JSON parseable line-by-line; the codelab payload (`{"class_method":"async_stream_query","input":{"user_id":"u","message":"hi"}}`) streams the fixture event exactly, modulo timestamp.
- Unknown method → 400 problem+json; streaming methods on the unary endpoint (and vice versa) → 400.
- `register_operations` output equals the fixture table.
- Fixture streamed events parse as `adk_core::Event` and re-serialize byte-for-byte (the wire-compatibility contract for PR 4.6).
- Property test (128 cases): arbitrary `class_method` strings and arbitrary JSON `input` never panic the dispatcher on either endpoint.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass (136 in `adk-server` with the feature; doctests and `RUSTDOCFLAGS="-D warnings"` doc build also pass)
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [ ] README updated if crate capabilities changed — deferred to PR 1.2 with the docs page (`docs/official_docs/deploy/agent-engine.md`), per the wave plan
- [ ] Examples added or updated for new features — the turnkey `serve_agent_engine` entrypoint (PR 1.2) is the example surface
