### PR TITLE
chore: ignore TypeScript incremental build metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,8 @@ temp/
 *.tmp
 node_modules/
 **/node_modules/
+# TypeScript incremental build metadata, emitted next to the tsconfig it belongs to.
+*.tsbuildinfo
 
 # OS Specific
 Thumbs.db


### PR DESCRIPTION
## What

Ignores `*.tsbuildinfo`, TypeScript's incremental build metadata.

## Why

A `tsconfig.tsbuildinfo` emitted under `adk-server/webui` made git report the
whole directory as untracked, because a directory surfaces if it holds any file
that is not ignored. `node_modules/` was already ignored; the build metadata was
not. The practical consequence is that `git add -A` in a tree with a built webui
stages 76 MB of `node_modules` along with it.

Found while staging #616, where the directory had to be excluded by hand.

## How

One rule in the temporary-files section. Verified that the pattern matches the
emitted file, that the directory no longer surfaces as untracked, and that no
currently tracked file becomes newly ignored:

```
$ git check-ignore -v adk-server/webui/tsconfig.tsbuildinfo
.gitignore:70:*.tsbuildinfo	adk-server/webui/tsconfig.tsbuildinfo

$ git ls-files | grep -c tsbuildinfo
0
```

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — no Rust changes
- [x] `devenv shell clippy` — no Rust changes
- [x] `devenv shell test` — no Rust changes
- [x] `devenv shell check` — no Rust changes

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch
