### PR TITLE
feat(deploy): add Agent Engine BYOC deployment client - PR 2.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,9 @@ jobs:
           # The Memory Bank backend (vertex-memory) is opt-in; its mock contract tests
           # only run with the feature on.
           - { package: adk-memory, features: vertex-memory }
+          # The Agent Engine deployment client (gcp) is opt-in; its golden DTO and
+          # mock contract tests only run with the feature on.
+          - { package: adk-deploy, features: gcp }
           # sandbox-linux is Linux-only *and* feature-gated, so nothing built it until a
           # container run found the bubblewrap probe could never succeed and that its
           # property tests did not compile.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -436,6 +436,7 @@ Production backend features (require external infrastructure, NOT included in `f
 
 Specialist opt-in features:
 - `yaml-agent`, `agent-registry` — YAML agent config and registry REST API
+- `gcp-deploy` — Agent Engine (ReasoningEngine) BYOC deployment client (adk-deploy): create/poll/get/delete; host-side tooling, deliberately excluded from `gemini-agent-platform`
 - `agent-engine` — Agent Engine runtime contract (adk-server): class-method dispatch endpoints and the turnkey `serve_agent_engine` entrypoint for Gemini Enterprise Agent Platform BYOC containers
 - `example-store` — Vertex AI Example Store client (adk-tool): v1beta1 data-plane upsert/search/fetch against a pre-provisioned store, plus `ExampleStoreProvider` for dynamic few-shot retrieval via a `BeforeModelCallback`
 - `gemini-interactions` — Gemini Interactions API (Beta): wire client surface (server-side history, step timeline) plus the runtime transport on `GeminiModel` (`use_interactions_api`) driving the standard `LlmAgent`/`Runner`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Agent Engine deployment client** (`adk-deploy`, feature `gcp`; umbrella
+  feature `gcp-deploy` — host-side tooling, deliberately not part of
+  `gemini-agent-platform`): `GcpDeployClient` with exactly four operations
+  against the v1beta1 `reasoningEngines` surface — `create_reasoning_engine`,
+  `poll_operation` (plus a backoff-polling `wait_for_operation`),
+  `get_reasoning_engine`, `delete_reasoning_engine`. Typed camelCase wire
+  DTOs for the BYOC create body (`containerSpec.imageUri`, `deploymentSpec`
+  env/secret-env/scaling/resource limits/PSC-I, `classMethods`,
+  `agentFramework`, `serviceAccount`, CMEK `encryptionSpec`);
+  `CreateReasoningEngineRequest::byoc` declares the full WP1 class-method
+  contract by default. Image build/push stays with Cloud Build
+  (`gcloud_build_submit_command` renders the documented command).
+  `reasoningEngines:asyncQuery` is deliberately not declared (cannot be
+  added post-create; adk-python parity excludes it).
+
 - **cargo-adk `docker` addon** (`cargo adk new my-agent --addon docker`): emits a
   multi-stage `Dockerfile` (`rust:1.95-slim` build stage kept in lockstep with
   `rust-toolchain.toml`, `gcr.io/distroless/cc-debian12` runtime, `ENV PORT=8080`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,9 +424,11 @@ name = "adk-deploy"
 version = "2.0.0"
 dependencies = [
  "anyhow",
+ "axum 0.8.9",
  "chrono",
  "dirs",
  "flate2",
+ "google-cloud-auth 1.12.0",
  "hex",
  "reqwest 0.12.28",
  "serde",
@@ -435,6 +437,7 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror 2.0.18",
+ "tokio",
  "toml 0.8.23",
  "tracing",
  "url",
@@ -858,6 +861,7 @@ dependencies = [
  "adk-codeact-monty",
  "adk-computer-use",
  "adk-core",
+ "adk-deploy",
  "adk-enterprise",
  "adk-eval",
  "adk-graph",

--- a/adk-deploy/Cargo.toml
+++ b/adk-deploy/Cargo.toml
@@ -29,6 +29,15 @@ flate2.workspace = true
 tar.workspace = true
 dirs = "6"
 url = "2"
+# Optional: Agent Engine (ReasoningEngine) deployment client
+google-cloud-auth = { version = "1.8", optional = true, default-features = false, features = ["default-rustls-provider"] }
+tokio = { workspace = true, features = ["sync", "time"], optional = true }
+
+[features]
+# Agent Engine (ReasoningEngine) BYOC deployment: create/poll/get/delete
+gcp = ["google-cloud-auth", "tokio"]
 
 [dev-dependencies]
 tempfile = "3"
+axum = "0.8"
+tokio = { workspace = true, features = ["rt", "macros", "net"] }

--- a/adk-deploy/README.md
+++ b/adk-deploy/README.md
@@ -278,6 +278,35 @@ The client config is stored at `~/.config/adk-deploy/config.json`:
 
 Load with `DeployClientConfig::load()` (defaults to `http://127.0.0.1:8090` if no config exists).
 
+## Agent Engine deployment (feature `gcp`)
+
+The `gcp` feature adds `gcp::GcpDeployClient`, a minimal ADC-authenticated
+client for deploying BYOC containers as Gemini Enterprise Agent Platform
+ReasoningEngines — exactly four operations: create, poll, get, delete.
+
+```rust
+use adk_deploy::gcp::{CreateReasoningEngineRequest, GcpDeployClient, GcpDeployConfig};
+
+async fn deploy() -> adk_deploy::DeployResult<()> {
+    let client =
+        GcpDeployClient::new_with_adc(GcpDeployConfig::new("my-project", "us-central1"))?;
+    let request = CreateReasoningEngineRequest::byoc(
+        "my-agent",
+        "us-central1-docker.pkg.dev/my-project/agents/my-agent:latest",
+    );
+    let operation = client.create_reasoning_engine(&request).await?;
+    let engine = client.wait_for_operation(operation).await?;
+    let _ = engine;
+    Ok(())
+}
+```
+
+Building and pushing the image is Cloud Build's job:
+
+```bash
+gcloud builds submit --tag us-central1-docker.pkg.dev/my-project/agents/my-agent:latest
+```
+
 ## Related Crates
 
 - [adk-rust](https://crates.io/crates/adk-rust) — Umbrella crate

--- a/adk-deploy/src/gcp.rs
+++ b/adk-deploy/src/gcp.rs
@@ -1,0 +1,715 @@
+//! Google Cloud deployment client for Agent Engine (ReasoningEngine) BYOC.
+//!
+//! A minimal REST client with exactly four operations against the v1beta1
+//! `reasoningEngines` surface: create, poll, get, delete. It deploys a
+//! prebuilt container image — building and pushing the image is out of
+//! scope; use Cloud Build:
+//!
+//! ```bash
+//! gcloud builds submit --tag us-central1-docker.pkg.dev/PROJECT/REPO/agent:latest
+//! ```
+//!
+//! ([`gcloud_build_submit_command`] renders this command for a given image
+//! URI.)
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use adk_deploy::gcp::{CreateReasoningEngineRequest, GcpDeployClient, GcpDeployConfig};
+//!
+//! # async fn deploy() -> adk_deploy::DeployResult<()> {
+//! let client = GcpDeployClient::new_with_adc(GcpDeployConfig::new("my-project", "us-central1"))?;
+//! let request = CreateReasoningEngineRequest::byoc(
+//!     "my-agent",
+//!     "us-central1-docker.pkg.dev/my-project/agents/my-agent:latest",
+//! );
+//! let operation = client.create_reasoning_engine(&request).await?;
+//! let engine = client.wait_for_operation(operation).await?;
+//! # let _ = engine;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # asyncQuery
+//!
+//! `reasoningEngines:asyncQuery` (durable query jobs) is not declared in
+//! [`default_class_methods`]: the capability cannot be added to an engine
+//! post-create, and adk-python's `AdkApp` does not register it either —
+//! strict parity excludes it (Agent Engine plan, verification task V12).
+
+// The ADC credential caching and LRO polling below are the deploy-side copy
+// of the pattern in adk-session/src/vertex.rs; Wave 3 of the Agent Engine
+// plan (adk-gcp, PR 3.5) consolidates all copies into one crate.
+
+use crate::error::{DeployError, DeployResult};
+use google_cloud_auth::credentials::{self, CacheableResource, Credentials};
+use reqwest::{Client, RequestBuilder, StatusCode};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::RwLock;
+use tokio::time::Instant;
+use tracing::info;
+
+const API_VERSION: &str = "v1beta1";
+const CLOUD_PLATFORM_SCOPE: &str = "https://www.googleapis.com/auth/cloud-platform";
+const HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+const AUTH_HEADERS_TIMEOUT: Duration = Duration::from_secs(30);
+// Engine creation provisions serving infrastructure and routinely takes
+// minutes, so the deploy deadline is far above the session/memory backends'
+// 120 s while keeping their backoff shape (100 ms initial, capped).
+const OPERATION_POLL_TIMEOUT: Duration = Duration::from_secs(900);
+const OPERATION_POLL_INITIAL_DELAY: Duration = Duration::from_millis(100);
+const OPERATION_POLL_MAX_DELAY: Duration = Duration::from_secs(10);
+const MAX_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
+
+/// Renders the Cloud Build command that builds and pushes the agent image.
+///
+/// # Example
+///
+/// ```rust
+/// use adk_deploy::gcp::gcloud_build_submit_command;
+///
+/// let command = gcloud_build_submit_command("us-central1-docker.pkg.dev/p/agents/a:latest");
+/// assert_eq!(
+///     command,
+///     "gcloud builds submit --tag us-central1-docker.pkg.dev/p/agents/a:latest",
+/// );
+/// ```
+pub fn gcloud_build_submit_command(image_uri: &str) -> String {
+    format!("gcloud builds submit --tag {image_uri}")
+}
+
+/// Configuration for [`GcpDeployClient`].
+#[derive(Debug, Clone)]
+pub struct GcpDeployConfig {
+    project_id: String,
+    location: String,
+    endpoint: Option<String>,
+}
+
+impl GcpDeployConfig {
+    /// Creates a config for the given project and location.
+    pub fn new(project_id: impl Into<String>, location: impl Into<String>) -> Self {
+        Self { project_id: project_id.into(), location: location.into(), endpoint: None }
+    }
+
+    /// Sets a custom API origin (loopback HTTP allowed for tests; anything
+    /// else must be HTTPS).
+    #[must_use]
+    pub fn with_endpoint(mut self, endpoint: impl Into<String>) -> Self {
+        self.endpoint = Some(endpoint.into());
+        self
+    }
+
+    fn endpoint(&self) -> String {
+        self.endpoint
+            .clone()
+            .unwrap_or_else(|| format!("https://{}-aiplatform.googleapis.com", self.location))
+    }
+}
+
+// ── Wire DTOs (camelCase per the v1beta1 REST reference) ─────────────────
+
+/// The `ReasoningEngine` resource sent to `reasoningEngines.create`.
+///
+/// Field placement follows the current REST surface: the image lives in
+/// `spec.containerSpec`, while env vars, scaling, and resource limits live
+/// in `spec.deploymentSpec`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateReasoningEngineRequest {
+    /// Required display name of the engine.
+    pub display_name: String,
+    /// Optional description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Engine configuration.
+    pub spec: ReasoningEngineSpec,
+    /// Customer-managed encryption key (CMEK) securing the engine and all
+    /// sub-resources.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub encryption_spec: Option<EncryptionSpec>,
+    /// Resource labels.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub labels: Option<BTreeMap<String, String>>,
+}
+
+impl CreateReasoningEngineRequest {
+    /// Builds a BYOC create request with the WP1 class-method contract, the
+    /// `google-adk` framework declaration, and the given container image.
+    pub fn byoc(display_name: impl Into<String>, image_uri: impl Into<String>) -> Self {
+        Self {
+            display_name: display_name.into(),
+            description: None,
+            spec: ReasoningEngineSpec {
+                container_spec: Some(ContainerSpec { image_uri: image_uri.into(), port: None }),
+                deployment_spec: None,
+                class_methods: default_class_methods(),
+                agent_framework: Some("google-adk".to_string()),
+                service_account: None,
+            },
+            encryption_spec: None,
+            labels: None,
+        }
+    }
+
+    /// Sets the service account the engine runs as.
+    #[must_use]
+    pub fn with_service_account(mut self, service_account: impl Into<String>) -> Self {
+        self.spec.service_account = Some(service_account.into());
+        self
+    }
+
+    /// Secures the engine with a customer-managed encryption key.
+    #[must_use]
+    pub fn with_kms_key(mut self, kms_key_name: impl Into<String>) -> Self {
+        self.encryption_spec = Some(EncryptionSpec { kms_key_name: kms_key_name.into() });
+        self
+    }
+
+    /// Sets the deployment spec (env vars, scaling, resource limits).
+    #[must_use]
+    pub fn with_deployment_spec(mut self, deployment_spec: DeploymentSpec) -> Self {
+        self.spec.deployment_spec = Some(deployment_spec);
+        self
+    }
+}
+
+/// `spec` of a ReasoningEngine (BYOC subset).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReasoningEngineSpec {
+    /// The container image to run (the BYOC `deployment_source`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub container_spec: Option<ContainerSpec>,
+    /// Runtime deployment configuration.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deployment_spec: Option<DeploymentSpec>,
+    /// Class-method declarations the host dispatches on. Defaults to the
+    /// WP1 contract via [`default_class_methods`].
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub class_methods: Vec<Value>,
+    /// The agent framework declaration (`"google-adk"` for adk-rust — the
+    /// runtime contract is the ADK one).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_framework: Option<String>,
+    /// Service account the engine artifact runs as.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_account: Option<String>,
+}
+
+/// `spec.containerSpec` — the container image and port.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContainerSpec {
+    /// Artifact Registry image URI.
+    pub image_uri: String,
+    /// Port the container listens on; the platform defaults to 8080.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub port: Option<i32>,
+}
+
+/// `spec.deploymentSpec` — env vars, scaling, and resource limits.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeploymentSpec {
+    /// Plain environment variables.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub env: Vec<EnvVar>,
+    /// Environment variables sourced from Secret Manager.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub secret_env: Vec<SecretEnvVar>,
+    /// PSC interface configuration (private networking). Passed through
+    /// opaquely — compose it per the REST reference.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub psc_interface_config: Option<Value>,
+    /// Container resource limits; only `cpu` and `memory` keys are
+    /// supported (platform default `{"cpu": "4", "memory": "4Gi"}`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resource_limits: Option<BTreeMap<String, String>>,
+    /// Minimum running instances (platform default 1, range 0–75).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_instances: Option<i32>,
+    /// Maximum instances (platform default 100, range 1–1000).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_instances: Option<i32>,
+    /// Requests handled concurrently per container (platform default 9).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub container_concurrency: Option<i32>,
+}
+
+/// A plain environment variable.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EnvVar {
+    /// Variable name.
+    pub name: String,
+    /// Variable value.
+    pub value: String,
+}
+
+/// An environment variable sourced from Cloud Secret Manager.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SecretEnvVar {
+    /// Variable name.
+    pub name: String,
+    /// The secret providing the value.
+    pub secret_ref: SecretRef,
+}
+
+/// Reference to a Secret Manager secret version.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SecretRef {
+    /// Secret name.
+    pub secret: String,
+    /// Secret version (`"latest"`, an integer, or a version alias).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+}
+
+/// Customer-managed encryption key spec.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EncryptionSpec {
+    /// Full Cloud KMS key resource name.
+    pub kms_key_name: String,
+}
+
+/// A `ReasoningEngine` resource as returned by get/create.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReasoningEngine {
+    /// Full resource name
+    /// (`projects/{p}/locations/{l}/reasoningEngines/{id}`).
+    pub name: String,
+    /// Display name.
+    #[serde(default)]
+    pub display_name: String,
+    /// Creation timestamp (RFC 3339).
+    #[serde(default)]
+    pub create_time: Option<String>,
+    /// Last-update timestamp (RFC 3339).
+    #[serde(default)]
+    pub update_time: Option<String>,
+}
+
+/// A long-running operation returned by create/delete.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Operation {
+    /// Operation resource name.
+    pub name: String,
+    /// Whether the operation has finished.
+    #[serde(default)]
+    pub done: bool,
+    /// Terminal error, when the operation failed.
+    #[serde(default)]
+    pub error: Option<OperationError>,
+    /// Terminal response, when the operation succeeded.
+    #[serde(default)]
+    pub response: Option<Value>,
+}
+
+/// The `google.rpc.Status` carried by a failed operation.
+#[derive(Debug, Clone, Deserialize)]
+pub struct OperationError {
+    /// Canonical gRPC status code.
+    #[serde(default)]
+    pub code: i64,
+    /// Human-readable message.
+    #[serde(default)]
+    pub message: String,
+}
+
+/// The WP1 class-method contract as `classMethods` declarations, matching
+/// what a container built on `adk_server::agent_engine` actually serves.
+///
+/// Entry shape `{"name": ..., "api_mode": ...}` follows the BYOC codelab's
+/// Terraform. `register_operations` is declared too — the dispatch surface
+/// serves it and hosts may call it for discovery.
+pub fn default_class_methods() -> Vec<Value> {
+    const METHODS: [(&str, &str); 14] = [
+        ("create_session", ""),
+        ("get_session", ""),
+        ("list_sessions", ""),
+        ("delete_session", ""),
+        ("register_operations", ""),
+        ("async_create_session", "async"),
+        ("async_get_session", "async"),
+        ("async_list_sessions", "async"),
+        ("async_delete_session", "async"),
+        ("async_add_session_to_memory", "async"),
+        ("async_search_memory", "async"),
+        ("stream_query", "stream"),
+        ("async_stream_query", "async_stream"),
+        ("streaming_agent_run_with_events", "async_stream"),
+    ];
+    METHODS.iter().map(|(name, api_mode)| json!({ "name": name, "api_mode": api_mode })).collect()
+}
+
+// ── Client ────────────────────────────────────────────────────────────────
+
+/// Minimal Agent Engine deployment client (create, poll, get, delete).
+pub struct GcpDeployClient {
+    http_client: Client,
+    endpoint: String,
+    project_id: String,
+    location: String,
+    credentials: Credentials,
+    auth_headers: Arc<RwLock<Option<reqwest::header::HeaderMap>>>,
+}
+
+impl GcpDeployClient {
+    /// Creates a client using Application Default Credentials (ADC).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when ADC cannot be constructed, the endpoint is not
+    /// a valid secure origin, or the HTTP client cannot be built.
+    pub fn new_with_adc(config: GcpDeployConfig) -> DeployResult<Self> {
+        let credentials = credentials::Builder::default()
+            .with_scopes([CLOUD_PLATFORM_SCOPE])
+            .build()
+            .map_err(|error| DeployError::Client {
+                message: format!("failed to build gcp deploy ADC credentials: {error}"),
+            })?;
+        Self::with_credentials(config, credentials)
+    }
+
+    /// Creates a client with explicit credentials.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the endpoint is not a valid secure origin or
+    /// the redirect-disabled HTTP client cannot be built.
+    pub fn with_credentials(
+        config: GcpDeployConfig,
+        credentials: Credentials,
+    ) -> DeployResult<Self> {
+        let http_client = Client::builder()
+            .connect_timeout(HTTP_CONNECT_TIMEOUT)
+            .timeout(HTTP_REQUEST_TIMEOUT)
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .map_err(|error| DeployError::Client {
+                message: format!("failed to build bounded gcp deploy HTTP client: {error}"),
+            })?;
+        let client = Self {
+            http_client,
+            endpoint: config.endpoint(),
+            project_id: config.project_id,
+            location: config.location,
+            credentials,
+            auth_headers: Arc::new(RwLock::new(None)),
+        };
+        client.build_url("")?;
+        Ok(client)
+    }
+
+    /// Creates a reasoning engine, returning the pending operation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the request fails or the response is not an
+    /// operation.
+    pub async fn create_reasoning_engine(
+        &self,
+        request: &CreateReasoningEngineRequest,
+    ) -> DeployResult<Operation> {
+        let url = self.build_url(&format!("{API_VERSION}/{}/reasoningEngines", self.parent()))?;
+        info!(engine.display_name = %request.display_name, "creating reasoning engine");
+        let http_request = self.apply_auth(self.http_client.post(url).json(request)).await?;
+        let value = self.send_value(http_request).await?;
+        parse_operation(value)
+    }
+
+    /// Fetches the current state of a long-running operation (single poll).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the name is outside this client's project and
+    /// location or the request fails.
+    pub async fn poll_operation(&self, operation_name: &str) -> DeployResult<Operation> {
+        self.validate_operation_name(operation_name)?;
+        let url = self.build_url(&format!("{API_VERSION}/{operation_name}"))?;
+        let request = self.apply_auth(self.http_client.get(url)).await?;
+        let value = self.send_value(request).await?;
+        parse_operation(value)
+    }
+
+    /// Polls an operation to completion with backoff and returns its
+    /// terminal response, if any.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the operation fails, does not finish within
+    /// the 15-minute deadline, or a poll changes operation identity.
+    pub async fn wait_for_operation(&self, operation: Operation) -> DeployResult<Option<Value>> {
+        self.validate_operation_name(&operation.name)?;
+        let operation_name = operation.name.clone();
+        let deadline = Instant::now() + OPERATION_POLL_TIMEOUT;
+        let mut delay = OPERATION_POLL_INITIAL_DELAY;
+        let mut operation = operation;
+
+        loop {
+            if operation.done {
+                if let Some(error) = operation.error {
+                    return Err(DeployError::Client {
+                        message: format!(
+                            "reasoning engine operation '{operation_name}' failed with code {}: {}",
+                            error.code, error.message,
+                        ),
+                    });
+                }
+                return Ok(operation.response);
+            }
+            if Instant::now() >= deadline {
+                return Err(DeployError::Client {
+                    message: format!(
+                        "reasoning engine operation '{operation_name}' did not complete within {} seconds; inspect the operation in Google Cloud before retrying",
+                        OPERATION_POLL_TIMEOUT.as_secs(),
+                    ),
+                });
+            }
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            tokio::time::sleep(delay.min(remaining)).await;
+            delay = delay.saturating_mul(2).min(OPERATION_POLL_MAX_DELAY);
+
+            let next = self.poll_operation(&operation_name).await?;
+            if next.name != operation_name {
+                return Err(DeployError::Client {
+                    message: format!(
+                        "operation poll changed identity from '{operation_name}' to '{}'; refusing to follow a different operation",
+                        next.name,
+                    ),
+                });
+            }
+            operation = next;
+        }
+    }
+
+    /// Fetches a reasoning engine by numeric ID or full resource name.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the request fails or the payload is not a
+    /// reasoning engine.
+    pub async fn get_reasoning_engine(&self, engine: &str) -> DeployResult<ReasoningEngine> {
+        let name = self.engine_name(engine)?;
+        let url = self.build_url(&format!("{API_VERSION}/{name}"))?;
+        let request = self.apply_auth(self.http_client.get(url)).await?;
+        let value = self.send_value(request).await?;
+        serde_json::from_value(value).map_err(|error| DeployError::Client {
+            message: format!("failed to parse reasoning engine payload: {error}"),
+        })
+    }
+
+    /// Deletes a reasoning engine, returning the pending operation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the request fails or the response is not an
+    /// operation.
+    pub async fn delete_reasoning_engine(&self, engine: &str) -> DeployResult<Operation> {
+        let name = self.engine_name(engine)?;
+        let url = self.build_url(&format!("{API_VERSION}/{name}"))?;
+        info!(engine.name = %name, "deleting reasoning engine");
+        let request = self.apply_auth(self.http_client.delete(url)).await?;
+        let value = self.send_value(request).await?;
+        parse_operation(value)
+    }
+
+    fn parent(&self) -> String {
+        format!("projects/{}/locations/{}", self.project_id, self.location)
+    }
+
+    fn engine_name(&self, engine: &str) -> DeployResult<String> {
+        let prefix = format!("{}/reasoningEngines/", self.parent());
+        if let Some(id) = engine.strip_prefix(&prefix) {
+            if !id.is_empty() && id.bytes().all(|byte| byte.is_ascii_digit()) {
+                return Ok(engine.to_string());
+            }
+        } else if !engine.is_empty() && engine.bytes().all(|byte| byte.is_ascii_digit()) {
+            return Ok(format!("{prefix}{engine}"));
+        }
+        Err(DeployError::Client {
+            message: format!(
+                "reasoning engine '{engine}' is invalid. Provide a numeric ID or the exact resource name '{prefix}<numeric-id>'",
+            ),
+        })
+    }
+
+    fn validate_operation_name(&self, name: &str) -> DeployResult<()> {
+        let prefix = format!("{}/", self.parent());
+        if name.starts_with(&prefix) && !name.contains("://") && !name.contains("..") {
+            return Ok(());
+        }
+        Err(DeployError::Client {
+            message: format!("operation name '{name}' does not belong to {}", self.parent()),
+        })
+    }
+
+    fn build_url(&self, path: &str) -> DeployResult<String> {
+        let mut url = reqwest::Url::parse(&self.endpoint).map_err(|error| DeployError::Client {
+            message: format!("invalid GCP endpoint URL: {error}"),
+        })?;
+        let loopback = matches!(url.host_str(), Some("localhost" | "127.0.0.1" | "::1"));
+        if url.scheme() != "https" && !(url.scheme() == "http" && loopback) {
+            return Err(DeployError::Client {
+                message: "GCP endpoint must use HTTPS for secure transmission of deploy requests"
+                    .to_string(),
+            });
+        }
+        if !url.username().is_empty()
+            || url.password().is_some()
+            || url.query().is_some()
+            || url.fragment().is_some()
+            || url.path() != "/"
+        {
+            return Err(DeployError::Client {
+                message:
+                    "GCP endpoint must be an origin without userinfo, path, query, or fragment"
+                        .to_string(),
+            });
+        }
+        url.set_path(&format!("/{}", path.trim_start_matches('/')));
+        Ok(url.to_string())
+    }
+
+    async fn auth_headers(&self) -> DeployResult<reqwest::header::HeaderMap> {
+        let cacheable_headers = tokio::time::timeout(
+            AUTH_HEADERS_TIMEOUT,
+            self.credentials.headers(Default::default()),
+        )
+        .await
+        .map_err(|_| DeployError::Client {
+            message: format!(
+                "gcp deploy credential header acquisition timed out after {} seconds",
+                AUTH_HEADERS_TIMEOUT.as_secs(),
+            ),
+        })?
+        .map_err(|error| DeployError::Client {
+            message: format!("failed to obtain google cloud auth headers: {error}"),
+        })?;
+
+        match cacheable_headers {
+            CacheableResource::New { data, .. } => {
+                *self.auth_headers.write().await = Some(data.clone());
+                Ok(data)
+            }
+            CacheableResource::NotModified => {
+                self.auth_headers.read().await.clone().ok_or_else(|| DeployError::Client {
+                    message: "google cloud credentials returned NotModified before any cached auth headers were available".to_string(),
+                })
+            }
+        }
+    }
+
+    async fn apply_auth(&self, request: RequestBuilder) -> DeployResult<RequestBuilder> {
+        let headers = self.auth_headers().await?;
+        Ok(request.headers(headers))
+    }
+
+    async fn send_value(&self, request: RequestBuilder) -> DeployResult<Value> {
+        let response = request.send().await?;
+        let status = response.status();
+        if let Some(declared) = response.content_length()
+            && declared > MAX_RESPONSE_BYTES as u64
+        {
+            return Err(DeployError::Client {
+                message: format!(
+                    "gcp deploy response Content-Length {declared} exceeds the {MAX_RESPONSE_BYTES}-byte limit",
+                ),
+            });
+        }
+        let body = response.bytes().await?;
+        if body.len() > MAX_RESPONSE_BYTES {
+            return Err(DeployError::Client {
+                message: format!(
+                    "gcp deploy response body of {} bytes exceeds the {MAX_RESPONSE_BYTES}-byte limit",
+                    body.len(),
+                ),
+            });
+        }
+        if !status.is_success() {
+            return Err(status_error(status, &String::from_utf8_lossy(&body)));
+        }
+        serde_json::from_slice(&body).map_err(|error| DeployError::Client {
+            message: format!("failed to parse gcp deploy response JSON: {error}"),
+        })
+    }
+}
+
+fn parse_operation(value: Value) -> DeployResult<Operation> {
+    let operation: Operation =
+        serde_json::from_value(value).map_err(|error| DeployError::Client {
+            message: format!("failed to parse reasoning engine operation: {error}"),
+        })?;
+    if operation.name.trim().is_empty() {
+        return Err(DeployError::Client {
+            message: "reasoning engine response did not contain an operation name".to_string(),
+        });
+    }
+    Ok(operation)
+}
+
+fn status_error(status: StatusCode, body: &str) -> DeployError {
+    let body = body.trim();
+    let body = if body.is_empty() { "<empty body>" } else { body };
+    // Keep upstream detail but bound it: error bodies can carry large
+    // debug payloads.
+    let snippet: String = body.chars().take(512).collect();
+    DeployError::Client {
+        message: format!("gcp deploy request failed with status {}: {snippet}", status.as_u16()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn class_methods_cover_the_wp1_contract_exactly_once() {
+        let methods = default_class_methods();
+        assert_eq!(methods.len(), 14);
+        let names: Vec<&str> =
+            methods.iter().map(|method| method["name"].as_str().unwrap()).collect();
+        for name in [
+            "create_session",
+            "async_stream_query",
+            "streaming_agent_run_with_events",
+            "register_operations",
+            "async_search_memory",
+        ] {
+            assert_eq!(names.iter().filter(|n| **n == name).count(), 1, "{name}");
+        }
+        // asyncQuery is deliberately absent (V12: cannot be added
+        // post-create; AdkApp parity excludes it).
+        assert!(!names.contains(&"async_query"));
+    }
+
+    // tokio::test: the google-cloud-auth credentials builder requires an
+    // ambient async runtime even for construction.
+    #[tokio::test]
+    async fn engine_names_resolve_ids_and_reject_foreign_names() {
+        let config = GcpDeployConfig::new("p", "l").with_endpoint("http://127.0.0.1:1");
+        let credentials =
+            google_cloud_auth::credentials::api_key_credentials::Builder::new("k").build();
+        let client = GcpDeployClient::with_credentials(config, credentials).unwrap();
+        assert_eq!(
+            client.engine_name("123").unwrap(),
+            "projects/p/locations/l/reasoningEngines/123",
+        );
+        assert_eq!(
+            client.engine_name("projects/p/locations/l/reasoningEngines/123").unwrap(),
+            "projects/p/locations/l/reasoningEngines/123",
+        );
+        assert!(client.engine_name("projects/other/locations/l/reasoningEngines/1").is_err());
+        assert!(client.engine_name("my-agent").is_err());
+    }
+}

--- a/adk-deploy/src/lib.rs
+++ b/adk-deploy/src/lib.rs
@@ -14,6 +14,8 @@ mod bundle;
 mod client;
 mod config;
 mod error;
+#[cfg(feature = "gcp")]
+pub mod gcp;
 mod manifest;
 mod models;
 

--- a/adk-deploy/tests/gcp_contract.rs
+++ b/adk-deploy/tests/gcp_contract.rs
@@ -1,0 +1,248 @@
+//! Contract tests for the Agent Engine deployment client.
+//!
+//! DTO golden tests pin the wire shapes against JSON transcribed from the
+//! v1beta1 REST reference; the mock-server tests exercise all four client
+//! operations end-to-end.
+
+#![cfg(feature = "gcp")]
+
+use adk_deploy::gcp::{
+    CreateReasoningEngineRequest, DeploymentSpec, EnvVar, GcpDeployClient, GcpDeployConfig,
+    SecretEnvVar, SecretRef, default_class_methods, gcloud_build_submit_command,
+};
+use axum::extract::State;
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use google_cloud_auth::credentials::api_key_credentials;
+use serde_json::{Value, json};
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+const PROJECT: &str = "test-project";
+const LOCATION: &str = "us-central1";
+
+fn operation_name() -> String {
+    format!("projects/{PROJECT}/locations/{LOCATION}/operations/9001")
+}
+
+fn engine_name() -> String {
+    format!("projects/{PROJECT}/locations/{LOCATION}/reasoningEngines/4242")
+}
+
+// ── DTO golden tests (shapes from the v1beta1 REST reference) ─────────────
+
+/// The full BYOC create body: every supported knob set once, serialized to
+/// exactly the reference shape. Field placement matters — env, scaling, and
+/// resource limits live under `deploymentSpec`, not `containerSpec`.
+#[test]
+fn create_request_serializes_to_the_reference_shape() {
+    let request = CreateReasoningEngineRequest::byoc(
+        "my-agent",
+        "us-central1-docker.pkg.dev/test-project/agents/my-agent:latest",
+    )
+    .with_service_account("agent-runner@test-project.iam.gserviceaccount.com")
+    .with_kms_key("projects/test-project/locations/us-central1/keyRings/kr/cryptoKeys/k")
+    .with_deployment_spec(DeploymentSpec {
+        env: vec![EnvVar { name: "LOG_LEVEL".to_string(), value: "info".to_string() }],
+        secret_env: vec![SecretEnvVar {
+            name: "GOOGLE_API_KEY".to_string(),
+            secret_ref: SecretRef {
+                secret: "google-api-key".to_string(),
+                version: Some("latest".to_string()),
+            },
+        }],
+        psc_interface_config: Some(json!({
+            "networkAttachment": "projects/test-project/regions/us-central1/networkAttachments/na"
+        })),
+        resource_limits: Some(BTreeMap::from([
+            ("cpu".to_string(), "4".to_string()),
+            ("memory".to_string(), "8Gi".to_string()),
+        ])),
+        min_instances: Some(1),
+        max_instances: Some(10),
+        container_concurrency: Some(9),
+    });
+
+    let expected = json!({
+        "displayName": "my-agent",
+        "spec": {
+            "containerSpec": {
+                "imageUri": "us-central1-docker.pkg.dev/test-project/agents/my-agent:latest",
+            },
+            "deploymentSpec": {
+                "env": [ { "name": "LOG_LEVEL", "value": "info" } ],
+                "secretEnv": [
+                    {
+                        "name": "GOOGLE_API_KEY",
+                        "secretRef": { "secret": "google-api-key", "version": "latest" },
+                    }
+                ],
+                "pscInterfaceConfig": {
+                    "networkAttachment": "projects/test-project/regions/us-central1/networkAttachments/na",
+                },
+                "resourceLimits": { "cpu": "4", "memory": "8Gi" },
+                "minInstances": 1,
+                "maxInstances": 10,
+                "containerConcurrency": 9,
+            },
+            "classMethods": default_class_methods(),
+            "agentFramework": "google-adk",
+            "serviceAccount": "agent-runner@test-project.iam.gserviceaccount.com",
+        },
+        "encryptionSpec": {
+            "kmsKeyName": "projects/test-project/locations/us-central1/keyRings/kr/cryptoKeys/k",
+        },
+    });
+    assert_eq!(serde_json::to_value(&request).unwrap(), expected);
+}
+
+/// The minimal BYOC body: no optional field leaks into the JSON.
+#[test]
+fn minimal_create_request_omits_every_optional_field() {
+    let request = CreateReasoningEngineRequest::byoc("my-agent", "gcr.io/p/agent:latest");
+    let value = serde_json::to_value(&request).unwrap();
+    assert_eq!(
+        value,
+        json!({
+            "displayName": "my-agent",
+            "spec": {
+                "containerSpec": { "imageUri": "gcr.io/p/agent:latest" },
+                "classMethods": default_class_methods(),
+                "agentFramework": "google-adk",
+            },
+        }),
+    );
+}
+
+#[test]
+fn build_command_is_the_documented_gcloud_invocation() {
+    assert_eq!(
+        gcloud_build_submit_command("us-central1-docker.pkg.dev/p/agents/a:latest"),
+        "gcloud builds submit --tag us-central1-docker.pkg.dev/p/agents/a:latest",
+    );
+}
+
+// ── Mock-server tests for the four operations ─────────────────────────────
+
+#[derive(Default)]
+struct MockState {
+    create_bodies: Vec<Value>,
+    polls: usize,
+    deleted: Vec<String>,
+}
+
+type SharedState = Arc<Mutex<MockState>>;
+
+async fn start_mock(state: SharedState) -> String {
+    let parent = format!("/v1beta1/projects/{PROJECT}/locations/{LOCATION}");
+    let app = Router::new()
+        .route(
+            &format!("{parent}/reasoningEngines"),
+            post(|State(state): State<SharedState>, Json(body): Json<Value>| async move {
+                state.lock().await.create_bodies.push(body);
+                Json(json!({ "name": operation_name(), "done": false }))
+            }),
+        )
+        .route(
+            &format!("{parent}/operations/{{op}}"),
+            get(|State(state): State<SharedState>| async move {
+                state.lock().await.polls += 1;
+                Json(json!({
+                    "name": operation_name(),
+                    "done": true,
+                    "response": {
+                        "@type": "type.googleapis.com/google.cloud.aiplatform.v1beta1.ReasoningEngine",
+                        "name": engine_name(),
+                        "displayName": "my-agent",
+                    },
+                }))
+            }),
+        )
+        .route(
+            &format!("{parent}/reasoningEngines/{{id}}"),
+            get(|| async move {
+                Json(json!({
+                    "name": engine_name(),
+                    "displayName": "my-agent",
+                    "createTime": "2025-03-01T00:00:00Z",
+                }))
+            })
+            .delete(
+                |State(state): State<SharedState>,
+                 axum::extract::Path(id): axum::extract::Path<String>| async move {
+                    state.lock().await.deleted.push(id);
+                    Json(json!({ "name": operation_name(), "done": true }))
+                },
+            ),
+        )
+        .with_state(state);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("http://{address}")
+}
+
+async fn build_client(endpoint: &str) -> GcpDeployClient {
+    let config = GcpDeployConfig::new(PROJECT, LOCATION).with_endpoint(endpoint);
+    let credentials = api_key_credentials::Builder::new("test-api-key").build();
+    GcpDeployClient::with_credentials(config, credentials).expect("build test client")
+}
+
+#[tokio::test]
+async fn create_posts_the_byoc_body_and_wait_polls_to_completion() {
+    let state = SharedState::default();
+    let endpoint = start_mock(state.clone()).await;
+    let client = build_client(&endpoint).await;
+
+    let request = CreateReasoningEngineRequest::byoc("my-agent", "gcr.io/p/agent:latest");
+    let operation = client.create_reasoning_engine(&request).await.unwrap();
+    assert!(!operation.done);
+
+    let response = client.wait_for_operation(operation).await.unwrap().unwrap();
+    assert_eq!(response["name"], engine_name());
+
+    let captured = state.lock().await;
+    assert_eq!(captured.create_bodies.len(), 1);
+    assert_eq!(captured.create_bodies[0], serde_json::to_value(&request).unwrap());
+    assert_eq!(captured.polls, 1);
+}
+
+#[tokio::test]
+async fn get_resolves_numeric_ids() {
+    let state = SharedState::default();
+    let endpoint = start_mock(state.clone()).await;
+    let client = build_client(&endpoint).await;
+
+    let engine = client.get_reasoning_engine("4242").await.unwrap();
+    assert_eq!(engine.name, engine_name());
+    assert_eq!(engine.display_name, "my-agent");
+    assert_eq!(engine.create_time.as_deref(), Some("2025-03-01T00:00:00Z"));
+}
+
+#[tokio::test]
+async fn delete_accepts_full_resource_names() {
+    let state = SharedState::default();
+    let endpoint = start_mock(state.clone()).await;
+    let client = build_client(&endpoint).await;
+
+    let operation = client.delete_reasoning_engine(&engine_name()).await.unwrap();
+    assert!(operation.done);
+    assert_eq!(state.lock().await.deleted, ["4242"]);
+}
+
+#[tokio::test]
+async fn foreign_operations_are_refused() {
+    let state = SharedState::default();
+    let endpoint = start_mock(state.clone()).await;
+    let client = build_client(&endpoint).await;
+
+    let error = client
+        .poll_operation("projects/other-project/locations/us-central1/operations/1")
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("does not belong"), "{error}");
+}

--- a/adk-rust/Cargo.toml
+++ b/adk-rust/Cargo.toml
@@ -79,21 +79,15 @@ full = [
 # Growth rule: every PR that introduces a Vertex/EAP feature flag appends it
 # here (or to `gemini-agent-platform-full` if it pulls in a realtime transport).
 gemini-agent-platform = [
-    # existing integrations (Wave 0 initial content)
     "gemini-vertex",  # Vertex model backend (adk-model → adk-gemini/vertex)
     "vertex-session", # managed Sessions (adk-session)
     "gcp-secrets",    # GCP Secret Manager (adk-auth)
     "gcs-artifacts",  # GCS artifact backend (adk-artifact)
     "gcp-telemetry",  # Cloud Trace/Logging transport (adk-telemetry)
     "agent-engine",   # class-method runtime contract + turnkey entrypoint (adk-server)
+    "vertex-memory",  # Memory Bank (adk-memory)
     "example-store",  # Example Store few-shot retrieval (adk-tool)
     # target end-state — appended by the PR that introduces each flag:
-    # "vertex-memory",          Memory Bank (adk-memory)
-    "vertex-memory",  # Memory Bank (adk-memory)
-    # target end-state — appended by the PR that introduces each flag:
-    # "example-store",          Example Store (adk-tool)
-    # "gcp-telemetry",          Cloud Trace/Logging transport (adk-telemetry)
-    # "gcs-artifacts",          GCS artifact backend (adk-artifact)
     # "vertex-sandbox",         managed code-execution sandbox (adk-code)
     # "vertex-eval",            Gen AI Evaluation bridge (adk-eval)
     # "vertex-rag",             RAG Engine retrieval (adk-rag)
@@ -216,6 +210,10 @@ agent-registry = ["server", "adk-server/agent-registry"]
 agent-engine = ["server", "adk-server/agent-engine"]
 # Vertex AI Example Store client and few-shot retrieval provider (forwarded to adk-tool)
 example-store = ["tools", "adk-tool/example-store"]
+# Agent Engine (ReasoningEngine) deployment client — host-side tooling, so
+# deliberately NOT part of gemini-agent-platform (the agent container never
+# deploys itself)
+gcp-deploy = ["dep:adk-deploy", "adk-deploy/gcp"]
 # MCP sampling callback support (forwarded to adk-tool)
 mcp = ["tools", "adk-tool/mcp"]
 mcp-http = ["mcp", "adk-tool/http-transport"]
@@ -315,6 +313,7 @@ adk-memory = { workspace = true, optional = true }
 adk-runner = { workspace = true, optional = true }
 adk-server = { workspace = true, optional = true }
 adk-telemetry = { workspace = true, optional = true }
+adk-deploy = { workspace = true, optional = true }
 adk-cli = { workspace = true, optional = true }
 adk-graph = { workspace = true, optional = true }
 adk-code = { workspace = true, optional = true }

--- a/adk-rust/src/lib.rs
+++ b/adk-rust/src/lib.rs
@@ -443,6 +443,7 @@
 //! | `example-store` | Vertex AI Example Store client + few-shot retrieval provider | (opt-in, any preset) |
 //! | `gemini-agent-platform` | Gemini Enterprise Agent Platform integrations (Vertex model backend, managed Sessions, GCP Secret Manager, GCS artifacts, Cloud telemetry, Agent Engine runtime contract, Example Store); excludes realtime transports and host-side deploy tooling | (opt-in, any preset) |
 //! | `vertex-memory` | Vertex AI Memory Bank backend for adk-memory | (opt-in, any preset) |
+//! | `gcp-deploy` | Agent Engine deployment client (host-side; not part of `gemini-agent-platform`) | (opt-in, any preset) |
 //! | `gemini-agent-platform` | Gemini Enterprise Agent Platform integrations (Vertex model backend, managed Sessions, GCP Secret Manager, GCS artifacts, Cloud telemetry, Agent Engine runtime contract, Memory Bank); excludes realtime transports and host-side deploy tooling | (opt-in, any preset) |
 //! | `gemini-agent-platform-full` | `gemini-agent-platform` + Vertex AI Live API (realtime stack) | (opt-in, any preset) |
 //!
@@ -645,6 +646,18 @@ pub mod server {
 #[cfg_attr(docsrs, doc(cfg(feature = "telemetry")))]
 pub mod telemetry {
     pub use adk_telemetry::*;
+}
+
+/// Deployment tooling (Agent Engine BYOC deployment client).
+///
+/// Host-side utilities for deploying agents:
+/// - `deploy::gcp` — create, poll, get, and delete ReasoningEngines
+///
+/// Available with feature: `gcp-deploy`
+#[cfg(feature = "gcp-deploy")]
+#[cfg_attr(docsrs, doc(cfg(feature = "gcp-deploy")))]
+pub mod deploy {
+    pub use adk_deploy::*;
 }
 
 /// Graph-based workflow engine (LangGraph-inspired).


### PR DESCRIPTION
## What

The Agent Engine deployment client (`adk-deploy`, new feature `gcp`; umbrella feature `gcp-deploy`): a minimal ADC-authenticated REST client with exactly four operations against the v1beta1 `reasoningEngines` surface — `create_reasoning_engine(CreateReasoningEngineRequest) -> Operation`, `poll_operation` (plus a backoff-polling `wait_for_operation` convenience), `get_reasoning_engine`, `delete_reasoning_engine`.

- Typed camelCase wire DTOs: `containerSpec { imageUri, port? }`, `deploymentSpec` (env, secretEnv, resourceLimits, minInstances/maxInstances, containerConcurrency, PSC-I passthrough), `classMethods`, `agentFramework`, `serviceAccount`, CMEK `encryptionSpec`.
- `CreateReasoningEngineRequest::byoc(display_name, image_uri)` declares the full WP1 class-method contract (all 14 methods) and `agentFramework: "google-adk"` by default, with `with_service_account` / `with_kms_key` / `with_deployment_spec` builders.
- No image building — `gcloud_build_submit_command(image_uri)` renders the documented Cloud Build command.
- Umbrella forwarding `gcp-deploy = ["dep:adk-deploy", "adk-deploy/gcp"]` — host-side tooling, deliberately **not** part of `gemini-agent-platform` (the agent container never deploys itself). CI feature-coverage entry; docs rows; CHANGELOG.
- Rides along: tidies the `gemini-agent-platform` list in `adk-rust/Cargo.toml` (stale commented duplicates left by the PR 2.1/2.2 merge-conflict resolution).

## Why

Part of #438 (Wave 2, PR 2.5 — WP6.3, on the critical path). DTO shapes verified against the current v1beta1 REST reference rather than the plan's sketch — notably, env vars, scaling, and resource limits live under `spec.deploymentSpec` (not `containerSpec`), and `encryptionSpec` sits at the resource level. PR 2.6 builds the CLI subcommand on this client.

## How

- **asyncQuery (V12 applied):** `reasoningEngines:asyncQuery` is deliberately absent from `default_class_methods` — the capability cannot be added post-create and adk-python's `AdkApp` does not register it; strict parity excludes it. Documented in module rustdoc and pinned by a test.
- **Copied ADC plumbing (deliberate debt):** the credential caching and LRO polling are the deploy-side copy of the adk-session pattern, with a comment naming Wave 3 (PR 3.5, `adk-gcp`) as the consolidation point. Errors use the crate's existing `DeployError`.
- **Deploy-scale polling:** engine creation takes minutes, so `wait_for_operation` keeps the copied backoff shape (100 ms initial) but with a 10 s delay cap and a 15-minute deadline, with operation-identity pinning.
- **Safety rails:** operation names and engine names are validated against the configured project/location; non-loopback endpoints must be HTTPS; responses are size-bounded; `pscInterfaceConfig` passes through as opaque JSON rather than guessing unverified field names.

**Tests** (`gcp_contract.rs` + unit tests, 18 passing):
- Golden DTO tests pin the full and minimal BYOC create bodies as whole JSON values against the REST reference shapes (field placement included).
- Mock-server tests cover all four operations: create posts the exact body and `wait_for_operation` polls to completion; get resolves numeric IDs to full names; delete accepts full resource names; foreign operation names are refused.
- Class-method contract test: every WP1 method exactly once, `async_query` absent.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings; `adk-deploy --features gcp`, `adk-rust --features gcp-deploy`, `adk-rust --features gemini-agent-platform`)
- [x] `devenv shell test` — all non-ignored tests pass (18 in adk-deploy with the feature; doctests; `RUSTDOCFLAGS="-D warnings"` doc build; `scripts/check-doc-examples.sh`)
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts
- [x] No unrelated changes mixed in (the meta-feature-list tidy-up is called out above)
- [x] Branch naming follows convention
- [x] Commit messages follow conventional format
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated (adk-deploy README gains the Agent Engine section; umbrella feature tables; AGENTS.md)
- [x] Examples — complete rustdoc + README examples; the CLI example surface lands with PR 2.6
