### PR TITLE
feat(cargo-adk): add agent-engine template with BYOC terraform - PR 2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **cargo-adk `agent-engine` template** (`cargo adk new my-agent --template
+  agent-engine`): scaffolds a Gemini Enterprise Agent Engine BYOC container — a
+  binary whose `main` is `serve_agent_engine(agent, AgentEngineOptions::new())`
+  (features `["minimal", "agent-engine"]`), the docker addon's `Dockerfile` and
+  `.dockerignore`, and `deploy/terraform/` with a
+  `google_vertex_ai_reasoning_engine` BYOC resource (`spec.container_spec.image_uri`,
+  the full 14-method `class_methods` contract in `jsonencode`,
+  `agent_framework = "google-adk"`, optional `service_account`), plus
+  `variables.tf`/`outputs.tf` mirroring the containerized-agent codelab. The
+  generated README covers `gcloud builds submit`, `terraform apply`, the
+  platform-set environment variables, the `/api` passthrough for querying the
+  deployed engine, and the optional A2A-routes setup via
+  `ServerBuilder::with_agent_engine(true)` + `.with_a2a(...)`. Template and
+  addon file fragments now support `{name}` substitution and path override
+  (a template file replaces a base file with the same path).
 - **cargo-adk `docker` addon** (`cargo adk new my-agent --addon docker`): emits a
   multi-stage `Dockerfile` (`rust:1.95-slim` build stage kept in lockstep with
   `rust-toolchain.toml`, `gcr.io/distroless/cc-debian12` runtime, `ENV PORT=8080`,

--- a/cargo-adk/README.md
+++ b/cargo-adk/README.md
@@ -154,6 +154,7 @@ The convention maps `UPPER_SNAKE_CASE` env var names to `lower-kebab-case` secre
 | `a2a` | A2A protocol server with `A2aServer::quick_start` |
 | `graph` | Graph-based workflow with checkpoints and durable execution |
 | `realtime` | Real-time bidirectional audio/video streaming agent |
+| `agent-engine` | Gemini Enterprise Agent Engine BYOC container: `serve_agent_engine` binary, `Dockerfile`, and `deploy/terraform/` |
 
 Each template generates:
 

--- a/cargo-adk/src/codegen.rs
+++ b/cargo-adk/src/codegen.rs
@@ -62,21 +62,26 @@ pub fn generate_project_with_registry(
     // File contents honor the same `{name}` placeholder as agent construction
     // fragments — the docker addon needs the crate name to locate the release
     // binary inside the build stage.
+    //
+    // A fragment with the same path as an earlier file replaces it, so a
+    // template can override a base file (the agent-engine template ships its
+    // own README.md).
+    let push_or_replace = |files: &mut Vec<GeneratedFile>, path: &str, content: &str| {
+        let content = content.replace("{name}", project_name);
+        match files.iter_mut().find(|f| f.path == path) {
+            Some(existing) => existing.content = content,
+            None => files.push(GeneratedFile { path: path.to_string(), content }),
+        }
+    };
     if let Some(template) = registry.resolve_template(&manifest.template_name) {
         for fragment in &template.code_fragments.additional_files {
-            files.push(GeneratedFile {
-                path: fragment.path.to_string(),
-                content: fragment.content.replace("{name}", project_name),
-            });
+            push_or_replace(&mut files, fragment.path, fragment.content);
         }
     }
     for addon_name in &manifest.addons {
         if let Some(addon) = registry.capability_addons.iter().find(|a| a.name == *addon_name) {
             for fragment in &addon.code_fragments.additional_files {
-                files.push(GeneratedFile {
-                    path: fragment.path.to_string(),
-                    content: fragment.content.replace("{name}", project_name),
-                });
+                push_or_replace(&mut files, fragment.path, fragment.content);
             }
         }
     }
@@ -92,8 +97,19 @@ pub fn generate_cargo_toml(manifest: &CompositionManifest, project_name: &str) -
     let features: Vec<&str> = manifest.feature_set.iter().map(|s| s.as_str()).collect();
     let features_str = features.iter().map(|f| format!("\"{f}\"")).collect::<Vec<_>>().join(", ");
 
+    // The agent-engine umbrella feature ships in the first release after the
+    // published 2.0.0, so a crates.io resolution of the generated manifest
+    // fails until then; the header comment states the workaround.
+    let header = if features.contains(&"agent-engine") {
+        "# The `agent-engine` feature requires the first adk-rust release after 2.0.0.\n\
+         # Until it is published on crates.io, use the git repository instead:\n\
+         #   adk-rust = { git = \"https://github.com/zavora-ai/adk-rust\", default-features = false, features = [\"minimal\", \"agent-engine\"] }\n\n"
+    } else {
+        ""
+    };
+
     let mut output = format!(
-        r#"[package]
+        r#"{header}[package]
 name = "{project_name}"
 version = "0.1.0"
 edition = "2024"
@@ -200,7 +216,7 @@ pub fn generate_main_rs_with_registry(
     // When nothing serves (no server addon, template doesn't start its own
     // server), run the agent in the interactive console so `cargo run` does
     // something useful out of the box.
-    const SELF_SERVING_TEMPLATES: &[&str] = &["api"];
+    const SELF_SERVING_TEMPLATES: &[&str] = &["api", "agent-engine"];
     let has_server_addon = manifest.addons.iter().any(|a| a == "server");
     let interactive =
         !has_server_addon && !SELF_SERVING_TEMPLATES.contains(&manifest.template_name.as_str());
@@ -716,6 +732,102 @@ mod tests {
         assert!(dockerignore.contains("target/"));
         assert!(dockerignore.contains(".git/"));
         assert!(dockerignore.contains(".env"));
+    }
+
+    #[test]
+    fn test_generate_project_agent_engine_renders_deploy_files() {
+        let reg = registry();
+        let manifest = resolve_composition(&reg, "agent-engine", &[], "gemini").unwrap();
+        let files = generate_project(&manifest, "my-agent");
+
+        let file = |path: &str| {
+            files
+                .iter()
+                .find(|f| f.path == path)
+                .map(|f| f.content.as_str())
+                .unwrap_or_else(|| panic!("expected generated file '{path}'"))
+        };
+
+        // main.rs serves the dispatch contract and nothing else drives it.
+        let main_rs = file("src/main.rs");
+        assert!(main_rs.contains(
+            "use adk_rust::server::agent_engine::{AgentEngineOptions, serve_agent_engine};"
+        ));
+        assert!(main_rs.contains("serve_agent_engine(agent, AgentEngineOptions::new()).await?;"));
+        assert!(main_rs.contains(r#"LlmAgentBuilder::new("my-agent")"#));
+        assert!(!main_rs.contains("Launcher"), "self-serving template must not run the console");
+
+        // Cargo.toml carries the features and the version-requirement comment.
+        let cargo_toml = file("Cargo.toml");
+        assert!(cargo_toml.contains("\"minimal\""));
+        assert!(cargo_toml.contains("\"agent-engine\""));
+        assert!(
+            cargo_toml.contains("first adk-rust release after 2.0.0"),
+            "Cargo.toml must state that the agent-engine feature is not in the published 2.0.0"
+        );
+
+        // The docker addon's Dockerfile, with the crate name substituted.
+        let dockerfile = file("Dockerfile");
+        assert!(dockerfile.contains("FROM rust:1.95-slim AS builder"));
+        assert!(dockerfile.contains("FROM gcr.io/distroless/cc-debian12"));
+        assert!(
+            dockerfile.contains("COPY --from=builder /build/target/release/my-agent /app/agent")
+        );
+        assert!(dockerfile.contains("ENV PORT=8080"));
+        assert!(dockerfile.contains(r#"ENTRYPOINT ["/app/agent"]"#));
+        assert!(files.iter().any(|f| f.path == ".dockerignore"));
+        assert!(
+            !files.iter().any(|f| f.path == "Dockerfile.static"),
+            "the static variant belongs to the docker addon, not this template"
+        );
+
+        // Terraform: BYOC resource, image variable, and all 14 class methods.
+        let main_tf = file("deploy/terraform/main.tf");
+        assert!(main_tf.contains(r#"resource "google_vertex_ai_reasoning_engine" "agent""#));
+        assert!(main_tf.contains("image_uri = var.image_uri"));
+        assert!(main_tf.contains("class_methods   = jsonencode(local.class_methods)"));
+        assert!(main_tf.contains(r#"agent_framework = "google-adk""#));
+        for method in [
+            "create_session",
+            "get_session",
+            "list_sessions",
+            "delete_session",
+            "register_operations",
+            "async_create_session",
+            "async_get_session",
+            "async_list_sessions",
+            "async_delete_session",
+            "async_add_session_to_memory",
+            "async_search_memory",
+            "stream_query",
+            "async_stream_query",
+            "streaming_agent_run_with_events",
+        ] {
+            assert!(
+                main_tf.contains(&format!(r#""name" = "{method}""#)),
+                "class_methods must declare '{method}'"
+            );
+        }
+
+        let variables_tf = file("deploy/terraform/variables.tf");
+        assert!(variables_tf.contains(r#"variable "project_id""#));
+        assert!(variables_tf.contains(r#"variable "location""#));
+        assert!(variables_tf.contains(r#"variable "image_uri""#));
+        assert!(variables_tf.contains(r#"variable "display_name""#));
+        assert!(variables_tf.contains(r#"variable "service_account""#));
+
+        let outputs_tf = file("deploy/terraform/outputs.tf");
+        assert!(outputs_tf.contains(r#"output "reasoning_engine_id""#));
+        assert!(outputs_tf.contains(r#"output "reasoning_engine_name""#));
+
+        // The template's README replaces the generic one (exactly one README).
+        let readmes: Vec<_> = files.iter().filter(|f| f.path == "README.md").collect();
+        assert_eq!(readmes.len(), 1);
+        let readme = readmes[0].content.as_str();
+        assert!(readme.contains("gcloud builds submit"));
+        assert!(readme.contains("terraform -chdir=deploy/terraform apply"));
+        assert!(readme.contains("GOOGLE_CLOUD_AGENT_ENGINE_ID"));
+        assert!(readme.contains("/.well-known/agent.json"), "README documents the A2A option");
     }
 
     #[test]

--- a/cargo-adk/src/codegen.rs
+++ b/cargo-adk/src/codegen.rs
@@ -100,10 +100,15 @@ pub fn generate_cargo_toml(manifest: &CompositionManifest, project_name: &str) -
     // The agent-engine umbrella feature ships in the first release after the
     // published 2.0.0, so a crates.io resolution of the generated manifest
     // fails until then; the header comment states the workaround.
+    // Raw string: scripts/check-doc-versions.py scans .rs sources for
+    // `adk-rust = { ... features = [...] }` snippets and validates the
+    // feature names; escaped quotes would corrupt what it extracts.
     let header = if features.contains(&"agent-engine") {
-        "# The `agent-engine` feature requires the first adk-rust release after 2.0.0.\n\
-         # Until it is published on crates.io, use the git repository instead:\n\
-         #   adk-rust = { git = \"https://github.com/zavora-ai/adk-rust\", default-features = false, features = [\"minimal\", \"agent-engine\"] }\n\n"
+        r#"# The `agent-engine` feature requires the first adk-rust release after 2.0.0.
+# Until it is published on crates.io, use the git repository instead:
+#   adk-rust = { git = "https://github.com/zavora-ai/adk-rust", default-features = false, features = ["minimal", "agent-engine"] }
+
+"#
     } else {
         ""
     };

--- a/cargo-adk/src/registry.rs
+++ b/cargo-adk/src/registry.rs
@@ -27,7 +27,7 @@ pub struct TemplateRegistry {
 impl TemplateRegistry {
     /// Build the default registry with all built-in templates.
     ///
-    /// Populates 12 agent templates, 10 capability addons, 5 enterprise patterns,
+    /// Populates 13 agent templates, 10 capability addons, 5 enterprise patterns,
     /// and 2 legacy aliases.
     pub fn builtin() -> Self {
         Self {
@@ -169,7 +169,7 @@ fn parse_custom_template(content: &str) -> Result<AgentTemplate, String> {
 // Built-in data population
 // ---------------------------------------------------------------------------
 
-/// All 12 built-in agent templates.
+/// All 13 built-in agent templates.
 fn builtin_agent_templates() -> Vec<AgentTemplate> {
     vec![
         AgentTemplate {
@@ -538,6 +538,60 @@ pub async fn greet(args: GreetArgs) -> std::result::Result<Value, AdkError> {
             },
         },
         AgentTemplate {
+            name: "agent-engine",
+            description: "Gemini Enterprise Agent Engine BYOC container with Dockerfile and Terraform deploy",
+            category: TemplateCategory::AgentType,
+            default_provider: "gemini",
+            required_features: vec!["minimal", "agent-engine"],
+            // `server` would serve a second HTTP surface on the same port;
+            // `docker` would collide with the Dockerfile this template ships.
+            incompatible_addons: vec!["server", "docker"],
+            additional_deps: vec![],
+            code_fragments: AgentCodeFragments {
+                imports: vec![
+                    "use std::sync::Arc;",
+                    "use adk_rust::server::agent_engine::{AgentEngineOptions, serve_agent_engine};",
+                ],
+                agent_construction: r#"let agent: Arc<dyn Agent> = Arc::new(
+        LlmAgentBuilder::new("{name}")
+            .description("Agent Engine BYOC agent")
+            .instruction("You are a helpful assistant.")
+            .model(Arc::new(model))
+            .build()?,
+    );
+
+    // serve_agent_engine is the whole main of a BYOC engine: it binds
+    // 0.0.0.0:$PORT (the platform sets PORT) and serves the class-method
+    // dispatch endpoints plus GET /health until the process stops.
+    //
+    // Production deployments configure managed backends here:
+    //   AgentEngineOptions::new()
+    //       .with_session_service(...)   // VertexAiSessionService (feature `vertex-session`)
+    //       .with_memory_service(...)    // enables the memory class methods
+    //       .with_artifact_service(...)  // GcsArtifactService (adk-artifact `gcs`)
+    serve_agent_engine(agent, AgentEngineOptions::new()).await?;"#,
+                additional_files: vec![
+                    FileFragment { path: "Dockerfile", content: DOCKERFILE },
+                    FileFragment { path: ".dockerignore", content: DOCKERIGNORE },
+                    FileFragment {
+                        path: "deploy/terraform/main.tf",
+                        content: AGENT_ENGINE_MAIN_TF,
+                    },
+                    FileFragment {
+                        path: "deploy/terraform/variables.tf",
+                        content: AGENT_ENGINE_VARIABLES_TF,
+                    },
+                    FileFragment {
+                        path: "deploy/terraform/outputs.tf",
+                        content: AGENT_ENGINE_OUTPUTS_TF,
+                    },
+                    // Replaces the generic generated README: deployment is the
+                    // whole point of this template.
+                    FileFragment { path: "README.md", content: AGENT_ENGINE_README },
+                ],
+            },
+        },
+        AgentTemplate {
             name: "openai",
             description: "OpenAI-powered LLM agent",
             category: TemplateCategory::AgentType,
@@ -559,6 +613,303 @@ pub async fn greet(args: GreetArgs) -> std::result::Result<Value, AdkError> {
         },
     ]
 }
+
+/// Multi-stage container build: `rust:1.95-slim` build stage, distroless
+/// runtime. Shared by the `docker` addon and the `agent-engine` template so
+/// the image definition is stated once.
+const DOCKERFILE: &str = r##"# Multi-stage image: compile with the full Rust toolchain, run on distroless.
+#
+# The build stage tag is kept in lockstep with rust-toolchain.toml at the
+# ADK-Rust workspace root, which pins Rust 1.95.0.
+FROM rust:1.95-slim AS builder
+
+WORKDIR /build
+
+# Optional compilation cache — uncomment to reuse artifacts across builds:
+# RUN cargo install sccache --locked
+# ENV RUSTC_WRAPPER=sccache
+
+COPY . .
+RUN cargo build --release
+
+# Distroless keeps the glibc C runtime the binary links against but ships no
+# shell or package manager, minimizing image size and attack surface.
+FROM gcr.io/distroless/cc-debian12
+
+COPY --from=builder /build/target/release/{name} /app/agent
+
+ENV PORT=8080
+ENTRYPOINT ["/app/agent"]
+"##;
+
+/// Fully static musl variant of [`DOCKERFILE`], emitted by the `docker` addon.
+const DOCKERFILE_STATIC: &str = r##"# Fully static image: musl-linked binary on a `FROM scratch` runtime.
+#
+# COMPATIBILITY GUARD — static linking only works when every native dependency
+# links statically:
+#
+#   works:  the `gemini-agent-platform` / `gemini-agent-platform-full` feature
+#           sets — the TLS stack is rustls with a statically built aws-lc, and
+#           no OpenSSL is involved.
+#   fails:  the `livekit` feature — pinned to native-tls, which requires a
+#           shared OpenSSL.
+#   fails:  the adk-audio `onnx` / `kokoro` / `desktop-audio` features — ONNX
+#           Runtime is a shared library, and espeak-ng / ALSA are system
+#           libraries with no static musl builds.
+#
+# A link-time failure in this file usually means the feature set above.
+
+# The build stage tag is kept in lockstep with rust-toolchain.toml at the
+# ADK-Rust workspace root, which pins Rust 1.95.0.
+FROM rust:1.95-slim AS builder
+
+# musl-tools provides musl-gcc; cmake builds aws-lc-sys for the musl target;
+# ca-certificates supplies the bundle copied into the runtime stage below.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends musl-tools cmake ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+RUN rustup target add x86_64-unknown-linux-musl
+
+WORKDIR /build
+
+COPY . .
+RUN cargo build --release --target x86_64-unknown-linux-musl
+
+FROM scratch
+
+# ADK-Rust uses rustls-tls-native-roots, which reads /etc/ssl/certs at runtime.
+# `scratch` ships no filesystem, so the CA bundle must be copied in or every
+# TLS connection fails certificate verification.
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=builder /build/target/x86_64-unknown-linux-musl/release/{name} /app/agent
+
+ENV PORT=8080
+ENTRYPOINT ["/app/agent"]
+"##;
+
+/// Build-context exclusions shared by the `docker` addon and the
+/// `agent-engine` template.
+const DOCKERIGNORE: &str = r##"# Keep build output, VCS state, and local secrets out of the build context.
+target/
+.git/
+.env
+.env.*
+!.env.example
+*.swp
+*.swo
+.DS_Store
+"##;
+
+/// Terraform resource for the `agent-engine` template, mirroring the BYOC
+/// codelab with the argument names from the `google_vertex_ai_reasoning_engine`
+/// provider documentation.
+const AGENT_ENGINE_MAIN_TF: &str = r#"terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      # google_vertex_ai_reasoning_engine gained spec.container_spec (BYOC),
+      # spec.class_methods, and spec.agent_framework by this version.
+      version = ">= 7.16.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.location
+}
+
+locals {
+  # The full class-method dispatch contract adk-server's register_operations
+  # reports. Terraform deployments must declare it explicitly — without it,
+  # client SDKs cannot discover the methods and calls to the engine fail.
+  class_methods = [
+    { "api_mode" = "", "name" = "create_session" },
+    { "api_mode" = "", "name" = "get_session" },
+    { "api_mode" = "", "name" = "list_sessions" },
+    { "api_mode" = "", "name" = "delete_session" },
+    { "api_mode" = "", "name" = "register_operations" },
+    { "api_mode" = "async", "name" = "async_create_session" },
+    { "api_mode" = "async", "name" = "async_get_session" },
+    { "api_mode" = "async", "name" = "async_list_sessions" },
+    { "api_mode" = "async", "name" = "async_delete_session" },
+    { "api_mode" = "async", "name" = "async_add_session_to_memory" },
+    { "api_mode" = "async", "name" = "async_search_memory" },
+    { "api_mode" = "stream", "name" = "stream_query" },
+    { "api_mode" = "async_stream", "name" = "async_stream_query" },
+    { "api_mode" = "async_stream", "name" = "streaming_agent_run_with_events" },
+  ]
+}
+
+# agent_framework is "google-adk" because the container serves the google-adk
+# class-method contract; the console Playground keys interactive features off it.
+resource "google_vertex_ai_reasoning_engine" "agent" {
+  display_name = var.display_name
+  description  = "{name} deployed as a BYOC container via Terraform"
+  project      = var.project_id
+  region       = var.location
+
+  spec {
+    class_methods   = jsonencode(local.class_methods)
+    agent_framework = "google-adk"
+    service_account = var.service_account
+
+    container_spec {
+      image_uri = var.image_uri
+    }
+  }
+}
+"#;
+
+/// Terraform input variables for the `agent-engine` template.
+const AGENT_ENGINE_VARIABLES_TF: &str = r#"variable "project_id" {
+  type        = string
+  description = "The Google Cloud project to deploy into"
+}
+
+variable "location" {
+  type        = string
+  description = "The region hosting the reasoning engine"
+  default     = "us-central1"
+}
+
+variable "image_uri" {
+  type        = string
+  description = "Artifact Registry image URI, e.g. us-central1-docker.pkg.dev/PROJECT/REPO/{name}:latest"
+}
+
+variable "display_name" {
+  type        = string
+  description = "Display name of the reasoning engine"
+  default     = "{name}"
+}
+
+variable "service_account" {
+  type        = string
+  description = "Optional service account the engine runs as; defaults to the Vertex AI Reasoning Engine service agent"
+  default     = null
+}
+"#;
+
+/// Terraform outputs for the `agent-engine` template.
+const AGENT_ENGINE_OUTPUTS_TF: &str = r#"output "reasoning_engine_id" {
+  value       = google_vertex_ai_reasoning_engine.agent.id
+  description = "Identifier of the deployed reasoning engine (projects/../locations/../reasoningEngines/..)"
+}
+
+output "reasoning_engine_name" {
+  value       = google_vertex_ai_reasoning_engine.agent.name
+  description = "The generated resource name of the deployed reasoning engine"
+}
+"#;
+
+/// Project README for the `agent-engine` template. Replaces the generic
+/// generated README because build, push, and Terraform deploy are the
+/// template's whole purpose.
+const AGENT_ENGINE_README: &str = r#"# {name}
+
+A Gemini Enterprise Agent Engine (Agent Runtime) BYOC container: the binary
+serves the platform's class-method dispatch contract via
+`serve_agent_engine`, and `deploy/terraform/` provisions the
+`google_vertex_ai_reasoning_engine` resource that runs the image.
+
+> **Note:** the `agent-engine` cargo feature ships in the first adk-rust
+> release after 2.0.0. Until that release is published, point the dependency
+> at the git repository instead of crates.io:
+>
+> ```toml
+> adk-rust = { git = "https://github.com/zavora-ai/adk-rust", default-features = false, features = ["minimal", "agent-engine"] }
+> ```
+
+## Run locally
+
+```bash
+cp .env.example .env    # add your GOOGLE_API_KEY
+cargo run
+
+# Unary dispatch
+curl -s -X POST localhost:8080/api/reasoning_engine \
+  -H 'Content-Type: application/json' \
+  -d '{"class_method": "create_session", "input": {"user_id": "u"}}'
+
+# Streaming dispatch (one JSON event per line)
+curl -s -X POST localhost:8080/api/stream_reasoning_engine \
+  -H 'Content-Type: application/json' \
+  -d '{"class_method": "async_stream_query", "input": {"user_id": "u", "message": "hi"}}'
+```
+
+## Build and push the image
+
+```bash
+export PROJECT_ID=your-project
+export LOCATION=us-central1
+export REPOSITORY=agents-repo   # an Artifact Registry docker repository
+
+gcloud builds submit \
+  --project=$PROJECT_ID \
+  --region=$LOCATION \
+  --tag $LOCATION-docker.pkg.dev/$PROJECT_ID/$REPOSITORY/{name}:latest \
+  .
+```
+
+## Deploy with Terraform
+
+```bash
+terraform -chdir=deploy/terraform init
+terraform -chdir=deploy/terraform apply \
+  -var project_id=$PROJECT_ID \
+  -var location=$LOCATION \
+  -var image_uri=$LOCATION-docker.pkg.dev/$PROJECT_ID/$REPOSITORY/{name}:latest
+```
+
+`deploy/terraform/main.tf` declares the full class-method contract in
+`jsonencode` — Terraform deployments must list the methods explicitly or
+client SDKs cannot discover them.
+
+## Environment inside the deployed container
+
+| Variable | Set by | Meaning |
+|----------|--------|---------|
+| `PORT` | platform | Port the container must listen on (default 8080) |
+| `GOOGLE_CLOUD_PROJECT` | platform | GCP project of the deployment |
+| `GOOGLE_CLOUD_LOCATION` | platform | GCP location of the deployment |
+| `GOOGLE_CLOUD_AGENT_ENGINE_ID` | platform | Bare numeric engine ID |
+| `GOOGLE_API_KEY` | you | Gemini API key for the model (e.g. via a secret) |
+
+## Query the deployed engine
+
+Every HTTP route the container serves is reachable through the Agent Runtime
+`/api` passthrough, authenticated with Google credentials:
+
+```
+https://{LOCATION}-aiplatform.googleapis.com/reasoningEngines/v1/{ENGINE_RESOURCE_NAME}/api/{container_path}
+```
+
+For example, the streaming dispatch endpoint is
+`.../api/api/stream_reasoning_engine` (the first `api` belongs to the
+passthrough, the second to the container route).
+
+## Optional: serve A2A routes in the same container
+
+There is no separate create-time A2A mode — the passthrough exposes every
+container route, so an agent that also serves adk-server's A2A surface
+(`/.well-known/agent.json`, `/a2a`, `/a2a/stream`) is reachable through it.
+To opt in, replace `serve_agent_engine` with a `ServerBuilder` that mounts
+both surfaces:
+
+```rust,ignore
+let app = adk_rust::server::ServerBuilder::new(config)
+    .with_agent_engine(true)
+    .with_a2a("https://your-passthrough-base-url")
+    .build();
+```
+
+## Extending
+
+- Wire managed backends via `AgentEngineOptions` (`with_session_service`,
+  `with_memory_service`, `with_artifact_service`) in `src/main.rs`
+- Add tools to the agent with `.tool(...)` on `LlmAgentBuilder`
+"#;
 
 /// All 10 built-in capability addons.
 fn builtin_capability_addons() -> Vec<CapabilityAddon> {
@@ -742,92 +1093,9 @@ fn builtin_capability_addons() -> Vec<CapabilityAddon> {
                 agent_builder_calls: "",
                 env_vars: vec![],
                 additional_files: vec![
-                    FileFragment {
-                        path: "Dockerfile",
-                        content: r##"# Multi-stage image: compile with the full Rust toolchain, run on distroless.
-#
-# The build stage tag is kept in lockstep with rust-toolchain.toml at the
-# ADK-Rust workspace root, which pins Rust 1.95.0.
-FROM rust:1.95-slim AS builder
-
-WORKDIR /build
-
-# Optional compilation cache — uncomment to reuse artifacts across builds:
-# RUN cargo install sccache --locked
-# ENV RUSTC_WRAPPER=sccache
-
-COPY . .
-RUN cargo build --release
-
-# Distroless keeps the glibc C runtime the binary links against but ships no
-# shell or package manager, minimizing image size and attack surface.
-FROM gcr.io/distroless/cc-debian12
-
-COPY --from=builder /build/target/release/{name} /app/agent
-
-ENV PORT=8080
-ENTRYPOINT ["/app/agent"]
-"##,
-                    },
-                    FileFragment {
-                        path: "Dockerfile.static",
-                        content: r##"# Fully static image: musl-linked binary on a `FROM scratch` runtime.
-#
-# COMPATIBILITY GUARD — static linking only works when every native dependency
-# links statically:
-#
-#   works:  the `gemini-agent-platform` / `gemini-agent-platform-full` feature
-#           sets — the TLS stack is rustls with a statically built aws-lc, and
-#           no OpenSSL is involved.
-#   fails:  the `livekit` feature — pinned to native-tls, which requires a
-#           shared OpenSSL.
-#   fails:  the adk-audio `onnx` / `kokoro` / `desktop-audio` features — ONNX
-#           Runtime is a shared library, and espeak-ng / ALSA are system
-#           libraries with no static musl builds.
-#
-# A link-time failure in this file usually means the feature set above.
-
-# The build stage tag is kept in lockstep with rust-toolchain.toml at the
-# ADK-Rust workspace root, which pins Rust 1.95.0.
-FROM rust:1.95-slim AS builder
-
-# musl-tools provides musl-gcc; cmake builds aws-lc-sys for the musl target;
-# ca-certificates supplies the bundle copied into the runtime stage below.
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends musl-tools cmake ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
-RUN rustup target add x86_64-unknown-linux-musl
-
-WORKDIR /build
-
-COPY . .
-RUN cargo build --release --target x86_64-unknown-linux-musl
-
-FROM scratch
-
-# ADK-Rust uses rustls-tls-native-roots, which reads /etc/ssl/certs at runtime.
-# `scratch` ships no filesystem, so the CA bundle must be copied in or every
-# TLS connection fails certificate verification.
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY --from=builder /build/target/x86_64-unknown-linux-musl/release/{name} /app/agent
-
-ENV PORT=8080
-ENTRYPOINT ["/app/agent"]
-"##,
-                    },
-                    FileFragment {
-                        path: ".dockerignore",
-                        content: r##"# Keep build output, VCS state, and local secrets out of the build context.
-target/
-.git/
-.env
-.env.*
-!.env.example
-*.swp
-*.swo
-.DS_Store
-"##,
-                    },
+                    FileFragment { path: "Dockerfile", content: DOCKERFILE },
+                    FileFragment { path: "Dockerfile.static", content: DOCKERFILE_STATIC },
+                    FileFragment { path: ".dockerignore", content: DOCKERIGNORE },
                 ],
             },
         },
@@ -908,6 +1176,38 @@ mod tests {
         // Aliases resolve to real targets.
         assert_eq!(registry.resolve_template("basic").unwrap().name, "llm");
         assert_eq!(registry.resolve_pattern("a2a").unwrap().name, "a2a-server");
+    }
+
+    #[test]
+    fn agent_engine_template_is_registered_with_deploy_files() {
+        let registry = TemplateRegistry::builtin();
+        let template =
+            registry.resolve_template("agent-engine").expect("agent-engine template registered");
+
+        assert_eq!(template.required_features, vec!["minimal", "agent-engine"]);
+        // The template serves itself and ships its own Dockerfile.
+        assert_eq!(template.incompatible_addons, vec!["server", "docker"]);
+
+        let paths: Vec<&str> =
+            template.code_fragments.additional_files.iter().map(|f| f.path).collect();
+        assert_eq!(
+            paths,
+            vec![
+                "Dockerfile",
+                ".dockerignore",
+                "deploy/terraform/main.tf",
+                "deploy/terraform/variables.tf",
+                "deploy/terraform/outputs.tf",
+                "README.md",
+            ]
+        );
+
+        // The Dockerfile is the docker addon's, stated once.
+        let docker = registry.capability_addons.iter().find(|a| a.name == "docker").unwrap();
+        assert_eq!(
+            template.code_fragments.additional_files[0].content,
+            docker.code_fragments.additional_files[0].content
+        );
     }
 
     #[test]

--- a/docs/official_docs/development/composable-templates.md
+++ b/docs/official_docs/development/composable-templates.md
@@ -38,7 +38,7 @@ documentation and automation.
 
 ## Built-in templates
 
-The built-in registry currently contains 12 templates.
+The built-in registry currently contains 13 templates.
 
 | Template | What it creates | Choose it when |
 |---|---|---|
@@ -54,6 +54,7 @@ The built-in registry currently contains 12 templates.
 | `graph` | A branching workflow with checkpoints | Work must resume, branch, join, or survive process failure |
 | `realtime` | Bidirectional audio and video handling | The product needs a live voice or multimodal conversation |
 | `custom` | A manual implementation of the `Agent` trait | The execution contract cannot be expressed by a built-in agent |
+| `agent-engine` | A Gemini Enterprise Agent Engine BYOC container with `Dockerfile` and `deploy/terraform/` | The agent deploys to Agent Runtime as a prebuilt container |
 
 Choose the execution shape first. Add sessions, MCP, telemetry, or other
 product capabilities afterward instead of using them to decide the workflow.


### PR DESCRIPTION
## What

A new `agent-engine` template in `cargo-adk` (WP6.2): `cargo adk new my-agent --template agent-engine` scaffolds a complete BYOC deployment for the Gemini Enterprise Agent Platform.

Generated project:
- `src/main.rs` — a binary calling `serve_agent_engine(agent, AgentEngineOptions::new())` (the Wave 1 turnkey entrypoint) with a Gemini `LlmAgent`.
- `Dockerfile` + `.dockerignore` — byte-identical to the docker addon's output (the image definition is stated once: the addon's fragments were extracted into shared consts referenced by both, with a test asserting identity).
- `deploy/terraform/` — `main.tf` with `google_vertex_ai_reasoning_engine` (`spec.container_spec.image_uri`, `spec.agent_framework = "google-adk"`, `spec.class_methods = jsonencode([...])` declaring all **14** WP1 class methods), plus `variables.tf` (project, location, image_uri, display_name, optional service_account) and `outputs.tf` (engine ID/name), mirroring the BYOC codelab.
- A deployment-centric `README.md` (`gcloud builds submit` → `terraform apply` → query), including the platform's `/api` passthrough URL shape and — per verification task V16 — how to optionally serve adk-server's A2A routes in the same container via `ServerBuilder::with_agent_engine(true)` + `.with_a2a(...)` (the passthrough carries them; no create-time A2A mode exists).

## Why

Part of #438 (Wave 2, PR 2.4 — WP6.2). Builds on the Wave 1 entrypoint (#583) and the docker addon (#586). V16 verified: Agent Runtime exposes all container HTTP routes externally under `https://{location}-aiplatform.googleapis.com/reasoningEngines/v1/{resource}/api/{container_path}`, so adk-server's existing A2A surface is compatible as-is — documented as a template option, not wired by default.

## How

- **Terraform verified against the codelab and the provider docs.** One codelab drift corrected: the resource argument is `region`, not `location`. `classMethods` entry keys `{"api_mode", "name"}` confirmed. The codelab declares 13 methods; the template declares 14 — `register_operations` is part of the Wave 1 dispatch contract.
- **Codegen extensions:** the template is self-serving (no `Launcher` console main), and template fragments can now override a base file by path (the generic generated README is wrong for a deployment template). Both are small, tested mechanism extensions.
- The template lists `docker` (file collision) and `server` (second HTTP surface) as incompatible addons.

**Acceptance criterion — partial, by circumstance:** `cargo adk new my-agent --template agent-engine` generates all files; `docker build .` fails today **only** because published adk-rust 2.0.0 predates the `agent-engine` feature (verified via the crates.io API — the feature ships with the next release). Mitigations: the generated `Cargo.toml` carries a comment stating the version requirement and the git-dependency workaround; `docker build --check` passes with zero warnings; and the generated project compiles against the local workspace via `[patch.crates-io]` (`cargo check` passes), proving the scaffold is correct against the real API. The Docker build will succeed as-is once the next release is published.

**Tests:** 46/46 cargo-adk tests pass, including new registry and codegen tests asserting all template files render with the crate name substituted and the terraform contains the image_uri variable, the resource, and all 14 class-method names.

### Remaining work

- When the next adk-rust version ships with `agent-engine`, drop the generated Cargo.toml header comment and README version note (release-checklist item).
- `terraform validate` was not run (no terraform binary on the dev machine); the HCL mirrors verified sources and is content-asserted in tests.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass (46 in cargo-adk; `scripts/check-doc-examples.sh`)
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts
- [x] No unrelated changes mixed in
- [x] Branch naming follows convention
- [x] Commit messages follow conventional format
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated (cargo-adk template table; composable-templates docs page)
- [x] Examples — the template itself is the example (generated README covers the full deploy flow)
