### PR TITLE
feat(anthropic): request betas and client auth options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **adk-anthropic request betas and client auth options**: `MessageCreateParams`
+  gains `betas` (`with_betas` / `with_beta`, mirroring `ModelListParams`) to
+  request additional `anthropic-beta` versions on Messages calls — sent via the
+  request header, never in the body, with feature-implied betas (structured
+  outputs, context management, fast mode) appended after the caller's. The
+  client builder gains `with_auth_token`, which replaces `x-api-key` with
+  `Authorization: Bearer …` for OAuth access tokens and bearer-authenticated
+  gateways, and `with_api_version` to select the `anthropic-version` header.
+  (#592)
+
 - **cargo-adk `docker` addon** (`cargo adk new my-agent --addon docker`): emits a
   multi-stage `Dockerfile` (`rust:1.95-slim` build stage kept in lockstep with
   `rust-toolchain.toml`, `gcr.io/distroless/cc-debian12` runtime, `ENV PORT=8080`,

--- a/adk-anthropic/src/client.rs
+++ b/adk-anthropic/src/client.rs
@@ -301,6 +301,49 @@ impl Anthropic {
         self.with_base_url(base_url)?.with_timeout(timeout)
     }
 
+    /// Use bearer-token authentication for this client.
+    ///
+    /// Replaces the `x-api-key` header with `Authorization: Bearer <token>` on
+    /// every request. Useful for OAuth access tokens and gateways that
+    /// authenticate Anthropic-shaped requests with a bearer credential.
+    ///
+    /// # Errors
+    ///
+    /// Returns a validation error when the token is not a valid header value.
+    pub fn with_auth_token(mut self, auth_token: String) -> Result<Self> {
+        let mut headers = (*self.cached_headers).clone();
+        headers.remove("x-api-key");
+        let value = HeaderValue::from_str(&format!("Bearer {auth_token}")).map_err(|e| {
+            Error::validation(
+                format!("Invalid auth token format: {e}"),
+                Some("auth_token".to_string()),
+            )
+        })?;
+        headers.insert(header::AUTHORIZATION, value);
+        self.cached_headers = Arc::new(headers);
+        Ok(self)
+    }
+
+    /// Set the `anthropic-version` header for this client.
+    ///
+    /// Defaults to `2023-06-01`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a validation error when the version is not a valid header value.
+    pub fn with_api_version(mut self, api_version: String) -> Result<Self> {
+        let mut headers = (*self.cached_headers).clone();
+        let value = HeaderValue::from_str(&api_version).map_err(|e| {
+            Error::validation(
+                format!("Invalid API version format: {e}"),
+                Some("api_version".to_string()),
+            )
+        })?;
+        headers.insert("anthropic-version", value);
+        self.cached_headers = Arc::new(headers);
+        Ok(self)
+    }
+
     /// Build default headers for API requests (static method for initialization).
     fn build_default_headers(api_key: &str) -> Result<HeaderMap> {
         let mut headers = HeaderMap::new();
@@ -552,9 +595,27 @@ impl Anthropic {
         // Build headers
         let mut headers = self.default_headers();
 
+        // When the caller supplied betas, seed the anthropic-beta header with them
+        if let Some(betas) = params.betas.as_ref().filter(|betas| !betas.is_empty())
+            && let Ok(value) = HeaderValue::from_str(&betas.join(","))
+        {
+            headers.insert("anthropic-beta", value);
+        }
+
         // Check if structured outputs beta header is needed
         if params.requires_structured_outputs_beta() {
-            headers.insert("anthropic-beta", HeaderValue::from_static(STRUCTURED_OUTPUTS_BETA));
+            let existing =
+                headers.get("anthropic-beta").and_then(|v| v.to_str().ok()).unwrap_or("");
+            let new_val = if existing.is_empty() {
+                STRUCTURED_OUTPUTS_BETA.to_string()
+            } else {
+                format!("{existing},{STRUCTURED_OUTPUTS_BETA}")
+            };
+            headers.insert(
+                "anthropic-beta",
+                HeaderValue::from_str(&new_val)
+                    .unwrap_or_else(|_| HeaderValue::from_static(STRUCTURED_OUTPUTS_BETA)),
+            );
         }
 
         // When context_management is set, add the beta header
@@ -654,6 +715,9 @@ impl Anthropic {
         // Check if fast-mode beta header is needed
         let needs_fast_mode = params.speed.is_some();
 
+        // Caller-supplied betas lead the anthropic-beta header
+        let caller_betas = params.betas.clone().unwrap_or_default();
+
         let response = self
             .retry_with_backoff(|| async {
                 let url = self.build_url("messages");
@@ -662,7 +726,7 @@ impl Anthropic {
                 headers.insert(header::ACCEPT, HeaderValue::from_static("text/event-stream"));
 
                 // Build anthropic-beta header combining all needed betas
-                let mut betas = Vec::new();
+                let mut betas: Vec<&str> = caller_betas.iter().map(String::as_str).collect();
                 if needs_beta {
                     betas.push(STRUCTURED_OUTPUTS_BETA);
                 }
@@ -1694,5 +1758,28 @@ mod tests {
 
         // Verify all operations executed
         assert_eq!(attempt_counter.load(Ordering::SeqCst), 3);
+    }
+
+    #[test]
+    fn with_auth_token_replaces_api_key_auth() {
+        let client = Anthropic::new(Some("test_key".to_string()))
+            .unwrap()
+            .with_auth_token("oauth-access-token".to_string())
+            .unwrap();
+
+        let headers = client.default_headers();
+        assert!(!headers.contains_key("x-api-key"));
+        assert_eq!(headers.get(header::AUTHORIZATION).unwrap(), "Bearer oauth-access-token");
+        assert!(headers.contains_key("anthropic-version"));
+    }
+
+    #[test]
+    fn with_api_version_overrides_default() {
+        let client = Anthropic::new(Some("test_key".to_string()))
+            .unwrap()
+            .with_api_version("2024-10-22".to_string())
+            .unwrap();
+
+        assert_eq!(client.default_headers().get("anthropic-version").unwrap(), "2024-10-22");
     }
 }

--- a/adk-anthropic/src/types/message_create_params.rs
+++ b/adk-anthropic/src/types/message_create_params.rs
@@ -135,6 +135,14 @@ pub struct MessageCreateParams {
     /// Opt into programmatic tool calling flow.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_runner: Option<bool>,
+
+    /// Optional header to specify the beta version(s) you want to use.
+    ///
+    /// Sent via the `anthropic-beta` request header, never in the request body.
+    /// Beta versions implied by param-gated features (structured outputs,
+    /// context management, fast mode) are appended after these.
+    #[serde(skip)]
+    pub betas: Option<Vec<String>>,
 }
 
 impl MessageCreateParams {
@@ -188,6 +196,7 @@ impl MessageCreateParams {
             citations: None,
             skills: None,
             tool_runner: None,
+            betas: None,
         }
     }
 
@@ -220,6 +229,7 @@ impl MessageCreateParams {
             citations: None,
             skills: None,
             tool_runner: None,
+            betas: None,
         }
     }
 
@@ -322,6 +332,21 @@ impl MessageCreateParams {
     /// Sets the streaming option.
     pub fn with_stream(mut self, stream: bool) -> Self {
         self.stream = stream;
+        self
+    }
+
+    /// Set the beta versions to use for this request.
+    pub fn with_betas(mut self, betas: Vec<String>) -> Self {
+        self.betas = Some(betas);
+        self
+    }
+
+    /// Add a single beta version to use for this request.
+    pub fn with_beta(mut self, beta: String) -> Self {
+        match &mut self.betas {
+            Some(betas) => betas.push(beta),
+            None => self.betas = Some(vec![beta]),
+        }
         self
     }
 
@@ -600,6 +625,7 @@ impl Default for MessageCreateParams {
             citations: None,
             skills: None,
             tool_runner: None,
+            betas: None,
         }
     }
 }
@@ -823,5 +849,15 @@ mod tests {
             !params.requires_structured_outputs_beta(),
             "params without output_format or strict tools should not require structured outputs beta"
         );
+    }
+
+    #[test]
+    fn betas_not_serialized_into_body() {
+        let params = MessageCreateParams::simple("Hello", KnownModel::ClaudeSonnet46)
+            .with_beta("interleaved-thinking-2025-05-14".to_string());
+
+        let json = to_value(&params).unwrap();
+        assert!(json.get("betas").is_none());
+        assert!(json.get("anthropic-beta").is_none());
     }
 }


### PR DESCRIPTION
## What

Caller-controlled beta versions on Messages requests — `MessageCreateParams.betas` with `with_betas` / `with_beta` builders — plus two client builder options: `with_auth_token` (bearer authentication) and `with_api_version`.

Fixes #592

## Why

Three capabilities the current public surface can't express:

- **Bearer-token auth** — OAuth access tokens, and gateways that authenticate Anthropic-shaped requests with a bearer credential — needs `Authorization: Bearer …` *instead of* `x-api-key`.
- **Requesting documented beta versions** on Messages calls (e.g. `fine-grained-tool-streaming-2025-05-14`, `interleaved-thinking-2025-05-14`). `ModelListParams` already has a caller `betas` field; Messages has no equivalent.
- **`anthropic-version` selection**, currently a constant.

The design follows the crate's existing patterns rather than adding new request entry points: per-request variation lives on the params struct (as with the feature-implied betas today, and mirroring `ModelListParams.betas` for naming and builder shape), and client-level configuration lives on builder setters (as with `with_base_url` / `with_timeout`).

## How

- `MessageCreateParams.betas: Option<Vec<String>>`, `#[serde(skip)]` — sent via the `anthropic-beta` header, never serialized into the body. `with_betas` / `with_beta` builders mirror `ModelListParams`.
- `send()` / `stream()` seed the composed `anthropic-beta` header with the caller's betas; feature-implied betas (structured outputs, context management, fast mode) append after them. The structured-outputs block in `send()` now uses the same append idiom as its context-management and fast-mode siblings so a seeded value survives — byte-identical behavior when no caller betas are set.
- `Anthropic::with_auth_token(token)` — removes `x-api-key` from the cached headers and sets `Authorization: Bearer <token>`; `Anthropic::with_api_version(version)` — overrides the `anthropic-version` header. Both follow the `with_base_url` builder style (validation errors on invalid header values).
- Tests: betas never serialized into the request body; `with_auth_token` replaces key auth (no `x-api-key`, bearer present, version intact); `with_api_version` overrides the default.
- CHANGELOG entry under `[Unreleased]`.

## PR Checklist

### Quality Gates (all required)

- [x] `cargo fmt --all -- --check` — code is formatted (Edition 2024)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo nextest run --workspace` — all non-ignored tests pass
- [x] `cargo check --workspace` — fast workspace compilation check

(Ran via the manual commands from CONTRIBUTING.md rather than `devenv shell`.)

### Code Quality

- [x] New code has tests
- [x] Public APIs have rustdoc comments
- [x] No `println!`/`eprintln!` in library code
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts
- [x] No unrelated changes mixed in
- [x] Branch naming follows convention (`feat/anthropic-request-headers`)
- [x] Commit messages follow conventional format
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [ ] README updated if crate capabilities changed (not needed — method-level docs cover it)
