### PR TITLE
feat(anthropic): add server-side fallback models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **adk-anthropic server-side fallback models** (`MessageCreateParams.fallbacks`
+  with `FallbackModel` and a `with_fallbacks` builder): names alternate models
+  the server may substitute when the requested model is unavailable, serialized
+  as the wire's `fallbacks` array. When set, `send`/`stream` include the
+  `server-side-fallback-2026-07-01` beta in the composed `anthropic-beta`
+  header, following the existing param-gated beta pattern. (#593)
+
 - **cargo-adk `docker` addon** (`cargo adk new my-agent --addon docker`): emits a
   multi-stage `Dockerfile` (`rust:1.95-slim` build stage kept in lockstep with
   `rust-toolchain.toml`, `gcr.io/distroless/cc-debian12` runtime, `ENV PORT=8080`,

--- a/adk-anthropic/src/client.rs
+++ b/adk-anthropic/src/client.rs
@@ -589,6 +589,23 @@ impl Anthropic {
             );
         }
 
+        // When fallbacks is set, add the server-side fallback beta header
+        if params.fallbacks.is_some() {
+            let existing =
+                headers.get("anthropic-beta").and_then(|v| v.to_str().ok()).unwrap_or("");
+            let new_val = if existing.is_empty() {
+                "server-side-fallback-2026-07-01".to_string()
+            } else {
+                format!("{existing},server-side-fallback-2026-07-01")
+            };
+            headers.insert(
+                "anthropic-beta",
+                HeaderValue::from_str(&new_val).unwrap_or_else(|_| {
+                    HeaderValue::from_static("server-side-fallback-2026-07-01")
+                }),
+            );
+        }
+
         let result = self
             .retry_with_backoff(|| async {
                 let url = self.build_url("messages");
@@ -654,6 +671,9 @@ impl Anthropic {
         // Check if fast-mode beta header is needed
         let needs_fast_mode = params.speed.is_some();
 
+        // Check if server-side fallback beta header is needed
+        let needs_fallbacks = params.fallbacks.is_some();
+
         let response = self
             .retry_with_backoff(|| async {
                 let url = self.build_url("messages");
@@ -671,6 +691,9 @@ impl Anthropic {
                 }
                 if needs_fast_mode {
                     betas.push("fast-mode-2026-02-01");
+                }
+                if needs_fallbacks {
+                    betas.push("server-side-fallback-2026-07-01");
                 }
                 if !betas.is_empty() {
                     let beta_val = betas.join(",");

--- a/adk-anthropic/src/types/fallback_model.rs
+++ b/adk-anthropic/src/types/fallback_model.rs
@@ -1,0 +1,34 @@
+use serde::{Deserialize, Serialize};
+
+/// A fallback model the server may substitute when the requested model is
+/// unavailable. Requires beta header `server-side-fallback-2026-07-01`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FallbackModel {
+    /// The model to fall back to.
+    pub model: String,
+}
+
+impl FallbackModel {
+    /// Create a new fallback model entry.
+    pub fn new(model: impl Into<String>) -> Self {
+        Self { model: model.into() }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serialization() {
+        let fallback = FallbackModel::new("claude-sonnet-4-6");
+        assert_eq!(serde_json::to_string(&fallback).unwrap(), r#"{"model":"claude-sonnet-4-6"}"#);
+    }
+
+    #[test]
+    fn deserialization() {
+        let fallback: FallbackModel =
+            serde_json::from_str(r#"{"model":"claude-sonnet-4-6"}"#).unwrap();
+        assert_eq!(fallback, FallbackModel::new("claude-sonnet-4-6"));
+    }
+}

--- a/adk-anthropic/src/types/message_create_params.rs
+++ b/adk-anthropic/src/types/message_create_params.rs
@@ -1,9 +1,9 @@
 use serde::{Deserialize, Serialize};
 
 use crate::types::{
-    CacheControlEphemeral, CitationsConfig, ContextManagement, EffortLevel, MessageParam, Metadata,
-    Model, OutputConfig, OutputFormat, SkillRef, SpeedMode, SystemPrompt, TextBlock,
-    ThinkingConfig, ToolChoice, ToolUnionParam,
+    CacheControlEphemeral, CitationsConfig, ContextManagement, EffortLevel, FallbackModel,
+    MessageParam, Metadata, Model, OutputConfig, OutputFormat, SkillRef, SpeedMode, SystemPrompt,
+    TextBlock, ThinkingConfig, ToolChoice, ToolUnionParam,
 };
 
 /// Security limits for DoS prevention
@@ -107,6 +107,11 @@ pub struct MessageCreateParams {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub context_management: Option<ContextManagement>,
 
+    /// Fallback models the server may substitute when the requested model is unavailable.
+    /// Requires beta header `server-side-fallback-2026-07-01`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fallbacks: Option<Vec<FallbackModel>>,
+
     /// Geographic routing for data residency control (e.g. "US", "EU").
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inference_geo: Option<String>,
@@ -181,6 +186,7 @@ impl MessageCreateParams {
             output_config: None,
 
             context_management: None,
+            fallbacks: None,
             inference_geo: None,
             service_tier: None,
             container: None,
@@ -213,6 +219,7 @@ impl MessageCreateParams {
             output_config: None,
 
             context_management: None,
+            fallbacks: None,
             inference_geo: None,
             service_tier: None,
             container: None,
@@ -322,6 +329,12 @@ impl MessageCreateParams {
     /// Sets the streaming option.
     pub fn with_stream(mut self, stream: bool) -> Self {
         self.stream = stream;
+        self
+    }
+
+    /// Sets the fallback models for server-side fallback.
+    pub fn with_fallbacks(mut self, fallbacks: Vec<FallbackModel>) -> Self {
+        self.fallbacks = Some(fallbacks);
         self
     }
 
@@ -593,6 +606,7 @@ impl Default for MessageCreateParams {
             output_config: None,
 
             context_management: None,
+            fallbacks: None,
             inference_geo: None,
             service_tier: None,
             container: None,
@@ -823,5 +837,22 @@ mod tests {
             !params.requires_structured_outputs_beta(),
             "params without output_format or strict tools should not require structured outputs beta"
         );
+    }
+
+    #[test]
+    fn fallbacks_serialization() {
+        let params = MessageCreateParams::simple("Hello", KnownModel::ClaudeSonnet46)
+            .with_fallbacks(vec![FallbackModel::new("claude-sonnet-4-6")]);
+
+        let json = to_value(&params).unwrap();
+        assert_eq!(json["fallbacks"], json!([{ "model": "claude-sonnet-4-6" }]));
+    }
+
+    #[test]
+    fn fallbacks_omitted_when_unset() {
+        let params = MessageCreateParams::simple("Hello", KnownModel::ClaudeSonnet46);
+
+        let json = to_value(&params).unwrap();
+        assert!(json.get("fallbacks").is_none());
     }
 }

--- a/adk-anthropic/src/types/mod.rs
+++ b/adk-anthropic/src/types/mod.rs
@@ -20,6 +20,7 @@ mod content_block_stop_event;
 mod context;
 mod document_block;
 mod effort_level;
+mod fallback_model;
 mod file_object;
 mod file_source;
 mod image_block;
@@ -112,6 +113,7 @@ pub use context::{
 };
 pub use document_block::{DocumentBlock, DocumentSource};
 pub use effort_level::EffortLevel;
+pub use fallback_model::FallbackModel;
 pub use file_object::FileObject;
 pub use file_source::FileSource;
 pub use image_block::{ImageBlock, ImageSource};


### PR DESCRIPTION
## What

Adds server-side fallback model support to `adk-anthropic`: a `fallbacks` field on `MessageCreateParams` (new `FallbackModel` type, `with_fallbacks` builder), with the `server-side-fallback-2026-07-01` beta header included by `send`/`stream` when the field is set.

Fixes #593

## Why

Anthropic's server-side fallback feature lets a request name alternate models the server may substitute when the requested model is unavailable, with billing staying on the requested model. It requires the `fallbacks` request field plus a beta header; `MessageCreateParams` is fully typed, so this could not be expressed from outside the crate.

## How

Follows the crate's existing param-gated beta pattern (context management, fast mode) throughout:

- `types/fallback_model.rs`: `FallbackModel { model }` with serde round-trip tests, structured like the existing one-type-per-file modules.
- `MessageCreateParams.fallbacks: Option<Vec<FallbackModel>>` (`skip_serializing_if` when unset), documented in the same style as `context_management`; entries added to `new`, `new_streaming`, and `Default`; `with_fallbacks` builder alongside the others.
- `send()`: a fallbacks beta block mirroring the existing context-management/fast-mode blocks. `stream()`: a `needs_fallbacks` flag and beta push mirroring the existing ones.
- Tests: `FallbackModel` serde round-trip; params serialization emits `"fallbacks":[{"model":…}]` when set and omits the key when unset.
- CHANGELOG entry under `[Unreleased]`.

The response side needs no new surface — the concrete serving model already arrives in `message_start`'s message.

Note: filed alongside #592 (#594); the two touch adjacent lines in the beta composition and CHANGELOG — happy to rebase whichever lands second.

## PR Checklist

### Quality Gates (all required)

- [x] `cargo fmt --all -- --check` — code is formatted (Edition 2024)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo nextest run --workspace` — all non-ignored tests pass
- [x] `cargo check --workspace` — fast workspace compilation check

(Ran via the manual commands from CONTRIBUTING.md rather than `devenv shell`.)

### Code Quality

- [x] New code has tests (serde round-trips for the type and the params field)
- [x] Public APIs have rustdoc comments
- [x] No `println!`/`eprintln!` in library code
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts
- [x] No unrelated changes mixed in
- [x] Branch naming follows convention (`feat/anthropic-server-side-fallbacks`)
- [x] Commit messages follow conventional format
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [ ] README updated if crate capabilities changed (not needed — method-level docs cover it)
