### PR TITLE
feat(memory): add Vertex AI Memory Bank backend - PR 2.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,9 @@ jobs:
           # contract) is behind `agent-engine`; its wire-fixture and dispatch tests only
           # run with the feature on. Umbrella forwarding follows in the entrypoint PR.
           - { package: adk-server, features: agent-engine }
+          # The Memory Bank backend (vertex-memory) is opt-in; its mock contract tests
+          # only run with the feature on.
+          - { package: adk-memory, features: vertex-memory }
           # sandbox-linux is Linux-only *and* feature-gated, so nothing built it until a
           # container run found the bubblewrap probe could never succeed and that its
           # property tests did not compile.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -414,7 +414,7 @@ Four tiered presets control which crates are compiled:
 Domain add-ons are composable with any tier: `features = ["minimal", "audio"]`.
 
 Platform meta-features (composable with any tier):
-- `gemini-agent-platform` — every Gemini Enterprise Agent Platform (Vertex/EAP) integration except realtime transports: `gemini-vertex`, `vertex-session`, `gcp-secrets`, `gcs-artifacts`, `gcp-telemetry`, `agent-engine` (grows as later integrations land). The right default for ReasoningEngine BYOC deployments. Deploy-time tooling is host-side and excluded.
+- `gemini-agent-platform` — every Gemini Enterprise Agent Platform (Vertex/EAP) integration except realtime transports: `gemini-vertex`, `vertex-session`, `gcp-secrets`, `gcs-artifacts`, `gcp-telemetry`, `agent-engine`, `vertex-memory` (grows as later integrations land). The right default for ReasoningEngine BYOC deployments. Deploy-time tooling is host-side and excluded.
 - `gemini-agent-platform-full` — `gemini-agent-platform` + `vertex-live` (Vertex AI Live API, pulls in the adk-realtime stack)
 
 Graph capability features (forwarded to `adk-graph`, which has no default features):
@@ -428,7 +428,8 @@ Graph capability features (forwarded to `adk-graph`, which has no default featur
 Production backend features (require external infrastructure, NOT included in `full`):
 - `postgres-session`, `redis-session`, `mongodb-session`, `firestore-session`, `neo4j-session`,
   `vertex-session`
-- `sqlite-memory`, `database-memory`, `redis-memory`, `mongodb-memory`, `neo4j-memory`
+- `sqlite-memory`, `database-memory`, `redis-memory`, `mongodb-memory`, `neo4j-memory`,
+  `vertex-memory`
 - `auth-bridge`
 - `managed-runtime` — Managed agent runtime (adk-managed): durable sessions, event streaming, provider parity
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Vertex AI Memory Bank backend** (`adk-memory`, feature `vertex-memory`;
+  umbrella feature `vertex-memory`, included in `gemini-agent-platform`):
+  `VertexAiMemoryBankService` implements `MemoryService` over the platform's
+  `memories:generate` (LRO-polled) and `memories:retrieve` (similarity
+  search) endpoints with the same `{app_name, user_id}` scope adk-python
+  writes, so both runtimes share one Memory Bank. `VertexAiMemoryConfig`
+  mirrors the session config (`from_env()` reads the platform's container
+  variables). `add_events_to_memory` persists a subset of events;
+  `delete_user` enumerates and deletes a scope's memories. This completes the
+  Agent Engine dispatch surface's `async_add_session_to_memory` /
+  `async_search_memory` class methods, which returned `Unsupported` until
+  now.
+
 - **Agent Engine turnkey entrypoint** (`adk-server`, feature `agent-engine`;
   umbrella feature `agent-engine`, included in `gemini-agent-platform`):
   `serve_agent_engine(agent, options)` is the whole `main` of a deployable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,17 +617,21 @@ version = "2.0.0"
 dependencies = [
  "adk-core",
  "async-trait",
+ "axum 0.8.9",
  "chrono",
  "fred",
+ "google-cloud-auth 1.12.0",
  "mongodb",
  "neo4rs",
  "pgvector",
  "proptest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sqlx",
  "tokio",
  "tracing",
+ "uuid 1.23.2",
 ]
 
 [[package]]

--- a/adk-memory/Cargo.toml
+++ b/adk-memory/Cargo.toml
@@ -24,12 +24,17 @@ pgvector = { version = "0.4", features = ["sqlx"], optional = true }
 mongodb = { version = "3", optional = true }
 neo4rs = { version = "0.8", optional = true }
 fred = { version = "10", optional = true }
+reqwest = { workspace = true, optional = true }
+tokio = { workspace = true, features = ["sync", "time"], optional = true }
+google-cloud-auth = { version = "1.8", optional = true, default-features = false, features = ["default-rustls-provider"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "macros"] }
 proptest = "1.5"
 serde_json.workspace = true
 chrono.workspace = true
+axum = "0.8"
+uuid = { version = "1.23", features = ["v4"] }
 
 [features]
 default = []
@@ -43,3 +48,5 @@ database-memory = ["sqlx/postgres", "pgvector"]
 redis-memory = ["fred"]
 mongodb-memory = ["dep:mongodb"]
 neo4j-memory = ["dep:neo4rs"]
+# Vertex AI Agent Engine Memory Bank backend (memories:generate / memories:retrieve)
+vertex-memory = ["google-cloud-auth", "reqwest", "tokio"]

--- a/adk-memory/README.md
+++ b/adk-memory/README.md
@@ -16,6 +16,7 @@ Semantic memory and search for Rust Agent Development Kit (ADK-Rust) agents.
 - **MongoMemoryService** - MongoDB-backed persistence (`mongodb-memory` feature)
 - **Neo4jMemoryService** - Neo4j-backed persistence (`neo4j-memory` feature)
 - **RedisMemoryService** - Redis-backed persistence (`redis-memory` feature)
+- **VertexAiMemoryBankService** - Vertex AI Agent Engine Memory Bank (`vertex-memory` feature)
 - **MemoryService** - Trait for custom storage backends
 - **Semantic Search** - Query memories by content similarity
 - **Project-Scoped Isolation** - Isolate memories by project within a user
@@ -178,6 +179,7 @@ validate_project_id(&"x".repeat(257))?; // Err: exceeds 256 chars
 | `redis-memory` | Redis | Low-latency in-memory persistence via fred |
 | `mongodb-memory` | MongoDB | Document-oriented persistence |
 | `neo4j-memory` | Neo4j | Graph database persistence |
+| `vertex-memory` | Vertex AI Memory Bank | Managed memory generation and retrieval on the Gemini Enterprise Agent Platform |
 
 ```toml
 # SQLite

--- a/adk-memory/src/lib.rs
+++ b/adk-memory/src/lib.rs
@@ -80,6 +80,8 @@ pub mod postgres;
 pub mod redis;
 #[cfg(feature = "sqlite-memory")]
 pub mod sqlite;
+#[cfg(feature = "vertex-memory")]
+pub mod vertex;
 
 pub use adapter::MemoryServiceAdapter;
 pub use inmemory::InMemoryMemoryService;
@@ -107,3 +109,5 @@ pub use postgres::{PostgresMemoryService, PostgresMemoryServiceBuilder, VectorIn
 pub use redis::{RedisMemoryConfig, RedisMemoryService};
 #[cfg(feature = "sqlite-memory")]
 pub use sqlite::SqliteMemoryService;
+#[cfg(feature = "vertex-memory")]
+pub use vertex::{VertexAiMemoryBankService, VertexAiMemoryConfig};

--- a/adk-memory/src/vertex.rs
+++ b/adk-memory/src/vertex.rs
@@ -1,0 +1,921 @@
+//! Vertex AI Agent Engine Memory Bank backend.
+//!
+//! Rust analog of Python ADK's `VertexAiMemoryBankService`: long-term
+//! memories are generated from conversation content with
+//! `memories:generate` (a long-running operation) and retrieved with
+//! `memories:retrieve` (similarity search), scoped to
+//! `{"app_name", "user_id"}` so one engine can serve many users.
+//!
+//! Endpoints are the v1beta1 Memory Bank surface under
+//! `projects/{project}/locations/{location}/reasoningEngines/{engine}`.
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use adk_memory::{VertexAiMemoryBankService, VertexAiMemoryConfig};
+//!
+//! # fn main() -> adk_core::Result<()> {
+//! // Inside a deployed engine container the platform sets the env vars.
+//! let config = VertexAiMemoryConfig::from_env()?;
+//! let memory = VertexAiMemoryBankService::new_with_adc(config)?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! `ToolContext::search_memory` works unchanged through the existing
+//! adapter: wrap the service in
+//! [`MemoryServiceAdapter`](crate::MemoryServiceAdapter) to obtain an
+//! `adk_core::Memory`.
+
+// The ADC credential caching, bounded HTTP, and LRO polling below are copied
+// from adk-session/src/vertex.rs rather than shared: extracting the pattern
+// into a helper crate is Wave 3's job (adk-gcp, PR 3.1/3.3 of the Agent
+// Engine plan), which migrates both call sites at once.
+
+use crate::{MemoryEntry, MemoryService, SearchRequest, SearchResponse};
+use adk_core::{AdkError, Content, ErrorCategory, ErrorComponent, Event, Result};
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use google_cloud_auth::credentials::{self, CacheableResource, Credentials};
+use reqwest::{Client, RequestBuilder, StatusCode};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value, json};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::RwLock;
+use tokio::time::Instant;
+use tracing::debug;
+
+const MEMORY_API_VERSION: &str = "v1beta1";
+const CLOUD_PLATFORM_SCOPE: &str = "https://www.googleapis.com/auth/cloud-platform";
+const HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+const AUTH_HEADERS_TIMEOUT: Duration = Duration::from_secs(30);
+// Same backoff policy as adk-session's wait_for_operation: 100 ms initial,
+// 2 s cap, bounded deadline.
+const OPERATION_POLL_TIMEOUT: Duration = Duration::from_secs(120);
+const OPERATION_POLL_INITIAL_DELAY: Duration = Duration::from_millis(100);
+const OPERATION_POLL_MAX_DELAY: Duration = Duration::from_secs(2);
+const MAX_RESPONSE_BYTES: usize = 64 * 1024 * 1024;
+/// Page size used when enumerating a scope's memories for deletion.
+const DELETE_PAGE_SIZE: usize = 100;
+/// Upper bound on delete pagination rounds, so a server that keeps returning
+/// page tokens cannot spin this client forever.
+const DELETE_MAX_PAGES: usize = 1_000;
+
+/// Environment variable holding the GCP project (set inside deployed engines).
+const ENV_GOOGLE_CLOUD_PROJECT: &str = "GOOGLE_CLOUD_PROJECT";
+/// Environment variable holding the GCP location.
+const ENV_GOOGLE_CLOUD_LOCATION: &str = "GOOGLE_CLOUD_LOCATION";
+/// Environment variable holding the bare numeric engine ID.
+const ENV_GOOGLE_CLOUD_AGENT_ENGINE_ID: &str = "GOOGLE_CLOUD_AGENT_ENGINE_ID";
+
+/// Configuration for [`VertexAiMemoryBankService`].
+///
+/// Mirrors `VertexAiSessionConfig`: project, location, optional reasoning
+/// engine, optional endpoint override, and a [`from_env`](Self::from_env)
+/// constructor reading the platform's container environment.
+///
+/// # Example
+///
+/// ```rust
+/// use adk_memory::VertexAiMemoryConfig;
+///
+/// let config = VertexAiMemoryConfig::new("my-project", "us-central1")
+///     .with_reasoning_engine("1234567890");
+/// ```
+#[derive(Debug, Clone)]
+pub struct VertexAiMemoryConfig {
+    project_id: String,
+    location: String,
+    reasoning_engine: Option<String>,
+    endpoint: Option<String>,
+}
+
+impl VertexAiMemoryConfig {
+    /// Creates a config for the given project and location.
+    pub fn new(project_id: impl Into<String>, location: impl Into<String>) -> Self {
+        Self {
+            project_id: project_id.into(),
+            location: location.into(),
+            reasoning_engine: None,
+            endpoint: None,
+        }
+    }
+
+    /// Builds a config from the environment variables the platform sets
+    /// inside deployed containers: `GOOGLE_CLOUD_PROJECT`,
+    /// `GOOGLE_CLOUD_LOCATION`, and `GOOGLE_CLOUD_AGENT_ENGINE_ID` (the bare
+    /// numeric engine ID). Values are trimmed; blank counts as missing.
+    ///
+    /// # Errors
+    ///
+    /// Returns an invalid-input error naming every missing or blank variable.
+    pub fn from_env() -> Result<Self> {
+        let read = |key: &str| {
+            std::env::var(key)
+                .ok()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+        };
+        let project_id = read(ENV_GOOGLE_CLOUD_PROJECT);
+        let location = read(ENV_GOOGLE_CLOUD_LOCATION);
+        let agent_engine_id = read(ENV_GOOGLE_CLOUD_AGENT_ENGINE_ID);
+
+        match (project_id, location, agent_engine_id) {
+            (Some(project_id), Some(location), Some(agent_engine_id)) => {
+                Ok(Self::new(project_id, location).with_reasoning_engine(agent_engine_id))
+            }
+            (project_id, location, agent_engine_id) => {
+                let missing = [
+                    (ENV_GOOGLE_CLOUD_PROJECT, project_id.is_none()),
+                    (ENV_GOOGLE_CLOUD_LOCATION, location.is_none()),
+                    (ENV_GOOGLE_CLOUD_AGENT_ENGINE_ID, agent_engine_id.is_none()),
+                ]
+                .into_iter()
+                .filter_map(|(key, is_missing)| is_missing.then_some(key))
+                .collect::<Vec<_>>()
+                .join(", ");
+                Err(AdkError::new(
+                    ErrorComponent::Memory,
+                    ErrorCategory::InvalidInput,
+                    "memory.vertex.missing_env",
+                    format!(
+                        "missing or blank environment variable(s): {missing}. The Agent Engine platform sets these inside deployed containers; set them explicitly elsewhere, or construct the config with VertexAiMemoryConfig::new",
+                    ),
+                )
+                .with_provider("vertex_ai"))
+            }
+        }
+    }
+
+    /// Sets the reasoning engine numeric ID or full resource name.
+    #[must_use]
+    pub fn with_reasoning_engine(mut self, reasoning_engine: impl Into<String>) -> Self {
+        self.reasoning_engine = Some(reasoning_engine.into());
+        self
+    }
+
+    /// Sets a custom API origin.
+    ///
+    /// The origin receives Google authorization headers plus memory content.
+    /// Use only a trusted HTTPS origin, or loopback HTTP for local tests.
+    /// Userinfo, paths, queries, and fragments are rejected before transport.
+    #[must_use]
+    pub fn with_endpoint(mut self, endpoint: impl Into<String>) -> Self {
+        self.endpoint = Some(endpoint.into());
+        self
+    }
+
+    fn endpoint(&self) -> String {
+        self.endpoint
+            .clone()
+            .unwrap_or_else(|| format!("https://{}-aiplatform.googleapis.com", self.location))
+    }
+}
+
+/// Vertex AI Agent Engine Memory Bank service.
+///
+/// Implements [`MemoryService`] over the platform's `memories:generate` and
+/// `memories:retrieve` endpoints. Memories are scoped to
+/// `{"app_name": ..., "user_id": ...}`, matching adk-python's
+/// `VertexAiMemoryBankService` so both runtimes share one Memory Bank.
+pub struct VertexAiMemoryBankService {
+    http_client: Client,
+    endpoint: String,
+    project_id: String,
+    location: String,
+    reasoning_engine: Option<String>,
+    credentials: Credentials,
+    auth_headers: Arc<RwLock<Option<reqwest::header::HeaderMap>>>,
+}
+
+impl VertexAiMemoryBankService {
+    /// Creates a new service using Application Default Credentials (ADC).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when ADC cannot be constructed, the endpoint is not
+    /// a valid secure origin, or the HTTP client cannot be built.
+    pub fn new_with_adc(config: VertexAiMemoryConfig) -> Result<Self> {
+        let credentials = credentials::Builder::default()
+            .with_scopes([CLOUD_PLATFORM_SCOPE])
+            .build()
+            .map_err(|error| {
+                let error = truncate_for_error(&error.to_string());
+                Self::auth_error(format!("failed to build vertex memory ADC credentials: {error}"))
+            })?;
+        Self::with_credentials(config, credentials)
+    }
+
+    /// Creates a new service with explicit credentials.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the endpoint is not a valid secure origin or
+    /// the redirect-disabled HTTP client cannot be built.
+    pub fn with_credentials(
+        config: VertexAiMemoryConfig,
+        credentials: Credentials,
+    ) -> Result<Self> {
+        let http_client = Client::builder()
+            .connect_timeout(HTTP_CONNECT_TIMEOUT)
+            .timeout(HTTP_REQUEST_TIMEOUT)
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .map_err(|error| {
+                let error = truncate_for_error(&error.without_url().to_string());
+                Self::memory_error(format!(
+                    "failed to build bounded vertex memory HTTP client: {error}"
+                ))
+            })?;
+        let service = Self {
+            http_client,
+            endpoint: config.endpoint(),
+            project_id: config.project_id,
+            location: config.location,
+            reasoning_engine: config.reasoning_engine,
+            credentials,
+            auth_headers: Arc::new(RwLock::new(None)),
+        };
+        service.build_url("")?;
+        Ok(service)
+    }
+
+    /// Generates memories from an explicit slice of events.
+    ///
+    /// Mirrors adk-python's `VertexAiMemoryBankService.add_events_to_memory`
+    /// so callers can persist only recent turns instead of a whole session.
+    /// Events without content are skipped; an all-skipped or empty slice is
+    /// a no-op.
+    ///
+    /// This is an inherent method, not part of [`MemoryService`] — the trait
+    /// has no subset-of-events operation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the request fails or the returned long-running
+    /// operation reports failure or does not finish within the poll deadline.
+    pub async fn add_events_to_memory(
+        &self,
+        app_name: &str,
+        user_id: &str,
+        events: &[Event],
+    ) -> Result<()> {
+        let contents: Vec<&Content> =
+            events.iter().filter_map(|event| event.llm_response.content.as_ref()).collect();
+        self.generate_memories(app_name, user_id, &contents).await
+    }
+
+    async fn generate_memories(
+        &self,
+        app_name: &str,
+        user_id: &str,
+        contents: &[&Content],
+    ) -> Result<()> {
+        if contents.is_empty() {
+            debug!("no content-bearing entries; skipping memories:generate");
+            return Ok(());
+        }
+        let parent = self.memories_parent(app_name)?;
+        let url = self.build_url(&format!("{MEMORY_API_VERSION}/{parent}/memories:generate"))?;
+        let events: Vec<Value> =
+            contents.iter().map(|content| json!({ "content": content })).collect();
+        let body = json!({
+            "directContentsSource": { "events": events },
+            "scope": memory_scope(app_name, user_id),
+        });
+        let request = self.apply_auth(self.http_client.post(url).json(&body)).await?;
+        let operation = self.send_value(request).await?;
+        // :generate's LRO response payload is not needed — only completion.
+        self.wait_for_operation(operation, "memories generate").await?;
+        Ok(())
+    }
+
+    async fn retrieve_page(
+        &self,
+        parent: &str,
+        scope: &Value,
+        retrieval_params_key: &str,
+        retrieval_params: Value,
+    ) -> Result<RetrieveMemoriesResponse> {
+        let url = self.build_url(&format!("{MEMORY_API_VERSION}/{parent}/memories:retrieve"))?;
+        let body = json!({
+            "scope": scope,
+            retrieval_params_key: retrieval_params,
+        });
+        let request = self.apply_auth(self.http_client.post(url).json(&body)).await?;
+        let value = self.send_value(request).await?;
+        serde_json::from_value(value).map_err(|error| {
+            let error = truncate_for_error(&error.to_string());
+            Self::memory_error(format!("failed to parse memories:retrieve response: {error}"))
+        })
+    }
+
+    async fn delete_memory(&self, memory_name: &str) -> Result<()> {
+        validate_memory_resource_name(memory_name, &self.project_id, &self.location)?;
+        let url = self.build_url(&format!("{MEMORY_API_VERSION}/{memory_name}"))?;
+        let request = self.apply_auth(self.http_client.delete(url)).await?;
+        let operation = self.send_value(request).await?;
+        self.wait_for_operation(operation, "memory delete").await?;
+        Ok(())
+    }
+
+    fn memories_parent(&self, app_name: &str) -> Result<String> {
+        let reasoning_engine = self.resolve_reasoning_engine_id(app_name)?;
+        Ok(format!(
+            "projects/{}/locations/{}/reasoningEngines/{reasoning_engine}",
+            self.project_id, self.location,
+        ))
+    }
+
+    fn resolve_reasoning_engine_id(&self, app_name: &str) -> Result<String> {
+        let Some(candidate) = self.reasoning_engine.as_deref() else {
+            if is_canonical_reasoning_engine_id(app_name) {
+                return Ok(app_name.to_string());
+            }
+            return Err(Self::invalid_input(
+                "when no fixed reasoning engine is configured, app_name must be its canonical numeric reasoning-engine ID without leading zeros; configure with_reasoning_engine for logical app names or full resource names",
+            ));
+        };
+        if is_canonical_reasoning_engine_id(candidate) {
+            return Ok(candidate.to_string());
+        }
+        let prefix =
+            format!("projects/{}/locations/{}/reasoningEngines/", self.project_id, self.location);
+        if let Some(id) = candidate.strip_prefix(&prefix)
+            && is_canonical_reasoning_engine_id(id)
+        {
+            return Ok(id.to_string());
+        }
+        let candidate = truncate_for_error(candidate);
+        Err(Self::invalid_input(format!(
+            "reasoning engine '{candidate}' is invalid. Provide a numeric ID or the exact resource name '{prefix}<numeric-id>'",
+        )))
+    }
+
+    /// Builds a URL from the endpoint base, requiring HTTPS for
+    /// non-loopback endpoints so memory content is never sent in cleartext.
+    fn build_url(&self, path: &str) -> Result<String> {
+        let mut url = reqwest::Url::parse(&self.endpoint).map_err(|error| {
+            let error = truncate_for_error(&error.to_string());
+            Self::invalid_input(format!("invalid Vertex AI endpoint URL: {error}"))
+        })?;
+        if url.scheme() != "https" && !(url.scheme() == "http" && is_loopback_host(&url)) {
+            return Err(Self::invalid_input(
+                "Vertex AI endpoint must use HTTPS for secure transmission of memory content",
+            ));
+        }
+        if !url.username().is_empty()
+            || url.password().is_some()
+            || url.query().is_some()
+            || url.fragment().is_some()
+            || url.path() != "/"
+        {
+            return Err(Self::invalid_input(
+                "Vertex AI endpoint must be an origin without userinfo, path, query, or fragment",
+            ));
+        }
+        url.set_path(&format!("/{}", path.trim_start_matches('/')));
+        Ok(url.to_string())
+    }
+
+    async fn auth_headers(&self) -> Result<reqwest::header::HeaderMap> {
+        let cacheable_headers = tokio::time::timeout(
+            AUTH_HEADERS_TIMEOUT,
+            self.credentials.headers(Default::default()),
+        )
+        .await
+        .map_err(|_| {
+            Self::timeout_error(format!(
+                "vertex memory credential header acquisition timed out after {} seconds",
+                AUTH_HEADERS_TIMEOUT.as_secs_f64(),
+            ))
+        })?
+        .map_err(Self::credentials_error)?;
+
+        match cacheable_headers {
+            CacheableResource::New { data, .. } => {
+                *self.auth_headers.write().await = Some(data.clone());
+                Ok(data)
+            }
+            CacheableResource::NotModified => {
+                self.auth_headers.read().await.clone().ok_or_else(|| {
+                    Self::auth_error(
+                        "google cloud credentials returned NotModified before any cached auth headers were available",
+                    )
+                })
+            }
+        }
+    }
+
+    async fn apply_auth(&self, request: RequestBuilder) -> Result<RequestBuilder> {
+        let headers = self.auth_headers().await?;
+        Ok(request.headers(headers))
+    }
+
+    async fn send_value(&self, request: RequestBuilder) -> Result<Value> {
+        let (status, body) = tokio::time::timeout(HTTP_REQUEST_TIMEOUT, async {
+            let response = request.send().await.map_err(Self::transport_error)?;
+            let status = response.status();
+            if let Some(declared) = response.content_length()
+                && declared > MAX_RESPONSE_BYTES as u64
+            {
+                return Err(Self::memory_error(format!(
+                    "vertex memory response Content-Length {declared} exceeds the {MAX_RESPONSE_BYTES}-byte limit",
+                ))
+                .with_upstream_status(status.as_u16()));
+            }
+            let body = response.bytes().await.map_err(|error| {
+                let error = truncate_for_error(&error.without_url().to_string());
+                AdkError::unavailable(
+                    ErrorComponent::Memory,
+                    "memory.vertex.unavailable",
+                    format!("failed to read vertex memory response body: {error}"),
+                )
+                .with_provider("vertex_ai")
+                .with_upstream_status(status.as_u16())
+            })?;
+            if body.len() > MAX_RESPONSE_BYTES {
+                return Err(Self::memory_error(format!(
+                    "vertex memory response body of {} bytes exceeds the {MAX_RESPONSE_BYTES}-byte limit",
+                    body.len(),
+                ))
+                .with_upstream_status(status.as_u16()));
+            }
+            Ok::<_, AdkError>((status, body))
+        })
+        .await
+        .map_err(|_| {
+            Self::timeout_error(format!(
+                "vertex memory request timed out after {} seconds",
+                HTTP_REQUEST_TIMEOUT.as_secs(),
+            ))
+        })??;
+
+        if !status.is_success() {
+            let body = String::from_utf8_lossy(&body);
+            let body = if body.trim().is_empty() { "<empty body>" } else { body.as_ref() };
+            return Err(Self::status_error(status, body));
+        }
+        if body.iter().all(u8::is_ascii_whitespace) {
+            return Ok(Value::Object(Map::new()));
+        }
+        serde_json::from_slice(&body).map_err(|error| {
+            let error = truncate_for_error(&error.to_string());
+            Self::memory_error(format!("failed to parse vertex memory response JSON: {error}"))
+                .with_upstream_status(status.as_u16())
+        })
+    }
+
+    /// Polls a long-running operation to completion with the session
+    /// backend's backoff policy, pinning the operation identity so a poll
+    /// can never silently follow a different operation.
+    async fn wait_for_operation(
+        &self,
+        initial: Value,
+        operation_kind: &str,
+    ) -> Result<Option<Value>> {
+        let mut operation = parse_operation(initial, operation_kind)?;
+        validate_operation_name(&operation.name, &self.project_id, &self.location)?;
+        let operation_name = operation.name.clone();
+        let deadline = Instant::now() + OPERATION_POLL_TIMEOUT;
+        let mut delay = OPERATION_POLL_INITIAL_DELAY;
+
+        loop {
+            if operation.done {
+                if let Some(error) = operation.error {
+                    return Err(Self::operation_error(operation_kind, &operation_name, error));
+                }
+                return Ok(operation.response);
+            }
+            if Instant::now() >= deadline {
+                return Err(Self::timeout_error(format!(
+                    "vertex {operation_kind} operation '{operation_name}' did not complete within {} seconds; inspect the operation in Google Cloud before retrying",
+                    OPERATION_POLL_TIMEOUT.as_secs_f64(),
+                )));
+            }
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let poll = async {
+                let url = self.build_url(&format!("{MEMORY_API_VERSION}/{operation_name}"))?;
+                let request = self.apply_auth(self.http_client.get(url)).await?;
+                self.send_value(request).await
+            };
+            let value = tokio::time::timeout(remaining, poll).await.map_err(|_| {
+                Self::timeout_error(format!(
+                    "vertex {operation_kind} operation '{operation_name}' did not complete within {} seconds; inspect the operation in Google Cloud before retrying",
+                    OPERATION_POLL_TIMEOUT.as_secs_f64(),
+                ))
+            })??;
+            let next = parse_operation(value, operation_kind)?;
+            if next.name != operation_name {
+                return Err(Self::memory_error(format!(
+                    "vertex {operation_kind} poll changed operation identity from '{operation_name}' to '{}'; refusing to follow a different operation",
+                    next.name,
+                )));
+            }
+            operation = next;
+            if !operation.done {
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                if remaining.is_zero() {
+                    continue;
+                }
+                tokio::time::sleep(delay.min(remaining)).await;
+                delay = delay.saturating_mul(2).min(OPERATION_POLL_MAX_DELAY);
+            }
+        }
+    }
+
+    fn memory_error(message: impl Into<String>) -> AdkError {
+        AdkError::internal(ErrorComponent::Memory, "memory.vertex.invalid_response", message)
+            .with_provider("vertex_ai")
+    }
+
+    fn invalid_input(message: impl Into<String>) -> AdkError {
+        AdkError::new(
+            ErrorComponent::Memory,
+            ErrorCategory::InvalidInput,
+            "memory.vertex.invalid_input",
+            message,
+        )
+        .with_provider("vertex_ai")
+    }
+
+    fn auth_error(message: impl Into<String>) -> AdkError {
+        AdkError::unauthorized(ErrorComponent::Memory, "memory.vertex.unauthorized", message)
+            .with_provider("vertex_ai")
+    }
+
+    fn credentials_error(error: google_cloud_auth::errors::CredentialsError) -> AdkError {
+        let message = format!(
+            "failed to obtain google cloud auth headers: {}",
+            truncate_for_error(&error.to_string()),
+        );
+        if error.is_transient() {
+            AdkError::unavailable(
+                ErrorComponent::Memory,
+                "memory.vertex.credentials_unavailable",
+                message,
+            )
+            .with_provider("vertex_ai")
+        } else {
+            Self::auth_error(message)
+        }
+    }
+
+    fn timeout_error(message: impl Into<String>) -> AdkError {
+        AdkError::timeout(ErrorComponent::Memory, "memory.vertex.timeout", message)
+            .with_provider("vertex_ai")
+    }
+
+    fn transport_error(error: reqwest::Error) -> AdkError {
+        let timeout = error.is_timeout();
+        let error = truncate_for_error(&error.without_url().to_string());
+        if timeout {
+            return Self::timeout_error(format!("vertex memory HTTP request timed out: {error}"));
+        }
+        AdkError::unavailable(
+            ErrorComponent::Memory,
+            "memory.vertex.unavailable",
+            format!("failed to send vertex memory request: {error}"),
+        )
+        .with_provider("vertex_ai")
+    }
+
+    fn status_error(status: StatusCode, body: &str) -> AdkError {
+        let message = format!(
+            "vertex memory request failed with status {}: {}",
+            status.as_u16(),
+            truncate_for_error(body),
+        );
+        let (category, code) = match status.as_u16() {
+            400 | 409 | 422 => (ErrorCategory::InvalidInput, "memory.vertex.invalid_request"),
+            401 => (ErrorCategory::Unauthorized, "memory.vertex.unauthorized"),
+            403 => (ErrorCategory::Forbidden, "memory.vertex.forbidden"),
+            404 => (ErrorCategory::NotFound, "memory.vertex.not_found"),
+            408 | 504 => (ErrorCategory::Timeout, "memory.vertex.timeout"),
+            429 => (ErrorCategory::RateLimited, "memory.vertex.rate_limited"),
+            500 | 502 | 503 => (ErrorCategory::Unavailable, "memory.vertex.unavailable"),
+            _ => (ErrorCategory::Internal, "memory.vertex.upstream_error"),
+        };
+        AdkError::new(ErrorComponent::Memory, category, code, message)
+            .with_provider("vertex_ai")
+            .with_upstream_status(status.as_u16())
+    }
+
+    fn operation_error(
+        operation_kind: &str,
+        operation_name: &str,
+        error: VertexOperationError,
+    ) -> AdkError {
+        let operation_name = truncate_for_error(operation_name);
+        let operation_message =
+            if error.message.trim().is_empty() { "<no error message>" } else { &error.message };
+        let message = format!(
+            "vertex {operation_kind} operation '{operation_name}' failed with code {}: {}",
+            error.code,
+            truncate_for_error(operation_message),
+        );
+        let category = match error.code {
+            1 => ErrorCategory::Cancelled,
+            3 | 6 | 9 | 11 => ErrorCategory::InvalidInput,
+            4 => ErrorCategory::Timeout,
+            5 => ErrorCategory::NotFound,
+            7 => ErrorCategory::Forbidden,
+            8 => ErrorCategory::RateLimited,
+            10 | 14 => ErrorCategory::Unavailable,
+            12 => ErrorCategory::Unsupported,
+            16 => ErrorCategory::Unauthorized,
+            _ => ErrorCategory::Internal,
+        };
+        AdkError::new(ErrorComponent::Memory, category, "memory.vertex.operation_failed", message)
+            .with_provider("vertex_ai")
+    }
+}
+
+#[async_trait]
+impl MemoryService for VertexAiMemoryBankService {
+    async fn add_session(
+        &self,
+        app_name: &str,
+        user_id: &str,
+        _session_id: &str,
+        entries: Vec<MemoryEntry>,
+    ) -> Result<()> {
+        let contents: Vec<&Content> = entries.iter().map(|entry| &entry.content).collect();
+        self.generate_memories(app_name, user_id, &contents).await
+    }
+
+    async fn search(&self, req: SearchRequest) -> Result<SearchResponse> {
+        if let Some(project_id) = &req.project_id {
+            // Memory Bank scopes are exact-match maps; a project dimension
+            // would need its own scope key, which no other runtime writes.
+            let project_id = truncate_for_error(project_id);
+            return Err(Self::invalid_input(format!(
+                "project-scoped search (project_id '{project_id}') is not supported by the Memory Bank backend; memories are scoped by app_name and user_id only",
+            )));
+        }
+        let parent = self.memories_parent(&req.app_name)?;
+        let scope = memory_scope(&req.app_name, &req.user_id);
+        let top_k = req.limit.unwrap_or(10);
+        let response = self
+            .retrieve_page(
+                &parent,
+                &scope,
+                "similaritySearchParams",
+                json!({ "searchQuery": req.query, "topK": top_k }),
+            )
+            .await?;
+        let memories = response.retrieved_memories.into_iter().map(retrieved_to_entry).collect();
+        Ok(SearchResponse { memories })
+    }
+
+    async fn delete_user(&self, app_name: &str, user_id: &str) -> Result<()> {
+        let parent = self.memories_parent(app_name)?;
+        let scope = memory_scope(app_name, user_id);
+        let mut page_token: Option<String> = None;
+        for _ in 0..DELETE_MAX_PAGES {
+            let mut params = json!({ "pageSize": DELETE_PAGE_SIZE });
+            if let Some(token) = &page_token {
+                params["pageToken"] = json!(token);
+            }
+            let response =
+                self.retrieve_page(&parent, &scope, "simpleRetrievalParams", params).await?;
+            for retrieved in &response.retrieved_memories {
+                self.delete_memory(&retrieved.memory.name).await?;
+            }
+            match response.next_page_token {
+                Some(token) if !token.is_empty() => page_token = Some(token),
+                _ => return Ok(()),
+            }
+        }
+        Err(Self::memory_error(format!(
+            "vertex memory deletion did not converge after {DELETE_MAX_PAGES} pages; remaining memories for this scope must be deleted in Google Cloud",
+        )))
+    }
+
+    async fn health_check(&self) -> Result<()> {
+        // Credential acquisition exercises ADC and token refresh — the
+        // failure mode a readiness probe needs to catch.
+        self.auth_headers().await.map(|_| ())
+    }
+}
+
+/// The exact scope map both adk-python and adk-rust write, so one Memory
+/// Bank serves both runtimes.
+fn memory_scope(app_name: &str, user_id: &str) -> Value {
+    json!({ "app_name": app_name, "user_id": user_id })
+}
+
+fn retrieved_to_entry(retrieved: RetrievedMemory) -> MemoryEntry {
+    // MemoryEntry has no metadata slot, so the memory resource name cannot
+    // be preserved; updateTime survives as the entry timestamp.
+    let timestamp = retrieved
+        .memory
+        .update_time
+        .as_deref()
+        .or(retrieved.memory.create_time.as_deref())
+        .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+        .map_or_else(Utc::now, |parsed| parsed.with_timezone(&Utc));
+    MemoryEntry {
+        content: Content::new("model").with_text(retrieved.memory.fact),
+        author: "memory_bank".to_string(),
+        timestamp,
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RetrieveMemoriesResponse {
+    #[serde(default)]
+    retrieved_memories: Vec<RetrievedMemory>,
+    #[serde(default)]
+    next_page_token: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RetrievedMemory {
+    memory: VertexMemory,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct VertexMemory {
+    name: String,
+    #[serde(default)]
+    fact: String,
+    #[serde(default)]
+    create_time: Option<String>,
+    #[serde(default)]
+    update_time: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct VertexOperation {
+    name: String,
+    #[serde(default)]
+    done: bool,
+    #[serde(default)]
+    error: Option<VertexOperationError>,
+    #[serde(default)]
+    response: Option<Value>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct VertexOperationError {
+    #[serde(default)]
+    code: i64,
+    #[serde(default)]
+    message: String,
+}
+
+fn parse_operation(value: Value, operation_kind: &str) -> Result<VertexOperation> {
+    let operation: VertexOperation = serde_json::from_value(value).map_err(|error| {
+        let error = truncate_for_error(&error.to_string());
+        VertexAiMemoryBankService::memory_error(format!(
+            "failed to parse vertex {operation_kind} operation: {error}"
+        ))
+    })?;
+    if operation.name.trim().is_empty() {
+        return Err(VertexAiMemoryBankService::memory_error(format!(
+            "vertex {operation_kind} response did not contain an operation name"
+        )));
+    }
+    if operation.error.is_some() && operation.response.is_some() {
+        return Err(VertexAiMemoryBankService::memory_error(format!(
+            "vertex {operation_kind} operation '{}' contains both error and response results",
+            operation.name,
+        )));
+    }
+    if !operation.done && (operation.error.is_some() || operation.response.is_some()) {
+        return Err(VertexAiMemoryBankService::memory_error(format!(
+            "vertex {operation_kind} operation '{}' contains a terminal result while done is false",
+            operation.name,
+        )));
+    }
+    Ok(operation)
+}
+
+/// Rejects operation names outside this service's project and location, so
+/// a compromised or buggy server cannot redirect polling elsewhere.
+fn validate_operation_name(name: &str, project_id: &str, location: &str) -> Result<()> {
+    let prefix = format!("projects/{project_id}/locations/{location}/");
+    if name.starts_with(&prefix) && !name.contains("://") && !name.contains("..") {
+        return Ok(());
+    }
+    let name = truncate_for_error(name);
+    Err(VertexAiMemoryBankService::memory_error(format!(
+        "vertex operation name '{name}' does not belong to projects/{project_id}/locations/{location}",
+    )))
+}
+
+/// Rejects memory resource names outside this service's project and
+/// location before issuing a DELETE.
+fn validate_memory_resource_name(name: &str, project_id: &str, location: &str) -> Result<()> {
+    let prefix = format!("projects/{project_id}/locations/{location}/reasoningEngines/");
+    if name.starts_with(&prefix)
+        && name.contains("/memories/")
+        && !name.contains("://")
+        && !name.contains("..")
+    {
+        return Ok(());
+    }
+    let name = truncate_for_error(name);
+    Err(VertexAiMemoryBankService::memory_error(format!(
+        "memory resource name '{name}' does not belong to projects/{project_id}/locations/{location}; refusing to delete it",
+    )))
+}
+
+fn is_canonical_reasoning_engine_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.bytes().all(|byte| byte.is_ascii_digit())
+        && (value == "0" || !value.starts_with('0'))
+}
+
+fn is_loopback_host(url: &reqwest::Url) -> bool {
+    matches!(url.host_str(), Some("localhost" | "127.0.0.1" | "::1"))
+}
+
+fn truncate_for_error(value: &str) -> String {
+    const MAX_LEN: usize = 512;
+    let mut sanitized = String::with_capacity(value.len().min(MAX_LEN));
+    let mut truncated = false;
+    for character in value.chars() {
+        let character =
+            if character.is_control() { char::REPLACEMENT_CHARACTER } else { character };
+        if sanitized.len() + character.len_utf8() > MAX_LEN {
+            truncated = true;
+            break;
+        }
+        sanitized.push(character);
+    }
+    if truncated {
+        sanitized.push_str("...");
+    }
+    sanitized
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_engine_ids() {
+        assert!(is_canonical_reasoning_engine_id("123"));
+        assert!(is_canonical_reasoning_engine_id("0"));
+        assert!(!is_canonical_reasoning_engine_id("0123"));
+        assert!(!is_canonical_reasoning_engine_id(""));
+        assert!(!is_canonical_reasoning_engine_id("my-app"));
+    }
+
+    #[test]
+    fn scope_matches_python_shape() {
+        assert_eq!(
+            memory_scope("weather-app", "u-1"),
+            json!({"app_name": "weather-app", "user_id": "u-1"}),
+        );
+    }
+
+    #[test]
+    fn operation_names_outside_the_scope_are_rejected() {
+        assert!(validate_operation_name("projects/p/locations/l/operations/1", "p", "l").is_ok());
+        assert!(
+            validate_operation_name("projects/other/locations/l/operations/1", "p", "l").is_err()
+        );
+        assert!(validate_operation_name("https://evil.example/op", "p", "l").is_err());
+    }
+
+    #[test]
+    fn memory_names_outside_the_scope_are_rejected() {
+        assert!(
+            validate_memory_resource_name(
+                "projects/p/locations/l/reasoningEngines/1/memories/m",
+                "p",
+                "l",
+            )
+            .is_ok()
+        );
+        assert!(
+            validate_memory_resource_name(
+                "projects/p/locations/l/reasoningEngines/1/sessions/s",
+                "p",
+                "l",
+            )
+            .is_err()
+        );
+        assert!(
+            validate_memory_resource_name(
+                "projects/other/locations/l/reasoningEngines/1/memories/m",
+                "p",
+                "l",
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn endpoint_defaults_to_regional_origin() {
+        let config = VertexAiMemoryConfig::new("p", "us-central1");
+        assert_eq!(config.endpoint(), "https://us-central1-aiplatform.googleapis.com");
+    }
+}

--- a/adk-memory/tests/memory_contract_vertex.rs
+++ b/adk-memory/tests/memory_contract_vertex.rs
@@ -1,0 +1,329 @@
+//! Contract tests for the Vertex AI Memory Bank backend against a mock
+//! server: `memories:generate` returns an LRO that completes on poll,
+//! `memories:retrieve` returns fixtures, and deletion enumerates a scope.
+//!
+//! The captured request bodies are compared as whole JSON values — they are
+//! the wire contract adk-python's `VertexAiMemoryBankService` shares.
+
+#![cfg(feature = "vertex-memory")]
+
+use adk_core::Content;
+use adk_memory::{
+    MemoryEntry, MemoryService, SearchRequest, VertexAiMemoryBankService, VertexAiMemoryConfig,
+};
+use axum::extract::{Path, State};
+use axum::routing::{delete, get, post};
+use axum::{Json, Router};
+use chrono::{TimeZone, Utc};
+use google_cloud_auth::credentials::api_key_credentials;
+use serde_json::{Value, json};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+const PROJECT: &str = "test-project";
+const LOCATION: &str = "us-central1";
+const ENGINE: &str = "4242";
+const APP: &str = "weather-app";
+const USER: &str = "u-1";
+
+#[derive(Default)]
+struct MockState {
+    generate_bodies: Vec<Value>,
+    retrieve_bodies: Vec<Value>,
+    deleted_memories: Vec<String>,
+    generate_polls: usize,
+    /// Queue of `memories:retrieve` responses, popped per request.
+    retrieve_responses: Vec<Value>,
+    /// When set, the generate operation completes with this error.
+    operation_error: Option<Value>,
+}
+
+type SharedState = Arc<Mutex<MockState>>;
+
+fn operation_name() -> String {
+    format!("projects/{PROJECT}/locations/{LOCATION}/reasoningEngines/{ENGINE}/operations/777")
+}
+
+fn memory_name(id: &str) -> String {
+    format!("projects/{PROJECT}/locations/{LOCATION}/reasoningEngines/{ENGINE}/memories/{id}")
+}
+
+async fn start_mock(state: SharedState) -> String {
+    let engine_path =
+        format!("/v1beta1/projects/{PROJECT}/locations/{LOCATION}/reasoningEngines/{ENGINE}");
+    let app = Router::new()
+        .route(
+            &format!("{engine_path}/memories:generate"),
+            post(|State(state): State<SharedState>, Json(body): Json<Value>| async move {
+                let mut state = state.lock().await;
+                state.generate_bodies.push(body);
+                // Not done yet: the client must poll the operation.
+                Json(json!({ "name": operation_name(), "done": false }))
+            }),
+        )
+        .route(
+            &format!("{engine_path}/memories:retrieve"),
+            post(|State(state): State<SharedState>, Json(body): Json<Value>| async move {
+                let mut state = state.lock().await;
+                state.retrieve_bodies.push(body);
+                let response = if state.retrieve_responses.is_empty() {
+                    json!({ "retrievedMemories": [] })
+                } else {
+                    state.retrieve_responses.remove(0)
+                };
+                Json(response)
+            }),
+        )
+        .route(
+            &format!("{engine_path}/operations/{{op}}"),
+            get(|State(state): State<SharedState>| async move {
+                let mut state = state.lock().await;
+                state.generate_polls += 1;
+                let mut operation = json!({ "name": operation_name(), "done": true });
+                if let Some(error) = &state.operation_error {
+                    operation["error"] = error.clone();
+                }
+                Json(operation)
+            }),
+        )
+        .route(
+            &format!("{engine_path}/memories/{{memory}}"),
+            delete(|State(state): State<SharedState>, Path(memory): Path<String>| async move {
+                let mut state = state.lock().await;
+                state.deleted_memories.push(memory);
+                // Delete completes synchronously: done with no error.
+                Json(json!({ "name": operation_name(), "done": true }))
+            }),
+        )
+        .with_state(state);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("http://{address}")
+}
+
+async fn build_service(endpoint: &str) -> VertexAiMemoryBankService {
+    let config = VertexAiMemoryConfig::new(PROJECT, LOCATION)
+        .with_reasoning_engine(ENGINE)
+        .with_endpoint(endpoint);
+    let credentials = api_key_credentials::Builder::new("test-api-key").build();
+    VertexAiMemoryBankService::with_credentials(config, credentials).expect("build test service")
+}
+
+fn entry(text: &str) -> MemoryEntry {
+    MemoryEntry {
+        content: Content::new("user").with_text(text),
+        author: "user".to_string(),
+        timestamp: Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap(),
+    }
+}
+
+#[tokio::test]
+async fn add_session_sends_direct_contents_and_polls_the_operation() {
+    let state = SharedState::default();
+    let endpoint = start_mock(state.clone()).await;
+    let service = build_service(&endpoint).await;
+
+    service
+        .add_session(APP, USER, "s-1", vec![entry("I live in Hamburg"), entry("I like tea")])
+        .await
+        .unwrap();
+
+    let captured = state.lock().await;
+    assert_eq!(captured.generate_bodies.len(), 1);
+    // Whole-value comparison: this is the exact adk-python-compatible body.
+    assert_eq!(
+        captured.generate_bodies[0],
+        json!({
+            "directContentsSource": {
+                "events": [
+                    { "content": { "role": "user", "parts": [{ "text": "I live in Hamburg" }] } },
+                    { "content": { "role": "user", "parts": [{ "text": "I like tea" }] } },
+                ]
+            },
+            "scope": { "app_name": APP, "user_id": USER },
+        }),
+    );
+    assert_eq!(captured.generate_polls, 1, "client polls the LRO to done");
+}
+
+#[tokio::test]
+async fn add_session_with_no_entries_is_a_no_op() {
+    let state = SharedState::default();
+    let endpoint = start_mock(state.clone()).await;
+    let service = build_service(&endpoint).await;
+
+    service.add_session(APP, USER, "s-1", vec![]).await.unwrap();
+
+    let captured = state.lock().await;
+    assert!(captured.generate_bodies.is_empty(), "no request for an empty session");
+}
+
+#[tokio::test]
+async fn add_events_to_memory_skips_content_free_events() {
+    let state = SharedState::default();
+    let endpoint = start_mock(state.clone()).await;
+    let service = build_service(&endpoint).await;
+
+    let mut with_content = adk_core::Event::new("inv-1");
+    with_content.llm_response.content = Some(Content::new("user").with_text("remember me"));
+    let without_content = adk_core::Event::new("inv-2");
+
+    service.add_events_to_memory(APP, USER, &[with_content, without_content]).await.unwrap();
+
+    let captured = state.lock().await;
+    assert_eq!(captured.generate_bodies.len(), 1);
+    let events = captured.generate_bodies[0]["directContentsSource"]["events"].as_array().unwrap();
+    assert_eq!(events.len(), 1, "content-free events are skipped");
+}
+
+#[tokio::test]
+async fn failed_operation_surfaces_the_operation_error() {
+    let state = SharedState::default();
+    state.lock().await.operation_error =
+        Some(json!({ "code": 7, "message": "memory bank is not provisioned" }));
+    let endpoint = start_mock(state.clone()).await;
+    let service = build_service(&endpoint).await;
+
+    let error = service.add_session(APP, USER, "s-1", vec![entry("x")]).await.unwrap_err();
+    assert_eq!(error.http_status_code(), 403);
+    assert!(error.message.contains("memory bank is not provisioned"), "{}", error.message);
+}
+
+#[tokio::test]
+async fn search_sends_similarity_params_and_maps_memories() {
+    let state = SharedState::default();
+    state.lock().await.retrieve_responses.push(json!({
+        "retrievedMemories": [
+            {
+                "memory": {
+                    "name": memory_name("m-1"),
+                    "fact": "User lives in Hamburg",
+                    "createTime": "2025-01-01T00:00:00Z",
+                    "updateTime": "2025-02-02T00:00:00Z",
+                },
+                "distance": 0.12,
+            }
+        ]
+    }));
+    let endpoint = start_mock(state.clone()).await;
+    let service = build_service(&endpoint).await;
+
+    let response = service
+        .search(SearchRequest {
+            query: "where does the user live".to_string(),
+            user_id: USER.to_string(),
+            app_name: APP.to_string(),
+            limit: Some(5),
+            min_score: None,
+            project_id: None,
+        })
+        .await
+        .unwrap();
+
+    let captured = state.lock().await;
+    assert_eq!(
+        captured.retrieve_bodies[0],
+        json!({
+            "scope": { "app_name": APP, "user_id": USER },
+            "similaritySearchParams": { "searchQuery": "where does the user live", "topK": 5 },
+        }),
+    );
+
+    assert_eq!(response.memories.len(), 1);
+    let memory = &response.memories[0];
+    assert_eq!(
+        serde_json::to_value(&memory.content).unwrap(),
+        json!({ "role": "model", "parts": [{ "text": "User lives in Hamburg" }] }),
+    );
+    assert_eq!(memory.author, "memory_bank");
+    assert_eq!(memory.timestamp, Utc.with_ymd_and_hms(2025, 2, 2, 0, 0, 0).unwrap());
+}
+
+#[tokio::test]
+async fn search_rejects_project_scoping() {
+    let state = SharedState::default();
+    let endpoint = start_mock(state.clone()).await;
+    let service = build_service(&endpoint).await;
+
+    let error = service
+        .search(SearchRequest {
+            query: "q".to_string(),
+            user_id: USER.to_string(),
+            app_name: APP.to_string(),
+            limit: None,
+            min_score: None,
+            project_id: Some("proj-x".to_string()),
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(error.http_status_code(), 400);
+}
+
+#[tokio::test]
+async fn delete_user_enumerates_the_scope_and_deletes_each_memory() {
+    let state = SharedState::default();
+    {
+        let mut lock = state.lock().await;
+        // Two pages: pagination must be followed.
+        lock.retrieve_responses.push(json!({
+            "retrievedMemories": [
+                { "memory": { "name": memory_name("m-1"), "fact": "a" } },
+                { "memory": { "name": memory_name("m-2"), "fact": "b" } },
+            ],
+            "nextPageToken": "page-2",
+        }));
+        lock.retrieve_responses.push(json!({
+            "retrievedMemories": [
+                { "memory": { "name": memory_name("m-3"), "fact": "c" } },
+            ],
+        }));
+    }
+    let endpoint = start_mock(state.clone()).await;
+    let service = build_service(&endpoint).await;
+
+    service.delete_user(APP, USER).await.unwrap();
+
+    let captured = state.lock().await;
+    assert_eq!(
+        captured.retrieve_bodies[0],
+        json!({
+            "scope": { "app_name": APP, "user_id": USER },
+            "simpleRetrievalParams": { "pageSize": 100 },
+        }),
+    );
+    assert_eq!(
+        captured.retrieve_bodies[1],
+        json!({
+            "scope": { "app_name": APP, "user_id": USER },
+            "simpleRetrievalParams": { "pageSize": 100, "pageToken": "page-2" },
+        }),
+    );
+    assert_eq!(captured.deleted_memories, ["m-1", "m-2", "m-3"]);
+}
+
+#[tokio::test]
+async fn adapter_exposes_the_backend_as_core_memory() {
+    let state = SharedState::default();
+    state.lock().await.retrieve_responses.push(json!({
+        "retrievedMemories": [
+            { "memory": { "name": memory_name("m-1"), "fact": "User likes tea" } }
+        ]
+    }));
+    let endpoint = start_mock(state.clone()).await;
+    let service = Arc::new(build_service(&endpoint).await);
+
+    // ToolContext::search_memory consumes adk_core::Memory; the existing
+    // adapter binds app and user so the backend needs nothing extra.
+    let memory: Arc<dyn adk_core::Memory> =
+        Arc::new(adk_memory::MemoryServiceAdapter::new(service, APP, USER));
+    let results = memory.search("tea").await.unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(
+        serde_json::to_value(&results[0].content).unwrap(),
+        json!({ "role": "model", "parts": [{ "text": "User likes tea" }] }),
+    );
+}

--- a/adk-memory/tests/memory_contract_vertex_live.rs
+++ b/adk-memory/tests/memory_contract_vertex_live.rs
@@ -1,0 +1,63 @@
+//! Live integration test for the Vertex AI Memory Bank backend.
+//!
+//! Requires a provisioned Agent Engine with Memory Bank and ADC:
+//!
+//! ```bash
+//! export GOOGLE_CLOUD_PROJECT=my-project
+//! export GOOGLE_CLOUD_LOCATION=us-central1
+//! export GOOGLE_CLOUD_AGENT_ENGINE_ID=1234567890
+//! cargo nextest run -p adk-memory --features vertex-memory \
+//!     --run-ignored all -E 'test(live_memory_bank_round_trip)'
+//! ```
+
+#![cfg(feature = "vertex-memory")]
+
+use adk_core::Content;
+use adk_memory::{
+    MemoryEntry, MemoryService, SearchRequest, VertexAiMemoryBankService, VertexAiMemoryConfig,
+};
+use chrono::Utc;
+
+#[tokio::test]
+#[ignore = "requires ADC and a provisioned Agent Engine with Memory Bank"]
+async fn live_memory_bank_round_trip() {
+    let config = VertexAiMemoryConfig::from_env().expect("platform env vars set");
+    let service = VertexAiMemoryBankService::new_with_adc(config).expect("ADC available");
+
+    let user_id = format!("adk-rust-live-{}", Utc::now().timestamp());
+    let app_name = "adk-rust-live-test";
+
+    service
+        .add_session(
+            app_name,
+            &user_id,
+            "live-session",
+            vec![MemoryEntry {
+                content: Content::new("user")
+                    .with_text("My favourite programming language is Rust."),
+                author: "user".to_string(),
+                timestamp: Utc::now(),
+            }],
+        )
+        .await
+        .expect("memories:generate succeeds");
+
+    let response = service
+        .search(SearchRequest {
+            query: "what programming language does the user like".to_string(),
+            user_id: user_id.clone(),
+            app_name: app_name.to_string(),
+            limit: Some(5),
+            min_score: None,
+            project_id: None,
+        })
+        .await
+        .expect("memories:retrieve succeeds");
+    assert!(
+        !response.memories.is_empty(),
+        "memory bank returned no memories for the generated fact"
+    );
+
+    // Leave no residue in the shared engine.
+    service.delete_user(app_name, &user_id).await.expect("scope cleanup succeeds");
+}

--- a/adk-rust/Cargo.toml
+++ b/adk-rust/Cargo.toml
@@ -86,8 +86,8 @@ gemini-agent-platform = [
     "gcs-artifacts",  # GCS artifact backend (adk-artifact)
     "gcp-telemetry",  # Cloud Trace/Logging transport (adk-telemetry)
     "agent-engine",   # class-method runtime contract + turnkey entrypoint (adk-server)
+    "vertex-memory",  # Memory Bank (adk-memory)
     # target end-state — appended by the PR that introduces each flag:
-    # "vertex-memory",          Memory Bank (adk-memory)
     # "example-store",          Example Store (adk-tool)
     # "gcp-telemetry",          Cloud Trace/Logging transport (adk-telemetry)
     # "gcs-artifacts",          GCS artifact backend (adk-artifact)
@@ -187,6 +187,8 @@ neo4j-session = ["sessions", "adk-session/neo4j"]
 vertex-session = ["sessions", "adk-session/vertex-session"]
 database-memory = ["memory", "adk-memory/database-memory"]
 sqlite-memory = ["memory", "adk-memory/sqlite-memory"]
+# Vertex AI Agent Engine Memory Bank backend (forwarded to adk-memory)
+vertex-memory = ["memory", "adk-memory/vertex-memory"]
 redis-memory = ["memory", "adk-memory/redis-memory"]
 mongodb-memory = ["memory", "adk-memory/mongodb-memory"]
 neo4j-memory = ["memory", "adk-memory/neo4j-memory"]

--- a/adk-rust/src/lib.rs
+++ b/adk-rust/src/lib.rs
@@ -440,7 +440,8 @@
 //! | `audio` | Audio processing | full (experimental) |
 //! | `cli` | CLI launcher | (opt-in, any preset) |
 //! | `agent-engine` | Agent Engine runtime contract: dispatch endpoints + `serve_agent_engine` entrypoint | (opt-in, any preset) |
-//! | `gemini-agent-platform` | Gemini Enterprise Agent Platform integrations (Vertex model backend, managed Sessions, GCP Secret Manager, GCS artifacts, Cloud telemetry, Agent Engine runtime contract); excludes realtime transports and host-side deploy tooling | (opt-in, any preset) |
+//! | `vertex-memory` | Vertex AI Memory Bank backend for adk-memory | (opt-in, any preset) |
+//! | `gemini-agent-platform` | Gemini Enterprise Agent Platform integrations (Vertex model backend, managed Sessions, GCP Secret Manager, GCS artifacts, Cloud telemetry, Agent Engine runtime contract, Memory Bank); excludes realtime transports and host-side deploy tooling | (opt-in, any preset) |
 //! | `gemini-agent-platform-full` | `gemini-agent-platform` + Vertex AI Live API (realtime stack) | (opt-in, any preset) |
 //!
 //! ## Examples


### PR DESCRIPTION
## What

The Vertex AI Memory Bank backend for `adk-memory` (feature `vertex-memory`): `VertexAiMemoryBankService`, the Rust analog of Python ADK's `VertexAiMemoryBankService`. This completes the Agent Engine dispatch surface's `async_add_session_to_memory` / `async_search_memory` class methods, which have returned `Unsupported` since Wave 1.

- `VertexAiMemoryConfig` — mirrors `VertexAiSessionConfig` (project, location, reasoning engine, endpoint override, `from_env()` reading the platform's container variables).
- `MemoryService` implementation: `add_session` → `memories:generate` with `directContentsSource` + `{app_name, user_id}` scope, LRO-polled; `search` → `memories:retrieve` with `similaritySearchParams`; `delete_user` → scope enumeration via `simpleRetrievalParams` pagination + per-memory DELETE.
- `add_events_to_memory` — inherent method generating memories from an explicit `&[Event]` slice (recent turns only), mirroring adk-python.
- `ToolContext::search_memory` works unchanged through the existing `MemoryServiceAdapter` (covered by a test).
- Umbrella feature `vertex-memory`, appended to `gemini-agent-platform`; CI feature-coverage entry; docs rows and CHANGELOG.

## Why

Part of #438 (Wave 2, PR 2.1 — WP3). Wire shapes confirmed against the v1beta1 REST reference (verification task V4): `memories:generate` LRO envelope, `memories:retrieve` request/response, the `Memory` resource, and delete's Operation response.

## How

- **Scope parity:** the scope map is exactly `{"app_name": ..., "user_id": ...}` — the same map adk-python writes, so both runtimes share one Memory Bank.
- **Copied ADC pattern (deliberate debt):** the credential caching (`CacheableResource`), bounded redirect-disabled HTTP client, status→category mapping, and `wait_for_operation` backoff (100 ms initial, 2 s cap, bounded deadline, operation-identity pinning) are copied from `adk-session/src/vertex.rs`, with a comment naming Wave 3 (`adk-gcp`, PR 3.1/3.3) as the consolidation point.
- **Safety rails:** operation names and memory resource names are validated against the configured project/location before polling or deleting; non-loopback endpoints must be HTTPS; responses are size-bounded; delete pagination is round-bounded so a misbehaving server cannot spin the client.
- **Mapping note:** `MemoryEntry` has no metadata slot, so the memory resource name is not preserved on search results (the plan suggested it); `updateTime` survives as the entry timestamp and `fact` becomes a one-part model `Content`. Called out in a code comment.
- **Project scoping** is rejected with an actionable error — Memory Bank scopes are exact-match maps with no project dimension.

**Tests** (`memory_contract_vertex.rs`, mock Axum server; whole-JSON-value request assertions):
- `add_session` sends the exact `directContentsSource` + scope body and polls the LRO to done; empty entries are a no-op.
- `add_events_to_memory` skips content-free events.
- A failed operation surfaces the operation error with the mapped category (403 for code 7).
- `search` sends `similaritySearchParams` and maps fact/updateTime; project-scoped search → 400.
- `delete_user` follows pagination and deletes each memory.
- Adapter test: the backend behind `MemoryServiceAdapter` serves `adk_core::Memory::search`.
- `memory_contract_vertex_live.rs`: `#[ignore]` generate→retrieve→cleanup round trip against a real engine.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings; workspace, `adk-memory --features vertex-memory`, `adk-rust --features gemini-agent-platform`)
- [x] `devenv shell test` — all non-ignored tests pass (44 in `adk-memory` with the feature; doctests; `RUSTDOCFLAGS="-D warnings"` doc build; `scripts/check-doc-examples.sh`)
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts
- [x] No unrelated changes mixed in
- [x] Branch naming follows convention
- [x] Commit messages follow conventional format
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated (adk-memory README backend list + feature table; umbrella feature tables; AGENTS.md)
- [ ] Examples — the live test documents end-to-end usage; a deployment example lands with the Wave 2 template PRs
