### PR TITLE
feat(server): add turnkey serve_agent_engine entrypoint and integration - PR 1.2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -414,7 +414,7 @@ Four tiered presets control which crates are compiled:
 Domain add-ons are composable with any tier: `features = ["minimal", "audio"]`.
 
 Platform meta-features (composable with any tier):
-- `gemini-agent-platform` — every Gemini Enterprise Agent Platform (Vertex/EAP) integration except realtime transports: `gemini-vertex`, `vertex-session`, `gcp-secrets` (grows as later integrations land). The right default for ReasoningEngine BYOC deployments. Deploy-time tooling is host-side and excluded.
+- `gemini-agent-platform` — every Gemini Enterprise Agent Platform (Vertex/EAP) integration except realtime transports: `gemini-vertex`, `vertex-session`, `gcp-secrets`, `gcs-artifacts`, `gcp-telemetry`, `agent-engine` (grows as later integrations land). The right default for ReasoningEngine BYOC deployments. Deploy-time tooling is host-side and excluded.
 - `gemini-agent-platform-full` — `gemini-agent-platform` + `vertex-live` (Vertex AI Live API, pulls in the adk-realtime stack)
 
 Graph capability features (forwarded to `adk-graph`, which has no default features):
@@ -434,6 +434,7 @@ Production backend features (require external infrastructure, NOT included in `f
 
 Specialist opt-in features:
 - `yaml-agent`, `agent-registry` — YAML agent config and registry REST API
+- `agent-engine` — Agent Engine runtime contract (adk-server): class-method dispatch endpoints and the turnkey `serve_agent_engine` entrypoint for Gemini Enterprise Agent Platform BYOC containers
 - `gemini-interactions` — Gemini Interactions API (Beta): wire client surface (server-side history, step timeline) plus the runtime transport on `GeminiModel` (`use_interactions_api`) driving the standard `LlmAgent`/`Runner`
 - `mcp`, `mcp-http`, `mcp-sampling` — MCP transport and sampling support
 - `code-tools` — Code execution tools over the adk-code substrate (`CodeTool`, `PythonCodeTool`, `JavaScriptCodeTool`, `MontyPythonCodeTool`; forwarded to adk-tool; included in `full`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Agent Engine turnkey entrypoint** (`adk-server`, feature `agent-engine`;
+  umbrella feature `agent-engine`, included in `gemini-agent-platform`):
+  `serve_agent_engine(agent, options)` is the whole `main` of a deployable
+  Gemini Enterprise Agent Platform engine — binds `0.0.0.0:$PORT` (fallback
+  `8080`), installs the crypto provider, and serves the dispatch endpoints
+  plus `GET /health`. `AgentEngineOptions` configures session, memory, and
+  artifact services, app name, and port; `build_agent_engine_app` returns the
+  same app as a plain `Router`. `ServerBuilder::with_agent_engine(true)`
+  mounts the dispatch surface alongside the built-in REST/UI/A2A routes.
+  New docs page: `docs/official_docs/deployment/agent-engine.md`.
+
 - **Agent Engine dispatch surface** (`adk-server`, feature `agent-engine`): the
   container-side runtime contract that makes an adk-rust agent drivable by the
   Gemini Enterprise Agent Platform (`reasoningEngines.query` /

--- a/adk-rust/Cargo.toml
+++ b/adk-rust/Cargo.toml
@@ -85,8 +85,8 @@ gemini-agent-platform = [
     "gcp-secrets",    # GCP Secret Manager (adk-auth)
     "gcs-artifacts",  # GCS artifact backend (adk-artifact)
     "gcp-telemetry",  # Cloud Trace/Logging transport (adk-telemetry)
+    "agent-engine",   # class-method runtime contract + turnkey entrypoint (adk-server)
     # target end-state — appended by the PR that introduces each flag:
-    # "agent-engine",           class-method runtime contract (adk-server)
     # "vertex-memory",          Memory Bank (adk-memory)
     # "example-store",          Example Store (adk-tool)
     # "gcp-telemetry",          Cloud Trace/Logging transport (adk-telemetry)
@@ -206,6 +206,9 @@ openai-webrtc = ["realtime", "adk-realtime/openai-webrtc"]
 yaml-agent = ["server", "adk-server/yaml-agent"]
 # Agent Registry REST API (forwarded to adk-server)
 agent-registry = ["server", "adk-server/agent-registry"]
+# Gemini Enterprise Agent Platform runtime contract: class-method dispatch
+# endpoints and the turnkey serve_agent_engine entrypoint (forwarded to adk-server)
+agent-engine = ["server", "adk-server/agent-engine"]
 # MCP sampling callback support (forwarded to adk-tool)
 mcp = ["tools", "adk-tool/mcp"]
 mcp-http = ["mcp", "adk-tool/http-transport"]

--- a/adk-rust/src/lib.rs
+++ b/adk-rust/src/lib.rs
@@ -439,7 +439,8 @@
 //! | `sandbox` | Sandboxed execution | full (experimental) |
 //! | `audio` | Audio processing | full (experimental) |
 //! | `cli` | CLI launcher | (opt-in, any preset) |
-//! | `gemini-agent-platform` | Gemini Enterprise Agent Platform integrations (Vertex model backend, managed Sessions, GCP Secret Manager); excludes realtime transports and host-side deploy tooling | (opt-in, any preset) |
+//! | `agent-engine` | Agent Engine runtime contract: dispatch endpoints + `serve_agent_engine` entrypoint | (opt-in, any preset) |
+//! | `gemini-agent-platform` | Gemini Enterprise Agent Platform integrations (Vertex model backend, managed Sessions, GCP Secret Manager, GCS artifacts, Cloud telemetry, Agent Engine runtime contract); excludes realtime transports and host-side deploy tooling | (opt-in, any preset) |
 //! | `gemini-agent-platform-full` | `gemini-agent-platform` + Vertex AI Live API (realtime stack) | (opt-in, any preset) |
 //!
 //! ## Examples

--- a/adk-server/Cargo.toml
+++ b/adk-server/Cargo.toml
@@ -72,7 +72,8 @@ openai-webhooks = ["dep:hmac", "dep:sha2", "dep:hex"]
 # Enable background run endpoints and cron job management
 background = ["dep:cron"]
 # Enable the Gemini Enterprise Agent Platform (ReasoningEngine) dispatch surface
-agent-engine = ["dep:adk-memory"]
+# and the turnkey serve_agent_engine entrypoint (tokio/net for the listener)
+agent-engine = ["dep:adk-memory", "tokio/net"]
 
 [dev-dependencies]
 async-stream.workspace = true

--- a/adk-server/src/agent_engine/entrypoint.rs
+++ b/adk-server/src/agent_engine/entrypoint.rs
@@ -1,0 +1,338 @@
+//! Turnkey entrypoint for Agent Engine BYOC containers.
+//!
+//! [`serve_agent_engine`] is the whole `main` of a deployable engine: it
+//! builds the dispatch app around an agent and serves it on `0.0.0.0:$PORT`.
+//! [`build_agent_engine_app`] exposes the same app as a plain [`Router`] for
+//! callers that manage their own listener or need to test without binding.
+
+use super::{AgentEngineState, agent_engine_router};
+use adk_core::{AdkError, Agent, ErrorCategory, ErrorComponent, Result};
+use axum::{Router, routing::get};
+use std::sync::Arc;
+use tracing::{info, warn};
+
+/// The port the platform assigns to the container.
+const ENV_PORT: &str = "PORT";
+/// GCP project of the deployment (set by the platform).
+const ENV_GOOGLE_CLOUD_PROJECT: &str = "GOOGLE_CLOUD_PROJECT";
+/// GCP location of the deployment (set by the platform).
+const ENV_GOOGLE_CLOUD_LOCATION: &str = "GOOGLE_CLOUD_LOCATION";
+/// The bare numeric engine ID (set by the platform inside deployed
+/// containers; not a full resource name).
+const ENV_GOOGLE_CLOUD_AGENT_ENGINE_ID: &str = "GOOGLE_CLOUD_AGENT_ENGINE_ID";
+
+/// The default port when neither `PORT` nor a port override is set.
+const DEFAULT_PORT: u16 = 8080;
+
+/// Options for [`serve_agent_engine`] and [`build_agent_engine_app`].
+///
+/// Every field is optional: the zero-configuration default serves the agent
+/// with an in-memory session service — enough to answer platform queries,
+/// but sessions do not survive a container restart. Production deployments
+/// configure managed backends:
+///
+/// - `session_service` — `VertexAiSessionService` (feature `vertex-session`
+///   in the consumer) picks up the platform's managed Sessions via
+///   `VertexAiSessionConfig::from_env()`, which reads the same
+///   `GOOGLE_CLOUD_*` variables the platform sets.
+/// - `artifact_service` — `GcsArtifactService` (feature `gcs` on
+///   `adk-artifact`) stores artifacts where the Gemini Enterprise console
+///   renders them; take the bucket from an environment variable or a flag.
+/// - `memory_service` — enables the `async_add_session_to_memory` /
+///   `async_search_memory` class methods; without one they return an
+///   `Unsupported` error.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use adk_server::agent_engine::AgentEngineOptions;
+///
+/// let opts = AgentEngineOptions::new().with_app_name("weather-agent");
+/// ```
+#[derive(Default)]
+pub struct AgentEngineOptions {
+    session_service: Option<Arc<dyn adk_session::SessionService>>,
+    memory_service: Option<Arc<dyn adk_memory::MemoryService>>,
+    artifact_service: Option<Arc<dyn adk_artifact::ArtifactService>>,
+    app_name: Option<String>,
+    port_override: Option<u16>,
+}
+
+impl AgentEngineOptions {
+    /// Creates empty options: in-memory sessions, no memory or artifact
+    /// service, app name from the agent, port from `$PORT`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the session persistence backend. Defaults to
+    /// `InMemorySessionService` when unset.
+    pub fn with_session_service(
+        mut self,
+        session_service: Arc<dyn adk_session::SessionService>,
+    ) -> Self {
+        self.session_service = Some(session_service);
+        self
+    }
+
+    /// Sets the memory service backing the memory class methods.
+    pub fn with_memory_service(
+        mut self,
+        memory_service: Arc<dyn adk_memory::MemoryService>,
+    ) -> Self {
+        self.memory_service = Some(memory_service);
+        self
+    }
+
+    /// Sets the artifact storage backend, wired into both the runner and the
+    /// dispatch state.
+    pub fn with_artifact_service(
+        mut self,
+        artifact_service: Arc<dyn adk_artifact::ArtifactService>,
+    ) -> Self {
+        self.artifact_service = Some(artifact_service);
+        self
+    }
+
+    /// Overrides the application name used for session scoping. Defaults to
+    /// the agent's name.
+    pub fn with_app_name(mut self, app_name: impl Into<String>) -> Self {
+        self.app_name = Some(app_name.into());
+        self
+    }
+
+    /// Overrides the serving port, taking precedence over `$PORT`.
+    pub fn with_port(mut self, port: u16) -> Self {
+        self.port_override = Some(port);
+        self
+    }
+}
+
+/// The platform-reserved environment, read once at startup for logging and
+/// configuration hints.
+struct PlatformEnv {
+    project: Option<String>,
+    location: Option<String>,
+    engine_id: Option<String>,
+}
+
+impl PlatformEnv {
+    fn read() -> Self {
+        let read = |key: &str| {
+            std::env::var(key)
+                .ok()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+        };
+        Self {
+            project: read(ENV_GOOGLE_CLOUD_PROJECT),
+            location: read(ENV_GOOGLE_CLOUD_LOCATION),
+            engine_id: read(ENV_GOOGLE_CLOUD_AGENT_ENGINE_ID),
+        }
+    }
+
+    /// Whether the container appears to be running as a deployed engine.
+    fn is_managed(&self) -> bool {
+        self.engine_id.is_some()
+    }
+}
+
+/// Resolves the serving port: explicit override, then `$PORT`, then 8080.
+///
+/// # Errors
+///
+/// Returns an invalid-input error when `$PORT` is set but not a valid port
+/// number — a misconfigured port means the platform cannot reach the
+/// container, so failing at startup beats serving on the wrong port.
+fn resolve_port(port_override: Option<u16>) -> Result<u16> {
+    if let Some(port) = port_override {
+        return Ok(port);
+    }
+    match std::env::var(ENV_PORT) {
+        Ok(raw) => {
+            let trimmed = raw.trim();
+            if trimmed.is_empty() {
+                return Ok(DEFAULT_PORT);
+            }
+            trimmed.parse().map_err(|_| {
+                AdkError::new(
+                    ErrorComponent::Server,
+                    ErrorCategory::InvalidInput,
+                    "agent_engine.invalid_port",
+                    format!("PORT must be a port number in 1-65535, got '{trimmed}'"),
+                )
+            })
+        }
+        Err(_) => Ok(DEFAULT_PORT),
+    }
+}
+
+/// Builds the complete Agent Engine app for an agent: the dispatch router
+/// plus a `GET /health` liveness route.
+///
+/// Use this instead of [`serve_agent_engine`] when you manage the listener
+/// yourself (custom TLS, tests, graceful shutdown).
+///
+/// # Errors
+///
+/// Returns an error when the runner cannot be constructed — in practice,
+/// when the resolved app name fails identity validation.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use adk_server::agent_engine::{AgentEngineOptions, build_agent_engine_app};
+/// use std::sync::Arc;
+///
+/// # async fn serve(agent: Arc<dyn adk_core::Agent>) -> anyhow::Result<()> {
+/// let app = build_agent_engine_app(agent, AgentEngineOptions::new())?;
+/// let listener = tokio::net::TcpListener::bind("0.0.0.0:8080").await?;
+/// axum::serve(listener, app).await?;
+/// # Ok(())
+/// # }
+/// ```
+pub fn build_agent_engine_app(agent: Arc<dyn Agent>, opts: AgentEngineOptions) -> Result<Router> {
+    let app_name = opts.app_name.unwrap_or_else(|| agent.name().to_string());
+    let env = PlatformEnv::read();
+    info!(
+        app.name = %app_name,
+        gcp.project = env.project.as_deref().unwrap_or(""),
+        gcp.location = env.location.as_deref().unwrap_or(""),
+        gcp.engine_id = env.engine_id.as_deref().unwrap_or(""),
+        "building agent engine app"
+    );
+
+    let session_service = match opts.session_service {
+        Some(session_service) => session_service,
+        None => {
+            if env.is_managed() {
+                // The platform sets GOOGLE_CLOUD_AGENT_ENGINE_ID inside deployed
+                // containers; an in-memory session store there loses every
+                // conversation on restart or scale-out.
+                warn!(
+                    "running as a deployed engine with in-memory sessions; conversations will \
+                     not survive restarts. Configure a managed backend, e.g. \
+                     VertexAiSessionService with VertexAiSessionConfig::from_env() (feature \
+                     `vertex-session`), via AgentEngineOptions::with_session_service"
+                );
+            }
+            Arc::new(adk_session::InMemorySessionService::new())
+        }
+    };
+
+    let mut runner_builder = adk_runner::Runner::builder()
+        .app_name(&app_name)
+        .agent(agent)
+        .session_service(session_service);
+    if let Some(artifact_service) = &opts.artifact_service {
+        runner_builder = runner_builder.artifact_service(artifact_service.clone());
+    }
+    let runner = Arc::new(runner_builder.build()?);
+
+    let mut state = AgentEngineState::new(runner);
+    if let Some(memory_service) = opts.memory_service {
+        state = state.with_memory_service(memory_service);
+    }
+    if let Some(artifact_service) = opts.artifact_service {
+        state = state.with_artifact_service(artifact_service);
+    }
+
+    Ok(agent_engine_router(state).route("/health", get(health)))
+}
+
+/// Liveness probe target for the platform's container health checks.
+async fn health() -> &'static str {
+    "ok"
+}
+
+/// Serves an agent as a complete Agent Engine container.
+///
+/// Binds `0.0.0.0:$PORT` (or [`AgentEngineOptions::with_port`], falling back
+/// to `8080`), installs the workspace crypto provider, and serves the
+/// dispatch endpoints until the process is stopped. This function is the
+/// whole `main` of a BYOC engine:
+///
+/// ```rust,no_run
+/// use adk_server::agent_engine::{AgentEngineOptions, serve_agent_engine};
+/// use std::sync::Arc;
+///
+/// # async fn run(agent: Arc<dyn adk_core::Agent>) -> adk_core::Result<()> {
+/// serve_agent_engine(agent, AgentEngineOptions::new()).await
+/// # }
+/// ```
+///
+/// # Errors
+///
+/// Returns an error when `$PORT` is invalid, the runner cannot be built, the
+/// listener cannot bind, or serving fails.
+pub async fn serve_agent_engine(agent: Arc<dyn Agent>, opts: AgentEngineOptions) -> Result<()> {
+    adk_core::ensure_crypto_provider();
+    let port = resolve_port(opts.port_override)?;
+    let app = build_agent_engine_app(agent, opts)?;
+
+    let addr = format!("0.0.0.0:{port}");
+    let listener = tokio::net::TcpListener::bind(&addr).await.map_err(|err| {
+        AdkError::new(
+            ErrorComponent::Server,
+            ErrorCategory::Unavailable,
+            "agent_engine.bind_failed",
+            format!("failed to bind {addr}: {err}"),
+        )
+    })?;
+    info!(server.address = %addr, "agent engine serving");
+    axum::serve(listener, app).await.map_err(|err| {
+        AdkError::new(
+            ErrorComponent::Server,
+            ErrorCategory::Internal,
+            "agent_engine.serve_failed",
+            format!("server terminated abnormally: {err}"),
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Env-var tests are safe under nextest (one process per test); they would
+    // race under plain `cargo test` threads.
+
+    #[test]
+    fn port_override_beats_env() {
+        unsafe { std::env::set_var(ENV_PORT, "9999") };
+        assert_eq!(resolve_port(Some(1234)).unwrap(), 1234);
+    }
+
+    #[test]
+    fn port_env_is_used_when_no_override() {
+        unsafe { std::env::set_var(ENV_PORT, "9042") };
+        assert_eq!(resolve_port(None).unwrap(), 9042);
+    }
+
+    #[test]
+    fn port_defaults_to_8080() {
+        unsafe { std::env::remove_var(ENV_PORT) };
+        assert_eq!(resolve_port(None).unwrap(), DEFAULT_PORT);
+    }
+
+    #[test]
+    fn blank_port_env_falls_back() {
+        unsafe { std::env::set_var(ENV_PORT, "  ") };
+        assert_eq!(resolve_port(None).unwrap(), DEFAULT_PORT);
+    }
+
+    #[test]
+    fn invalid_port_env_is_an_error() {
+        unsafe { std::env::set_var(ENV_PORT, "not-a-port") };
+        let err = resolve_port(None).unwrap_err();
+        assert_eq!(err.http_status_code(), 400);
+    }
+
+    #[test]
+    fn platform_env_detects_managed_deployments() {
+        unsafe { std::env::set_var(ENV_GOOGLE_CLOUD_AGENT_ENGINE_ID, "12345") };
+        assert!(PlatformEnv::read().is_managed());
+        unsafe { std::env::remove_var(ENV_GOOGLE_CLOUD_AGENT_ENGINE_ID) };
+        assert!(!PlatformEnv::read().is_managed());
+    }
+}

--- a/adk-server/src/agent_engine/mod.rs
+++ b/adk-server/src/agent_engine/mod.rs
@@ -25,9 +25,11 @@
 //! # }
 //! ```
 
+mod entrypoint;
 mod envelope;
 mod operations;
 
+pub use entrypoint::{AgentEngineOptions, build_agent_engine_app, serve_agent_engine};
 pub use envelope::DispatchRequest;
 pub use operations::{
     AddSessionToMemoryInput, AgentRunRequest, ApiMode, ClassMethod, CreateSessionInput,

--- a/adk-server/src/lib.rs
+++ b/adk-server/src/lib.rs
@@ -83,7 +83,10 @@ pub mod background;
 pub mod agent_engine;
 
 #[cfg(feature = "agent-engine")]
-pub use agent_engine::{AgentEngineState, agent_engine_router};
+pub use agent_engine::{
+    AgentEngineOptions, AgentEngineState, agent_engine_router, build_agent_engine_app,
+    serve_agent_engine,
+};
 
 // Background runs and cron scheduling re-exports
 #[cfg(feature = "background")]

--- a/adk-server/src/rest/mod.rs
+++ b/adk-server/src/rest/mod.rs
@@ -541,6 +541,8 @@ pub struct ServerBuilder {
     root_routes: Vec<Router>,
     shutdown_endpoint: bool,
     skill_index: Option<Arc<adk_skill::SkillIndex>>,
+    #[cfg(feature = "agent-engine")]
+    agent_engine: bool,
 }
 
 impl ServerBuilder {
@@ -553,6 +555,8 @@ impl ServerBuilder {
             root_routes: Vec::new(),
             shutdown_endpoint: false,
             skill_index: None,
+            #[cfg(feature = "agent-engine")]
+            agent_engine: false,
         }
     }
 
@@ -616,6 +620,29 @@ impl ServerBuilder {
     /// ```
     pub fn with_skill_index(mut self, skill_index: Arc<adk_skill::SkillIndex>) -> Self {
         self.skill_index = Some(skill_index);
+        self
+    }
+
+    /// Mount the Agent Engine dispatch endpoints alongside the built-in routes.
+    ///
+    /// When enabled, `POST /api/reasoning_engine` and
+    /// `POST /api/stream_reasoning_engine` serve the Gemini Enterprise Agent
+    /// Platform runtime contract for the loader's root agent, using the
+    /// configured session and artifact services. The routes carry the shared
+    /// middleware stack but **not** the auth middleware — a deployed engine is
+    /// fronted by the platform, which authenticates callers before they reach
+    /// the container. The memory class methods report `Unsupported`; use
+    /// [`serve_agent_engine`](crate::agent_engine::serve_agent_engine) with
+    /// [`AgentEngineOptions`](crate::agent_engine::AgentEngineOptions) to
+    /// configure a memory service.
+    ///
+    /// # Panics
+    ///
+    /// [`build`](Self::build) panics when the root agent's name is not a
+    /// valid app name, mirroring the builder's other misuse panics.
+    #[cfg(feature = "agent-engine")]
+    pub fn with_agent_engine(mut self, enabled: bool) -> Self {
+        self.agent_engine = enabled;
         self
     }
 
@@ -817,6 +844,30 @@ impl ServerBuilder {
         // Merge custom root routes
         for custom_routes in self.root_routes {
             app = app.merge(custom_routes);
+        }
+
+        // Agent Engine dispatch surface: root-level merge (its routes carry
+        // their own /api/... paths) so the platform host reaches it without
+        // the local auth middleware — the platform authenticates callers
+        // before they reach the container.
+        #[cfg(feature = "agent-engine")]
+        if self.agent_engine {
+            let root_agent = config.agent_loader.root_agent();
+            let mut runner_builder = adk_runner::Runner::builder()
+                .app_name(root_agent.name())
+                .agent(root_agent.clone())
+                .session_service(config.session_service.clone());
+            if let Some(artifact_service) = &config.artifact_service {
+                runner_builder = runner_builder.artifact_service(artifact_service.clone());
+            }
+            let runner = runner_builder
+                .build()
+                .expect("with_agent_engine requires the root agent's name to be a valid app name");
+            let mut state = crate::agent_engine::AgentEngineState::new(Arc::new(runner));
+            if let Some(artifact_service) = &config.artifact_service {
+                state = state.with_artifact_service(artifact_service.clone());
+            }
+            app = app.merge(crate::agent_engine::agent_engine_router(state));
         }
 
         if let Some(base_url) = &self.a2a_base_url {

--- a/adk-server/tests/agent_engine_entrypoint_tests.rs
+++ b/adk-server/tests/agent_engine_entrypoint_tests.rs
@@ -1,0 +1,216 @@
+//! Integration tests for the turnkey Agent Engine entrypoint and the
+//! `ServerBuilder` integration.
+//!
+//! The wave's acceptance criterion is exercised here without a container:
+//! the app built by `build_agent_engine_app` must answer the codelab's
+//! `query_agent.py` payload at `/api/stream_reasoning_engine` with streamed
+//! ADK events.
+
+#![cfg(feature = "agent-engine")]
+
+use adk_server::agent_engine::{AgentEngineOptions, build_agent_engine_app};
+use async_stream::stream;
+use async_trait::async_trait;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use std::sync::Arc;
+use tower::ServiceExt;
+
+struct EchoAgent;
+
+#[async_trait]
+impl adk_core::Agent for EchoAgent {
+    fn name(&self) -> &str {
+        "echo-agent"
+    }
+
+    fn description(&self) -> &str {
+        "Echo agent for entrypoint tests"
+    }
+
+    fn sub_agents(&self) -> &[Arc<dyn adk_core::Agent>] {
+        &[]
+    }
+
+    async fn run(
+        &self,
+        _ctx: Arc<dyn adk_core::InvocationContext>,
+    ) -> adk_core::Result<adk_core::EventStream> {
+        let s = stream! {
+            let mut event = adk_core::Event::new("entrypoint-invocation");
+            event.author = "echo-agent".to_string();
+            event.llm_response.content =
+                Some(adk_core::Content::new("model").with_text("echo: hi"));
+            yield Ok(event);
+        };
+        Ok(Box::pin(s))
+    }
+}
+
+async fn post(app: &axum::Router, uri: &str, body: serde_json::Value) -> axum::response::Response {
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(uri)
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+/// The wave's exit criterion: the codelab payload answered with streamed ADK
+/// events, one JSON object per line.
+#[tokio::test]
+async fn turnkey_app_answers_the_codelab_payload() {
+    let app = build_agent_engine_app(Arc::new(EchoAgent), AgentEngineOptions::new()).unwrap();
+
+    let payload = serde_json::json!({
+        "class_method": "async_stream_query",
+        "input": {"user_id": "u", "message": "hi"}
+    });
+    let response = post(&app, "/api/stream_reasoning_engine", payload).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let content_type =
+        response.headers().get("content-type").and_then(|v| v.to_str().ok()).unwrap().to_string();
+    assert!(content_type.starts_with("application/json"), "content-type was {content_type}");
+
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let text = String::from_utf8(bytes.to_vec()).unwrap();
+    let lines: Vec<serde_json::Value> =
+        text.lines().map(|line| serde_json::from_str(line).unwrap()).collect();
+    assert_eq!(lines.len(), 1);
+    let event: adk_core::Event = serde_json::from_value(lines[0].clone()).unwrap();
+    assert_eq!(event.author, "echo-agent");
+}
+
+#[tokio::test]
+async fn turnkey_app_serves_unary_dispatch_and_health() {
+    let app = build_agent_engine_app(Arc::new(EchoAgent), AgentEngineOptions::new()).unwrap();
+
+    let response = post(
+        &app,
+        "/api/reasoning_engine",
+        serde_json::json!({"class_method": "register_operations"}),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let health = app
+        .clone()
+        .oneshot(Request::builder().uri("/health").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(health.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn app_name_override_scopes_sessions() {
+    let app = build_agent_engine_app(
+        Arc::new(EchoAgent),
+        AgentEngineOptions::new().with_app_name("custom-app"),
+    )
+    .unwrap();
+
+    let payload = serde_json::json!({
+        "class_method": "create_session",
+        "input": {"user_id": "u", "session_id": "s-1"}
+    });
+    let response = post(&app, "/api/reasoning_engine", payload).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(body["output"]["app_name"], "custom-app");
+}
+
+#[tokio::test]
+async fn memory_service_option_enables_memory_methods() {
+    let app = build_agent_engine_app(
+        Arc::new(EchoAgent),
+        AgentEngineOptions::new()
+            .with_memory_service(Arc::new(adk_memory::InMemoryMemoryService::new())),
+    )
+    .unwrap();
+
+    // With a memory service configured, search succeeds (empty) instead of 501.
+    let payload = serde_json::json!({
+        "class_method": "async_search_memory",
+        "input": {"user_id": "u", "query": "anything"}
+    });
+    let response = post(&app, "/api/reasoning_engine", payload).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(body, serde_json::json!({"output": {"memories": []}}));
+}
+
+// ── ServerBuilder integration ────────────────────────────────────────────
+
+struct SingleAgentLoader;
+
+#[async_trait]
+impl adk_core::AgentLoader for SingleAgentLoader {
+    async fn load_agent(&self, _app_name: &str) -> adk_core::Result<Arc<dyn adk_core::Agent>> {
+        Ok(Arc::new(EchoAgent))
+    }
+
+    fn list_agents(&self) -> Vec<String> {
+        vec!["echo-agent".to_string()]
+    }
+
+    fn root_agent(&self) -> Arc<dyn adk_core::Agent> {
+        Arc::new(EchoAgent)
+    }
+}
+
+#[tokio::test]
+async fn server_builder_mounts_the_dispatch_surface() {
+    let config = adk_server::ServerConfig::new(
+        Arc::new(SingleAgentLoader),
+        Arc::new(adk_session::InMemorySessionService::new()),
+    );
+    let app = adk_server::ServerBuilder::new(config).with_agent_engine(true).build();
+
+    // Dispatch reachable alongside the built-in /api routes.
+    let response = post(
+        &app,
+        "/api/reasoning_engine",
+        serde_json::json!({"class_method": "register_operations"}),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let payload = serde_json::json!({
+        "class_method": "async_stream_query",
+        "input": {"user_id": "u", "message": "hi"}
+    });
+    let response = post(&app, "/api/stream_reasoning_engine", payload).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Built-in routes still work next to the merged dispatch routes.
+    let health = app
+        .clone()
+        .oneshot(Request::builder().uri("/api/health").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(health.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn server_builder_without_agent_engine_has_no_dispatch_routes() {
+    let config = adk_server::ServerConfig::new(
+        Arc::new(SingleAgentLoader),
+        Arc::new(adk_session::InMemorySessionService::new()),
+    );
+    let app = adk_server::ServerBuilder::new(config).build();
+
+    let response = post(
+        &app,
+        "/api/reasoning_engine",
+        serde_json::json!({"class_method": "register_operations"}),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}

--- a/docs/official_docs/deployment/agent-engine.md
+++ b/docs/official_docs/deployment/agent-engine.md
@@ -1,0 +1,180 @@
+# Agent Engine (Gemini Enterprise Agent Platform)
+
+The `agent-engine` feature makes an ADK-Rust agent drivable by the Gemini
+Enterprise Agent Platform as a custom-container ReasoningEngine. A container
+running [`serve_agent_engine`] answers `reasoningEngines.query`,
+`reasoningEngines.streamQuery`, the console Playground, and the platform
+SDKs — the same runtime contract adk-python's `AdkApp` implements.
+
+## Overview
+
+The platform drives a deployed engine through two container endpoints:
+
+| Endpoint | Mode | Response |
+|----------|------|----------|
+| `POST /api/reasoning_engine` | unary | `{"output": ...}` |
+| `POST /api/stream_reasoning_engine` | streaming | one JSON object per line (`Content-Type: application/json`, no SSE framing) |
+
+Both take the dispatch envelope `{"class_method": "...", "input": {...}}`.
+The envelope is snake_case — the platform dispatches on Python method names.
+The turnkey app also serves `GET /health` for container health checks.
+
+## Quick start
+
+Enable the feature (it is included in the `gemini-agent-platform`
+meta-feature):
+
+```toml
+[dependencies]
+adk-rust = { version = "2.0.0", features = ["minimal", "agent-engine"] }
+```
+
+`serve_agent_engine` is the whole `main` of a deployable engine. It binds
+`0.0.0.0:$PORT` (fallback `8080`) and serves until stopped:
+
+```rust
+use adk_rust::prelude::*;
+use adk_server::agent_engine::{AgentEngineOptions, serve_agent_engine};
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let api_key = std::env::var("GOOGLE_API_KEY")?;
+    let model = Arc::new(GeminiModel::new(&api_key, "gemini-2.5-flash")?);
+
+    let agent = LlmAgentBuilder::new("weather_agent")
+        .description("Answers weather questions")
+        .instruction("You are a helpful weather assistant.")
+        .model(model)
+        .build()?;
+
+    serve_agent_engine(Arc::new(agent), AgentEngineOptions::new()).await
+}
+```
+
+Verify with the codelab's payload:
+
+```bash
+curl -s -X POST localhost:8080/api/stream_reasoning_engine \
+  -H 'Content-Type: application/json' \
+  -d '{"class_method": "async_stream_query", "input": {"user_id": "u", "message": "hi"}}'
+```
+
+Each response line is one ADK event as JSON.
+
+## Operations
+
+The engine registers the exact operation set adk-python's `AdkApp`
+advertises. Sync/async name pairs map to the same handler — the split is a
+Python artifact the wire contract preserves.
+
+| `class_method` | API mode | Behavior |
+|---|---|---|
+| `create_session`, `async_create_session` | `""` / `async` | Create a session (optional caller-chosen ID and initial state) |
+| `get_session`, `async_get_session` | `""` / `async` | Fetch a session with its events |
+| `list_sessions`, `async_list_sessions` | `""` / `async` | List a user's sessions |
+| `delete_session`, `async_delete_session` | `""` / `async` | Delete a session |
+| `stream_query`, `async_stream_query` | `stream` / `async_stream` | Run the agent; the session is created automatically when absent |
+| `streaming_agent_run_with_events` | `async_stream` | Run the agent from an `AgentRunRequest` JSON string (console Playground path) |
+| `async_add_session_to_memory` | `async` | Extract a session's events into the configured memory service |
+| `async_search_memory` | `async` | Search the configured memory service |
+| `register_operations` | `""` | Advertise this table to the host |
+
+Unknown class methods return `400` with a problem-JSON body. The memory
+methods return an `Unsupported` error (`501`) until a memory service is
+configured.
+
+> **Note:** `reasoningEngines:asyncQuery` (durable query jobs) is not
+> registered: the capability must be declared at engine create time, cannot
+> be added post-create, and adk-python's `AdkApp` does not register it
+> either.
+
+## Managed backends
+
+The zero-configuration default keeps sessions in memory — enough to answer
+queries, but conversations do not survive a container restart. Deployed
+engines configure managed backends through `AgentEngineOptions`.
+
+### Managed sessions (Vertex AI Sessions)
+
+With the `vertex-session` feature, `VertexAiSessionConfig::from_env()` reads
+the variables the platform sets inside deployed containers
+(`GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`, and
+`GOOGLE_CLOUD_AGENT_ENGINE_ID` — the bare numeric engine ID):
+
+```rust
+use adk_server::agent_engine::AgentEngineOptions;
+use adk_session::{VertexAiSessionConfig, VertexAiSessionService};
+use std::sync::Arc;
+
+fn managed_sessions() -> adk_core::Result<AgentEngineOptions> {
+    let config = VertexAiSessionConfig::from_env()?;
+    let sessions = Arc::new(VertexAiSessionService::new_with_adc(config)?);
+    Ok(AgentEngineOptions::new().with_session_service(sessions))
+}
+```
+
+Outside a deployed container, construct the config explicitly with
+`VertexAiSessionConfig::new(project, location).with_reasoning_engine(id)`.
+
+### Artifacts (Google Cloud Storage)
+
+With the `gcs-artifacts` feature, `GcsArtifactService` stores artifacts in
+the blob layout the Gemini Enterprise console reads (byte-for-byte parity
+with adk-python). Take the bucket from an environment variable or a flag:
+
+```rust
+use adk_artifact::GcsArtifactService;
+use adk_server::agent_engine::AgentEngineOptions;
+use std::sync::Arc;
+
+fn gcs_artifacts() -> adk_core::Result<AgentEngineOptions> {
+    let bucket = std::env::var("ADK_ARTIFACT_BUCKET").unwrap_or_else(|_| "my-bucket".to_string());
+    let artifacts = Arc::new(GcsArtifactService::new_with_adc(bucket)?);
+    Ok(AgentEngineOptions::new().with_artifact_service(artifacts))
+}
+```
+
+The artifact service is wired into both the runner (tool-facing saves and
+loads) and the dispatch state.
+
+### Memory
+
+`AgentEngineOptions::with_memory_service` accepts any
+`adk_memory::MemoryService` and enables the two memory class methods. The
+platform's Memory Bank backend arrives with the `vertex-memory` feature in a
+later release.
+
+## ServerBuilder integration
+
+An existing ADK server can expose the dispatch surface alongside its REST,
+UI, and A2A routes:
+
+```rust
+use adk_server::{ServerBuilder, ServerConfig};
+
+fn build_app(config: ServerConfig) -> axum::Router {
+    ServerBuilder::new(config).with_agent_engine(true).build()
+}
+```
+
+The dispatch routes serve the loader's root agent with the configured
+session and artifact services. They do **not** carry the server's auth
+middleware: a deployed engine is fronted by the platform, which
+authenticates callers before they reach the container. Do not expose these
+endpoints directly to untrusted networks.
+
+## Environment variables
+
+| Variable | Meaning |
+|----------|---------|
+| `PORT` | Serving port assigned by the platform (fallback `8080`; an invalid value fails startup) |
+| `GOOGLE_CLOUD_PROJECT` | GCP project of the deployment |
+| `GOOGLE_CLOUD_LOCATION` | GCP location of the deployment |
+| `GOOGLE_CLOUD_AGENT_ENGINE_ID` | Bare numeric engine ID, set inside deployed containers |
+
+When `GOOGLE_CLOUD_AGENT_ENGINE_ID` is present and the session service is
+the in-memory default, the entrypoint logs a warning: deployed engines
+should use managed sessions.
+
+[`serve_agent_engine`]: https://docs.rs/adk-server/latest/adk_server/agent_engine/fn.serve_agent_engine.html

--- a/docs/official_docs/index.md
+++ b/docs/official_docs/index.md
@@ -117,6 +117,7 @@ Long-term memory that outlives a session — the persistent counterpart to sessi
 - [Server](deployment/server.md) - REST API and web UI integration
 - [A2A Protocol](deployment/a2a.md) - Agent-to-Agent communication
 - [Agentic Web Protocol](deployment/awp.md) - AWP protocol for agent-native web services
+- [Agent Engine](deployment/agent-engine.md) - Deploying on the Gemini Enterprise Agent Platform
 
 ## Evaluation
 


### PR DESCRIPTION
## What

The turnkey Agent Engine entrypoint and its integrations, completing Wave 1's runtime contract (WP1.4):

- `serve_agent_engine(agent, options)` (`adk-server/src/agent_engine/entrypoint.rs`) — the whole `main` of a deployable engine: installs the crypto provider, binds `0.0.0.0:$PORT` (fallback `8080`), and serves the dispatch endpoints plus `GET /health`.
- `AgentEngineOptions` builder — `session_service`, `memory_service`, `artifact_service`, `app_name`, `port` overrides; the zero-configuration default serves with in-memory sessions.
- `build_agent_engine_app` — the same app as a plain `Router` for custom listeners and tests.
- `ServerBuilder::with_agent_engine(bool)` — mounts the dispatch surface alongside the built-in REST/UI/A2A routes (behind `#[cfg(feature = "agent-engine")]`).
- Umbrella forwarding `agent-engine = ["server", "adk-server/agent-engine"]`, appended to the `gemini-agent-platform` meta-feature (growth rule).
- New docs page `docs/official_docs/deployment/agent-engine.md`; feature-table rows in `adk-rust`'s crate docs and `AGENTS.md`; CHANGELOG entry.

## Why

Part of #438 (Wave 1, PR 1.2 — WP1.4). PR 1.1 (#579) landed the dispatch core; this PR makes it deployable: a single function turns any `Agent` into a platform-drivable BYOC container.

## How

**Entrypoint.**
- Port resolution: explicit override → `$PORT` → `8080`. An invalid `$PORT` fails startup with an `InvalidInput` error — a misconfigured port means the platform cannot reach the container, so failing loudly beats serving on the wrong port.
- Reads the platform-reserved variables (`GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`, `GOOGLE_CLOUD_AGENT_ENGINE_ID` — V1) for startup logging. When the engine ID is present and sessions are the in-memory default, it warns and points at `VertexAiSessionService` with `VertexAiSessionConfig::from_env()` (the Wave 0 constructor).
- The artifact service is wired into both the runner and the dispatch state; the docs page shows `GcsArtifactService::new_with_adc(bucket)` wiring (the deferred Wave 0 WP5.4 documentation item).
- `GET /health` answers container health probes; the dispatch router itself is unchanged from PR 1.1.

**ServerBuilder.** The dispatch routes merge at root level (they carry their own `/api/...` paths), so they receive the shared middleware stack but not the local auth middleware — a deployed engine is fronted by the platform, which authenticates callers first. Documented on the method and in the docs page. `build()` panics when the root agent's name is not a valid app name, mirroring `build_with_shutdown`'s misuse panic.

**Growth rule.** The umbrella `agent-engine` feature is uncommented in `gemini-agent-platform`'s target end-state list. The PR-tier feature-coverage entries already cover both axes: `{adk-server, agent-engine}` (added in PR 1.1) and `{adk-rust, gemini-agent-platform}` (added in PR 0.1), which now compiles the forwarding.

**Dependencies.** No new crates; `tokio/net` is enabled by the `agent-engine` feature for the listener. All optional — the default workspace build and example lockfiles are unchanged.

**Tests** (`agent_engine_entrypoint_tests.rs` + entrypoint unit tests):
- **Acceptance criterion:** the turnkey app answers the codelab payload (`{"class_method":"async_stream_query","input":{"user_id":"u","message":"hi"}}`) at `/api/stream_reasoning_engine` with newline-delimited ADK events that parse as `adk_core::Event`.
- Unary dispatch and `/health` on the turnkey app; `app_name` override scopes session dumps; `with_memory_service` flips the memory methods from 501 to working.
- `ServerBuilder::with_agent_engine(true)` serves dispatch alongside `/api/health`; without it, the dispatch routes 404.
- Port resolution: override precedence, `$PORT` parsing, blank fallback, invalid value → error (env-var tests are safe under nextest's process-per-test).

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings; workspace, `adk-server --features agent-engine`, and `adk-rust --features gemini-agent-platform`)
- [x] `devenv shell test` — all non-ignored tests pass (148 in `adk-server` with the feature; umbrella `gemini-agent-platform` tests; doctests; `RUSTDOCFLAGS="-D warnings"` doc build; `scripts/check-doc-examples.sh`)
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed (`adk-rust` crate-docs feature table, `AGENTS.md` feature lists, docs index)
- [x] Examples added or updated for new features (complete `main` in the docs page quick start)
