### PR TITLE
docs: align v2.1 overview and remove live audio tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,16 @@
 [![GitHub Discussions](https://img.shields.io/github/discussions/zavora-ai/adk-rust?style=flat&logo=github&color=5865F2)](https://github.com/zavora-ai/adk-rust/discussions)
 
 A production-ready Rust framework for building AI agents. Model-agnostic, type-safe
-and async, across 42 crates for agent orchestration.
+and async, across 43 publishable crates for agent orchestration.
 
-> **v2.1.0 release candidate — unpublished.** This minor release preserves the 2.0
-> public API while adding Anthropic request customization and typed server-side
-> safety-refusal fallbacks. The 2.0 graph foundation remains intact: subgraphs,
-> dynamic routing, imperative child invocation, per-node retries and timeouts,
-> bounded frontier concurrency, checkpoint retention, and cross-process resume.
+> **v2.1.0 release candidate — unpublished.** This API-compatible minor release
+> adds portable, validated teams with exact handoff and delegation semantics; a
+> Gemini Enterprise Agent Platform path spanning Agent Engine runtime and BYOC
+> deployment, Vertex sessions and Memory Bank, GCS artifacts, Example Store,
+> Cloud telemetry, and managed code sandboxes; hardened ambient scheduling,
+> runtime skill writing, and argument-level tool guardrails; plus Anthropic
+> request customization and typed safety-refusal fallback. crates.io remains on
+> 2.0.0 until the release is published.
 >
 > Coming from 1.x: six APIs changed shape and the fan-in default changed behaviour
 > without an API change. See the [migration guide](docs/official_docs/migration/1.0-to-2.0.md)
@@ -205,6 +208,7 @@ Each row links to its guide and a runnable example.
 | Tools — `#[tool]` derives the JSON schema from your argument type | [tools](docs/official_docs/tools/function-tools.md) | [`examples/coding_agent`](examples/coding_agent) |
 | MCP clients and servers on `rmcp 3.1` — tools, resources, prompts, elicitation, tasks | [mcp](docs/official_docs/mcp/index.md) | [`examples/mcp_protocol_revisions`](examples/mcp_protocol_revisions) |
 | Workflow agents — sequential, parallel, loop | [agents](docs/official_docs/agents/workflow-agents.md) | [`examples/multi_perspective_analysis`](examples/multi_perspective_analysis) |
+| Portable teams — validated handoff, delegation, policies, receipts and shared state | [multi-agent](docs/official_docs/agents/multi-agent.md) | [`examples/team_architectures`](examples/team_architectures) |
 | Graph workflows — checkpoints, durable resume, human-in-the-loop, subgraphs | [graph-agents](docs/official_docs/agents/graph-agents.md) | [`examples/graph_subgraph_claims`](examples/graph_subgraph_claims) |
 | Coding agents — read, edit and run code in a confined workspace | [coding-agent](docs/official_docs/coding-agent/index.md) | [`examples/coding_goal`](examples/coding_goal) |
 | Realtime voice and video — OpenAI Realtime, Gemini Live, Vertex, LiveKit, WebRTC | [realtime](docs/official_docs/agents/realtime-agents.md) | [`examples/realtime_voice`](examples/realtime_voice) |
@@ -212,6 +216,7 @@ Each row links to its guide and a runnable example.
 | RAG — chunking, embeddings, vector search, 6 backends | [rag](docs/official_docs/tools/rag.md) | — |
 | Memory — semantic search, project isolation, a bi-temporal knowledge graph | [memory](docs/official_docs/tools/memory-tools.md) | [`examples/skill_memory_improvements`](examples/skill_memory_improvements) |
 | Servers — REST with SSE, A2A v1.0.0, background runs, cron | [deployment](docs/official_docs/deployment/server.md) | [`examples/ambient_cron_agent`](examples/ambient_cron_agent) |
+| Gemini Enterprise Agent Platform — Agent Engine BYOC, managed state, memory, artifacts, telemetry and sandbox | [agent-engine](docs/official_docs/deployment/agent-engine.md) | [`examples/vertex_sandbox`](examples/vertex_sandbox) |
 | Agentic Web Protocol — discovery, manifests, trust levels, consent | [awp](docs/official_docs/deployment/awp.md) | [`examples/awp_agent`](examples/awp_agent) |
 | Agentic commerce — ACP and AP2 with durable journals | [payments](docs/official_docs/security/payments.md) | [`examples/payments`](examples/payments) |
 | Editor interop — use an ACP coding agent as a tool, or expose yours | [acp](docs/official_docs/acp/index.md) | — |
@@ -231,6 +236,7 @@ cargo adk new my-agent --template rag        # RAG with vector search
 cargo adk new my-agent --template api        # REST server
 cargo adk new my-agent --template graph      # graph workflow with checkpoints
 cargo adk new my-agent --template realtime   # realtime voice agent
+cargo adk new my-agent --template agent-engine # Gemini Enterprise Agent Engine BYOC
 
 # Compose addons with any template
 cargo adk new my-agent --template tools --addon telemetry --addon sessions
@@ -255,6 +261,7 @@ cargo run
 | `realtime` | Bidirectional audio and video streaming |
 | `rag` | Vector search over a knowledge base |
 | `api` | REST server exposing the agent over HTTP |
+| `agent-engine` | Gemini Enterprise Agent Engine BYOC container and Terraform deployment |
 | `openai` | OpenAI-powered agent |
 | `custom` | Manual `Agent` trait implementation |
 
@@ -267,7 +274,7 @@ cargo run
 | `pipeline` | Sequential data processing with session state |
 | `chatbot` | Conversational agent with memory and an HTTP interface |
 | `a2a-server` (alias `a2a`) | A2A protocol server with session management |
-| `managed-agents` | Anthropic Managed Agents session with SSE streaming |
+| `managed-agents` | Anthropic Managed Agents API session with SSE streaming |
 
 **Addons** — composable with any template, and with each other.
 
@@ -292,46 +299,47 @@ checks an agent definition without building. `cargo adk templates` and
 | Crate | Purpose | Key Features |
 |-------|---------|--------------|
 | `adk-core` | Foundational traits and types | `Agent` trait, `Content`, `Part`, error types, streaming primitives |
-| `adk-agent` | Agent implementations | `LlmAgent`, `SequentialAgent`, `ParallelAgent`, `LoopAgent`, builder patterns |
+| `adk-agent` | Agent implementations | `LlmAgent`, workflow agents, and portable `TeamSpec` / `CompiledTeam` composition |
 | `adk-skill` | AgentSkills parsing and selection | Skill markdown parser, `.skills` discovery/indexing, lexical matching, prompt injection helpers |
 | `adk-model` | LLM integrations | Gemini, OpenAI, Anthropic, DeepSeek, Groq, Ollama, Bedrock, Azure AI + OpenAI-compatible presets (Fireworks, Together, Mistral, Perplexity, Cerebras, SambaNova, xAI) |
 | `adk-gemini` | Gemini client | Google Gemini API client with streaming and multimodal support |
+| `adk-gcp` | Shared Google Cloud plumbing | ADC credential caching, bounded REST transport, Vertex resource names, and LRO polling |
 | `adk-anthropic` | Anthropic client | Dedicated Anthropic API client with streaming, thinking, caching, citations, vision, PDF, pricing |
 | `adk-mistralrs` | Native local inference | mistral.rs v0.8 — **Gemma 4**, Qwen 3.5, Voxtral, ISQ/MXFP4 quantization, LoRA adapters |
-| `adk-tool` | Tool system and extensibility | Typed Rust tools, provider-native tools, composable toolsets, MCP clients and server SDK, dynamic local-server management |
+| `adk-tool` | Tool system and extensibility | Typed Rust tools, provider-native tools, MCP clients and server SDK, and Vertex AI Example Store |
 | `adk-devtools` | Coding-agent dev tools | `read_file`/`write_file`/`edit_file`/`glob`/`grep`/`bash` as a `DevToolset`, scoped to a sandboxed `Workspace` |
-| `adk-session` | Session and state management | SQLite/in-memory backends, conversation history, state persistence |
-| `adk-artifact` | Binary artifacts for agents | File-based storage, MIME type handling, image/PDF/video support |
-| `adk-memory` | Long-term memory | Vector embeddings, semantic search, project-scoped isolation, bi-temporal knowledge graph (`GraphMemoryService`), 6 backends |
+| `adk-session` | Session and state management | In-memory, SQL, Redis, MongoDB, Firestore, Neo4j, and Vertex AI backends |
+| `adk-artifact` | Binary artifacts for agents | In-memory and GCS storage, versioning, MIME types, and image/PDF/video support |
+| `adk-memory` | Long-term memory | Semantic stores, Vertex AI Memory Bank, project isolation, and bi-temporal knowledge graphs |
 | `adk-payments` | Agentic commerce orchestration | ACP/AP2 adapters, canonical transaction kernel, durable journals, evidence-backed payment flows |
 | `awp-types` | AWP protocol types | Trust levels, requester types, discovery documents, capability manifests, payment intents, typed A2A messages — zero `adk-*` deps |
 | `adk-awp` | Agentic Web Protocol implementation | Business context loading, discovery/manifest generation, rate limiting, consent, events, health state machine, AWP routes |
 | `adk-acp` | Agent Client Protocol integration | Official stable v1 client and server, one-shot and persistent sessions, streaming, cancellation, async permissions, client files and terminals, per-session MCP, and editor-facing ADK agents |
 | `adk-rag` | RAG pipeline | Document chunking, embeddings, vector search, reranking, 6 backends |
 | `adk-runner` | Agent execution runtime | Context management, event streaming, session lifecycle, callbacks |
-| `adk-server` | Production API servers | REST API, A2A v1.0.0 protocol (11 JSON-RPC operations; `tasks/resubscribe` returns a snapshot, not a live re-attach), middleware, health checks |
+| `adk-server` | Production API servers | REST, A2A v1.0.0, and Gemini Enterprise Agent Engine runtime dispatch |
 | `adk-cli` | Run and inspect agents from a terminal | Interactive REPL, session management, MCP server integration |
 | `adk-realtime` | Real-time voice & multimodal agents | OpenAI Realtime + Gemini Live, bidirectional audio, video frames, VAD, affective dialogue, server-side tools via `IntegratedRealtimeRunner` |
 | `adk-graph` | Graph-based workflows | LangGraph-style orchestration, state reducers, checkpointing (memory, SQLite, delta), durable resume, human-in-the-loop interrupts, subgraphs, `with_goto` routing, per-node retry and timeouts, time travel |
 | `adk-browser` | Browser automation | 46 WebDriver tools, navigation, forms, screenshots, PDF generation |
 | `adk-computer-use` | Governed desktop automation | Deterministic graph over `computer-use-mcp`: parallel observation, digest-bound approval interrupts, single-executor mutation, verification; wire contracts + tamper-evident evaluation receipts |
 | `adk-eval` | Agent evaluation | Test definitions, trajectory validation, LLM-judged scoring, rubrics |
-| `adk-guardrail` | Input/output validation | PII redaction, content filtering, JSON schema validation |
+| `adk-guardrail` | Runtime validation | Input/output checks, PII redaction, and argument-level tool allow/deny/revision |
 | `adk-auth` | Access control | Role-based permissions, declarative scope-based security, SSO/OAuth, audit logging |
 | `adk-sandbox` | Sandboxed code execution | Process/WASM backends, OS-level sandbox profiles (Seatbelt on macOS, bubblewrap on Linux; Windows AppContainer not implemented) |
-| `adk-telemetry` | Observability | Structured logging, OpenTelemetry tracing, span helpers |
+| `adk-telemetry` | Observability | OpenTelemetry tracing, structured logging, and Google Cloud export |
 | `adk-managed` | Managed agent runtime (Experimental) | Provider-neutral agent execution, in-process checkpointing and event replay (state does not survive process loss) |
 | `adk-enterprise` | Enterprise client SDK (Experimental) | HTTP/SSE client for managed agent service, zero runtime deps |
 | `adk-plugin` | Lifecycle hooks | `EnhancedPlugin` trait, tool and model interception, priority pipeline, shared `PluginContext` |
 | `adk-retry-reflect` | Retry and reflect plugin | Intercepts tool failures, injects reflection prompts, exponential backoff, circuit breaker |
 | `adk-action` | Action node types | 14 deterministic node types, `StandardProperties`, variable interpolation — the shared types behind `adk-graph`'s `ActionNodeExecutor` |
-| `adk-code` | Code execution substrate | Process, Docker and embedded runtimes; the kernel `adk-codeact-monty` and the code tools build on |
+| `adk-code` | Code execution substrate | Process, Docker, embedded runtimes, and Vertex AI Agent Engine managed sandboxes |
 | `adk-codeact-monty` | Python runtime for CodeAct (Experimental) | Pydantic Monty interpreter, sandboxed OS access, suspend and resume snapshots |
 | `adk-audio` | Audio processing | STT and TTS providers, Deepgram streaming, desktop capture and playback, VAD, ONNX models (Whisper, Moonshine, Kokoro) |
 | `adk-bench` | Benchmarking | Framework runtime performance against real LLM APIs, and cross-framework comparison with Python ADK |
-| `adk-deploy` | Deployment utilities | Targets and manifests for shipping an agent |
+| `adk-deploy` | Deployment utilities | Targets, manifests, and Gemini Enterprise Agent Engine BYOC deployment |
 | `adk-rust-macros` | Procedural macros | `#[tool]` with `read_only`/`concurrency_safe`/`long_running` metadata, `#[entrypoint]` and `#[task]` for the functional API |
-| `cargo-adk` | Cargo subcommand | `cargo adk new`, `templates`, `addons`, `bench`, `deploy` |
+| `cargo-adk` | Cargo subcommand | Project templates including Agent Engine BYOC, composable addons, benchmarks, and deployment |
 | `adk-rust` | Umbrella crate | Re-exports every crate above behind tiered feature presets — the one dependency most projects need |
 
 > **Extracted to standalone repos:** [adk-ui](https://github.com/zavora-ai/adk-ui) (dynamic UI generation), [adk-studio](https://github.com/zavora-ai/adk-studio) (visual agent builder), [adk-playground](https://github.com/zavora-ai/adk-playground) (120+ examples).
@@ -382,7 +390,7 @@ per-platform tool matrix and the CI cost tiers.
 
 ## Project
 
-- [ROADMAP.md](ROADMAP.md) — **v2.1.0** (release candidate). The authoritative roadmap, and
+- [ROADMAP.md](ROADMAP.md) — **v2.1.0** (release candidate). Longer-term direction and
   why both orchestration APIs are supported
 - [CHANGELOG.md](CHANGELOG.md) — every release
 - [CONTRIBUTORS.md](CONTRIBUTORS.md) — the people who built this

--- a/adk-audio/tests/bug_condition_silent_streams_test.rs
+++ b/adk-audio/tests/bug_condition_silent_streams_test.rs
@@ -2,7 +2,7 @@
 //!
 //! **Property 1 (Bug 2): Unimplemented streams return explicit errors**
 //!
-//! For each provider in `{"assemblyai", "deepgram", "MLX"}`, calling
+//! For each provider without streaming support in `{"assemblyai", "MLX"}`, calling
 //! `transcribe_stream()` SHALL return `Err(AudioError::Stt { .. })` with a
 //! message containing "not yet implemented".
 //!
@@ -44,39 +44,6 @@ async fn bug_condition_assemblyai_transcribe_stream_returns_error() {
             "BUG CONFIRMED: transcribe_stream() returned Ok(empty_stream) instead of Err. \
              This is the silent stream bug."
         ),
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Deepgram — streaming is now implemented, so it attempts a real WebSocket
-// connection. With a fake API key it returns a connection/auth error, which
-// is correct behavior (not the silent-stream bug).
-// ---------------------------------------------------------------------------
-
-#[tokio::test]
-async fn bug_condition_deepgram_transcribe_stream_returns_error() {
-    init_crypto();
-    let provider = adk_audio::DeepgramStt::with_api_key("test-key".to_string());
-
-    let result = provider
-        .transcribe_stream(Box::pin(futures::stream::empty()), &SttOptions::default())
-        .await;
-
-    match result {
-        Err(AudioError::Stt { provider, message }) => {
-            assert_eq!(provider, "deepgram");
-            // With a fake key, Deepgram returns a WebSocket connection error (401).
-            assert!(
-                message.contains("WebSocket connection failed"),
-                "expected WebSocket connection error, got: {message}"
-            );
-        }
-        Err(other) => panic!("expected AudioError::Stt, got: {other}"),
-        Ok(_) => {
-            // Streaming is implemented — getting Ok means the connection succeeded,
-            // which shouldn't happen with a fake key.
-            panic!("unexpected Ok with fake API key");
-        }
     }
 }
 

--- a/adk-audio/tests/preservation_batch_transcription_test.rs
+++ b/adk-audio/tests/preservation_batch_transcription_test.rs
@@ -1,38 +1,22 @@
-//! Preservation Property Test B — Batch Transcription Unchanged
+//! Preservation Property Test B — STT Surface Unchanged
 //!
 //! **Property 4: Preservation — batch transcribe() code paths unchanged**
 //!
-//! Verifies that `AssemblyAiStt::transcribe()` and `DeepgramStt::transcribe()`
-//! are structurally unchanged by the streaming fix. Since these methods are
-//! HTTP-dependent, we verify:
+//! Verifies the provider-facing structures used by batch transcription without
+//! contacting an external service:
 //!
 //! 1. The `SttProvider` trait still requires both `transcribe()` and `transcribe_stream()`
-//! 2. AssemblyAI `transcribe()` fails with expected HTTP error (no real server)
-//! 3. Deepgram `transcribe()` fails with expected HTTP error (no real server)
-//! 4. The error types are `AudioError::Stt` with the correct provider name
-//! 5. AudioFrame construction from arbitrary PCM-16 LE data is unchanged
+//! 2. AudioFrame construction from arbitrary PCM-16 LE data is unchanged
 //!
-//! This confirms the batch transcription code paths are untouched by the
-//! streaming stub fix.
+//! This confirms the batch transcription surface is untouched by the streaming
+//! stub fix.
 //!
 //! **Validates: Requirements 3.4, 3.5**
 
-use adk_audio::error::AudioError;
 use adk_audio::frame::AudioFrame;
 use adk_audio::traits::{SttOptions, SttProvider};
 use bytes::Bytes;
 use proptest::prelude::*;
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-fn make_audio_frame(sample_count: usize) -> AudioFrame {
-    // AudioFrame::new expects raw PCM-16 LE bytes, not i16 samples directly.
-    let samples: Vec<i16> = (0..sample_count).map(|i| (i % 256) as i16).collect();
-    let byte_data: Vec<u8> = samples.iter().flat_map(|s| s.to_le_bytes()).collect();
-    AudioFrame::new(Bytes::from(byte_data), 16000, 1)
-}
 
 // ---------------------------------------------------------------------------
 // Property tests — AudioFrame construction preservation
@@ -84,54 +68,6 @@ proptest! {
         // SttOptions::default() should always be constructible
         // (compile-time check that the struct hasn't changed shape)
         let _ = opts;
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Integration tests — verify transcribe() HTTP code paths
-// ---------------------------------------------------------------------------
-
-/// AssemblyAI transcribe() with invalid key returns Stt error with provider "assemblyai".
-/// This confirms the upload → create → poll workflow is unchanged.
-#[tokio::test]
-async fn assemblyai_transcribe_returns_stt_error() {
-    let provider = adk_audio::AssemblyAiStt::with_api_key("invalid-key".to_string());
-    let frame = make_audio_frame(1600); // 100ms of audio
-
-    let result = provider.transcribe(&frame, &SttOptions::default()).await;
-
-    match result {
-        Err(AudioError::Stt { provider, .. }) => {
-            assert_eq!(provider, "assemblyai");
-        }
-        Err(other) => {
-            panic!("unexpected error variant (expected Stt): {other}");
-        }
-        Ok(_) => {
-            panic!("transcribe() should not succeed with invalid key");
-        }
-    }
-}
-
-/// Deepgram transcribe() with invalid key returns Stt error with provider "deepgram".
-/// This confirms the /v1/listen endpoint workflow is unchanged.
-#[tokio::test]
-async fn deepgram_transcribe_returns_stt_error() {
-    let provider = adk_audio::DeepgramStt::with_api_key("invalid-key".to_string());
-    let frame = make_audio_frame(1600); // 100ms of audio
-
-    let result = provider.transcribe(&frame, &SttOptions::default()).await;
-
-    match result {
-        Err(AudioError::Stt { provider, .. }) => {
-            assert_eq!(provider, "deepgram");
-        }
-        Err(other) => {
-            panic!("unexpected error variant (expected Stt): {other}");
-        }
-        Ok(_) => {
-            panic!("transcribe() should not succeed with invalid key");
-        }
     }
 }
 


### PR DESCRIPTION
## Summary

- update the top-level README so the v2.1.0 release-candidate banner, capability matrix, templates, and crate table represent portable teams and the Gemini Enterprise Agent Platform work already merged
- distinguish the Anthropic Managed Agents template from the provider-neutral managed runtime and Agent Engine path
- remove default-suite Deepgram REST/WebSocket fake-key checks and the analogous AssemblyAI REST check
- retain Deepgram and AssemblyAI provider support plus deterministic STT surface, parser, URL, and trait coverage

## Why

The removed negative tests made PR and merge CI depend on public provider authentication endpoints. During an upstream Deepgram incident, invalid-key requests temporarily received successful responses, which failed the macOS merge tier even though no audio code had changed. Default CI should be hermetic and should not treat a third-party authentication response as a unit-test oracle.

This does **not** remove Deepgram or AssemblyAI from ADK-Rust. It only removes live-network checks from the default test suite, as requested.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo nextest run --workspace` — 4,445 passed, 85 skipped
- `cargo test -p adk-audio`
- `bash scripts/check-release-consistency.sh`
- `bash scripts/check-doc-versions.sh`
- `python3 scripts/check-doc-examples.py`
- pre-push standalone example compilation — 108 passed across four shards
