### PR TITLE
ci: prepare merge queue and simplify docs setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ name: CI
 on:
   pull_request:
     branches: [ main ]
+  # Required checks must also run against GitHub's synthetic merge-group ref
+  # when a pull request enters the merge queue.
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 permissions:
@@ -295,16 +299,24 @@ jobs:
   docs:
     needs: fmt
     runs-on: ubuntu-latest
+    env:
+      CI: true
     steps:
     - uses: actions/checkout@v7
 
-    - uses: cachix/install-nix-action@v30
+    # Documentation needs the pinned Rust toolchain, not the full devenv
+    # shell. Running directly avoids Nix bootstrap latency and transient
+    # invalid-store-path failures while retaining the workspace build cache.
+    - name: Setup Rust
+      uses: ./.github/actions/setup-rust
       with:
-        nix_path: nixpkgs=channel:nixos-unstable
-    - uses: cachix/cachix-action@v17
-      with:
-        name: devenv
-    - run: nix profile install nixpkgs#devenv
+        cache-key: pr-docs
+        cache-save: 'false'
+
+    # adk-cli's keyring dependency links libdbus on Linux even when rustdoc is
+    # only documenting the workspace's default feature sets.
+    - name: Install documentation system dependencies
+      run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev
 
     - name: Check documentation coverage
       env:
@@ -312,7 +324,7 @@ jobs:
       run: |
         echo "### 📚 Documentation Coverage" >> "$GITHUB_STEP_SUMMARY"
         echo "" >> "$GITHUB_STEP_SUMMARY"
-        if CI=true devenv shell cargo doc --workspace --no-deps; then
+        if cargo doc --workspace --no-deps; then
           echo "✅ Workspace documentation built with no warnings" >> "$GITHUB_STEP_SUMMARY"
         else
           echo "❌ Workspace documentation build failed (missing or broken docs)" >> "$GITHUB_STEP_SUMMARY"
@@ -332,8 +344,8 @@ jobs:
     # [package.metadata.docs.rs]).
     - name: Run doctests
       run: |
-        CI=true devenv shell cargo test --workspace --doc --exclude adk-rust
-        CI=true devenv shell cargo test -p adk-rust --features full --doc
+        cargo test --workspace --doc --exclude adk-rust
+        cargo test -p adk-rust --features full --doc
 
     - name: Doctest summary
       if: always()

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -3,6 +3,10 @@ name: Semver Checks
 on:
   pull_request:
     branches: [ main ]
+  # The merge queue creates a synthetic merge-group ref and requires this
+  # check to be reported for that ref before it can advance.
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Problem

Pull requests currently require every branch to remain current with `main`, but the repository is not configured for GitHub merge queue events. Updating several numbered PRs therefore launches overlapping 50-job matrices and saturates runner capacity. The docs job also bootstraps Nix/devenv solely to run Cargo, which caused the transient invalid Nix store path failure seen on #600.

## Changes

- Run required CI and semver workflows for `merge_group` events so GitHub merge queue can report every required check.
- Replace the docs job Nix/devenv bootstrap with the shared pinned Rust setup action.
- Install the Linux `libdbus-1-dev` dependency required by the documented workspace.
- Preserve `CI=true` for documentation builds and keep the existing rustdoc/doctest commands and warning policy.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- parsed both workflow files with Ruby YAML
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo test --workspace --doc --exclude adk-rust`
- `cargo test -p adk-rust --features full --doc`
- pre-push `cargo check --workspace`

## Rollout

Merge #600 first. After this PR merges, enable the repository merge-queue rule; enabling it before these `merge_group` triggers reach `main` would leave queued pull requests without their required checks.