### PR TITLE
feat(gcp): add adk-gcp shared ADC/LRO plumbing crate - PR 3.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,6 +236,10 @@ adk-gemini/      Dedicated Gemini client with GeminiBackend trait (Studio + Vert
                  streaming step events, and lifecycle (get/delete/cancel). The runtime
                  transport lives in adk-model (`gemini-interactions`): a `GeminiModel`
                  toggle that drives the standard LlmAgent/Runner through this endpoint.
+adk-gcp/         Shared Google Cloud REST plumbing for Vertex AI backends: ADC credential
+                 caching (GcpHttpClient), bounded HTTP transport, LRO polling (LroPoller),
+                 resource-name parsing (VertexResourceName), consumer-branded errors
+                 (GcpErrorContext). Wave 3 consolidation target for the ADC/LRO pattern.
 adk-anthropic/   Dedicated Anthropic API client: streaming, adaptive thinking, prompt caching,
                  citations, context management, fast mode, vision, PDF processing, pricing.
                  Supports Claude Opus 4.8, Opus 4.7, Sonnet 4.6, Haiku 4.5.
@@ -808,14 +812,14 @@ Always verify builds during publish — never use `--no-verify`. Verification en
 Crates must be published in dependency order. `cargo xtask publish` (via
 `./publish.sh`) computes the order from the workspace graph, so this list is
 documentation rather than configuration — `scripts/check-publish-order.sh` is the
-gate that keeps it satisfiable. The current 8 tiers over 42 publishable crates:
+gate that keeps it satisfiable. The current 8 tiers over 43 publishable crates:
 
 ```
 Tier 1: adk-core, adk-anthropic, adk-deploy, adk-enterprise, adk-rust-macros,
         adk-telemetry, awp-types
-Tier 2: adk-action, adk-artifact, adk-awp, adk-browser, adk-devtools, adk-gemini,
-        adk-guardrail, adk-memory, adk-mistralrs, adk-plugin, adk-sandbox,
-        adk-session
+Tier 2: adk-action, adk-artifact, adk-awp, adk-browser, adk-devtools, adk-gcp,
+        adk-gemini, adk-guardrail, adk-memory, adk-mistralrs, adk-plugin,
+        adk-sandbox, adk-session
 Tier 3: adk-code, adk-graph, adk-model, adk-rag, adk-realtime, adk-retry-reflect,
         adk-skill
 Tier 4: adk-agent, adk-audio, adk-runner, adk-tool

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`adk-gcp` crate**: shared Google Cloud REST plumbing for Vertex AI
+  backends — `GcpHttpClient` (ADC with cached auth headers per
+  `CacheableResource` semantics, redirect-disabled bounded transport,
+  HTTPS-or-loopback endpoint validation), `LroPoller` (long-running-operation
+  polling with capped backoff, operation identity pinning, and
+  project/location scope validation), `VertexResourceName`
+  (`projects/*/locations/*/reasoningEngines/*` parse/format), and
+  `GcpErrorContext` (consumer-branded errors across the `AdkError`
+  boundary). Purely additive: consolidates the pattern duplicated across
+  `adk-session`, `adk-memory`, `adk-tool`, `adk-deploy`, and `adk-artifact`;
+  call-site migrations follow in later PRs.
+
 - **CLI deploy subcommand** (`adk-cli`, feature `gcp-deploy`):
   `adk-rust deploy agent-engine --image-uri <uri> --project <p> --location <l>
   [--service-account <sa>] [--kms-key <key>] [--display-name <n>]` deploys a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,6 +509,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "adk-gcp"
+version = "2.0.0"
+dependencies = [
+ "adk-core",
+ "axum 0.8.9",
+ "google-cloud-auth 1.12.0",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "adk-gemini"
 version = "2.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     "adk-skill",
     "adk-rust",
     "adk-gemini",
+    "adk-gcp",
     "adk-code",
     "adk-devtools",
     "adk-sandbox",
@@ -181,6 +182,7 @@ adk-auth = { path = "adk-auth", version = "2.0.0" }
 adk-plugin = { path = "adk-plugin", version = "2.0.0" }
 adk-skill = { path = "adk-skill", version = "2.0.0" }
 adk-gemini = { path = "adk-gemini", version = "2.0.0" }
+adk-gcp = { path = "adk-gcp", version = "2.0.0" }
 adk-code = { path = "adk-code", version = "2.0.0" }
 adk-codeact-monty = { path = "adk-codeact-monty", version = "2.0.0" }
 adk-devtools = { path = "adk-devtools", version = "2.0.0" }

--- a/adk-gcp/Cargo.toml
+++ b/adk-gcp/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "adk-gcp"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Shared Google Cloud REST plumbing for Rust Agent Development Kit (ADK-Rust): ADC credential caching, bounded HTTP transport, and long-running-operation polling"
+repository = "https://github.com/zavora-ai/adk-rust"
+documentation = "https://docs.rs/adk-gcp"
+keywords = ["ai", "agent", "adk", "gcp", "vertex-ai"]
+
+[dependencies]
+adk-core.workspace = true
+google-cloud-auth = { version = "1.8", default-features = false, features = ["default-rustls-provider"] }
+reqwest.workspace = true
+serde = { workspace = true }
+serde_json.workspace = true
+tokio = { workspace = true, features = ["sync", "time"] }
+
+[dev-dependencies]
+axum = "0.8"
+tokio = { workspace = true, features = ["rt", "macros"] }

--- a/adk-gcp/README.md
+++ b/adk-gcp/README.md
@@ -1,0 +1,92 @@
+# adk-gcp
+
+Shared Google Cloud REST plumbing for [ADK-Rust](https://github.com/zavora-ai/adk-rust) Vertex AI backends: Application Default Credentials with cached auth headers, a bounded redirect-disabled HTTP transport, and long-running-operation polling.
+
+Every Vertex integration in the workspace — sessions, memory, example store, artifact storage, deployment — needs the same three pieces. This crate holds the single copy.
+
+## Components
+
+| Type | Purpose |
+|------|---------|
+| `GcpHttpClient` | ADC (or explicit) credentials with `CacheableResource` header caching, HTTPS-or-loopback endpoint validation, connect/request timeouts, bounded JSON response reads |
+| `LroPoller` | `google.longrunning.Operation` polling with capped exponential backoff, operation identity pinning, and project/location scope validation |
+| `VertexResourceName` | Parse and format `projects/*/locations/*/reasoningEngines/*` resource names |
+| `GcpErrorContext` | Consumer-branded error construction — component, code table, subject, provider — across the `adk_core::AdkError` boundary |
+
+## Error identity
+
+`AdkError` codes are `&'static str`, so each consuming crate declares its code table as a `const` and the shared plumbing stamps every failure with that identity. Errors produced through this crate are indistinguishable from the ones each backend previously built for itself — contract tests keep passing across the migration.
+
+```rust
+use adk_core::ErrorComponent;
+use adk_gcp::{GcpErrorCodes, GcpErrorContext, GcpHttpClient, LroPoller};
+use serde_json::json;
+
+const CODES: GcpErrorCodes = GcpErrorCodes {
+    invalid_input: "memory.vertex.invalid_input",
+    unauthorized: "memory.vertex.unauthorized",
+    forbidden: "memory.vertex.forbidden",
+    not_found: "memory.vertex.not_found",
+    rate_limited: "memory.vertex.rate_limited",
+    timeout: "memory.vertex.timeout",
+    unavailable: "memory.vertex.unavailable",
+    credentials_unavailable: "memory.vertex.credentials_unavailable",
+    invalid_response: "memory.vertex.invalid_response",
+    invalid_request: "memory.vertex.invalid_request",
+    upstream_error: "memory.vertex.upstream_error",
+    operation_failed: "memory.vertex.operation_failed",
+};
+
+async fn generate() -> adk_core::Result<()> {
+    let client = GcpHttpClient::builder(
+        GcpErrorContext::new(ErrorComponent::Memory, CODES, "vertex memory"),
+        "https://us-central1-aiplatform.googleapis.com",
+    )
+    .build()?;
+
+    let parent = "projects/my-project/locations/us-central1/reasoningEngines/4242";
+    let request = client
+        .request(reqwest::Method::POST, &format!("{parent}/memories:generate"))
+        .await?
+        .json(&json!({ "directContentsSource": { "events": [] } }));
+    let operation = client.send_value(request).await?;
+
+    LroPoller::new()
+        .wait_for_operation(
+            &client,
+            operation,
+            "memories generate",
+            false,
+            "my-project",
+            "us-central1",
+        )
+        .await?;
+    Ok(())
+}
+```
+
+## Configuration
+
+Defaults mirror the workspace's Vertex backends; every knob is a builder method for deployments that need different bounds (e.g. engine provisioning widens the LRO deadline to 900 s).
+
+| Knob | Default |
+|------|---------|
+| Connect timeout | 10 s |
+| Request timeout | 120 s |
+| Credential acquisition timeout | 30 s |
+| Max response bytes | 64 MiB |
+| API version | `v1beta1` |
+| OAuth scope | `https://www.googleapis.com/auth/cloud-platform` |
+| LRO deadline / initial delay / delay cap | 120 s / 100 ms / 2 s |
+
+## Security posture
+
+- Endpoints must be bare HTTPS origins (HTTP only to loopback hosts, for tests); userinfo, path, query, and fragment components are rejected.
+- Redirects are never followed.
+- Operation names are validated against the configured project and location, and polling refuses to follow a changed operation identity.
+- Responses are size-bounded at the `Content-Length` declaration and again while streaming.
+- Untrusted text is sanitized and truncated before entering error messages.
+
+## License
+
+Apache-2.0

--- a/adk-gcp/src/client.rs
+++ b/adk-gcp/src/client.rs
@@ -1,0 +1,527 @@
+//! Authenticated, bounded HTTP transport for Google Cloud REST APIs.
+
+use crate::error::{GcpErrorContext, truncate_for_error};
+use adk_core::Result;
+use google_cloud_auth::credentials::{self, CacheableResource, Credentials};
+use reqwest::header::HeaderMap;
+use reqwest::{Client, Method, RequestBuilder, StatusCode, Url};
+use serde_json::{Map, Value};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::RwLock;
+
+const CLOUD_PLATFORM_SCOPE: &str = "https://www.googleapis.com/auth/cloud-platform";
+const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+const DEFAULT_AUTH_TIMEOUT: Duration = Duration::from_secs(30);
+const DEFAULT_MAX_RESPONSE_BYTES: usize = 64 * 1024 * 1024;
+const DEFAULT_API_VERSION: &str = "v1beta1";
+
+/// Builder for [`GcpHttpClient`].
+///
+/// Defaults mirror the workspace's Vertex backends: 10 s connect timeout,
+/// 120 s request timeout, 30 s credential-acquisition timeout, 64 MiB
+/// response cap, API version `v1beta1`, and the `cloud-platform` OAuth scope.
+#[derive(Debug)]
+pub struct GcpHttpClientBuilder {
+    errors: GcpErrorContext,
+    endpoint: String,
+    api_version: String,
+    credentials: Option<Credentials>,
+    scopes: Vec<String>,
+    connect_timeout: Duration,
+    request_timeout: Duration,
+    auth_timeout: Duration,
+    max_response_bytes: usize,
+}
+
+impl GcpHttpClientBuilder {
+    /// Sets the API version segment prefixed to every request path.
+    #[must_use]
+    pub fn api_version(mut self, api_version: impl Into<String>) -> Self {
+        self.api_version = api_version.into();
+        self
+    }
+
+    /// Uses explicit credentials instead of Application Default Credentials.
+    #[must_use]
+    pub fn credentials(mut self, credentials: Credentials) -> Self {
+        self.credentials = Some(credentials);
+        self
+    }
+
+    /// Overrides the OAuth scopes requested when building ADC.
+    ///
+    /// Ignored when explicit [`credentials`](Self::credentials) are set.
+    #[must_use]
+    pub fn scopes<I, S>(mut self, scopes: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.scopes = scopes.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Sets the TCP connect timeout.
+    #[must_use]
+    pub fn connect_timeout(mut self, timeout: Duration) -> Self {
+        self.connect_timeout = timeout;
+        self
+    }
+
+    /// Sets the whole-request timeout, including body streaming.
+    #[must_use]
+    pub fn request_timeout(mut self, timeout: Duration) -> Self {
+        self.request_timeout = timeout;
+        self
+    }
+
+    /// Sets the credential-header acquisition timeout.
+    #[must_use]
+    pub fn auth_timeout(mut self, timeout: Duration) -> Self {
+        self.auth_timeout = timeout;
+        self
+    }
+
+    /// Sets the maximum accepted response size in bytes.
+    ///
+    /// Responses declaring or streaming more than this are rejected. The
+    /// caller is responsible for selecting a bound appropriate for the
+    /// deployment.
+    #[must_use]
+    pub fn max_response_bytes(mut self, max_response_bytes: usize) -> Self {
+        self.max_response_bytes = max_response_bytes;
+        self
+    }
+
+    /// Validates the endpoint, resolves credentials, and builds the client.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the endpoint is not a valid secure origin
+    /// (HTTPS, or HTTP to a loopback host, with no userinfo, path, query,
+    /// or fragment), ADC cannot be constructed, or the redirect-disabled
+    /// HTTP client cannot be built.
+    pub fn build(self) -> Result<GcpHttpClient> {
+        let errors = self.errors;
+        let base_url = validate_endpoint(&self.endpoint, &errors)?;
+
+        let credentials = match self.credentials {
+            Some(credentials) => credentials,
+            None => credentials::Builder::default().with_scopes(&self.scopes).build().map_err(
+                |error| {
+                    let error = truncate_for_error(&error.to_string());
+                    errors.unauthorized(format!(
+                        "failed to build {} ADC credentials: {error}",
+                        errors.subject(),
+                    ))
+                },
+            )?,
+        };
+
+        let http_client = Client::builder()
+            .connect_timeout(self.connect_timeout)
+            .timeout(self.request_timeout)
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .map_err(|error| {
+                let error = truncate_for_error(&error.without_url().to_string());
+                errors.invalid_response(format!(
+                    "failed to build bounded {} HTTP client: {error}",
+                    errors.subject(),
+                ))
+            })?;
+
+        Ok(GcpHttpClient {
+            http_client,
+            base_url,
+            api_version: self.api_version,
+            credentials,
+            auth_headers: Arc::new(RwLock::new(None)),
+            request_timeout: self.request_timeout,
+            auth_timeout: self.auth_timeout,
+            max_response_bytes: self.max_response_bytes,
+            errors,
+        })
+    }
+}
+
+/// Authenticated, bounded HTTP client for Google Cloud REST APIs.
+///
+/// Consolidates the pattern shared by every Vertex backend in the
+/// workspace: cached ADC auth headers (honoring `CacheableResource`
+/// semantics), a redirect-disabled `reqwest` client with connect and
+/// request timeouts, HTTPS-or-loopback endpoint validation, and bounded
+/// JSON response reads with typed, consumer-branded errors.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use adk_core::ErrorComponent;
+/// use adk_gcp::{GcpErrorCodes, GcpErrorContext, GcpHttpClient};
+/// use serde_json::json;
+///
+/// const CODES: GcpErrorCodes = GcpErrorCodes {
+///     invalid_input: "memory.vertex.invalid_input",
+///     unauthorized: "memory.vertex.unauthorized",
+///     forbidden: "memory.vertex.forbidden",
+///     not_found: "memory.vertex.not_found",
+///     rate_limited: "memory.vertex.rate_limited",
+///     timeout: "memory.vertex.timeout",
+///     unavailable: "memory.vertex.unavailable",
+///     credentials_unavailable: "memory.vertex.credentials_unavailable",
+///     invalid_response: "memory.vertex.invalid_response",
+///     invalid_request: "memory.vertex.invalid_request",
+///     upstream_error: "memory.vertex.upstream_error",
+///     operation_failed: "memory.vertex.operation_failed",
+/// };
+///
+/// # async fn call() -> adk_core::Result<()> {
+/// let client = GcpHttpClient::builder(
+///     GcpErrorContext::new(ErrorComponent::Memory, CODES, "vertex memory"),
+///     "https://us-central1-aiplatform.googleapis.com",
+/// )
+/// .build()?;
+///
+/// let request = client
+///     .request(reqwest::Method::POST, "projects/p/locations/l/reasoningEngines/1/memories:generate")
+///     .await?
+///     .json(&json!({ "scope": { "app_name": "app" } }));
+/// let operation = client.send_value(request).await?;
+/// # let _ = operation;
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug)]
+pub struct GcpHttpClient {
+    http_client: Client,
+    base_url: Url,
+    api_version: String,
+    credentials: Credentials,
+    auth_headers: Arc<RwLock<Option<HeaderMap>>>,
+    request_timeout: Duration,
+    auth_timeout: Duration,
+    max_response_bytes: usize,
+    errors: GcpErrorContext,
+}
+
+impl GcpHttpClient {
+    /// Starts building a client for the given error identity and endpoint.
+    pub fn builder(errors: GcpErrorContext, endpoint: impl Into<String>) -> GcpHttpClientBuilder {
+        GcpHttpClientBuilder {
+            errors,
+            endpoint: endpoint.into(),
+            api_version: DEFAULT_API_VERSION.to_string(),
+            credentials: None,
+            scopes: vec![CLOUD_PLATFORM_SCOPE.to_string()],
+            connect_timeout: DEFAULT_CONNECT_TIMEOUT,
+            request_timeout: DEFAULT_REQUEST_TIMEOUT,
+            auth_timeout: DEFAULT_AUTH_TIMEOUT,
+            max_response_bytes: DEFAULT_MAX_RESPONSE_BYTES,
+        }
+    }
+
+    /// The error identity this client stamps on failures.
+    pub fn errors(&self) -> &GcpErrorContext {
+        &self.errors
+    }
+
+    /// The configured maximum response size in bytes.
+    pub fn max_response_bytes(&self) -> usize {
+        self.max_response_bytes
+    }
+
+    /// Builds the absolute URL for an API path (version prefix applied).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the resulting URL cannot be constructed.
+    pub fn url(&self, path: &str) -> Result<Url> {
+        let mut url = self.base_url.clone();
+        url.set_path(&format!("/{}/{}", self.api_version, path.trim_start_matches('/')));
+        Ok(url)
+    }
+
+    /// Builds an authorized request for an API path.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when credential headers cannot be acquired within
+    /// the configured auth timeout.
+    pub async fn request(&self, method: Method, path: &str) -> Result<RequestBuilder> {
+        let url = self.url(path)?;
+        let request = self.http_client.request(method, url);
+        self.apply_auth(request).await
+    }
+
+    /// Applies cached credential headers to a request.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when credential headers cannot be acquired within
+    /// the configured auth timeout.
+    pub async fn apply_auth(&self, request: RequestBuilder) -> Result<RequestBuilder> {
+        let headers = self.auth_headers().await?;
+        Ok(request.headers(headers))
+    }
+
+    /// Acquires credential headers, serving cached headers on `NotModified`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when acquisition times out, the credential source
+    /// fails, or the source reports `NotModified` before any headers were
+    /// cached.
+    pub async fn auth_headers(&self) -> Result<HeaderMap> {
+        let cacheable_headers =
+            tokio::time::timeout(self.auth_timeout, self.credentials.headers(Default::default()))
+                .await
+                .map_err(|_| {
+                    self.errors.timeout(format!(
+                        "{} credential header acquisition timed out after {} seconds",
+                        self.errors.subject(),
+                        self.auth_timeout.as_secs_f64(),
+                    ))
+                })?
+                .map_err(|error| self.errors.credentials_error(&error))?;
+
+        match cacheable_headers {
+            CacheableResource::New { data, .. } => {
+                *self.auth_headers.write().await = Some(data.clone());
+                Ok(data)
+            }
+            CacheableResource::NotModified => {
+                self.auth_headers.read().await.clone().ok_or_else(|| {
+                    self.errors.unauthorized(
+                        "google cloud credentials returned NotModified before any cached auth headers were available",
+                    )
+                })
+            }
+        }
+    }
+
+    /// Sends a request and parses the response as JSON.
+    ///
+    /// Empty or whitespace-only success bodies parse as an empty object.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the request times out, transport fails, the
+    /// response exceeds the configured size bound, the status is not a
+    /// success, or the body is not valid JSON.
+    pub async fn send_value(&self, request: RequestBuilder) -> Result<Value> {
+        match self.send_value_internal(request, false).await? {
+            Some(value) => Ok(value),
+            None => Ok(Value::Object(Map::new())),
+        }
+    }
+
+    /// Sends a request, mapping `404 Not Found` to `Ok(None)`.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`send_value`](Self::send_value), except
+    /// a 404 status which becomes `Ok(None)`.
+    pub async fn send_value_allow_not_found(
+        &self,
+        request: RequestBuilder,
+    ) -> Result<Option<Value>> {
+        self.send_value_internal(request, true).await
+    }
+
+    async fn send_value_internal(
+        &self,
+        request: RequestBuilder,
+        allow_not_found: bool,
+    ) -> Result<Option<Value>> {
+        let (status, body) = tokio::time::timeout(self.request_timeout, async {
+            let mut response =
+                request.send().await.map_err(|error| self.errors.transport_error(error))?;
+            let status = response.status();
+            if let Some(declared) = response.content_length()
+                && declared > self.max_response_bytes as u64
+            {
+                return Err(self
+                    .errors
+                    .response_too_large(
+                        "response Content-Length",
+                        self.max_response_bytes,
+                        declared,
+                    )
+                    .with_upstream_status(status.as_u16()));
+            }
+            let capacity = response
+                .content_length()
+                .and_then(|length| usize::try_from(length).ok())
+                .unwrap_or_default();
+            let mut body = Vec::with_capacity(capacity);
+            while let Some(chunk) = response.chunk().await.map_err(|error| {
+                let timeout = error.is_timeout();
+                let detail = truncate_for_error(&error.without_url().to_string());
+                let error = if timeout {
+                    self.errors.timeout(format!(
+                        "{} response body timed out: {detail}",
+                        self.errors.subject(),
+                    ))
+                } else {
+                    self.errors.unavailable(format!(
+                        "failed to read {} response body: {detail}",
+                        self.errors.subject(),
+                    ))
+                };
+                error.with_upstream_status(status.as_u16())
+            })? {
+                let observed = body.len().checked_add(chunk.len()).ok_or_else(|| {
+                    self.errors
+                        .response_too_large("response body", self.max_response_bytes, u64::MAX)
+                        .with_upstream_status(status.as_u16())
+                })?;
+                if observed > self.max_response_bytes {
+                    return Err(self
+                        .errors
+                        .response_too_large(
+                            "response body",
+                            self.max_response_bytes,
+                            observed as u64,
+                        )
+                        .with_upstream_status(status.as_u16()));
+                }
+                body.extend_from_slice(&chunk);
+            }
+            Ok::<_, adk_core::AdkError>((status, body))
+        })
+        .await
+        .map_err(|_| {
+            self.errors.timeout(format!(
+                "{} request timed out after {} seconds",
+                self.errors.subject(),
+                self.request_timeout.as_secs(),
+            ))
+        })??;
+
+        if allow_not_found && status == StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+
+        if !status.is_success() {
+            let body = String::from_utf8_lossy(&body);
+            let body = if body.trim().is_empty() { "<empty body>" } else { body.as_ref() };
+            return Err(self.errors.status_error(status, body));
+        }
+
+        if body.iter().all(u8::is_ascii_whitespace) {
+            return Ok(Some(Value::Object(Map::new())));
+        }
+
+        let value = serde_json::from_slice(&body).map_err(|error| {
+            let error = truncate_for_error(&error.to_string());
+            self.errors
+                .invalid_response(format!(
+                    "failed to parse {} response JSON: {error}",
+                    self.errors.subject(),
+                ))
+                .with_upstream_status(status.as_u16())
+        })?;
+        Ok(Some(value))
+    }
+}
+
+/// Validates an endpoint as a bare secure origin.
+///
+/// Requires HTTPS (or HTTP to a loopback host, for tests) and rejects
+/// userinfo, path, query, and fragment components, so credentialed traffic
+/// can never be redirected or downgraded by configuration.
+fn validate_endpoint(endpoint: &str, errors: &GcpErrorContext) -> Result<Url> {
+    let url = Url::parse(endpoint).map_err(|error| {
+        let error = truncate_for_error(&error.to_string());
+        errors.invalid_input(format!("invalid {} endpoint URL: {error}", errors.subject()))
+    })?;
+    if url.scheme() != "https" && !(url.scheme() == "http" && is_loopback_host(&url)) {
+        return Err(errors.invalid_input(format!(
+            "{} endpoint must use HTTPS for secure transmission",
+            errors.subject(),
+        )));
+    }
+    if !url.username().is_empty()
+        || url.password().is_some()
+        || url.query().is_some()
+        || url.fragment().is_some()
+        || url.path() != "/"
+    {
+        return Err(errors.invalid_input(format!(
+            "{} endpoint must be an origin without userinfo, path, query, or fragment",
+            errors.subject(),
+        )));
+    }
+    Ok(url)
+}
+
+fn is_loopback_host(url: &Url) -> bool {
+    matches!(url.host_str(), Some("localhost" | "127.0.0.1" | "::1"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::GcpErrorCodes;
+    use adk_core::{ErrorCategory, ErrorComponent};
+
+    const CODES: GcpErrorCodes = GcpErrorCodes {
+        invalid_input: "session.vertex.invalid_input",
+        unauthorized: "session.vertex.unauthorized",
+        forbidden: "session.vertex.forbidden",
+        not_found: "session.vertex.not_found",
+        rate_limited: "session.vertex.rate_limited",
+        timeout: "session.vertex.timeout",
+        unavailable: "session.vertex.unavailable",
+        credentials_unavailable: "session.vertex.credentials_unavailable",
+        invalid_response: "session.vertex.invalid_response",
+        invalid_request: "session.vertex.invalid_request",
+        upstream_error: "session.vertex.upstream_error",
+        operation_failed: "session.vertex.operation_failed",
+    };
+
+    fn errors() -> GcpErrorContext {
+        GcpErrorContext::new(ErrorComponent::Session, CODES, "vertex session")
+    }
+
+    #[test]
+    fn endpoint_validation_requires_secure_origins() {
+        assert!(
+            validate_endpoint("https://us-central1-aiplatform.googleapis.com", &errors()).is_ok()
+        );
+        assert!(validate_endpoint("http://127.0.0.1:8080", &errors()).is_ok());
+        assert!(validate_endpoint("http://localhost:8080", &errors()).is_ok());
+
+        let rejected = [
+            "http://example.com",
+            "ftp://example.com",
+            "https://user:pass@example.com",
+            "https://example.com/path",
+            "https://example.com?query=1",
+            "https://example.com#fragment",
+            "not a url",
+        ];
+        for endpoint in rejected {
+            let error = validate_endpoint(endpoint, &errors()).unwrap_err();
+            assert_eq!(error.category, ErrorCategory::InvalidInput, "accepted {endpoint:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn url_prefixes_the_api_version() {
+        let client = GcpHttpClient::builder(errors(), "https://example.googleapis.com")
+            .api_version("v1")
+            .credentials(
+                google_cloud_auth::credentials::api_key_credentials::Builder::new("k").build(),
+            )
+            .build()
+            .unwrap();
+        let url = client.url("projects/p/locations/l/reasoningEngines/1").unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://example.googleapis.com/v1/projects/p/locations/l/reasoningEngines/1",
+        );
+    }
+}

--- a/adk-gcp/src/error.rs
+++ b/adk-gcp/src/error.rs
@@ -1,0 +1,375 @@
+//! Consumer-branded error construction for Google Cloud REST clients.
+//!
+//! Every Vertex backend in the workspace stamps its own error identity —
+//! component, machine-readable code, and human-readable subject — onto the
+//! same transport failures. [`GcpErrorContext`] carries that identity so the
+//! shared client and poller produce errors indistinguishable from the ones
+//! each backend built for itself.
+
+use adk_core::{AdkError, ErrorCategory, ErrorComponent};
+use reqwest::StatusCode;
+
+/// The machine-readable error codes a consumer brands its errors with.
+///
+/// [`AdkError`] codes are `&'static str`, so each consuming crate declares
+/// its table as a `const` — one literal per failure class, following the
+/// workspace `<component>.<backend>.<failure>` convention.
+///
+/// # Example
+///
+/// ```rust
+/// use adk_gcp::GcpErrorCodes;
+///
+/// const CODES: GcpErrorCodes = GcpErrorCodes {
+///     invalid_input: "memory.vertex.invalid_input",
+///     unauthorized: "memory.vertex.unauthorized",
+///     forbidden: "memory.vertex.forbidden",
+///     not_found: "memory.vertex.not_found",
+///     rate_limited: "memory.vertex.rate_limited",
+///     timeout: "memory.vertex.timeout",
+///     unavailable: "memory.vertex.unavailable",
+///     credentials_unavailable: "memory.vertex.credentials_unavailable",
+///     invalid_response: "memory.vertex.invalid_response",
+///     invalid_request: "memory.vertex.invalid_request",
+///     upstream_error: "memory.vertex.upstream_error",
+///     operation_failed: "memory.vertex.operation_failed",
+/// };
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct GcpErrorCodes {
+    /// Caller-side input rejected before any request is sent.
+    pub invalid_input: &'static str,
+    /// Missing or invalid credentials (401 and non-transient credential failures).
+    pub unauthorized: &'static str,
+    /// Valid credentials but insufficient permissions (403).
+    pub forbidden: &'static str,
+    /// Requested resource does not exist (404).
+    pub not_found: &'static str,
+    /// Upstream rate limit hit (429).
+    pub rate_limited: &'static str,
+    /// Request, credential acquisition, or operation deadline exceeded.
+    pub timeout: &'static str,
+    /// Transport failures and upstream 5xx availability errors.
+    pub unavailable: &'static str,
+    /// Transient credential acquisition failures.
+    pub credentials_unavailable: &'static str,
+    /// Malformed, oversized, or unparsable upstream responses.
+    pub invalid_response: &'static str,
+    /// Upstream rejected the request as invalid (400, 409, 422).
+    pub invalid_request: &'static str,
+    /// Any other non-success upstream status.
+    pub upstream_error: &'static str,
+    /// A long-running operation completed with an error result.
+    pub operation_failed: &'static str,
+}
+
+/// Error identity for one consuming backend.
+///
+/// Bundles the [`ErrorComponent`], the code table, the human-readable
+/// subject used in messages (e.g. `"vertex memory"`), and the provider tag.
+///
+/// # Example
+///
+/// ```rust
+/// use adk_core::ErrorComponent;
+/// use adk_gcp::{GcpErrorCodes, GcpErrorContext};
+///
+/// const CODES: GcpErrorCodes = GcpErrorCodes {
+///     invalid_input: "memory.vertex.invalid_input",
+///     unauthorized: "memory.vertex.unauthorized",
+///     forbidden: "memory.vertex.forbidden",
+///     not_found: "memory.vertex.not_found",
+///     rate_limited: "memory.vertex.rate_limited",
+///     timeout: "memory.vertex.timeout",
+///     unavailable: "memory.vertex.unavailable",
+///     credentials_unavailable: "memory.vertex.credentials_unavailable",
+///     invalid_response: "memory.vertex.invalid_response",
+///     invalid_request: "memory.vertex.invalid_request",
+///     upstream_error: "memory.vertex.upstream_error",
+///     operation_failed: "memory.vertex.operation_failed",
+/// };
+///
+/// let errors = GcpErrorContext::new(ErrorComponent::Memory, CODES, "vertex memory");
+/// let error = errors.invalid_input("reasoning engine ID must be numeric");
+/// assert!(error.is_not_found() == false);
+/// ```
+#[derive(Debug, Clone)]
+pub struct GcpErrorContext {
+    component: ErrorComponent,
+    codes: GcpErrorCodes,
+    subject: String,
+    provider: String,
+}
+
+impl GcpErrorContext {
+    /// Creates an error context with the default `vertex_ai` provider tag.
+    pub fn new(
+        component: ErrorComponent,
+        codes: GcpErrorCodes,
+        subject: impl Into<String>,
+    ) -> Self {
+        Self { component, codes, subject: subject.into(), provider: "vertex_ai".to_string() }
+    }
+
+    /// Overrides the provider tag stamped on every error.
+    #[must_use]
+    pub fn with_provider(mut self, provider: impl Into<String>) -> Self {
+        self.provider = provider.into();
+        self
+    }
+
+    /// The human-readable subject used in error messages.
+    pub fn subject(&self) -> &str {
+        &self.subject
+    }
+
+    /// The component every error is attributed to.
+    pub fn component(&self) -> ErrorComponent {
+        self.component
+    }
+
+    /// The consumer's error code table.
+    pub fn codes(&self) -> &GcpErrorCodes {
+        &self.codes
+    }
+
+    /// Builds an error with an explicit category and code.
+    pub fn error(
+        &self,
+        category: ErrorCategory,
+        code: &'static str,
+        message: impl Into<String>,
+    ) -> AdkError {
+        AdkError::new(self.component, category, code, message).with_provider(self.provider.clone())
+    }
+
+    /// Caller-side input rejected before any request is sent.
+    pub fn invalid_input(&self, message: impl Into<String>) -> AdkError {
+        self.error(ErrorCategory::InvalidInput, self.codes.invalid_input, message)
+    }
+
+    /// Missing or invalid credentials.
+    pub fn unauthorized(&self, message: impl Into<String>) -> AdkError {
+        self.error(ErrorCategory::Unauthorized, self.codes.unauthorized, message)
+    }
+
+    /// A deadline was exceeded.
+    pub fn timeout(&self, message: impl Into<String>) -> AdkError {
+        self.error(ErrorCategory::Timeout, self.codes.timeout, message)
+    }
+
+    /// The upstream service is temporarily unavailable.
+    pub fn unavailable(&self, message: impl Into<String>) -> AdkError {
+        self.error(ErrorCategory::Unavailable, self.codes.unavailable, message)
+    }
+
+    /// A malformed, oversized, or unparsable upstream response.
+    pub fn invalid_response(&self, message: impl Into<String>) -> AdkError {
+        self.error(ErrorCategory::Internal, self.codes.invalid_response, message)
+    }
+
+    /// Classifies a credential acquisition failure as transient or terminal.
+    pub fn credentials_error(
+        &self,
+        error: &google_cloud_auth::errors::CredentialsError,
+    ) -> AdkError {
+        let message = format!(
+            "failed to obtain google cloud auth headers: {}",
+            truncate_for_error(&error.to_string()),
+        );
+        if error.is_transient() {
+            self.error(ErrorCategory::Unavailable, self.codes.credentials_unavailable, message)
+        } else {
+            self.unauthorized(message)
+        }
+    }
+
+    /// Classifies a request transport failure, distinguishing timeouts.
+    pub fn transport_error(&self, error: reqwest::Error) -> AdkError {
+        let timeout = error.is_timeout();
+        let detail = truncate_for_error(&error.without_url().to_string());
+        if timeout {
+            return self.timeout(format!("{} HTTP request timed out: {detail}", self.subject));
+        }
+        self.unavailable(format!("failed to send {} request: {detail}", self.subject))
+    }
+
+    /// Maps a non-success HTTP status and response body to a categorized error.
+    pub fn status_error(&self, status: StatusCode, body: &str) -> AdkError {
+        let message = format!(
+            "{} request failed with status {}: {}",
+            self.subject,
+            status.as_u16(),
+            truncate_for_error(body),
+        );
+        let (category, code) = match status.as_u16() {
+            400 | 409 | 422 => (ErrorCategory::InvalidInput, self.codes.invalid_request),
+            401 => (ErrorCategory::Unauthorized, self.codes.unauthorized),
+            403 => (ErrorCategory::Forbidden, self.codes.forbidden),
+            404 => (ErrorCategory::NotFound, self.codes.not_found),
+            408 | 504 => (ErrorCategory::Timeout, self.codes.timeout),
+            429 => (ErrorCategory::RateLimited, self.codes.rate_limited),
+            500 | 502 | 503 => (ErrorCategory::Unavailable, self.codes.unavailable),
+            _ => (ErrorCategory::Internal, self.codes.upstream_error),
+        };
+        self.error(category, code, message).with_upstream_status(status.as_u16())
+    }
+
+    /// Maps a completed operation's gRPC status code to a categorized error.
+    pub fn operation_error(
+        &self,
+        operation_kind: &str,
+        operation_name: &str,
+        code: i64,
+        message: &str,
+    ) -> AdkError {
+        let operation_name = truncate_for_error(operation_name);
+        let operation_message =
+            if message.trim().is_empty() { "<no error message>" } else { message };
+        let message = format!(
+            "{} {operation_kind} operation '{operation_name}' failed with code {code}: {}",
+            self.subject,
+            truncate_for_error(operation_message),
+        );
+        let category = match code {
+            1 => ErrorCategory::Cancelled,
+            3 | 6 | 9 | 11 => ErrorCategory::InvalidInput,
+            4 => ErrorCategory::Timeout,
+            5 => ErrorCategory::NotFound,
+            7 => ErrorCategory::Forbidden,
+            8 => ErrorCategory::RateLimited,
+            10 | 14 => ErrorCategory::Unavailable,
+            12 => ErrorCategory::Unsupported,
+            16 => ErrorCategory::Unauthorized,
+            _ => ErrorCategory::Internal,
+        };
+        self.error(category, self.codes.operation_failed, message)
+    }
+
+    /// An oversized response, reporting the observed size against the limit.
+    pub fn response_too_large(&self, context: &str, limit: usize, observed: u64) -> AdkError {
+        self.invalid_response(format!(
+            "{} {context} of at least {observed} bytes exceeds the {limit}-byte limit",
+            self.subject,
+        ))
+    }
+}
+
+/// Sanitizes and truncates untrusted text for inclusion in error messages.
+///
+/// Control characters are replaced with `U+FFFD` and the result is capped at
+/// 512 bytes (with a `...` suffix when truncated), so upstream response
+/// bodies can never flood logs or smuggle terminal escapes.
+pub fn truncate_for_error(value: &str) -> String {
+    const MAX_LEN: usize = 512;
+    let mut sanitized = String::with_capacity(value.len().min(MAX_LEN));
+    let mut truncated = false;
+    for character in value.chars() {
+        let character =
+            if character.is_control() { char::REPLACEMENT_CHARACTER } else { character };
+        if sanitized.len() + character.len_utf8() > MAX_LEN {
+            truncated = true;
+            break;
+        }
+        sanitized.push(character);
+    }
+    if truncated {
+        sanitized.push_str("...");
+    }
+    sanitized
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CODES: GcpErrorCodes = GcpErrorCodes {
+        invalid_input: "memory.vertex.invalid_input",
+        unauthorized: "memory.vertex.unauthorized",
+        forbidden: "memory.vertex.forbidden",
+        not_found: "memory.vertex.not_found",
+        rate_limited: "memory.vertex.rate_limited",
+        timeout: "memory.vertex.timeout",
+        unavailable: "memory.vertex.unavailable",
+        credentials_unavailable: "memory.vertex.credentials_unavailable",
+        invalid_response: "memory.vertex.invalid_response",
+        invalid_request: "memory.vertex.invalid_request",
+        upstream_error: "memory.vertex.upstream_error",
+        operation_failed: "memory.vertex.operation_failed",
+    };
+
+    fn context() -> GcpErrorContext {
+        GcpErrorContext::new(ErrorComponent::Memory, CODES, "vertex memory")
+    }
+
+    #[test]
+    fn status_errors_map_to_the_backend_categories_and_codes() {
+        let cases: &[(u16, ErrorCategory, &str)] = &[
+            (400, ErrorCategory::InvalidInput, "memory.vertex.invalid_request"),
+            (401, ErrorCategory::Unauthorized, "memory.vertex.unauthorized"),
+            (403, ErrorCategory::Forbidden, "memory.vertex.forbidden"),
+            (404, ErrorCategory::NotFound, "memory.vertex.not_found"),
+            (408, ErrorCategory::Timeout, "memory.vertex.timeout"),
+            (409, ErrorCategory::InvalidInput, "memory.vertex.invalid_request"),
+            (422, ErrorCategory::InvalidInput, "memory.vertex.invalid_request"),
+            (429, ErrorCategory::RateLimited, "memory.vertex.rate_limited"),
+            (500, ErrorCategory::Unavailable, "memory.vertex.unavailable"),
+            (502, ErrorCategory::Unavailable, "memory.vertex.unavailable"),
+            (503, ErrorCategory::Unavailable, "memory.vertex.unavailable"),
+            (504, ErrorCategory::Timeout, "memory.vertex.timeout"),
+            (418, ErrorCategory::Internal, "memory.vertex.upstream_error"),
+        ];
+        for (status, category, code) in cases {
+            let error =
+                context().status_error(StatusCode::from_u16(*status).unwrap(), "upstream detail");
+            assert_eq!(error.category, *category, "status {status}");
+            assert_eq!(error.code, *code, "status {status}");
+            assert_eq!(error.details.upstream_status_code, Some(*status));
+            assert_eq!(error.details.provider.as_deref(), Some("vertex_ai"));
+        }
+    }
+
+    #[test]
+    fn operation_errors_map_grpc_codes_to_categories() {
+        let cases: &[(i64, ErrorCategory)] = &[
+            (1, ErrorCategory::Cancelled),
+            (3, ErrorCategory::InvalidInput),
+            (4, ErrorCategory::Timeout),
+            (5, ErrorCategory::NotFound),
+            (7, ErrorCategory::Forbidden),
+            (8, ErrorCategory::RateLimited),
+            (10, ErrorCategory::Unavailable),
+            (12, ErrorCategory::Unsupported),
+            (13, ErrorCategory::Internal),
+            (14, ErrorCategory::Unavailable),
+            (16, ErrorCategory::Unauthorized),
+        ];
+        for (code, category) in cases {
+            let error = context().operation_error("generate", "projects/p/op", *code, "boom");
+            assert_eq!(error.category, *category, "grpc code {code}");
+            assert_eq!(error.code, "memory.vertex.operation_failed");
+        }
+    }
+
+    #[test]
+    fn operation_errors_substitute_a_placeholder_for_blank_messages() {
+        let error = context().operation_error("generate", "projects/p/op", 13, "  ");
+        assert!(error.message.contains("<no error message>"), "{}", error.message);
+    }
+
+    #[test]
+    fn truncate_replaces_control_characters_and_caps_length() {
+        assert_eq!(truncate_for_error("plain"), "plain");
+        assert_eq!(truncate_for_error("a\x1b[31mb\n"), "a\u{fffd}[31mb\u{fffd}");
+        let long = "x".repeat(1000);
+        let truncated = truncate_for_error(&long);
+        assert_eq!(truncated.len(), 515);
+        assert!(truncated.ends_with("..."));
+    }
+
+    #[test]
+    fn provider_override_is_stamped_on_errors() {
+        let error = context().with_provider("gcs").invalid_input("bad");
+        assert_eq!(error.details.provider.as_deref(), Some("gcs"));
+    }
+}

--- a/adk-gcp/src/lib.rs
+++ b/adk-gcp/src/lib.rs
@@ -1,0 +1,77 @@
+//! Shared Google Cloud REST plumbing for ADK-Rust Vertex AI backends.
+//!
+//! Every Vertex integration in the workspace — sessions, memory, example
+//! store, artifact storage, deployment — needs the same three pieces:
+//!
+//! - **[`GcpHttpClient`]** — Application Default Credentials with cached
+//!   auth headers, a redirect-disabled HTTP client with connect/request
+//!   timeouts, HTTPS-or-loopback endpoint validation, and bounded JSON
+//!   response reads.
+//! - **[`LroPoller`]** — `google.longrunning.Operation` polling with capped
+//!   exponential backoff, operation identity pinning, and project/location
+//!   scope validation.
+//! - **[`VertexResourceName`]** — parsing and formatting of
+//!   `projects/*/locations/*/reasoningEngines/*` resource names.
+//!
+//! Errors cross the [`adk_core::AdkError`] boundary carrying each
+//! consumer's own identity: a [`GcpErrorContext`] bundles the
+//! [`ErrorComponent`](adk_core::ErrorComponent), a
+//! [`GcpErrorCodes`] table of `&'static str` codes, the human-readable
+//! subject, and the provider tag, so errors from the shared plumbing are
+//! indistinguishable from the ones each backend previously built for
+//! itself.
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use adk_core::ErrorComponent;
+//! use adk_gcp::{GcpErrorCodes, GcpErrorContext, GcpHttpClient, LroPoller};
+//! use serde_json::json;
+//!
+//! const CODES: GcpErrorCodes = GcpErrorCodes {
+//!     invalid_input: "memory.vertex.invalid_input",
+//!     unauthorized: "memory.vertex.unauthorized",
+//!     forbidden: "memory.vertex.forbidden",
+//!     not_found: "memory.vertex.not_found",
+//!     rate_limited: "memory.vertex.rate_limited",
+//!     timeout: "memory.vertex.timeout",
+//!     unavailable: "memory.vertex.unavailable",
+//!     credentials_unavailable: "memory.vertex.credentials_unavailable",
+//!     invalid_response: "memory.vertex.invalid_response",
+//!     invalid_request: "memory.vertex.invalid_request",
+//!     upstream_error: "memory.vertex.upstream_error",
+//!     operation_failed: "memory.vertex.operation_failed",
+//! };
+//!
+//! # async fn generate() -> adk_core::Result<()> {
+//! let client = GcpHttpClient::builder(
+//!     GcpErrorContext::new(ErrorComponent::Memory, CODES, "vertex memory"),
+//!     "https://us-central1-aiplatform.googleapis.com",
+//! )
+//! .build()?;
+//!
+//! let parent = "projects/my-project/locations/us-central1/reasoningEngines/4242";
+//! let request = client
+//!     .request(reqwest::Method::POST, &format!("{parent}/memories:generate"))
+//!     .await?
+//!     .json(&json!({ "directContentsSource": { "events": [] } }));
+//! let operation = client.send_value(request).await?;
+//!
+//! LroPoller::new()
+//!     .wait_for_operation(&client, operation, "memories generate", false, "my-project", "us-central1")
+//!     .await?;
+//! # Ok(())
+//! # }
+//! ```
+
+#![warn(missing_docs)]
+
+mod client;
+mod error;
+mod lro;
+mod resource;
+
+pub use client::{GcpHttpClient, GcpHttpClientBuilder};
+pub use error::{GcpErrorCodes, GcpErrorContext, truncate_for_error};
+pub use lro::{LroPoller, Operation, OperationError};
+pub use resource::{VertexResourceName, is_canonical_reasoning_engine_id, is_scoped_resource_name};

--- a/adk-gcp/src/lro.rs
+++ b/adk-gcp/src/lro.rs
@@ -1,0 +1,241 @@
+//! Long-running-operation polling with identity pinning.
+
+use crate::client::GcpHttpClient;
+use crate::error::truncate_for_error;
+use crate::resource::is_scoped_resource_name;
+use adk_core::Result;
+use reqwest::Method;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::time::Duration;
+use tokio::time::Instant;
+
+const DEFAULT_POLL_TIMEOUT: Duration = Duration::from_secs(120);
+const DEFAULT_INITIAL_DELAY: Duration = Duration::from_millis(100);
+const DEFAULT_MAX_DELAY: Duration = Duration::from_secs(2);
+
+/// A `google.longrunning.Operation` wire value.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Operation {
+    /// The server-assigned operation resource name.
+    pub name: String,
+    /// Whether the operation has reached a terminal state.
+    #[serde(default)]
+    pub done: bool,
+    /// The error result, set only on failed terminal operations.
+    #[serde(default)]
+    pub error: Option<OperationError>,
+    /// The success result, set only on completed terminal operations.
+    #[serde(default)]
+    pub response: Option<Value>,
+}
+
+/// The `google.rpc.Status` error carried by a failed operation.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct OperationError {
+    /// The gRPC status code.
+    #[serde(default)]
+    pub code: i64,
+    /// The developer-facing error message.
+    #[serde(default)]
+    pub message: String,
+}
+
+/// Polls long-running operations to completion with capped backoff.
+///
+/// The poller pins the operation identity — a poll can never silently
+/// follow a different operation — and validates the operation name against
+/// the caller's project and location, so a compromised or buggy server
+/// cannot redirect polling elsewhere.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use adk_gcp::LroPoller;
+/// use std::time::Duration;
+///
+/// // Engine provisioning takes minutes; the deploy client widens the deadline.
+/// let poller = LroPoller::new()
+///     .with_poll_timeout(Duration::from_secs(900))
+///     .with_max_delay(Duration::from_secs(10));
+/// # let _ = poller;
+/// ```
+#[derive(Debug, Clone)]
+pub struct LroPoller {
+    poll_timeout: Duration,
+    initial_delay: Duration,
+    max_delay: Duration,
+}
+
+impl Default for LroPoller {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LroPoller {
+    /// Creates a poller with the workspace defaults: 120 s deadline,
+    /// 100 ms initial delay, 2 s delay cap.
+    pub fn new() -> Self {
+        Self {
+            poll_timeout: DEFAULT_POLL_TIMEOUT,
+            initial_delay: DEFAULT_INITIAL_DELAY,
+            max_delay: DEFAULT_MAX_DELAY,
+        }
+    }
+
+    /// Sets the overall completion deadline.
+    #[must_use]
+    pub fn with_poll_timeout(mut self, timeout: Duration) -> Self {
+        self.poll_timeout = timeout;
+        self
+    }
+
+    /// Sets the delay before the first poll.
+    #[must_use]
+    pub fn with_initial_delay(mut self, delay: Duration) -> Self {
+        self.initial_delay = delay;
+        self
+    }
+
+    /// Sets the backoff delay cap.
+    #[must_use]
+    pub fn with_max_delay(mut self, delay: Duration) -> Self {
+        self.max_delay = delay;
+        self
+    }
+
+    /// Polls the operation in `initial` to completion.
+    ///
+    /// `operation_kind` names the operation in error messages (e.g.
+    /// `"memories generate"`). When `require_response` is set, a completed
+    /// operation without a `response` payload is an error.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the initial value is not a valid operation,
+    /// the operation name is outside `project_id`/`location`, a poll
+    /// changes the operation identity, the operation completes with an
+    /// error result, or the deadline passes before completion.
+    pub async fn wait_for_operation(
+        &self,
+        client: &GcpHttpClient,
+        initial: Value,
+        operation_kind: &str,
+        require_response: bool,
+        project_id: &str,
+        location: &str,
+    ) -> Result<Option<Value>> {
+        let errors = client.errors();
+        let mut operation = parse_operation(client, initial, operation_kind)?;
+        if !is_scoped_resource_name(&operation.name, project_id, location) {
+            let name = truncate_for_error(&operation.name);
+            return Err(errors.invalid_response(format!(
+                "{} operation name '{name}' does not belong to projects/{project_id}/locations/{location}",
+                errors.subject(),
+            )));
+        }
+        let operation_name = operation.name.clone();
+        let deadline = Instant::now() + self.poll_timeout;
+        let mut delay = self.initial_delay;
+
+        loop {
+            if operation.done {
+                if let Some(error) = operation.error {
+                    return Err(errors.operation_error(
+                        operation_kind,
+                        &operation_name,
+                        error.code,
+                        &error.message,
+                    ));
+                }
+                if require_response && operation.response.is_none() {
+                    return Err(errors.invalid_response(format!(
+                        "{} {operation_kind} operation '{operation_name}' completed without a response; retry the request and inspect the operation in Google Cloud",
+                        errors.subject(),
+                    )));
+                }
+                return Ok(operation.response);
+            }
+            if Instant::now() >= deadline {
+                return Err(self.deadline_error(client, operation_kind, &operation_name));
+            }
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let poll = async {
+                let request = client.request(Method::GET, &operation_name).await?;
+                client.send_value(request).await
+            };
+            let value = tokio::time::timeout(remaining, poll)
+                .await
+                .map_err(|_| self.deadline_error(client, operation_kind, &operation_name))??;
+            let next = parse_operation(client, value, operation_kind)?;
+            if next.name != operation_name {
+                return Err(errors.invalid_response(format!(
+                    "{} {operation_kind} poll changed operation identity from '{operation_name}' to '{}'; refusing to follow a different operation",
+                    errors.subject(),
+                    truncate_for_error(&next.name),
+                )));
+            }
+            operation = next;
+            if !operation.done {
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                if remaining.is_zero() {
+                    continue;
+                }
+                tokio::time::sleep(delay.min(remaining)).await;
+                delay = delay.saturating_mul(2).min(self.max_delay);
+            }
+        }
+    }
+
+    fn deadline_error(
+        &self,
+        client: &GcpHttpClient,
+        operation_kind: &str,
+        operation_name: &str,
+    ) -> adk_core::AdkError {
+        let errors = client.errors();
+        errors.timeout(format!(
+            "{} {operation_kind} operation '{operation_name}' did not complete within {} seconds; inspect the operation in Google Cloud before retrying",
+            errors.subject(),
+            self.poll_timeout.as_secs_f64(),
+        ))
+    }
+}
+
+/// Parses an operation wire value, rejecting inconsistent shapes.
+fn parse_operation(
+    client: &GcpHttpClient,
+    value: Value,
+    operation_kind: &str,
+) -> Result<Operation> {
+    let errors = client.errors();
+    let operation: Operation = serde_json::from_value(value).map_err(|error| {
+        let error = truncate_for_error(&error.to_string());
+        errors.invalid_response(format!(
+            "failed to parse {} {operation_kind} operation: {error}",
+            errors.subject(),
+        ))
+    })?;
+    if operation.name.trim().is_empty() {
+        return Err(errors.invalid_response(format!(
+            "{} {operation_kind} response did not contain an operation name",
+            errors.subject(),
+        )));
+    }
+    if operation.error.is_some() && operation.response.is_some() {
+        return Err(errors.invalid_response(format!(
+            "{} {operation_kind} operation '{}' contains both error and response results",
+            errors.subject(),
+            truncate_for_error(&operation.name),
+        )));
+    }
+    if !operation.done && (operation.error.is_some() || operation.response.is_some()) {
+        return Err(errors.invalid_response(format!(
+            "{} {operation_kind} operation '{}' contains a terminal result while done is false",
+            errors.subject(),
+            truncate_for_error(&operation.name),
+        )));
+    }
+    Ok(operation)
+}

--- a/adk-gcp/src/resource.rs
+++ b/adk-gcp/src/resource.rs
@@ -1,0 +1,208 @@
+//! Vertex AI resource-name parsing, formatting, and scope validation.
+
+use std::fmt;
+
+/// A parsed `projects/*/locations/*/reasoningEngines/*` resource name.
+///
+/// # Example
+///
+/// ```rust
+/// use adk_gcp::VertexResourceName;
+///
+/// let name = VertexResourceName::new("my-project", "us-central1", "4242");
+/// assert_eq!(
+///     name.to_string(),
+///     "projects/my-project/locations/us-central1/reasoningEngines/4242",
+/// );
+///
+/// let parsed = VertexResourceName::parse(&name.to_string()).unwrap();
+/// assert_eq!(parsed, name);
+/// assert!(parsed.has_canonical_engine_id());
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct VertexResourceName {
+    project_id: String,
+    location: String,
+    engine_id: String,
+}
+
+impl VertexResourceName {
+    /// Creates a resource name from its parts.
+    pub fn new(
+        project_id: impl Into<String>,
+        location: impl Into<String>,
+        engine_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            project_id: project_id.into(),
+            location: location.into(),
+            engine_id: engine_id.into(),
+        }
+    }
+
+    /// Parses a full `projects/*/locations/*/reasoningEngines/*` name.
+    ///
+    /// Returns `None` when the shape does not match, any segment is empty,
+    /// or the name carries traversal or scheme characters (`..`, `://`).
+    pub fn parse(name: &str) -> Option<Self> {
+        if name.contains("://") || name.contains("..") {
+            return None;
+        }
+        let mut segments = name.split('/');
+        let (
+            Some("projects"),
+            Some(project_id),
+            Some("locations"),
+            Some(location),
+            Some("reasoningEngines"),
+            Some(engine_id),
+            None,
+        ) = (
+            segments.next(),
+            segments.next(),
+            segments.next(),
+            segments.next(),
+            segments.next(),
+            segments.next(),
+            segments.next(),
+        )
+        else {
+            return None;
+        };
+        if project_id.is_empty() || location.is_empty() || engine_id.is_empty() {
+            return None;
+        }
+        Some(Self::new(project_id, location, engine_id))
+    }
+
+    /// The project ID segment.
+    pub fn project_id(&self) -> &str {
+        &self.project_id
+    }
+
+    /// The location segment.
+    pub fn location(&self) -> &str {
+        &self.location
+    }
+
+    /// The reasoning-engine ID segment.
+    pub fn engine_id(&self) -> &str {
+        &self.engine_id
+    }
+
+    /// Whether the engine ID is the canonical numeric form.
+    pub fn has_canonical_engine_id(&self) -> bool {
+        is_canonical_reasoning_engine_id(&self.engine_id)
+    }
+
+    /// The parent `projects/*/locations/*` prefix.
+    pub fn parent(&self) -> String {
+        format!("projects/{}/locations/{}", self.project_id, self.location)
+    }
+}
+
+impl fmt::Display for VertexResourceName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "projects/{}/locations/{}/reasoningEngines/{}",
+            self.project_id, self.location, self.engine_id,
+        )
+    }
+}
+
+/// Whether `value` is a canonical numeric reasoning-engine ID.
+///
+/// Canonical IDs are all-ASCII digits without leading zeros (`"0"` itself
+/// is canonical), matching the form the Vertex AI API mints.
+///
+/// # Example
+///
+/// ```rust
+/// use adk_gcp::is_canonical_reasoning_engine_id;
+///
+/// assert!(is_canonical_reasoning_engine_id("4242"));
+/// assert!(is_canonical_reasoning_engine_id("0"));
+/// assert!(!is_canonical_reasoning_engine_id("042"));
+/// assert!(!is_canonical_reasoning_engine_id("my-engine"));
+/// ```
+pub fn is_canonical_reasoning_engine_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.bytes().all(|byte| byte.is_ascii_digit())
+        && (value == "0" || !value.starts_with('0'))
+}
+
+/// Whether `name` belongs to the given project and location scope.
+///
+/// Accepts names starting with `projects/{project_id}/locations/{location}/`
+/// that carry no traversal or scheme characters, so a compromised or buggy
+/// server cannot redirect follow-up requests (operation polls, deletes)
+/// outside the configured scope.
+pub fn is_scoped_resource_name(name: &str, project_id: &str, location: &str) -> bool {
+    let prefix = format!("projects/{project_id}/locations/{location}/");
+    name.starts_with(&prefix) && !name.contains("://") && !name.contains("..")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_and_format_round_trip() {
+        let text = "projects/my-project/locations/us-central1/reasoningEngines/4242";
+        let name = VertexResourceName::parse(text).unwrap();
+        assert_eq!(name, VertexResourceName::new("my-project", "us-central1", "4242"),);
+        assert_eq!(name.to_string(), text);
+        assert_eq!(name.parent(), "projects/my-project/locations/us-central1");
+    }
+
+    #[test]
+    fn parse_rejects_malformed_names() {
+        let rejected = [
+            "",
+            "projects/p/locations/l",
+            "projects/p/locations/l/reasoningEngines",
+            "projects/p/locations/l/reasoningEngines/",
+            "projects//locations/l/reasoningEngines/1",
+            "projects/p/locations//reasoningEngines/1",
+            "projects/p/locations/l/reasoningEngines/1/memories/2",
+            "projects/p/locations/l/somethingElse/1",
+            "https://evil.example/projects/p/locations/l/reasoningEngines/1",
+            "projects/p/locations/l/reasoningEngines/../1",
+        ];
+        for name in rejected {
+            assert!(VertexResourceName::parse(name).is_none(), "accepted {name:?}");
+        }
+    }
+
+    #[test]
+    fn canonical_engine_ids() {
+        assert!(is_canonical_reasoning_engine_id("1"));
+        assert!(is_canonical_reasoning_engine_id("0"));
+        assert!(is_canonical_reasoning_engine_id("123456789"));
+        assert!(!is_canonical_reasoning_engine_id(""));
+        assert!(!is_canonical_reasoning_engine_id("01"));
+        assert!(!is_canonical_reasoning_engine_id("12a"));
+        assert!(!is_canonical_reasoning_engine_id("-1"));
+    }
+
+    #[test]
+    fn scope_validation_pins_project_and_location() {
+        assert!(is_scoped_resource_name(
+            "projects/p/locations/l/reasoningEngines/1/operations/2",
+            "p",
+            "l",
+        ));
+        assert!(!is_scoped_resource_name(
+            "projects/other/locations/l/reasoningEngines/1/operations/2",
+            "p",
+            "l",
+        ));
+        assert!(!is_scoped_resource_name(
+            "projects/p/locations/l/../../other/operations/2",
+            "p",
+            "l",
+        ));
+        assert!(!is_scoped_resource_name("https://projects/p/locations/l/operations/2", "p", "l",));
+    }
+}

--- a/adk-gcp/tests/client_lro_contract.rs
+++ b/adk-gcp/tests/client_lro_contract.rs
@@ -1,0 +1,335 @@
+//! Contract tests for the shared GCP client and LRO poller against a mock
+//! server: auth headers are attached, LROs poll to completion with pinned
+//! identity, error results map to categories, and oversized or non-JSON
+//! responses are rejected.
+
+use adk_core::{ErrorCategory, ErrorComponent};
+use adk_gcp::{GcpErrorCodes, GcpErrorContext, GcpHttpClient, LroPoller};
+use axum::extract::State;
+use axum::http::HeaderMap;
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use google_cloud_auth::credentials::api_key_credentials;
+use reqwest::Method;
+use serde_json::{Value, json};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Mutex;
+
+const PROJECT: &str = "test-project";
+const LOCATION: &str = "us-central1";
+
+const CODES: GcpErrorCodes = GcpErrorCodes {
+    invalid_input: "memory.vertex.invalid_input",
+    unauthorized: "memory.vertex.unauthorized",
+    forbidden: "memory.vertex.forbidden",
+    not_found: "memory.vertex.not_found",
+    rate_limited: "memory.vertex.rate_limited",
+    timeout: "memory.vertex.timeout",
+    unavailable: "memory.vertex.unavailable",
+    credentials_unavailable: "memory.vertex.credentials_unavailable",
+    invalid_response: "memory.vertex.invalid_response",
+    invalid_request: "memory.vertex.invalid_request",
+    upstream_error: "memory.vertex.upstream_error",
+    operation_failed: "memory.vertex.operation_failed",
+};
+
+fn operation_name() -> String {
+    format!("projects/{PROJECT}/locations/{LOCATION}/reasoningEngines/4242/operations/777")
+}
+
+#[derive(Default)]
+struct MockState {
+    start_headers: Vec<HeaderMap>,
+    start_bodies: Vec<Value>,
+    polls: usize,
+    /// Queue of poll responses, popped per request; the last repeats.
+    poll_responses: Vec<Value>,
+}
+
+type SharedState = Arc<Mutex<MockState>>;
+
+async fn start_mock(state: SharedState) -> String {
+    let operation_path = format!("/v1beta1/{}", operation_name());
+    let app =
+        Router::new()
+            .route(
+                "/v1beta1/things:start",
+                post(
+                    |State(state): State<SharedState>,
+                     headers: HeaderMap,
+                     Json(body): Json<Value>| async move {
+                        let mut state = state.lock().await;
+                        state.start_headers.push(headers);
+                        state.start_bodies.push(body);
+                        Json(json!({ "name": operation_name(), "done": false }))
+                    },
+                ),
+            )
+            .route(
+                &operation_path,
+                get(|State(state): State<SharedState>| async move {
+                    let mut state = state.lock().await;
+                    state.polls += 1;
+                    let response =
+                        if state.poll_responses.len() > 1 {
+                            state.poll_responses.remove(0)
+                        } else {
+                            state.poll_responses.first().cloned().unwrap_or_else(
+                                || json!({ "name": operation_name(), "done": true }),
+                            )
+                        };
+                    Json(response)
+                }),
+            )
+            .with_state(state);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("http://{address}")
+}
+
+fn build_client(endpoint: &str) -> GcpHttpClient {
+    GcpHttpClient::builder(
+        GcpErrorContext::new(ErrorComponent::Memory, CODES, "vertex memory"),
+        endpoint,
+    )
+    .credentials(api_key_credentials::Builder::new("test-api-key").build())
+    .build()
+    .expect("build test client")
+}
+
+#[tokio::test]
+async fn requests_carry_credential_headers_and_json_bodies() {
+    let state = SharedState::default();
+    let endpoint = start_mock(state.clone()).await;
+    let client = build_client(&endpoint);
+
+    let request = client
+        .request(Method::POST, "things:start")
+        .await
+        .unwrap()
+        .json(&json!({ "key": "value" }));
+    let operation = client.send_value(request).await.unwrap();
+    assert_eq!(operation, json!({ "name": operation_name(), "done": false }));
+
+    let state = state.lock().await;
+    assert_eq!(state.start_bodies, vec![json!({ "key": "value" })]);
+    let headers = &state.start_headers[0];
+    assert_eq!(
+        headers.get("x-goog-api-key").map(|value| value.to_str().unwrap()),
+        Some("test-api-key"),
+    );
+}
+
+#[tokio::test]
+async fn lro_polls_to_completion_and_returns_the_response() {
+    let state = SharedState::default();
+    state.lock().await.poll_responses = vec![
+        json!({ "name": operation_name(), "done": false }),
+        json!({ "name": operation_name(), "done": true, "response": { "ok": true } }),
+    ];
+    let endpoint = start_mock(state.clone()).await;
+    let client = build_client(&endpoint);
+
+    let request = client.request(Method::POST, "things:start").await.unwrap().json(&json!({}));
+    let operation = client.send_value(request).await.unwrap();
+    let response = LroPoller::new()
+        .with_initial_delay(Duration::from_millis(1))
+        .wait_for_operation(&client, operation, "things start", true, PROJECT, LOCATION)
+        .await
+        .unwrap();
+
+    assert_eq!(response, Some(json!({ "ok": true })));
+    assert_eq!(state.lock().await.polls, 2);
+}
+
+#[tokio::test]
+async fn lro_operation_errors_map_grpc_codes_to_categories() {
+    let state = SharedState::default();
+    state.lock().await.poll_responses = vec![json!({
+        "name": operation_name(),
+        "done": true,
+        "error": { "code": 8, "message": "quota exhausted" },
+    })];
+    let endpoint = start_mock(state.clone()).await;
+    let client = build_client(&endpoint);
+
+    let request = client.request(Method::POST, "things:start").await.unwrap().json(&json!({}));
+    let operation = client.send_value(request).await.unwrap();
+    let error = LroPoller::new()
+        .with_initial_delay(Duration::from_millis(1))
+        .wait_for_operation(&client, operation, "things start", false, PROJECT, LOCATION)
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.category, ErrorCategory::RateLimited);
+    assert_eq!(error.code, "memory.vertex.operation_failed");
+    assert!(error.message.contains("quota exhausted"), "{}", error.message);
+}
+
+#[tokio::test]
+async fn lro_refuses_to_follow_a_changed_operation_identity() {
+    let state = SharedState::default();
+    state.lock().await.poll_responses = vec![json!({
+        "name": format!("projects/{PROJECT}/locations/{LOCATION}/reasoningEngines/4242/operations/999"),
+        "done": true,
+    })];
+    let endpoint = start_mock(state.clone()).await;
+    let client = build_client(&endpoint);
+
+    let request = client.request(Method::POST, "things:start").await.unwrap().json(&json!({}));
+    let operation = client.send_value(request).await.unwrap();
+    let error = LroPoller::new()
+        .with_initial_delay(Duration::from_millis(1))
+        .wait_for_operation(&client, operation, "things start", false, PROJECT, LOCATION)
+        .await
+        .unwrap_err();
+
+    assert!(error.message.contains("changed operation identity"), "{}", error.message);
+}
+
+#[tokio::test]
+async fn lro_rejects_operations_outside_the_configured_scope() {
+    let endpoint = start_mock(SharedState::default()).await;
+    let client = build_client(&endpoint);
+
+    let foreign = json!({
+        "name": "projects/other-project/locations/us-central1/reasoningEngines/1/operations/2",
+        "done": false,
+    });
+    let error = LroPoller::new()
+        .wait_for_operation(&client, foreign, "things start", false, PROJECT, LOCATION)
+        .await
+        .unwrap_err();
+
+    assert!(error.message.contains("does not belong to"), "{}", error.message);
+}
+
+#[tokio::test]
+async fn lro_requires_a_response_when_asked() {
+    let endpoint = start_mock(SharedState::default()).await;
+    let client = build_client(&endpoint);
+
+    let done_without_response = json!({ "name": operation_name(), "done": true });
+    let error = LroPoller::new()
+        .wait_for_operation(&client, done_without_response, "things start", true, PROJECT, LOCATION)
+        .await
+        .unwrap_err();
+
+    assert!(error.message.contains("completed without a response"), "{}", error.message);
+}
+
+#[tokio::test]
+async fn lro_deadline_produces_a_timeout_error() {
+    let state = SharedState::default();
+    state.lock().await.poll_responses = vec![json!({ "name": operation_name(), "done": false })];
+    let endpoint = start_mock(state.clone()).await;
+    let client = build_client(&endpoint);
+
+    let request = client.request(Method::POST, "things:start").await.unwrap().json(&json!({}));
+    let operation = client.send_value(request).await.unwrap();
+    let error = LroPoller::new()
+        .with_poll_timeout(Duration::from_millis(50))
+        .with_initial_delay(Duration::from_millis(5))
+        .wait_for_operation(&client, operation, "things start", false, PROJECT, LOCATION)
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.category, ErrorCategory::Timeout);
+    assert_eq!(error.code, "memory.vertex.timeout");
+}
+
+#[tokio::test]
+async fn non_success_statuses_map_to_branded_errors() {
+    let app = Router::new().route(
+        "/v1beta1/things:start",
+        post(|| async { (axum::http::StatusCode::TOO_MANY_REQUESTS, "slow down") }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    let client = build_client(&format!("http://{address}"));
+
+    let request = client.request(Method::POST, "things:start").await.unwrap().json(&json!({}));
+    let error = client.send_value(request).await.unwrap_err();
+
+    assert_eq!(error.category, ErrorCategory::RateLimited);
+    assert_eq!(error.code, "memory.vertex.rate_limited");
+    assert_eq!(error.details.upstream_status_code, Some(429));
+    assert!(error.message.contains("slow down"), "{}", error.message);
+}
+
+#[tokio::test]
+async fn not_found_is_optional_only_when_allowed() {
+    let app = Router::new().route(
+        "/v1beta1/things/missing",
+        get(|| async { (axum::http::StatusCode::NOT_FOUND, "gone") }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    let client = build_client(&format!("http://{address}"));
+
+    let request = client.request(Method::GET, "things/missing").await.unwrap();
+    let value = client.send_value_allow_not_found(request).await.unwrap();
+    assert_eq!(value, None);
+
+    let request = client.request(Method::GET, "things/missing").await.unwrap();
+    let error = client.send_value(request).await.unwrap_err();
+    assert_eq!(error.category, ErrorCategory::NotFound);
+    assert_eq!(error.code, "memory.vertex.not_found");
+}
+
+#[tokio::test]
+async fn oversized_responses_are_rejected() {
+    let app = Router::new()
+        .route("/v1beta1/things/huge", get(|| async { format!("\"{}\"", "x".repeat(1024)) }));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    let client = GcpHttpClient::builder(
+        GcpErrorContext::new(ErrorComponent::Memory, CODES, "vertex memory"),
+        format!("http://{address}"),
+    )
+    .credentials(api_key_credentials::Builder::new("test-api-key").build())
+    .max_response_bytes(256)
+    .build()
+    .unwrap();
+
+    let request = client.request(Method::GET, "things/huge").await.unwrap();
+    let error = client.send_value(request).await.unwrap_err();
+
+    assert_eq!(error.code, "memory.vertex.invalid_response");
+    assert!(error.message.contains("exceeds the 256-byte limit"), "{}", error.message);
+}
+
+#[tokio::test]
+async fn empty_success_bodies_parse_as_an_empty_object() {
+    let app = Router::new()
+        .route("/v1beta1/things/empty", get(|| async { "" }))
+        .route("/v1beta1/things/garbage", get(|| async { "not json" }));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    let client = build_client(&format!("http://{address}"));
+
+    let request = client.request(Method::GET, "things/empty").await.unwrap();
+    let value = client.send_value(request).await.unwrap();
+    assert_eq!(value, json!({}));
+
+    let request = client.request(Method::GET, "things/garbage").await.unwrap();
+    let error = client.send_value(request).await.unwrap_err();
+    assert_eq!(error.code, "memory.vertex.invalid_response");
+}


### PR DESCRIPTION
## What

Creates the `adk-gcp` crate — shared Google Cloud REST plumbing for Vertex AI backends. Wave 3 PR 3.1 of the Agent Engine plan: the purely additive half of the ADC/LRO consolidation. No call-site migration in this PR; the crate lands with its own unit and mock contract tests only.

| Public item | Purpose |
|-------------|---------|
| `GcpHttpClient` / `GcpHttpClientBuilder` | ADC (or explicit) credentials with `CacheableResource` header caching, redirect-disabled transport with connect/request timeouts, HTTPS-or-loopback origin validation, bounded JSON response reads |
| `LroPoller` | `google.longrunning.Operation` polling with capped exponential backoff, operation identity pinning, project/location scope validation |
| `Operation` / `OperationError` | LRO wire types with the shape-consistency checks the backends enforce |
| `VertexResourceName` | Parse/format `projects/*/locations/*/reasoningEngines/*`; `is_canonical_reasoning_engine_id`, `is_scoped_resource_name` |
| `GcpErrorContext` / `GcpErrorCodes` | Consumer-branded error construction across the `AdkError` boundary |
| `truncate_for_error` | Sanitizes and caps untrusted text before it enters error messages |

## Why

Part of #438.

Waves 0–2 deliberately accumulated four-to-five copies of the ADC + cached-auth-header + LRO-polling pattern (`adk-session/src/vertex.rs`, `adk-memory/src/vertex.rs`, `adk-tool/src/example_store/`, `adk-deploy/src/gcp.rs`, `adk-artifact/src/gcs.rs`). This crate is the consolidation target, and the foundation dependency for every Wave 4 feature (`vertex-eval`, `vertex-rag`, `agent-retrieval`, `vertex-agent-registry`, `vertex-remote-engine`, `vertex-skill-registry` all declare `dep:adk-gcp`).

A separate crate rather than `adk-core/gcp`: `adk-core` is the foundational trait crate every workspace member depends on; keeping HTTP/auth deps out of it avoids semver churn on the most depended-upon crate.

## How

- **Error identity is configurable per consumer.** Each existing copy stamps its own `ErrorComponent`, code prefix (`memory.vertex.*`, `tool.example_store.*`, …), message subject, and provider tag. `AdkError` codes are `&'static str`, so `GcpErrorCodes` is a `const`-declarable table of literal codes each consuming crate provides — errors from the shared plumbing are indistinguishable from the ones each backend built for itself, keeping the migration PRs' contract-test behavior locks intact.
- **Limits and timeouts are configurable.** The copies diverge deliberately (deploy: 900 s LRO deadline, 10 s delay cap, 8 MiB response cap; session/memory: 120 s, 2 s, 64 MiB). Builder methods cover every knob; defaults match the session/memory backends.
- **Transport semantics follow `adk-session/src/vertex.rs`** (the original): `Content-Length` precheck plus streamed chunk-bounded reads, empty-body-as-empty-object, `allow_not_found`, status→category mapping, gRPC operation-code→category mapping, operation shape validation, and identity pinning are transcribed verbatim.
- **Pre-work finding recorded:** `adk-artifact/src/gcs.rs` confirmed as the fifth call site (reqwest + ADC route), so PR 3.5b applies with the GCS mock contract + blob-name golden tests as the behavior lock.

Housekeeping in the same PR: workspace member + `[workspace.dependencies]` entry, publish-order Tier 2 placement (`check-publish-order.sh`: OK, 43 publishable crates, 8 tiers), root `AGENTS.md` workspace listing and tier list, crate README, `CHANGELOG.md`.

No feature flags are introduced, so no umbrella forwarding, `gemini-agent-platform` append, or CI feature-coverage entry — the crate builds in the default workspace build and the PR-tier workspace jobs cover it.

Verification: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo nextest run -p adk-gcp` (22 tests), `cargo test -p adk-gcp --doc` (7 doctests), `RUSTDOCFLAGS=-D warnings cargo doc -p adk-gcp --no-deps`, `cargo check --workspace`, `./scripts/check-publish-order.sh`, `./scripts/check-doc-examples.sh`, `python3 scripts/check-doc-versions.py` — all pass.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed
- [x] Examples added or updated for new features
