### PR TITLE
feat(rag): add Agent Retrieval VectorStore backend - PR 4.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,9 +764,12 @@ name = "adk-rag"
 version = "2.1.0"
 dependencies = [
  "adk-core",
+ "adk-gcp",
  "adk-gemini",
  "async-trait",
+ "axum 0.8.9",
  "futures",
+ "google-cloud-auth 1.12.0",
  "lancedb",
  "proptest",
  "qdrant-client",

--- a/adk-rag/Cargo.toml
+++ b/adk-rag/Cargo.toml
@@ -14,6 +14,7 @@ readme = "README.md"
 
 [dependencies]
 adk-core.workspace = true
+adk-gcp = { workspace = true, optional = true }
 async-trait.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -23,6 +24,7 @@ tokio = { workspace = true, features = ["sync"] }
 
 # Feature-gated dependencies
 adk-gemini = { workspace = true, optional = true }
+google-cloud-auth = { version = "1.8", optional = true, default-features = false, features = ["default-rustls-provider"] }
 reqwest = { workspace = true, optional = true }
 qdrant-client = { version = "1.13", optional = true }
 # lancedb's public API takes and returns arrow types, so our arrow types must come from
@@ -38,6 +40,7 @@ surrealdb-types = { version = "3.0.1", optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros", "rt-multi-thread"] }
+axum = "0.8"
 proptest = "1.6"
 tempfile = "3"
 
@@ -48,5 +51,6 @@ openai = ["dep:reqwest"]
 qdrant = ["dep:qdrant-client"]
 lancedb = ["dep:lancedb", "dep:futures"]
 pgvector = ["dep:sqlx"]
+agent-retrieval = ["dep:adk-gcp", "dep:google-cloud-auth", "dep:reqwest"]
 surrealdb = ["dep:surrealdb", "dep:surrealdb-types"]
 full = ["gemini", "openai", "qdrant", "lancedb", "pgvector", "surrealdb"]

--- a/adk-rag/src/agent_retrieval.rs
+++ b/adk-rag/src/agent_retrieval.rs
@@ -1,0 +1,676 @@
+//! Agent Retrieval (formerly Vector Search 2.0) [`VectorStore`] backend.
+//!
+//! Agent Retrieval is Google's managed vector database on the Gemini
+//! Enterprise Agent Platform, served by `vectorsearch.googleapis.com` (v1,
+//! GA). This backend maps the [`VectorStore`] trait onto Collections and
+//! Data Objects:
+//!
+//! | Trait operation | Agent Retrieval call |
+//! |-----------------|----------------------|
+//! | `create_collection` | `POST {parent}/collections` (LRO; `ALREADY_EXISTS` is a no-op) |
+//! | `delete_collection` | `DELETE {collection}` (LRO; `NOT_FOUND` is a no-op) |
+//! | `upsert` | `dataObjects:batchCreate`, falling back to per-object create-else-patch when IDs already exist |
+//! | `delete` | `dataObjects:batchDelete`, falling back to per-object delete when IDs are missing |
+//! | `search` | `dataObjects:search` with a `vectorSearch` query (`DOT_PRODUCT`) |
+//!
+//! Chunk text and metadata are stored **in** the Data Object alongside the
+//! vector, so no companion store is needed. The store operates in BYOE
+//! (bring-your-own-embeddings) mode — embeddings come from adk-rag's
+//! embedder pipeline, and auto-embedding is deliberately not enabled, to
+//! keep parity with the other backends. Scores are `DOT_PRODUCT` distances,
+//! which equal cosine similarity for the normalized embeddings the pipeline
+//! produces (higher is more relevant).
+//!
+//! **Vector Search 1.0 is deliberately not implemented.** Its
+//! index/endpoint infrastructure model fits the [`VectorStore`] trait
+//! poorly, and Google positions Agent Retrieval as its successor.
+//!
+//! Collection IDs must be RFC 1035 labels, so trait-level collection names
+//! are sanitized deterministically (lowercased, invalid characters become
+//! hyphens). Distinct names that sanitize identically collide; choose
+//! names that differ in more than case or punctuation.
+//!
+//! Beyond the trait, [`AgentRetrievalStore::hybrid_search`] exposes
+//! semantic + text search fused with reciprocal rank fusion for callers
+//! holding the concrete type.
+
+use crate::document::{Chunk, SearchResult};
+use crate::error::{RagError, Result};
+use crate::vectorstore::VectorStore;
+use adk_core::ErrorComponent;
+use adk_gcp::{GcpErrorCodes, GcpErrorContext, GcpHttpClient, LroPoller};
+use async_trait::async_trait;
+use reqwest::Method;
+use serde::Deserialize;
+use serde_json::{Value, json};
+use std::collections::HashMap;
+
+const DEFAULT_ENDPOINT: &str = "https://vectorsearch.googleapis.com";
+const API_VERSION: &str = "v1";
+const VECTOR_FIELD: &str = "embedding";
+const BATCH_LIMIT: usize = 1000;
+const ENV_GOOGLE_CLOUD_PROJECT: &str = "GOOGLE_CLOUD_PROJECT";
+const ENV_GOOGLE_CLOUD_LOCATION: &str = "GOOGLE_CLOUD_LOCATION";
+
+const GCP_ERROR_CODES: GcpErrorCodes = GcpErrorCodes {
+    invalid_input: "rag.agent_retrieval.invalid_input",
+    unauthorized: "rag.agent_retrieval.unauthorized",
+    forbidden: "rag.agent_retrieval.forbidden",
+    not_found: "rag.agent_retrieval.not_found",
+    rate_limited: "rag.agent_retrieval.rate_limited",
+    timeout: "rag.agent_retrieval.timeout",
+    unavailable: "rag.agent_retrieval.unavailable",
+    credentials_unavailable: "rag.agent_retrieval.credentials_unavailable",
+    invalid_response: "rag.agent_retrieval.invalid_response",
+    invalid_request: "rag.agent_retrieval.invalid_request",
+    upstream_error: "rag.agent_retrieval.upstream_error",
+    operation_failed: "rag.agent_retrieval.operation_failed",
+};
+
+fn gcp_error_context() -> GcpErrorContext {
+    GcpErrorContext::new(ErrorComponent::Memory, GCP_ERROR_CODES, "agent retrieval")
+}
+
+/// Maps an `adk-gcp` error onto the crate's vector-store error surface.
+fn store_error(error: adk_core::AdkError) -> RagError {
+    RagError::VectorStoreError { backend: "agent_retrieval".to_string(), message: error.message }
+}
+
+/// Configuration for [`AgentRetrievalStore`].
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use adk_rag::agent_retrieval::AgentRetrievalConfig;
+///
+/// let config = AgentRetrievalConfig::new("my-project", "us-central1")
+///     .with_collection_prefix("rag-")
+///     .with_existing_collections_only(true);
+/// # let _ = config;
+/// ```
+#[derive(Debug, Clone)]
+pub struct AgentRetrievalConfig {
+    project_id: String,
+    location: String,
+    collection_prefix: Option<String>,
+    existing_collections_only: bool,
+    endpoint: Option<String>,
+}
+
+impl AgentRetrievalConfig {
+    /// Creates a config for the given project and location.
+    pub fn new(project_id: impl Into<String>, location: impl Into<String>) -> Self {
+        Self {
+            project_id: project_id.into(),
+            location: location.into(),
+            collection_prefix: None,
+            existing_collections_only: false,
+            endpoint: None,
+        }
+    }
+
+    /// Creates a config from `GOOGLE_CLOUD_PROJECT` and
+    /// `GOOGLE_CLOUD_LOCATION`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when either variable is unset or blank.
+    pub fn from_env() -> Result<Self> {
+        let read = |key: &str| {
+            std::env::var(key).ok().filter(|value| !value.trim().is_empty()).ok_or_else(|| {
+                RagError::ConfigError(format!(
+                    "missing or blank environment variable {key}; set it or use AgentRetrievalConfig::new",
+                ))
+            })
+        };
+        Ok(Self::new(read(ENV_GOOGLE_CLOUD_PROJECT)?, read(ENV_GOOGLE_CLOUD_LOCATION)?))
+    }
+
+    /// Prefixes every sanitized collection ID, isolating this store's
+    /// collections from others in the same project.
+    #[must_use]
+    pub fn with_collection_prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.collection_prefix = Some(prefix.into());
+        self
+    }
+
+    /// Turns `create_collection` into validate-and-fail-if-missing for
+    /// deployments that pre-provision collections.
+    #[must_use]
+    pub fn with_existing_collections_only(mut self, existing_only: bool) -> Self {
+        self.existing_collections_only = existing_only;
+        self
+    }
+
+    /// Sets a custom API origin (loopback HTTP allowed for tests).
+    #[must_use]
+    pub fn with_endpoint(mut self, endpoint: impl Into<String>) -> Self {
+        self.endpoint = Some(endpoint.into());
+        self
+    }
+
+    fn endpoint(&self) -> String {
+        self.endpoint.clone().unwrap_or_else(|| DEFAULT_ENDPOINT.to_string())
+    }
+}
+
+/// [`VectorStore`] backend for Agent Retrieval.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use adk_rag::VectorStore;
+/// use adk_rag::agent_retrieval::{AgentRetrievalConfig, AgentRetrievalStore};
+///
+/// # async fn run() -> adk_rag::Result<()> {
+/// let store = AgentRetrievalStore::new_with_adc(
+///     AgentRetrievalConfig::new("my-project", "us-central1"),
+/// )?;
+/// store.create_collection("docs", 768).await?;
+/// # Ok(())
+/// # }
+/// ```
+pub struct AgentRetrievalStore {
+    client: GcpHttpClient,
+    poller: LroPoller,
+    project_id: String,
+    location: String,
+    collection_prefix: Option<String>,
+    existing_collections_only: bool,
+}
+
+impl AgentRetrievalStore {
+    /// Creates a store using Application Default Credentials (ADC).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when ADC cannot be constructed or the endpoint is
+    /// not a valid secure origin.
+    pub fn new_with_adc(config: AgentRetrievalConfig) -> Result<Self> {
+        let client = GcpHttpClient::builder(gcp_error_context(), config.endpoint())
+            .api_version(API_VERSION)
+            .build()
+            .map_err(store_error)?;
+        Ok(Self::with_client(config, client))
+    }
+
+    /// Creates a store with explicit credentials.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the endpoint is not a valid secure origin.
+    pub fn with_credentials(
+        config: AgentRetrievalConfig,
+        credentials: google_cloud_auth::credentials::Credentials,
+    ) -> Result<Self> {
+        let client = GcpHttpClient::builder(gcp_error_context(), config.endpoint())
+            .api_version(API_VERSION)
+            .credentials(credentials)
+            .build()
+            .map_err(store_error)?;
+        Ok(Self::with_client(config, client))
+    }
+
+    fn with_client(config: AgentRetrievalConfig, client: GcpHttpClient) -> Self {
+        Self {
+            client,
+            poller: LroPoller::new(),
+            project_id: config.project_id,
+            location: config.location,
+            collection_prefix: config.collection_prefix,
+            existing_collections_only: config.existing_collections_only,
+        }
+    }
+
+    fn parent(&self) -> String {
+        format!("projects/{}/locations/{}", self.project_id, self.location)
+    }
+
+    /// The full resource name for a trait-level collection name.
+    fn collection_resource(&self, name: &str) -> String {
+        format!("{}/collections/{}", self.parent(), self.collection_id(name))
+    }
+
+    /// Sanitizes a trait-level collection name into an RFC 1035 label.
+    fn collection_id(&self, name: &str) -> String {
+        let raw = format!("{}{name}", self.collection_prefix.as_deref().unwrap_or(""));
+        sanitize_collection_id(&raw)
+    }
+
+    async fn wait_for_operation(&self, operation: Value, kind: &str) -> Result<Option<Value>> {
+        self.poller
+            .wait_for_operation(
+                &self.client,
+                operation,
+                kind,
+                false,
+                &self.project_id,
+                &self.location,
+            )
+            .await
+            .map_err(store_error)
+    }
+
+    async fn get_collection(&self, resource: &str) -> Result<Option<Value>> {
+        let request = self.client.request(Method::GET, resource).await.map_err(store_error)?;
+        self.client.send_value_allow_not_found(request).await.map_err(store_error)
+    }
+
+    fn data_object_name(&self, collection: &str, id: &str) -> String {
+        format!("{}/dataObjects/{id}", self.collection_resource(collection))
+    }
+
+    async fn create_objects_batch(&self, collection: &str, chunks: &[Chunk]) -> Result<()> {
+        let parent = self.collection_resource(collection);
+        let requests: Vec<Value> = chunks
+            .iter()
+            .map(|chunk| {
+                json!({
+                    "parent": parent,
+                    "dataObjectId": chunk.id,
+                    "dataObject": data_object_body(chunk),
+                })
+            })
+            .collect();
+        let request = self
+            .client
+            .request(Method::POST, &format!("{parent}/dataObjects:batchCreate"))
+            .await
+            .map_err(store_error)?
+            .json(&json!({ "requests": requests }));
+        self.client.send_value(request).await.map_err(store_error)?;
+        Ok(())
+    }
+
+    /// Last-write-wins upsert for one object: create, then patch on
+    /// `ALREADY_EXISTS`.
+    async fn upsert_object(&self, collection: &str, chunk: &Chunk) -> Result<()> {
+        let parent = self.collection_resource(collection);
+        let request = self
+            .client
+            .request(Method::POST, &format!("{parent}/dataObjects"))
+            .await
+            .map_err(store_error)?
+            .query(&[("dataObjectId", chunk.id.as_str())])
+            .json(&data_object_body(chunk));
+        match self.client.send_value(request).await {
+            Ok(_) => Ok(()),
+            Err(error) if error.details.upstream_status_code == Some(409) => {
+                let name = self.data_object_name(collection, &chunk.id);
+                let request = self
+                    .client
+                    .request(Method::PATCH, &name)
+                    .await
+                    .map_err(store_error)?
+                    .json(&data_object_body(chunk));
+                self.client.send_value(request).await.map_err(store_error)?;
+                Ok(())
+            }
+            Err(error) => Err(store_error(error)),
+        }
+    }
+
+    async fn delete_objects_batch(&self, collection: &str, ids: &[&str]) -> Result<()> {
+        let parent = self.collection_resource(collection);
+        let requests: Vec<Value> =
+            ids.iter().map(|id| json!({ "name": self.data_object_name(collection, id) })).collect();
+        let request = self
+            .client
+            .request(Method::POST, &format!("{parent}/dataObjects:batchDelete"))
+            .await
+            .map_err(store_error)?
+            .json(&json!({ "requests": requests }));
+        self.client.send_value(request).await.map_err(store_error)?;
+        Ok(())
+    }
+
+    /// Semantic + text search fused with reciprocal rank fusion.
+    ///
+    /// A beyond-trait extra for callers holding the concrete type: runs a
+    /// vector query and a keyword query over `text` in one `:batchSearch`
+    /// call and returns the fused ranked list. `weights` are the RRF
+    /// weights for the vector and text searches respectively.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the request fails or the response cannot be
+    /// parsed.
+    pub async fn hybrid_search(
+        &self,
+        collection: &str,
+        embedding: &[f32],
+        query_text: &str,
+        top_k: usize,
+        weights: (f64, f64),
+    ) -> Result<Vec<SearchResult>> {
+        let parent = self.collection_resource(collection);
+        let body = json!({
+            "searches": [
+                { "vectorSearch": {
+                    "searchField": VECTOR_FIELD,
+                    "vector": { "values": embedding },
+                    "topK": top_k,
+                    "outputFields": output_fields(),
+                } },
+                { "textSearch": {
+                    "searchText": query_text,
+                    "dataFieldNames": ["text"],
+                    "topK": top_k,
+                    "outputFields": output_fields(),
+                } },
+            ],
+            "combine": {
+                "ranker": { "rrf": { "weights": [weights.0, weights.1] } },
+                "topK": top_k,
+                "outputFields": output_fields(),
+            },
+        });
+        let request = self
+            .client
+            .request(Method::POST, &format!("{parent}/dataObjects:batchSearch"))
+            .await
+            .map_err(store_error)?
+            .json(&body);
+        let value = self.client.send_value(request).await.map_err(store_error)?;
+        let response: BatchSearchResponse =
+            serde_json::from_value(value).map_err(|error| RagError::VectorStoreError {
+                backend: "agent_retrieval".to_string(),
+                message: format!("failed to parse batchSearch response: {error}"),
+            })?;
+        let fused = response.results.into_iter().next().unwrap_or_default();
+        fused.results.into_iter().map(search_result_from_wire).collect()
+    }
+}
+
+#[async_trait]
+impl VectorStore for AgentRetrievalStore {
+    async fn create_collection(&self, name: &str, dimensions: usize) -> Result<()> {
+        let resource = self.collection_resource(name);
+        if self.existing_collections_only {
+            return match self.get_collection(&resource).await? {
+                Some(_) => Ok(()),
+                None => Err(RagError::ConfigError(format!(
+                    "collection '{resource}' does not exist and existing_collections_only is set; provision it with platform tooling",
+                ))),
+            };
+        }
+        let body = json!({
+            "displayName": name,
+            "vectorSchema": {
+                VECTOR_FIELD: { "denseVector": { "dimensions": dimensions } },
+            },
+        });
+        let request = self
+            .client
+            .request(Method::POST, &format!("{}/collections", self.parent()))
+            .await
+            .map_err(store_error)?
+            .query(&[("collectionId", self.collection_id(name).as_str())])
+            .json(&body);
+        // The trait requires idempotent creation; ALREADY_EXISTS preserves
+        // the existing collection and its rows.
+        let operation = match self.client.send_value(request).await {
+            Ok(operation) => operation,
+            Err(error) if error.details.upstream_status_code == Some(409) => return Ok(()),
+            Err(error) => return Err(store_error(error)),
+        };
+        self.wait_for_operation(operation, "collection create").await?;
+        Ok(())
+    }
+
+    async fn delete_collection(&self, name: &str) -> Result<()> {
+        let resource = self.collection_resource(name);
+        let request = self.client.request(Method::DELETE, &resource).await.map_err(store_error)?;
+        // Idempotent: deleting a missing collection is a no-op.
+        let Some(operation) =
+            self.client.send_value_allow_not_found(request).await.map_err(store_error)?
+        else {
+            return Ok(());
+        };
+        self.wait_for_operation(operation, "collection delete").await?;
+        Ok(())
+    }
+
+    async fn upsert(&self, collection: &str, chunks: &[Chunk]) -> Result<()> {
+        for batch in chunks.chunks(BATCH_LIMIT) {
+            // Fast path: one atomic batchCreate per 1000. Batches are
+            // atomic, so any ALREADY_EXISTS fails the whole batch; fall
+            // back to per-object create-else-patch for last-write-wins.
+            match self.create_objects_batch(collection, batch).await {
+                Ok(()) => {}
+                Err(_) => {
+                    for chunk in batch {
+                        self.upsert_object(collection, chunk).await?;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn delete(&self, collection: &str, ids: &[&str]) -> Result<()> {
+        for batch in ids.chunks(BATCH_LIMIT) {
+            // Batches are atomic, so one missing ID fails the whole batch;
+            // fall back to per-object deletes that ignore NOT_FOUND.
+            if self.delete_objects_batch(collection, batch).await.is_err() {
+                for id in batch {
+                    let name = self.data_object_name(collection, id);
+                    let request =
+                        self.client.request(Method::DELETE, &name).await.map_err(store_error)?;
+                    self.client.send_value_allow_not_found(request).await.map_err(store_error)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn search(
+        &self,
+        collection: &str,
+        embedding: &[f32],
+        top_k: usize,
+    ) -> Result<Vec<SearchResult>> {
+        let parent = self.collection_resource(collection);
+        let body = json!({
+            "vectorSearch": {
+                "searchField": VECTOR_FIELD,
+                "vector": { "values": embedding },
+                "topK": top_k,
+                "outputFields": output_fields(),
+            },
+        });
+        let request = self
+            .client
+            .request(Method::POST, &format!("{parent}/dataObjects:search"))
+            .await
+            .map_err(store_error)?
+            .json(&body);
+        let value = self.client.send_value(request).await.map_err(store_error)?;
+        let response: SearchResponse =
+            serde_json::from_value(value).map_err(|error| RagError::VectorStoreError {
+                backend: "agent_retrieval".to_string(),
+                message: format!("failed to parse search response: {error}"),
+            })?;
+        response.results.into_iter().map(search_result_from_wire).collect()
+    }
+}
+
+/// Sanitizes a name into an RFC 1035 label (lowercase letter first, then
+/// lowercase letters, digits, and hyphens, at most 63 characters).
+fn sanitize_collection_id(name: &str) -> String {
+    let mut id: String = name
+        .chars()
+        .map(|c| match c {
+            'a'..='z' | '0'..='9' | '-' => c,
+            'A'..='Z' => c.to_ascii_lowercase(),
+            _ => '-',
+        })
+        .collect();
+    if !id.starts_with(|c: char| c.is_ascii_lowercase()) {
+        id = format!("c-{id}");
+    }
+    id.truncate(63);
+    while id.ends_with('-') {
+        id.pop();
+    }
+    if id.is_empty() { "c".to_string() } else { id }
+}
+
+fn output_fields() -> Value {
+    json!({
+        "dataFields": ["text", "documentId", "metadata"],
+        "vectorFields": [VECTOR_FIELD],
+    })
+}
+
+fn data_object_body(chunk: &Chunk) -> Value {
+    json!({
+        "data": {
+            "text": chunk.text,
+            "documentId": chunk.document_id,
+            "metadata": chunk.metadata,
+        },
+        "vectors": {
+            VECTOR_FIELD: { "dense": { "values": chunk.embedding } },
+        },
+    })
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct SearchResponse {
+    #[serde(default)]
+    results: Vec<WireSearchResult>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct BatchSearchResponse {
+    #[serde(default)]
+    results: Vec<SearchResponse>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WireSearchResult {
+    #[serde(default)]
+    data_object: WireDataObject,
+    #[serde(default)]
+    distance: f64,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WireDataObject {
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    data_object_id: Option<String>,
+    #[serde(default)]
+    data: WireData,
+    #[serde(default)]
+    vectors: HashMap<String, WireVector>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WireData {
+    #[serde(default)]
+    text: String,
+    #[serde(default)]
+    document_id: String,
+    #[serde(default)]
+    metadata: HashMap<String, String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct WireVector {
+    #[serde(default)]
+    dense: Option<WireDenseVector>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct WireDenseVector {
+    #[serde(default)]
+    values: Vec<f32>,
+}
+
+fn search_result_from_wire(wire: WireSearchResult) -> Result<SearchResult> {
+    let id = wire
+        .data_object
+        .data_object_id
+        .clone()
+        .or_else(|| wire.data_object.name.rsplit('/').next().map(str::to_string))
+        .filter(|id| !id.is_empty())
+        .ok_or_else(|| RagError::VectorStoreError {
+            backend: "agent_retrieval".to_string(),
+            message: "search result data object carries no ID".to_string(),
+        })?;
+    let embedding = wire
+        .data_object
+        .vectors
+        .get(VECTOR_FIELD)
+        .and_then(|vector| vector.dense.as_ref())
+        .map(|dense| dense.values.clone())
+        .unwrap_or_default();
+    Ok(SearchResult {
+        chunk: Chunk {
+            id,
+            text: wire.data_object.data.text,
+            embedding,
+            metadata: wire.data_object.data.metadata,
+            document_id: wire.data_object.data.document_id,
+        },
+        score: wire.distance as f32,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collection_ids_are_rfc1035_labels() {
+        assert_eq!(sanitize_collection_id("contract_search"), "contract-search");
+        assert_eq!(sanitize_collection_id("Docs V2"), "docs-v2");
+        assert_eq!(sanitize_collection_id("9lives"), "c-9lives");
+        assert_eq!(sanitize_collection_id("trailing-"), "trailing");
+        assert_eq!(sanitize_collection_id(""), "c");
+        let long = sanitize_collection_id(&"x".repeat(100));
+        assert_eq!(long.len(), 63);
+    }
+
+    #[tokio::test]
+    async fn prefix_applies_before_sanitization() {
+        let store = AgentRetrievalStore::with_client(
+            AgentRetrievalConfig::new("p", "l").with_collection_prefix("Rag_"),
+            GcpHttpClient::builder(gcp_error_context(), "https://vectorsearch.googleapis.com")
+                .api_version(API_VERSION)
+                .credentials(
+                    google_cloud_auth::credentials::api_key_credentials::Builder::new("k").build(),
+                )
+                .build()
+                .expect("build client"),
+        );
+        assert_eq!(
+            store.collection_resource("Docs"),
+            "projects/p/locations/l/collections/rag-docs",
+        );
+    }
+
+    #[test]
+    fn data_object_body_stores_text_and_metadata_with_the_vector() {
+        let chunk = Chunk {
+            id: "c1".to_string(),
+            text: "hello".to_string(),
+            embedding: vec![0.1, 0.2],
+            metadata: HashMap::from([("k".to_string(), "v".to_string())]),
+            document_id: "d1".to_string(),
+        };
+        assert_eq!(
+            data_object_body(&chunk),
+            json!({
+                "data": { "text": "hello", "documentId": "d1", "metadata": { "k": "v" } },
+                "vectors": { "embedding": { "dense": { "values": [0.1f32, 0.2f32] } } },
+            }),
+        );
+    }
+}

--- a/adk-rag/src/lib.rs
+++ b/adk-rag/src/lib.rs
@@ -21,6 +21,7 @@
 //! | `qdrant`     | `QdrantVectorStore` via qdrant-client     |
 //! | `lancedb`    | `LanceDBVectorStore` via lancedb          |
 //! | `pgvector`   | `PgVectorStore` via sqlx                  |
+//! | `agent-retrieval` | `AgentRetrievalStore` via Agent Retrieval (Vector Search 2.0) |
 //! | `surrealdb`  | `SurrealVectorStore` via surrealdb        |
 //! | `full`       | All of the above                          |
 
@@ -35,6 +36,8 @@ pub mod reranker;
 pub mod tool;
 pub mod vectorstore;
 
+#[cfg(feature = "agent-retrieval")]
+pub mod agent_retrieval;
 #[cfg(feature = "gemini")]
 pub mod gemini;
 #[cfg(feature = "lancedb")]
@@ -48,6 +51,8 @@ pub mod qdrant;
 #[cfg(feature = "surrealdb")]
 pub mod surrealdb;
 
+#[cfg(feature = "agent-retrieval")]
+pub use agent_retrieval::{AgentRetrievalConfig, AgentRetrievalStore};
 pub use chunking::{Chunker, FixedSizeChunker, MarkdownChunker, RecursiveChunker};
 pub use config::{RagConfig, RagConfigBuilder};
 pub use document::{Chunk, Document, SearchResult};

--- a/adk-rag/tests/agent_retrieval_live.rs
+++ b/adk-rag/tests/agent_retrieval_live.rs
@@ -1,0 +1,53 @@
+//! Live round-trip against a real Agent Retrieval project.
+//!
+//! Data-plane only, mirroring how the pgvector/Qdrant live tests manage
+//! tables: the test creates a uniquely-named collection, exercises the
+//! store, and deletes the collection. Requires ADC plus
+//! `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION` (an Agent Retrieval
+//! region, e.g. `us-central1`).
+
+#![cfg(feature = "agent-retrieval")]
+
+use adk_rag::VectorStore;
+use adk_rag::agent_retrieval::{AgentRetrievalConfig, AgentRetrievalStore};
+use adk_rag::{Chunk, RagError};
+use std::collections::HashMap;
+
+fn chunk(id: &str, text: &str, embedding: Vec<f32>) -> Chunk {
+    Chunk {
+        id: id.to_string(),
+        text: text.to_string(),
+        embedding,
+        metadata: HashMap::from([("suite".to_string(), "live".to_string())]),
+        document_id: "live-doc".to_string(),
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires ADC, GOOGLE_CLOUD_PROJECT, and GOOGLE_CLOUD_LOCATION"]
+async fn agent_retrieval_live_round_trip() -> Result<(), RagError> {
+    let config = AgentRetrievalConfig::from_env()?;
+    let store = AgentRetrievalStore::new_with_adc(config)?;
+    let collection = format!("adk-live-{}", std::process::id());
+
+    store.create_collection(&collection, 4).await?;
+    let result = async {
+        let stored = vec![
+            chunk("live-a", "alpha", vec![1.0, 0.0, 0.0, 0.0]),
+            chunk("live-b", "beta", vec![0.0, 1.0, 0.0, 0.0]),
+        ];
+        store.upsert(&collection, &stored).await?;
+
+        let results = store.search(&collection, &[0.0, 1.0, 0.0, 0.0], 2).await?;
+        assert!(!results.is_empty(), "live search returned no results");
+        assert_eq!(results[0].chunk.id, "live-b");
+
+        store.delete(&collection, &["live-a", "live-b"]).await?;
+        Ok::<_, RagError>(())
+    }
+    .await;
+
+    // Always delete the collection, then surface the inner result.
+    store.delete_collection(&collection).await?;
+    result
+}

--- a/adk-rag/tests/vector_store_contract_agent_retrieval.rs
+++ b/adk-rag/tests/vector_store_contract_agent_retrieval.rs
@@ -1,0 +1,474 @@
+//! Shared [`VectorStore`] contract suite and wire-shape assertions for the
+//! Agent Retrieval backend, run against an in-process mock of the
+//! `vectorsearch.googleapis.com` v1 surface (golden shapes per the REST
+//! reference): collection create/delete LROs, data-object CRUD and atomic
+//! batches, and `dataObjects:search`/`:batchSearch` with real dot-product
+//! scoring.
+
+#![cfg(feature = "agent-retrieval")]
+
+mod common;
+
+use adk_rag::VectorStore;
+use adk_rag::agent_retrieval::{AgentRetrievalConfig, AgentRetrievalStore};
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::{delete, get, post};
+use axum::{Json, Router};
+use common::vector_store_contract::{
+    ContractOptions, arb_normalized_embedding, arb_unique_chunks, assert_vector_store_contract,
+    check_search_invariants,
+};
+use google_cloud_auth::credentials::api_key_credentials;
+use proptest::prelude::*;
+use serde_json::{Value, json};
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+const PROJECT: &str = "test-project";
+const LOCATION: &str = "us-central1";
+
+#[derive(Default)]
+struct MockState {
+    /// collectionId → (dataObjectId → stored object body).
+    collections: BTreeMap<String, BTreeMap<String, Value>>,
+    /// Captured wire bodies for golden assertions.
+    create_collection_bodies: Vec<Value>,
+    search_bodies: Vec<Value>,
+}
+
+type Shared = Arc<Mutex<MockState>>;
+
+fn operation(done_response: Option<Value>) -> Value {
+    let mut op = json!({
+        "name": format!("projects/{PROJECT}/locations/{LOCATION}/operations/1"),
+        "done": true,
+    });
+    if let Some(response) = done_response {
+        op["response"] = response;
+    }
+    op
+}
+
+fn error_status(status: StatusCode, message: &str) -> Response {
+    (status, Json(json!({ "error": { "code": status.as_u16(), "message": message } })))
+        .into_response()
+}
+
+fn dense_values(object: &Value) -> Vec<f64> {
+    object["vectors"]["embedding"]["dense"]["values"]
+        .as_array()
+        .map(|values| values.iter().filter_map(Value::as_f64).collect())
+        .unwrap_or_default()
+}
+
+fn dot(a: &[f64], b: &[f64]) -> f64 {
+    a.iter().zip(b).map(|(x, y)| x * y).sum()
+}
+
+fn ranked_vector_results(
+    objects: &BTreeMap<String, Value>,
+    query: &[f64],
+    top_k: usize,
+) -> Vec<(String, f64)> {
+    let mut scored: Vec<(String, f64)> = objects
+        .iter()
+        .map(|(id, object)| (id.clone(), dot(&dense_values(object), query)))
+        .collect();
+    scored.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    scored.truncate(top_k);
+    scored
+}
+
+fn ranked_text_results(
+    objects: &BTreeMap<String, Value>,
+    needle: &str,
+    top_k: usize,
+) -> Vec<(String, f64)> {
+    let mut hits: Vec<(String, f64)> = objects
+        .iter()
+        .filter(|(_, object)| {
+            object["data"]["text"].as_str().is_some_and(|text| text.contains(needle))
+        })
+        .map(|(id, _)| (id.clone(), 1.0))
+        .collect();
+    hits.sort_by(|a, b| a.0.cmp(&b.0));
+    hits.truncate(top_k);
+    hits
+}
+
+fn results_json(objects: &BTreeMap<String, Value>, ranked: &[(String, f64)]) -> Value {
+    let results: Vec<Value> = ranked
+        .iter()
+        .map(|(id, score)| {
+            let mut object = objects[id].clone();
+            object["dataObjectId"] = json!(id);
+            object["name"] = json!(format!(
+                "projects/{PROJECT}/locations/{LOCATION}/collections/c/dataObjects/{id}",
+            ));
+            json!({ "dataObject": object, "distance": score })
+        })
+        .collect();
+    json!({ "results": results })
+}
+
+/// Reciprocal rank fusion over per-search ranked ID lists.
+fn rrf_fuse(rankings: &[Vec<(String, f64)>], weights: &[f64], top_k: usize) -> Vec<(String, f64)> {
+    const K: f64 = 60.0;
+    let mut fused: HashMap<String, f64> = HashMap::new();
+    for (ranking, weight) in rankings.iter().zip(weights) {
+        for (rank, (id, _)) in ranking.iter().enumerate() {
+            *fused.entry(id.clone()).or_default() += weight / (K + rank as f64 + 1.0);
+        }
+    }
+    let mut fused: Vec<(String, f64)> = fused.into_iter().collect();
+    fused.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    fused.truncate(top_k);
+    fused
+}
+
+async fn start_mock(state: Shared) -> String {
+    let base = format!("/v1/projects/{PROJECT}/locations/{LOCATION}");
+    let app = Router::new()
+        .route(
+            &format!("{base}/collections"),
+            post(
+                |State(state): State<Shared>,
+                 Query(params): Query<HashMap<String, String>>,
+                 Json(body): Json<Value>| async move {
+                    let mut state = state.lock().await;
+                    let id = params.get("collectionId").cloned().unwrap_or_default();
+                    if state.collections.contains_key(&id) {
+                        return error_status(StatusCode::CONFLICT, "collection already exists");
+                    }
+                    state.create_collection_bodies.push(body);
+                    state.collections.insert(id, BTreeMap::new());
+                    Json(operation(Some(json!({ "@type": "t", "name": "c" })))).into_response()
+                },
+            ),
+        )
+        .route(
+            &format!("{base}/collections/{{cid}}"),
+            delete(|State(state): State<Shared>, Path(cid): Path<String>| async move {
+                let mut state = state.lock().await;
+                if state.collections.remove(&cid).is_none() {
+                    return error_status(StatusCode::NOT_FOUND, "collection not found");
+                }
+                Json(operation(None)).into_response()
+            })
+            .merge(get(
+                |State(state): State<Shared>, Path(cid): Path<String>| async move {
+                    let state = state.lock().await;
+                    if state.collections.contains_key(&cid) {
+                        Json(json!({ "name": cid })).into_response()
+                    } else {
+                        error_status(StatusCode::NOT_FOUND, "collection not found")
+                    }
+                },
+            )),
+        )
+        .route(
+            &format!("{base}/collections/{{cid}}/{{action}}"),
+            post(
+                |State(state): State<Shared>,
+                 Path((cid, action)): Path<(String, String)>,
+                 Query(params): Query<HashMap<String, String>>,
+                 Json(body): Json<Value>| async move {
+                    let mut state = state.lock().await;
+                    if !state.collections.contains_key(&cid) {
+                        return error_status(StatusCode::NOT_FOUND, "collection not found");
+                    }
+                    match action.as_str() {
+                        "dataObjects" => {
+                            let id = params.get("dataObjectId").cloned().unwrap_or_default();
+                            let objects = state.collections.get_mut(&cid).unwrap();
+                            if objects.contains_key(&id) {
+                                return error_status(
+                                    StatusCode::CONFLICT,
+                                    "data object already exists",
+                                );
+                            }
+                            objects.insert(id, body);
+                            Json(json!({})).into_response()
+                        }
+                        "dataObjects:batchCreate" => {
+                            let requests = body["requests"].as_array().cloned().unwrap_or_default();
+                            let objects = state.collections.get_mut(&cid).unwrap();
+                            // Atomic: any existing ID fails the whole batch.
+                            if requests.iter().any(|request| {
+                                request["dataObjectId"]
+                                    .as_str()
+                                    .is_some_and(|id| objects.contains_key(id))
+                            }) {
+                                return error_status(
+                                    StatusCode::CONFLICT,
+                                    "data object already exists",
+                                );
+                            }
+                            for request in &requests {
+                                objects.insert(
+                                    request["dataObjectId"]
+                                        .as_str()
+                                        .unwrap_or_default()
+                                        .to_string(),
+                                    request["dataObject"].clone(),
+                                );
+                            }
+                            Json(json!({ "dataObjects": [] })).into_response()
+                        }
+                        "dataObjects:batchDelete" => {
+                            let requests = body["requests"].as_array().cloned().unwrap_or_default();
+                            let names: Vec<String> = requests
+                                .iter()
+                                .filter_map(|request| request["name"].as_str())
+                                .filter_map(|name| name.rsplit('/').next().map(str::to_string))
+                                .collect();
+                            let objects = state.collections.get_mut(&cid).unwrap();
+                            // Atomic: any missing ID fails the whole batch.
+                            if names.iter().any(|id| !objects.contains_key(id)) {
+                                return error_status(StatusCode::NOT_FOUND, "data object missing");
+                            }
+                            for id in &names {
+                                objects.remove(id);
+                            }
+                            Json(json!({})).into_response()
+                        }
+                        "dataObjects:search" => {
+                            state.search_bodies.push(body.clone());
+                            let objects = &state.collections[&cid];
+                            let search = &body["vectorSearch"];
+                            let query: Vec<f64> = search["vector"]["values"]
+                                .as_array()
+                                .map(|values| values.iter().filter_map(Value::as_f64).collect())
+                                .unwrap_or_default();
+                            let top_k = search["topK"].as_u64().unwrap_or(10) as usize;
+                            let ranked = ranked_vector_results(objects, &query, top_k);
+                            Json(results_json(objects, &ranked)).into_response()
+                        }
+                        "dataObjects:batchSearch" => {
+                            let objects = &state.collections[&cid];
+                            let searches = body["searches"].as_array().cloned().unwrap_or_default();
+                            let rankings: Vec<Vec<(String, f64)>> = searches
+                                .iter()
+                                .map(|search| {
+                                    if let Some(vector_search) = search.get("vectorSearch") {
+                                        let query: Vec<f64> = vector_search["vector"]["values"]
+                                            .as_array()
+                                            .map(|values| {
+                                                values.iter().filter_map(Value::as_f64).collect()
+                                            })
+                                            .unwrap_or_default();
+                                        let top_k =
+                                            vector_search["topK"].as_u64().unwrap_or(10) as usize;
+                                        ranked_vector_results(objects, &query, top_k)
+                                    } else {
+                                        let text_search = &search["textSearch"];
+                                        let needle =
+                                            text_search["searchText"].as_str().unwrap_or_default();
+                                        let top_k =
+                                            text_search["topK"].as_u64().unwrap_or(10) as usize;
+                                        ranked_text_results(objects, needle, top_k)
+                                    }
+                                })
+                                .collect();
+                            let combine = &body["combine"];
+                            let weights: Vec<f64> = combine["ranker"]["rrf"]["weights"]
+                                .as_array()
+                                .map(|values| values.iter().filter_map(Value::as_f64).collect())
+                                .unwrap_or_default();
+                            let top_k = combine["topK"].as_u64().unwrap_or(10) as usize;
+                            let fused = rrf_fuse(&rankings, &weights, top_k);
+                            Json(json!({ "results": [results_json(objects, &fused)] }))
+                                .into_response()
+                        }
+                        _ => error_status(StatusCode::NOT_FOUND, "unknown action"),
+                    }
+                },
+            ),
+        )
+        .route(
+            &format!("{base}/collections/{{cid}}/dataObjects/{{oid}}"),
+            axum::routing::patch(
+                |State(state): State<Shared>,
+                 Path((cid, oid)): Path<(String, String)>,
+                 Json(body): Json<Value>| async move {
+                    let mut state = state.lock().await;
+                    let Some(objects) = state.collections.get_mut(&cid) else {
+                        return error_status(StatusCode::NOT_FOUND, "collection not found");
+                    };
+                    if !objects.contains_key(&oid) {
+                        return error_status(StatusCode::NOT_FOUND, "data object missing");
+                    }
+                    objects.insert(oid, body);
+                    Json(json!({})).into_response()
+                },
+            )
+            .merge(delete(
+                |State(state): State<Shared>, Path((cid, oid)): Path<(String, String)>| async move {
+                    let mut state = state.lock().await;
+                    let Some(objects) = state.collections.get_mut(&cid) else {
+                        return error_status(StatusCode::NOT_FOUND, "collection not found");
+                    };
+                    if objects.remove(&oid).is_none() {
+                        return error_status(StatusCode::NOT_FOUND, "data object missing");
+                    }
+                    Json(json!({})).into_response()
+                },
+            )),
+        )
+        .with_state(state);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("bind mock");
+    let address = listener.local_addr().expect("mock address");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve mock");
+    });
+    format!("http://{address}")
+}
+
+fn build_store(endpoint: &str) -> AgentRetrievalStore {
+    AgentRetrievalStore::with_credentials(
+        AgentRetrievalConfig::new(PROJECT, LOCATION).with_endpoint(endpoint),
+        api_key_credentials::Builder::new("test-api-key").build(),
+    )
+    .expect("build store")
+}
+
+#[tokio::test]
+async fn test_agent_retrieval_vector_store_contract() {
+    let state = Shared::default();
+    let endpoint = start_mock(state.clone()).await;
+    let store = build_store(&endpoint);
+    assert_vector_store_contract(&store, ContractOptions::default()).await;
+}
+
+#[tokio::test]
+async fn create_collection_declares_a_byoe_dense_vector_schema() {
+    let state = Shared::default();
+    let endpoint = start_mock(state.clone()).await;
+    let store = build_store(&endpoint);
+
+    store.create_collection("golden_wire", 768).await.expect("create");
+
+    let state = state.lock().await;
+    // BYOE: no vertexEmbeddingConfig — the embedder pipeline owns vectors.
+    assert_eq!(
+        state.create_collection_bodies,
+        vec![json!({
+            "displayName": "golden_wire",
+            "vectorSchema": { "embedding": { "denseVector": { "dimensions": 768 } } },
+        })],
+    );
+}
+
+#[tokio::test]
+async fn search_sends_the_documented_vector_search_shape() {
+    let state = Shared::default();
+    let endpoint = start_mock(state.clone()).await;
+    let store = build_store(&endpoint);
+
+    store.create_collection("golden_search", 3).await.expect("create");
+    store.search("golden_search", &[0.5, 0.25, 0.25], 7).await.expect("search");
+
+    let state = state.lock().await;
+    assert_eq!(
+        state.search_bodies,
+        vec![json!({
+            "vectorSearch": {
+                "searchField": "embedding",
+                "vector": { "values": [0.5f32, 0.25f32, 0.25f32] },
+                "topK": 7,
+                "outputFields": {
+                    "dataFields": ["text", "documentId", "metadata"],
+                    "vectorFields": ["embedding"],
+                },
+            },
+        })],
+    );
+}
+
+#[tokio::test]
+async fn existing_collections_only_validates_instead_of_creating() {
+    let state = Shared::default();
+    let endpoint = start_mock(state.clone()).await;
+    let store = AgentRetrievalStore::with_credentials(
+        AgentRetrievalConfig::new(PROJECT, LOCATION)
+            .with_endpoint(&endpoint)
+            .with_existing_collections_only(true),
+        api_key_credentials::Builder::new("test-api-key").build(),
+    )
+    .expect("build store");
+
+    let error = store
+        .create_collection("never_provisioned", 4)
+        .await
+        .expect_err("missing collection must fail in existing-only mode");
+    assert!(error.to_string().contains("does not exist"), "{error}");
+    assert!(state.lock().await.create_collection_bodies.is_empty(), "must not create");
+}
+
+#[tokio::test]
+async fn hybrid_search_fuses_semantic_and_text_rankings() {
+    let state = Shared::default();
+    let endpoint = start_mock(state.clone()).await;
+    let store = build_store(&endpoint);
+
+    store.create_collection("hybrid", 2).await.expect("create");
+    let chunks = vec![
+        adk_rag::Chunk {
+            id: "vector-hit".to_string(),
+            text: "unrelated words".to_string(),
+            embedding: vec![1.0, 0.0],
+            metadata: std::collections::HashMap::new(),
+            document_id: "d".to_string(),
+        },
+        adk_rag::Chunk {
+            id: "text-hit".to_string(),
+            text: "the searched phrase".to_string(),
+            embedding: vec![0.0, 1.0],
+            metadata: std::collections::HashMap::new(),
+            document_id: "d".to_string(),
+        },
+    ];
+    store.upsert("hybrid", &chunks).await.expect("upsert");
+
+    let results = store
+        .hybrid_search("hybrid", &[1.0, 0.0], "searched phrase", 2, (0.5, 0.5))
+        .await
+        .expect("hybrid search");
+
+    let mut ids: Vec<String> = results.iter().map(|result| result.chunk.id.clone()).collect();
+    ids.sort();
+    assert_eq!(ids, vec!["text-hit".to_string(), "vector-hit".to_string()]);
+}
+
+/// **VectorStore contract, search invariants (Agent Retrieval)**
+/// *For any* set of uniquely-identified chunks and any non-zero query, `search`
+/// SHALL return at most `top_k` distinct stored IDs ordered by descending
+/// score, and every inserted chunk SHALL be retrievable.
+mod prop_agent_retrieval_search_invariants {
+    use super::*;
+
+    const DIM: usize = 8;
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(30))]
+
+        #[test]
+        fn search_invariants_hold(
+            chunks in arb_unique_chunks(DIM, 20),
+            query in arb_normalized_embedding(DIM),
+            top_k in 1usize..25,
+        ) {
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            rt.block_on(async {
+                let state = Shared::default();
+                let endpoint = start_mock(state).await;
+                let store = build_store(&endpoint);
+                check_search_invariants(&store, "contract", &chunks, &query, top_k).await
+            })?;
+        }
+    }
+}

--- a/docs/official_docs/rag/agent-retrieval.md
+++ b/docs/official_docs/rag/agent-retrieval.md
@@ -1,0 +1,76 @@
+# Agent Retrieval Vector Store
+
+Agent Retrieval (formerly Vector Search 2.0) is Google's managed vector database on the Gemini Enterprise Agent Platform, generally available at `vectorsearch.googleapis.com`. The `agent-retrieval` feature of `adk-rag` implements the [`VectorStore`] trait against it, so it slots into the existing RAG pipeline exactly like the pgvector, Qdrant, LanceDB, and SurrealDB backends.
+
+```toml
+[dependencies]
+adk-rag = { version = "2.1.0", features = ["agent-retrieval"] }
+```
+
+## Quick start
+
+```rust,no_run
+use adk_rag::VectorStore;
+use adk_rag::agent_retrieval::{AgentRetrievalConfig, AgentRetrievalStore};
+
+async fn run() -> adk_rag::Result<()> {
+    // Application Default Credentials; project/location from the environment.
+    let store = AgentRetrievalStore::new_with_adc(AgentRetrievalConfig::from_env()?)?;
+
+    store.create_collection("docs", 768).await?;
+    // upsert / search / delete exactly as with any other VectorStore backend
+    Ok(())
+}
+```
+
+## Mapping onto the platform
+
+| Trait operation | Agent Retrieval call |
+|-----------------|----------------------|
+| `create_collection` | `POST {parent}/collections` (long-running operation; `ALREADY_EXISTS` is a no-op) |
+| `delete_collection` | `DELETE {collection}` (long-running operation; `NOT_FOUND` is a no-op) |
+| `upsert` | `dataObjects:batchCreate` (≤1000, atomic), falling back to per-object create-else-patch for last-write-wins |
+| `delete` | `dataObjects:batchDelete`, falling back to per-object delete when IDs are missing |
+| `search` | `dataObjects:search` with a `vectorSearch` query |
+
+Chunk text and metadata are stored **in** the Data Object alongside the vector — no companion store is needed. The store runs in BYOE (bring-your-own-embeddings) mode: embeddings come from adk-rag's embedder pipeline, keeping behavior identical across backends. Scores are `DOT_PRODUCT` distances, which equal cosine similarity for normalized embeddings (higher is more relevant).
+
+## Configuration
+
+| Option | Effect |
+|--------|--------|
+| `with_collection_prefix("rag-")` | Prefixes every collection ID, isolating this store's collections |
+| `with_existing_collections_only(true)` | `create_collection` validates the collection exists instead of creating it — for deployments that pre-provision with platform tooling |
+| `with_endpoint(...)` | Custom API origin (loopback HTTP allowed for tests) |
+
+Collection names are sanitized into RFC 1035 labels (lowercased; invalid characters become hyphens), so `my_docs` becomes collection ID `my-docs`. Distinct names that sanitize identically collide — choose names that differ in more than case or punctuation.
+
+## Beyond the trait
+
+For callers holding the concrete `AgentRetrievalStore`, `hybrid_search` runs a semantic and a keyword query in one `dataObjects:batchSearch` call and returns the reciprocal-rank-fusion ranked list:
+
+```rust,no_run
+# use adk_rag::agent_retrieval::{AgentRetrievalConfig, AgentRetrievalStore};
+# async fn run(store: AgentRetrievalStore, embedding: Vec<f32>) -> adk_rag::Result<()> {
+let results = store
+    .hybrid_search("docs", &embedding, "quarterly revenue", 10, (0.6, 0.4))
+    .await?;
+# Ok(())
+# }
+```
+
+## Platform notes
+
+- **Regions:** Agent Retrieval is regional; supported regions include `us-central1`, `us-east4`, `us-west1`, `europe-north1`, `europe-west2`, `europe-west4`, `asia-east1`, `asia-northeast1`, and `asia-southeast1`.
+- **CMEK:** standalone Agent Retrieval supports customer-managed encryption keys via the collection's `encryptionSpec` (immutable at creation). Pre-provision CMEK collections with platform tooling and use `with_existing_collections_only(true)`.
+- **Vector Search 1.0 is deliberately not implemented.** Its index/endpoint infrastructure model fits the `VectorStore` trait poorly, and Google positions Agent Retrieval as its successor.
+- **Quotas:** batch writes are capped at 1000 objects per request and are atomic; the store chunks larger upserts automatically.
+
+## Testing
+
+The backend passes the shared `VectorStore` contract and property suite that all adk-rag backends run, so it is behaviorally interchangeable with the other stores. The `#[ignore]` live test creates and deletes its own uniquely-named collection (data-plane, like the pgvector and Qdrant live tests):
+
+```bash
+GOOGLE_CLOUD_PROJECT=my-project GOOGLE_CLOUD_LOCATION=us-central1 \
+  cargo test -p adk-rag --features agent-retrieval -- --ignored
+```


### PR DESCRIPTION
## What

Adds `AgentRetrievalStore` — an `adk-rag` `VectorStore` backend for **Agent Retrieval** (formerly Vector Search 2.0, GA at `vectorsearch.googleapis.com`), behind the new `agent-retrieval` feature. Wave 4 PR 4.4 (WP12.4) of the Agent Engine plan.

| Item | Detail |
|------|--------|
| `AgentRetrievalConfig` | project/location (+`from_env`), `collection_prefix`, `existing_collections_only` (create → validate-and-fail-if-missing), endpoint override |
| `AgentRetrievalStore` | Full `VectorStore` impl on `adk-gcp`'s `GcpHttpClient` + `LroPoller` (v1, BYOE mode — no auto-embedding, parity with the other backends) |
| Trait mapping | create/delete collection → LROs (`ALREADY_EXISTS`/`NOT_FOUND` are no-ops per trait semantics); upsert → atomic `batchCreate` with per-object create-else-patch fallback (last-write-wins, no ETags); delete → atomic `batchDelete` with per-object fallback; search → `vectorSearch` with `DOT_PRODUCT` |
| Chunk storage | text/metadata/document ID stored **in** the Data Object alongside the vector — no companion store (the gap that made Vector Search 1.0 a poor fit) |
| Beyond-trait extra | `hybrid_search` (semantic + text via `:batchSearch` with RRF fusion), inherent method only |
| Collection names | sanitized to RFC 1035 labels deterministically; documented collision caveat |

## Why

Part of #438.

Track B of Wave 4 delivers managed-retrieval parity. Agent Retrieval is a managed *database*: creating a `Collection` is data-plane (analogous to the table creation the pgvector/Qdrant/LanceDB backends perform), so the full trait including `create_collection`/`delete_collection` is in scope — unlike EAP control-plane resources. Strict pre-provisioning deployments use `existing_collections_only`.

## How

- Wire shapes follow verification task V6 (transcribed from the official REST reference and confirmed against the live docs): `vectorSchema.{field}.denseVector.dimensions`, `dataObjects:batchCreate` requests (≤1000, atomic), `vectorSearch {searchField, vector.values, topK, outputFields}`, `batchSearch` with `combine.ranker.rrf.weights`, and the `{results: [{dataObject, distance}]}` response.
- Scores are `DOT_PRODUCT` distances — equal to cosine similarity for the normalized embeddings the embedder pipeline produces; documented in rustdoc.
- **The shared `VectorStore` contract/property suite (Wave 0, PR 0.9) runs against this backend** with an in-process mock of the v1 surface implementing real dot-product ranking, atomic batch semantics, 409/404 statuses, and RRF fusion — so all store backends stay behaviorally interchangeable. Golden wire assertions capture the create-collection and search bodies whole.
- `#[ignore]` live test creates and deletes its own uniquely-named collection (data-plane, mirroring pgvector/Qdrant live tests).
- Vector Search 1.0 deliberately not implemented (legacy; recorded in module rustdoc).
- Errors cross the `RagError::VectorStoreError` boundary; internally branded via a `rag.agent_retrieval.*` `GcpErrorCodes` table (component `Memory` — matching PR 4.2's choice; `adk-core` has no RAG component).

### Deviations

| Deviation | Rationale |
|-----------|-----------|
| Umbrella forwarding, CI matrix, `AGENTS.md`, `CHANGELOG.md` untouched | Consolidated in the round-one forwarding PR so the six parallel Wave 4 PRs merge conflict-free in any order (approved) |
| Ranking-API reranking not included | The wave file lists it as optional; the Ranking API is a separate aiplatform surface — deferred, `hybrid_search` RRF covers fusion |
| Feature is not in `full` | Workspace convention: external-infrastructure backends stay out of `full` (matches pgvector/qdrant/etc.) |
| Upsert fallback is per-object on conflict | Batches are atomic and PATCH-create-if-missing is undocumented; fast path stays 1 request/1000 for fresh ingests — candidate optimization once live PATCH semantics are confirmed |

## Verification

| Command | Result |
|---------|--------|
| `cargo fmt --all -- --check` | pass |
| `cargo clippy -p adk-rag --features agent-retrieval --all-targets -- -D warnings` | pass |
| `cargo nextest run -p adk-rag --features agent-retrieval` | 17 passed (incl. shared contract suite + 30 property cases), 1 skipped (live) |
| `cargo nextest run -p adk-rag` (no features) | 8 passed |
| `cargo test -p adk-rag --features agent-retrieval --doc` | pass |
| `RUSTDOCFLAGS='-D warnings' cargo doc -p adk-rag --no-deps --features agent-retrieval` | pass |
| `cargo check --workspace` | pass |
| `./scripts/check-doc-examples.sh` / `check-doc-versions.py` | pass (101 files / 2.1.0) |

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes (consolidated into the round-one forwarding PR)
- [x] README updated if crate capabilities changed
- [x] Examples added or updated for new features (live + mock tests; Track B example ships in PR 4.2)
