### PR TITLE
docs(release): finalize 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -435,6 +435,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (parsed JSON plus decoded body size, for aggregate pagination bounds) and
   a post-construction `with_max_response_bytes` override.
 
+### Contributors
+
+Thank you to [@joseph-wortmann](https://github.com/joseph-wortmann),
+[@1111mp](https://github.com/1111mp), and
+[@jkmaina](https://github.com/jkmaina) for their contributions to v2.1.0.
+
 ## [2.0.0] - 2026-08-09
 
 ### Breaking

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 A production-ready Rust framework for building AI agents. Model-agnostic, type-safe
 and async, across 43 publishable crates for agent orchestration.
 
-> **v2.1.0 release candidate — unpublished.** This API-compatible minor release
+> **v2.1.0 Released!** This API-compatible minor release
 > adds portable, validated teams with exact handoff and delegation semantics; a
 > Gemini Enterprise Agent Platform path spanning Agent Engine runtime and BYOC
 > deployment, Vertex sessions and Memory Bank, GCS artifacts, Example Store,
@@ -19,8 +19,8 @@ and async, across 43 publishable crates for agent orchestration.
 > runtime skill writing, and argument-level tool guardrails; plus Anthropic
 > request customization and typed safety-refusal fallback; and a new ADK-Rust-owned
 > responsive runtime UI for conversations, exact team topology, event timelines,
-> shared state, artifacts, sessions, and UI-protocol discovery. crates.io remains on
-> 2.0.0 until the release is published.
+> shared state, artifacts, sessions, and UI-protocol discovery. All 43 crates are
+> available on [crates.io](https://crates.io/crates/adk-rust/2.1.0).
 >
 > Coming from 1.x: six APIs changed shape and the fan-in default changed behaviour
 > without an API change. See the [migration guide](docs/official_docs/migration/1.0-to-2.0.md)
@@ -423,7 +423,7 @@ per-platform tool matrix and the CI cost tiers.
 
 ## Project
 
-- [ROADMAP.md](ROADMAP.md) — **v2.1.0** (release candidate). Longer-term direction and
+- [ROADMAP.md](ROADMAP.md) — **v2.1.0** (current). Longer-term direction and
   why both orchestration APIs are supported
 - [CHANGELOG.md](CHANGELOG.md) — every release
 - [CONTRIBUTORS.md](CONTRIBUTORS.md) — the people who built this


### PR DESCRIPTION
## Summary

- mark v2.1.0 as released/current in the README
- link the published umbrella crate on crates.io
- add explicit permanent contributor attribution for @joseph-wortmann, @1111mp, and @jkmaina

## Release evidence

- annotated tag `v2.1.0` points to `993126f18b8038123efe98566d4e058bd69c0f4e`
- PR-tier and exact-commit merge-tier CI passed
- `cargo xtask publish --dry-run` passed for all 43 crates
- all 43 versions are published and unyanked on crates.io
- all 43 docs.rs builds are accepted in the external build queue
- `bash scripts/check-release-consistency.sh` passes in released state
- workspace check and all four example shards passed in the pre-push hook

Release: https://github.com/zavora-ai/adk-rust/releases/tag/v2.1.0