### PR TITLE
feat(skill): add Skill Registry read client and safe extraction - PR 4.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,8 +1036,13 @@ name = "adk-skill"
 version = "2.1.0"
 dependencies = [
  "adk-core",
+ "adk-gcp",
  "adk-plugin",
  "async-trait",
+ "axum 0.8.9",
+ "base64 0.22.1",
+ "google-cloud-auth 1.12.0",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1047,6 +1052,7 @@ dependencies = [
  "tokio",
  "tracing",
  "walkdir",
+ "zip 7.2.0",
 ]
 
 [[package]]
@@ -21893,9 +21899,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
 dependencies = [
  "crc32fast",
+ "flate2",
  "indexmap 2.14.0",
  "memchr",
  "typed-path",
+ "zopfli",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,6 +153,7 @@ sha2 = "0.10"
 hex = "0.4"
 flate2 = "1.0"
 tar = "0.4"
+zip = { version = "7.2", default-features = false, features = ["deflate"] }
 livekit = { version = "=0.8.1", default-features = false, features = ["tokio", "native-tls"] }
 livekit-api = { version = "=0.6.1", default-features = false, features = ["services-tokio", "access-token"] }
 livekit-datatrack = { version = "=0.1.13", default-features = false }

--- a/adk-skill/Cargo.toml
+++ b/adk-skill/Cargo.toml
@@ -12,8 +12,20 @@ readme = "README.md"
 keywords = ["adk", "skills", "agent", "prompt"]
 categories = ["development-tools", "asynchronous"]
 
+[features]
+# Read-only Vertex AI Skill Registry client (Build pillar, aiplatform v1beta1)
+# with safe archive extraction. Lifecycle operations are platform-owned.
+vertex-skill-registry = [
+    "dep:adk-gcp",
+    "dep:google-cloud-auth",
+    "dep:reqwest",
+    "dep:base64",
+    "dep:zip",
+]
+
 [dependencies]
 adk-core.workspace = true
+adk-gcp = { workspace = true, optional = true }
 adk-plugin.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -23,7 +35,16 @@ serde_yaml = "0.9"
 walkdir = "2.5"
 sha2 = "0.10"
 tempfile = "3"
+base64 = { version = "0.22", optional = true }
+google-cloud-auth = { version = "1.8", optional = true, default-features = false, features = ["default-rustls-provider"] }
+reqwest = { workspace = true, optional = true }
+zip = { workspace = true, optional = true }
 
 [dev-dependencies]
 async-trait.workspace = true
 tokio = { workspace = true, features = ["full"] }
+axum = "0.8"
+
+[[test]]
+name = "skill_registry_contract"
+required-features = ["vertex-skill-registry"]

--- a/adk-skill/src/error.rs
+++ b/adk-skill/src/error.rs
@@ -22,6 +22,91 @@ pub enum SkillError {
 
     #[error("index error: {0}")]
     IndexError(String),
+
+    // ===== Skill Registry payloads (feature `vertex-skill-registry`) =====
+    /// The `zippedFilesystem` field was not valid standard base64.
+    #[cfg(feature = "vertex-skill-registry")]
+    #[error(
+        "skill registry payload is not valid base64: {message}. The zippedFilesystem field must be standard base64; re-fetch the skill or report the registry entry"
+    )]
+    RegistryPayloadDecode { message: String },
+
+    /// The decoded zip did not match the registry's `sha256` field.
+    #[cfg(feature = "vertex-skill-registry")]
+    #[error(
+        "skill registry payload sha256 mismatch: expected {expected}, computed {actual}. The payload may be corrupt or tampered with; re-fetch the skill before using its contents"
+    )]
+    RegistryChecksumMismatch { expected: String, actual: String },
+
+    /// The payload is not a well-formed zip archive.
+    #[cfg(feature = "vertex-skill-registry")]
+    #[error(
+        "skill archive is not a valid zip: {message}. The registry serves SKILL.md packages as zip archives; re-fetch the skill or report the registry entry"
+    )]
+    ArchiveFormat { message: String },
+
+    /// The archive exceeds the maximum accepted size.
+    #[cfg(feature = "vertex-skill-registry")]
+    #[error(
+        "skill archive is {size} bytes, exceeding the {limit}-byte limit. The registry rejects archives over this size; do not extract oversized payloads"
+    )]
+    ArchiveTooLarge { size: u64, limit: u64 },
+
+    /// The archive contains more entries than allowed.
+    #[cfg(feature = "vertex-skill-registry")]
+    #[error(
+        "skill archive contains {count} entries, exceeding the limit of {limit}. Split the skill into smaller packages or remove unneeded files"
+    )]
+    ArchiveTooManyEntries { count: usize, limit: usize },
+
+    /// An entry path contains a `..` component.
+    #[cfg(feature = "vertex-skill-registry")]
+    #[error(
+        "skill archive entry `{name}` contains a `..` path component. Path traversal is rejected; all entries must resolve inside the extraction root"
+    )]
+    ArchivePathTraversal { name: String },
+
+    /// An entry path is absolute.
+    #[cfg(feature = "vertex-skill-registry")]
+    #[error(
+        "skill archive entry `{name}` is an absolute path. Entries must be relative so extraction stays inside the target directory"
+    )]
+    ArchiveAbsolutePath { name: String },
+
+    /// An entry is a symbolic link.
+    #[cfg(feature = "vertex-skill-registry")]
+    #[error(
+        "skill archive entry `{name}` is a symlink. Symlinks are rejected because they can escape the extraction root"
+    )]
+    ArchiveSymlink { name: String },
+
+    /// Two entries share the same normalized name.
+    #[cfg(feature = "vertex-skill-registry")]
+    #[error(
+        "skill archive contains duplicate entry `{name}`. Duplicate names are rejected because later entries would silently overwrite earlier ones"
+    )]
+    ArchiveDuplicateEntry { name: String },
+
+    /// The declared uncompressed total exceeds the limit.
+    #[cfg(feature = "vertex-skill-registry")]
+    #[error(
+        "skill archive declares {total} uncompressed bytes, exceeding the {limit}-byte limit. Refusing to extract to avoid resource exhaustion"
+    )]
+    ArchiveUncompressedTooLarge { total: u64, limit: u64 },
+
+    /// An entry's compression ratio exceeds the limit (zip-bomb defense).
+    #[cfg(feature = "vertex-skill-registry")]
+    #[error(
+        "skill archive entry `{name}` has compression ratio {ratio}, exceeding the limit of {limit}. Highly compressed entries are rejected as potential zip bombs"
+    )]
+    ArchiveCompressionRatio { name: String, ratio: u64, limit: u64 },
+
+    /// An entry nests deeper than the allowed directory depth.
+    #[cfg(feature = "vertex-skill-registry")]
+    #[error(
+        "skill archive entry `{name}` nests {depth} directory levels, exceeding the limit of {limit}. Flatten the skill's directory layout"
+    )]
+    ArchiveDepthExceeded { name: String, depth: usize, limit: usize },
 }
 
 pub type SkillResult<T> = Result<T, SkillError>;
@@ -41,6 +126,56 @@ impl From<SkillError> for adk_core::AdkError {
             }
             SkillError::Validation(_) => (ErrorCategory::InvalidInput, "skill.validation"),
             SkillError::IndexError(_) => (ErrorCategory::Internal, "skill.index"),
+            // Decode and checksum failures are corrupt upstream payloads;
+            // archive-rule violations are rejected input data.
+            #[cfg(feature = "vertex-skill-registry")]
+            SkillError::RegistryPayloadDecode { .. } => {
+                (ErrorCategory::Internal, "skill.registry.payload_decode")
+            }
+            #[cfg(feature = "vertex-skill-registry")]
+            SkillError::RegistryChecksumMismatch { .. } => {
+                (ErrorCategory::Internal, "skill.registry.checksum_mismatch")
+            }
+            #[cfg(feature = "vertex-skill-registry")]
+            SkillError::ArchiveFormat { .. } => {
+                (ErrorCategory::InvalidInput, "skill.archive.invalid_format")
+            }
+            #[cfg(feature = "vertex-skill-registry")]
+            SkillError::ArchiveTooLarge { .. } => {
+                (ErrorCategory::InvalidInput, "skill.archive.too_large")
+            }
+            #[cfg(feature = "vertex-skill-registry")]
+            SkillError::ArchiveTooManyEntries { .. } => {
+                (ErrorCategory::InvalidInput, "skill.archive.too_many_entries")
+            }
+            #[cfg(feature = "vertex-skill-registry")]
+            SkillError::ArchivePathTraversal { .. } => {
+                (ErrorCategory::InvalidInput, "skill.archive.path_traversal")
+            }
+            #[cfg(feature = "vertex-skill-registry")]
+            SkillError::ArchiveAbsolutePath { .. } => {
+                (ErrorCategory::InvalidInput, "skill.archive.absolute_path")
+            }
+            #[cfg(feature = "vertex-skill-registry")]
+            SkillError::ArchiveSymlink { .. } => {
+                (ErrorCategory::InvalidInput, "skill.archive.symlink")
+            }
+            #[cfg(feature = "vertex-skill-registry")]
+            SkillError::ArchiveDuplicateEntry { .. } => {
+                (ErrorCategory::InvalidInput, "skill.archive.duplicate_entry")
+            }
+            #[cfg(feature = "vertex-skill-registry")]
+            SkillError::ArchiveUncompressedTooLarge { .. } => {
+                (ErrorCategory::InvalidInput, "skill.archive.uncompressed_too_large")
+            }
+            #[cfg(feature = "vertex-skill-registry")]
+            SkillError::ArchiveCompressionRatio { .. } => {
+                (ErrorCategory::InvalidInput, "skill.archive.compression_ratio")
+            }
+            #[cfg(feature = "vertex-skill-registry")]
+            SkillError::ArchiveDepthExceeded { .. } => {
+                (ErrorCategory::InvalidInput, "skill.archive.depth_exceeded")
+            }
         };
         adk_core::AdkError::new(ErrorComponent::Tool, category, code, err.to_string())
             .with_source(err)

--- a/adk-skill/src/lib.rs
+++ b/adk-skill/src/lib.rs
@@ -31,6 +31,8 @@ mod index;
 mod injector;
 mod model;
 mod parser;
+#[cfg(feature = "vertex-skill-registry")]
+pub mod registry;
 mod select;
 mod writer;
 

--- a/adk-skill/src/registry/client.rs
+++ b/adk-skill/src/registry/client.rs
@@ -1,0 +1,698 @@
+//! REST client for the Vertex AI Skill Registry v1beta1 (read-only).
+
+use crate::error::SkillError;
+use crate::registry::extract::{extract_skill_archive, write_files_to_dir};
+use adk_core::{AdkError, ErrorCategory, ErrorComponent, Result};
+use adk_gcp::{GcpErrorCodes, GcpErrorContext, GcpHttpClient, truncate_for_error};
+use base64::Engine as _;
+use google_cloud_auth::credentials::Credentials;
+use reqwest::Method;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+const SKILL_REGISTRY_API_VERSION: &str = "v1beta1";
+const HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+const AUTH_HEADERS_TIMEOUT: Duration = Duration::from_secs(30);
+const ENV_GOOGLE_CLOUD_PROJECT: &str = "GOOGLE_CLOUD_PROJECT";
+const ENV_GOOGLE_CLOUD_LOCATION: &str = "GOOGLE_CLOUD_LOCATION";
+/// Server-side default and maximum for `skills:retrieve` `topK`.
+const RETRIEVE_MAX_TOP_K: u32 = 100;
+
+/// Configuration for the Vertex AI Skill Registry client.
+///
+/// > **Note:** the Skill Registry API is **v1beta1 (Preview)**, served from
+/// > regional `https://{location}-aiplatform.googleapis.com` endpoints in
+/// > `us-central1`, `europe-west4`, and `us-east5` only. It is a Build-pillar
+/// > service distinct from the Agent Registry (a separate Govern-pillar
+/// > service).
+#[derive(Debug, Clone)]
+pub struct SkillRegistryConfig {
+    /// Google Cloud project ID.
+    pub project_id: String,
+    /// GCP region (`us-central1`, `europe-west4`, or `us-east5`).
+    pub location: String,
+    /// Optional custom API origin.
+    ///
+    /// The origin receives Google authorization headers plus skill payloads.
+    /// It must not contain userinfo, a path, a query, or a fragment.
+    pub endpoint: Option<String>,
+}
+
+impl SkillRegistryConfig {
+    /// Creates a new config with the given project ID and location.
+    pub fn new(project_id: impl Into<String>, location: impl Into<String>) -> Self {
+        Self { project_id: project_id.into(), location: location.into(), endpoint: None }
+    }
+
+    /// Builds a config from environment variables.
+    ///
+    /// Reads `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION`. Values are
+    /// trimmed; blank values count as missing.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use adk_skill::registry::{SkillRegistryClient, SkillRegistryConfig};
+    ///
+    /// # fn main() -> adk_core::Result<()> {
+    /// let config = SkillRegistryConfig::from_env()?;
+    /// let client = SkillRegistryClient::new_with_adc(config)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an invalid-input error naming every missing or blank variable.
+    pub fn from_env() -> Result<Self> {
+        let read = |key: &str| {
+            std::env::var(key)
+                .ok()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+        };
+        let project_id = read(ENV_GOOGLE_CLOUD_PROJECT);
+        let location = read(ENV_GOOGLE_CLOUD_LOCATION);
+
+        match (project_id, location) {
+            (Some(project_id), Some(location)) => Ok(Self::new(project_id, location)),
+            (project_id, location) => {
+                let missing = [
+                    (ENV_GOOGLE_CLOUD_PROJECT, project_id.is_none()),
+                    (ENV_GOOGLE_CLOUD_LOCATION, location.is_none()),
+                ]
+                .into_iter()
+                .filter_map(|(key, is_missing)| is_missing.then_some(key))
+                .collect::<Vec<_>>()
+                .join(", ");
+                Err(AdkError::new(
+                    ErrorComponent::Tool,
+                    ErrorCategory::InvalidInput,
+                    "skill.registry.missing_env",
+                    format!(
+                        "missing or blank environment variable(s): {missing}. Set them, or construct the config with SkillRegistryConfig::new",
+                    ),
+                )
+                .with_provider("vertex_ai"))
+            }
+        }
+    }
+
+    /// Sets a custom API origin.
+    ///
+    /// Use only a trusted HTTPS origin, or loopback HTTP for local tests.
+    /// Userinfo, paths, queries, and fragments are rejected before transport.
+    pub fn with_endpoint(mut self, endpoint: impl Into<String>) -> Self {
+        self.endpoint = Some(endpoint.into());
+        self
+    }
+
+    fn endpoint(&self) -> String {
+        let endpoint = self
+            .endpoint
+            .clone()
+            .unwrap_or_else(|| format!("https://{}-aiplatform.googleapis.com", self.location));
+        if endpoint.contains("://") { endpoint } else { format!("https://{endpoint}") }
+    }
+
+    fn parent_path(&self) -> String {
+        format!("projects/{}/locations/{}", self.project_id, self.location)
+    }
+}
+
+/// Lifecycle state of a skill.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum SkillState {
+    /// State not specified.
+    #[default]
+    StateUnspecified,
+    /// The skill is ready for use.
+    Active,
+    /// The skill is being created.
+    Creating,
+    /// Skill creation failed.
+    Failed,
+    /// The skill is being deleted.
+    Deleting,
+    /// A state this client version does not know about.
+    #[serde(other)]
+    Unknown,
+}
+
+/// Origin of a skill.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum SkillSource {
+    /// Uploaded by a user.
+    #[default]
+    User,
+    /// Provisioned by the platform — e.g. the built-in `gcp-skill-registry`
+    /// skill, which the service provisions lazily on the first API call to a
+    /// project/location.
+    System,
+    /// A source this client version does not know about.
+    #[serde(other)]
+    Unknown,
+}
+
+/// A skill resource as served by the registry.
+///
+/// `displayName` aligns with the `SKILL.md` frontmatter `name`; `description`,
+/// `license`, and `compatibility` mirror their frontmatter counterparts. All
+/// other frontmatter (e.g. `metadata.category`, `allowed-tools`) lives only
+/// inside the zip payload.
+///
+/// Deserialization is lenient: every field is defaulted so undocumented or
+/// elided fields never fail a response parse.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct Skill {
+    /// Full resource name: `projects/{p}/locations/{l}/skills/{skill}`.
+    pub name: String,
+    /// Human-readable name; aligns with the `SKILL.md` frontmatter `name`.
+    pub display_name: String,
+    /// What the skill does and when an agent should use it.
+    pub description: String,
+    /// Optional SPDX license identifier.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub license: Option<String>,
+    /// Optional environment requirements.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub compatibility: Option<String>,
+    /// Base64-encoded zip archive with `SKILL.md` at its root.
+    ///
+    /// Populated by `skills.get` (the latest revision's payload — this **is**
+    /// the content download; there is no `:download` endpoint). May be elided
+    /// on `skills.list` responses.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub zipped_filesystem: Option<String>,
+    /// Lifecycle state.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<SkillState>,
+    /// User-defined labels.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub labels: BTreeMap<String, String>,
+    /// Output only: SHA-256 hex digest of the decoded zip payload.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
+    /// Whether the skill was uploaded by a user or provisioned by the system.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub skill_source: Option<SkillSource>,
+    /// Output only: creation timestamp (RFC 3339).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub create_time: Option<String>,
+    /// Output only: last update timestamp (RFC 3339).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub update_time: Option<String>,
+}
+
+/// An immutable snapshot of a skill at a point in time.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct SkillRevision {
+    /// Full resource name:
+    /// `projects/{p}/locations/{l}/skills/{skill}/revisions/{revision}`.
+    pub name: String,
+    /// Output only: creation timestamp (RFC 3339).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub create_time: Option<String>,
+    /// The embedded full skill snapshot.
+    ///
+    /// Whether the snapshot's `zippedFilesystem` is populated is
+    /// undocumented; treat it as optional and fall back to
+    /// [`SkillRegistryClient::fetch_skill_content`] on the parent skill for
+    /// the latest payload.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub skill: Option<Skill>,
+    /// Lifecycle state of the revision.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<SkillState>,
+}
+
+/// Response page from `skills.list`.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct ListSkillsResponse {
+    /// Skills on this page. `zippedFilesystem` may be elided.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub skills: Vec<Skill>,
+    /// Token for the next page, when more results exist.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_page_token: Option<String>,
+}
+
+/// Response page from `skills.revisions.list`.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct ListSkillRevisionsResponse {
+    /// Revisions on this page.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub skill_revisions: Vec<SkillRevision>,
+    /// Token for the next page, when more results exist.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_page_token: Option<String>,
+}
+
+/// One semantic search hit from `skills:retrieve`.
+///
+/// The API returns no scores; results are ranked by array order.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct RetrievedSkill {
+    /// Full resource name of the matched skill.
+    pub skill_name: String,
+    /// Description of the matched skill.
+    pub description: String,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+struct RetrieveSkillsResponse {
+    retrieved_skills: Vec<RetrievedSkill>,
+}
+
+/// A skill's verified, safely extracted zip payload.
+///
+/// Produced by [`SkillRegistryClient::fetch_skill_content`]. The `SKILL.md`
+/// bytes surface via [`skill_md`](Self::skill_md) and can be fed directly to
+/// [`parse_skill_markdown`](crate::parse_skill_markdown).
+#[derive(Debug, Clone)]
+pub struct SkillContent {
+    /// Skill metadata as returned by `skills.get`, with `zippedFilesystem`
+    /// cleared (the decoded contents live in [`files`](Self::files)).
+    pub skill: Skill,
+    /// SHA-256 hex digest computed over the decoded zip payload.
+    pub sha256: String,
+    /// Extracted files keyed by archive path (`SKILL.md` at the root).
+    pub files: BTreeMap<String, Vec<u8>>,
+}
+
+impl SkillContent {
+    /// Archive path of the skill definition file.
+    pub const SKILL_MD: &'static str = "SKILL.md";
+
+    /// The raw `SKILL.md` bytes, when present at the archive root.
+    pub fn skill_md(&self) -> Option<&[u8]> {
+        self.files.get(Self::SKILL_MD).map(Vec::as_slice)
+    }
+
+    /// Writes the extracted files under `dir`, returning the written paths.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SkillError::Io`] when a file or directory cannot be written.
+    pub fn write_to_dir(&self, dir: &Path) -> std::result::Result<Vec<PathBuf>, SkillError> {
+        write_files_to_dir(&self.files, dir)
+    }
+}
+
+const GCP_ERROR_CODES: GcpErrorCodes = GcpErrorCodes {
+    invalid_input: "skill.registry.invalid_input",
+    unauthorized: "skill.registry.unauthorized",
+    forbidden: "skill.registry.forbidden",
+    not_found: "skill.registry.not_found",
+    rate_limited: "skill.registry.rate_limited",
+    timeout: "skill.registry.timeout",
+    unavailable: "skill.registry.unavailable",
+    credentials_unavailable: "skill.registry.credentials_unavailable",
+    invalid_response: "skill.registry.invalid_response",
+    invalid_request: "skill.registry.invalid_request",
+    upstream_error: "skill.registry.upstream_error",
+    // The read-only surface has no long-running operations; required by the
+    // table but never stamped.
+    operation_failed: "skill.registry.operation_failed",
+};
+
+/// ADC-authenticated, read-only REST client for the Skill Registry v1beta1.
+///
+/// Performs [`get_skill`](Self::get_skill), [`list_skills`](Self::list_skills),
+/// [`search_skills`](Self::search_skills),
+/// [`list_skill_revisions`](Self::list_skill_revisions),
+/// [`get_skill_revision`](Self::get_skill_revision), and
+/// [`fetch_skill_content`](Self::fetch_skill_content) against
+/// `projects/*/locations/*/skills/*` resources.
+///
+/// Lifecycle operations (create, update, delete) are intentionally
+/// unimplemented — platform tooling owns them.
+///
+/// > **Note:** this is the **Skill Registry** (Build pillar, `SKILL.md`
+/// > packages on `aiplatform.googleapis.com` v1beta1) — not the Agent
+/// > Registry, a separate Govern-pillar service for cataloging agents.
+///
+/// > **Note:** the built-in `gcp-skill-registry` system skill is provisioned
+/// > lazily on the first API call to a project/location, so a first `list`
+/// > may return it even in an otherwise empty project.
+pub struct SkillRegistryClient {
+    client: GcpHttpClient,
+    parent: String,
+}
+
+impl std::fmt::Debug for SkillRegistryClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // The transport carries credentials; expose only the parent resource.
+        f.debug_struct("SkillRegistryClient").field("parent", &self.parent).finish_non_exhaustive()
+    }
+}
+
+impl SkillRegistryClient {
+    /// Creates a new client using Application Default Credentials (ADC).
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use adk_skill::registry::{SkillRegistryClient, SkillRegistryConfig};
+    ///
+    /// # fn main() -> adk_core::Result<()> {
+    /// let config = SkillRegistryConfig::new("my-project", "us-central1");
+    /// let client = SkillRegistryClient::new_with_adc(config)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when ADC cannot be constructed, the endpoint is not a
+    /// valid secure origin, or the redirect-disabled HTTP client cannot be
+    /// constructed.
+    pub fn new_with_adc(config: SkillRegistryConfig) -> Result<Self> {
+        Self::build(config, None)
+    }
+
+    /// Creates a new client with explicit credentials.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the endpoint is not a valid secure origin or the
+    /// redirect-disabled HTTP client cannot be constructed.
+    pub fn with_credentials(config: SkillRegistryConfig, credentials: Credentials) -> Result<Self> {
+        Self::build(config, Some(credentials))
+    }
+
+    fn build(config: SkillRegistryConfig, credentials: Option<Credentials>) -> Result<Self> {
+        let errors = GcpErrorContext::new(ErrorComponent::Tool, GCP_ERROR_CODES, "skill registry");
+        let mut builder = GcpHttpClient::builder(errors, config.endpoint())
+            .api_version(SKILL_REGISTRY_API_VERSION)
+            .connect_timeout(HTTP_CONNECT_TIMEOUT)
+            .request_timeout(HTTP_REQUEST_TIMEOUT)
+            .auth_timeout(AUTH_HEADERS_TIMEOUT);
+        if let Some(credentials) = credentials {
+            builder = builder.credentials(credentials);
+        }
+        Ok(Self { client: builder.build()?, parent: config.parent_path() })
+    }
+
+    /// The `projects/*/locations/*` parent this client operates on.
+    pub fn parent_resource_name(&self) -> &str {
+        &self.parent
+    }
+
+    /// Resolves a bare skill ID or full resource name to a full name.
+    fn skill_path(&self, skill: &str) -> String {
+        if skill.contains('/') {
+            skill.to_string()
+        } else {
+            format!("{}/skills/{skill}", self.parent)
+        }
+    }
+
+    /// Gets a skill, including its `zippedFilesystem` payload.
+    ///
+    /// `GET {skill}`. This is also the content download: the response
+    /// carries the latest revision's base64 zip payload; there is no
+    /// separate `:download` endpoint. Prefer
+    /// [`fetch_skill_content`](Self::fetch_skill_content) to get the payload
+    /// decoded, digest-verified, and safely extracted.
+    ///
+    /// `skill` may be a bare skill ID or a full
+    /// `projects/*/locations/*/skills/*` resource name.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error on transport failure, timeout, a non-success HTTP
+    /// status, or an unparseable response body.
+    pub async fn get_skill(&self, skill: &str) -> Result<Skill> {
+        self.get_json(&self.skill_path(skill), &[]).await
+    }
+
+    /// Lists skills under the configured project/location.
+    ///
+    /// `GET {parent}/skills?pageSize=&pageToken=`. Listed skills may have
+    /// `zippedFilesystem` elided; use [`get_skill`](Self::get_skill) or
+    /// [`fetch_skill_content`](Self::fetch_skill_content) for the payload.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error on transport failure, timeout, a non-success HTTP
+    /// status, or an unparseable response body.
+    pub async fn list_skills(
+        &self,
+        page_size: Option<u32>,
+        page_token: Option<&str>,
+    ) -> Result<ListSkillsResponse> {
+        let mut query = Vec::new();
+        if let Some(page_size) = page_size {
+            query.push(("pageSize", page_size.to_string()));
+        }
+        if let Some(page_token) = page_token {
+            query.push(("pageToken", page_token.to_string()));
+        }
+        self.get_json(&format!("{}/skills", self.parent), &query).await
+    }
+
+    /// Semantically searches skills by `displayName` and `description`.
+    ///
+    /// `GET {parent}/skills:retrieve?query=&topK=` with an **empty request
+    /// body**. `top_k` defaults to 10 server-side and caps at 100. The
+    /// response carries no scores; results are ranked by array order.
+    ///
+    /// # Errors
+    ///
+    /// Returns an invalid-input error when `top_k` exceeds 100, and
+    /// otherwise an error on transport failure, timeout, a non-success HTTP
+    /// status, or an unparseable response body.
+    pub async fn search_skills(
+        &self,
+        query: &str,
+        top_k: Option<u32>,
+    ) -> Result<Vec<RetrievedSkill>> {
+        if let Some(top_k) = top_k
+            && top_k > RETRIEVE_MAX_TOP_K
+        {
+            return Err(self.client.errors().invalid_input(format!(
+                "topK {top_k} exceeds the skills:retrieve maximum of {RETRIEVE_MAX_TOP_K}. Pass a value between 1 and {RETRIEVE_MAX_TOP_K}, or None for the server default of 10",
+            )));
+        }
+        let mut params = vec![("query", query.to_string())];
+        if let Some(top_k) = top_k {
+            params.push(("topK", top_k.to_string()));
+        }
+        let response: RetrieveSkillsResponse =
+            self.get_json(&format!("{}/skills:retrieve", self.parent), &params).await?;
+        Ok(response.retrieved_skills)
+    }
+
+    /// Lists the revisions of a skill.
+    ///
+    /// `GET {skill}/revisions?pageSize=&pageToken=&filter=`. The only
+    /// supported `filter` syntax is labels equality (e.g.
+    /// `labels.env=prod`). There is no `revisions/latest` alias — the latest
+    /// payload is what [`get_skill`](Self::get_skill) returns on the parent.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error on transport failure, timeout, a non-success HTTP
+    /// status, or an unparseable response body.
+    pub async fn list_skill_revisions(
+        &self,
+        skill: &str,
+        page_size: Option<u32>,
+        page_token: Option<&str>,
+        filter: Option<&str>,
+    ) -> Result<ListSkillRevisionsResponse> {
+        let mut query = Vec::new();
+        if let Some(page_size) = page_size {
+            query.push(("pageSize", page_size.to_string()));
+        }
+        if let Some(page_token) = page_token {
+            query.push(("pageToken", page_token.to_string()));
+        }
+        if let Some(filter) = filter {
+            query.push(("filter", filter.to_string()));
+        }
+        self.get_json(&format!("{}/revisions", self.skill_path(skill)), &query).await
+    }
+
+    /// Gets a single revision of a skill.
+    ///
+    /// `GET {skill}/revisions/{revision}`. Whether the embedded skill
+    /// snapshot carries `zippedFilesystem` is undocumented; see
+    /// [`SkillRevision::skill`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error on transport failure, timeout, a non-success HTTP
+    /// status, or an unparseable response body.
+    pub async fn get_skill_revision(&self, skill: &str, revision: &str) -> Result<SkillRevision> {
+        let path = if revision.contains('/') {
+            revision.to_string()
+        } else {
+            format!("{}/revisions/{revision}", self.skill_path(skill))
+        };
+        self.get_json(&path, &[]).await
+    }
+
+    /// Downloads, verifies, and safely extracts a skill's content.
+    ///
+    /// Runs [`get_skill`](Self::get_skill), base64-decodes the
+    /// `zippedFilesystem` payload, verifies its SHA-256 digest against the
+    /// registry's `sha256` field, and extracts the archive in memory with
+    /// the full defense-in-depth validation of
+    /// [`extract_skill_archive`](crate::registry::extract_skill_archive).
+    ///
+    /// The returned [`SkillContent`] surfaces the raw `SKILL.md` bytes via
+    /// [`SkillContent::skill_md`], ready for
+    /// [`parse_skill_markdown`](crate::parse_skill_markdown).
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use adk_skill::registry::{SkillRegistryClient, SkillRegistryConfig};
+    ///
+    /// # async fn fetch() -> adk_core::Result<()> {
+    /// let config = SkillRegistryConfig::new("my-project", "us-central1");
+    /// let client = SkillRegistryClient::new_with_adc(config)?;
+    /// let content = client.fetch_skill_content("my-skill").await?;
+    /// let skill_md = content.skill_md().expect("SKILL.md at the archive root");
+    /// println!("{} bytes of SKILL.md", skill_md.len());
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an error on transport failure, timeout, a non-success HTTP
+    /// status, an unparseable response body, a missing or undecodable
+    /// payload, a digest mismatch, or any archive-safety violation.
+    pub async fn fetch_skill_content(&self, skill: &str) -> Result<SkillContent> {
+        let mut skill = self.get_skill(skill).await?;
+        let encoded = skill
+            .zipped_filesystem
+            .take()
+            .filter(|payload| !payload.trim().is_empty())
+            .ok_or_else(|| {
+                self.client.errors().invalid_response(format!(
+                    "skill `{}` response carried no zippedFilesystem payload; the skill may still be CREATING",
+                    skill.name,
+                ))
+            })?;
+
+        let bytes =
+            base64::engine::general_purpose::STANDARD.decode(encoded.trim()).map_err(|error| {
+                SkillError::RegistryPayloadDecode {
+                    message: truncate_for_error(&error.to_string()),
+                }
+            })?;
+
+        let computed = format!("{:x}", Sha256::digest(&bytes));
+        match skill.sha256.as_deref().map(str::trim).filter(|digest| !digest.is_empty()) {
+            Some(expected) if !expected.eq_ignore_ascii_case(&computed) => {
+                return Err(SkillError::RegistryChecksumMismatch {
+                    expected: expected.to_string(),
+                    actual: computed,
+                }
+                .into());
+            }
+            Some(_) => {}
+            None => {
+                tracing::warn!(
+                    skill.name = %skill.name,
+                    "skill registry response carried no sha256 digest; skipping verification"
+                );
+            }
+        }
+
+        let files = extract_skill_archive(&bytes)?;
+        tracing::debug!(
+            skill.name = %skill.name,
+            file.count = files.len(),
+            "fetched and extracted skill content"
+        );
+        Ok(SkillContent { skill, sha256: computed, files })
+    }
+
+    async fn get_json<R: for<'de> Deserialize<'de>>(
+        &self,
+        path: &str,
+        query: &[(&str, String)],
+    ) -> Result<R> {
+        tracing::debug!(skill_registry.path = path, "sending skill registry request");
+        let mut request = self.client.request(Method::GET, path).await?;
+        if !query.is_empty() {
+            request = request.query(query);
+        }
+        let value = self.client.send_value(request).await?;
+        serde_json::from_value(value).map_err(|error| {
+            let error = truncate_for_error(&error.to_string());
+            self.client
+                .errors()
+                .invalid_response(format!("failed to parse skill registry response JSON: {error}"))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_config_resolves_paths_and_default_endpoint() {
+        let config = SkillRegistryConfig::new("p", "europe-west4");
+        assert_eq!(config.parent_path(), "projects/p/locations/europe-west4");
+        assert_eq!(config.endpoint(), "https://europe-west4-aiplatform.googleapis.com");
+    }
+
+    #[test]
+    fn test_skill_deserializes_leniently_with_unknown_state_and_fields() {
+        let skill: Skill = serde_json::from_value(json!({
+            "name": "projects/p/locations/l/skills/s",
+            "displayName": "s",
+            "description": "d",
+            "state": "SOME_FUTURE_STATE",
+            "skillSource": "SOME_FUTURE_SOURCE",
+            "undocumentedField": { "nested": true },
+        }))
+        .unwrap();
+        assert_eq!(skill.state, Some(SkillState::Unknown));
+        assert_eq!(skill.skill_source, Some(SkillSource::Unknown));
+        assert!(skill.zipped_filesystem.is_none());
+
+        let revision: SkillRevision = serde_json::from_value(json!({
+            "name": "projects/p/locations/l/skills/s/revisions/1",
+            "updateTime": "2026-01-01T00:00:00Z",
+        }))
+        .unwrap();
+        assert!(revision.skill.is_none());
+    }
+
+    // async: the credentials builder requires an ambient tokio runtime.
+    #[tokio::test]
+    async fn test_endpoint_rejects_cleartext_and_decorated_origins() {
+        let credentials =
+            google_cloud_auth::credentials::api_key_credentials::Builder::new("k").build();
+        let config =
+            SkillRegistryConfig::new("p", "us-central1").with_endpoint("http://example.com");
+        let error = SkillRegistryClient::with_credentials(config, credentials.clone()).unwrap_err();
+        assert!(error.message.contains("HTTPS"), "unexpected error: {}", error.message);
+
+        let config =
+            SkillRegistryConfig::new("p", "us-central1").with_endpoint("https://example.com/path");
+        let error = SkillRegistryClient::with_credentials(config, credentials).unwrap_err();
+        assert!(error.message.contains("origin"), "unexpected error: {}", error.message);
+    }
+}

--- a/adk-skill/src/registry/extract.rs
+++ b/adk-skill/src/registry/extract.rs
@@ -1,0 +1,293 @@
+//! Safe extraction of Skill Registry zip payloads.
+//!
+//! The Skill Registry validates every uploaded archive server-side. This
+//! module mirrors those rules as defense-in-depth, so a corrupt or hostile
+//! payload is rejected locally with a typed [`SkillError`] before any bytes
+//! reach the filesystem:
+//!
+//! | Rule | Limit | Error |
+//! |------|-------|-------|
+//! | Archive size | ≤ [`MAX_ARCHIVE_BYTES`] | [`SkillError::ArchiveTooLarge`] |
+//! | Entry count | ≤ [`MAX_ENTRIES`] | [`SkillError::ArchiveTooManyEntries`] |
+//! | `..` components | none | [`SkillError::ArchivePathTraversal`] |
+//! | Absolute paths (`/`, `\`) | none | [`SkillError::ArchiveAbsolutePath`] |
+//! | Symlinks | none | [`SkillError::ArchiveSymlink`] |
+//! | Duplicate names | none | [`SkillError::ArchiveDuplicateEntry`] |
+//! | Uncompressed total | ≤ [`MAX_UNCOMPRESSED_BYTES`] | [`SkillError::ArchiveUncompressedTooLarge`] |
+//! | Compression ratio | ≤ [`MAX_COMPRESSION_RATIO`] | [`SkillError::ArchiveCompressionRatio`] |
+//! | Directory depth | ≤ [`MAX_DIRECTORY_DEPTH`] | [`SkillError::ArchiveDepthExceeded`] |
+//!
+//! Validation runs in two phases: the central directory is checked first
+//! (names, symlinks, duplicates, declared sizes, ratios) without
+//! decompressing anything, then entry contents are read with the declared
+//! size enforced as a hard read bound.
+
+use crate::error::{SkillError, SkillResult};
+use std::collections::BTreeMap;
+use std::io::{Cursor, Read};
+use std::path::{Path, PathBuf};
+use zip::ZipArchive;
+
+/// Maximum accepted archive size in bytes (10 MB).
+pub const MAX_ARCHIVE_BYTES: u64 = 10 * 1024 * 1024;
+/// Maximum number of entries in an archive.
+pub const MAX_ENTRIES: usize = 10_000;
+/// Maximum declared uncompressed total in bytes (500 MB).
+pub const MAX_UNCOMPRESSED_BYTES: u64 = 500 * 1024 * 1024;
+/// Maximum per-entry compression ratio (uncompressed / compressed).
+pub const MAX_COMPRESSION_RATIO: u64 = 100;
+/// Maximum directory nesting depth for any entry.
+pub const MAX_DIRECTORY_DEPTH: usize = 8;
+
+/// Safely extracts a skill zip archive into an in-memory file map.
+///
+/// Keys are the entry paths exactly as stored in the archive (always
+/// `/`-separated after validation); values are the decompressed file
+/// contents. Directory entries are validated but not materialized.
+///
+/// # Example
+///
+/// ```
+/// use adk_skill::registry::extract_skill_archive;
+/// use std::io::Write;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut writer = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+/// writer.start_file("SKILL.md", zip::write::SimpleFileOptions::default())?;
+/// writer.write_all(b"---\nname: demo\ndescription: demo skill\n---\nBody")?;
+/// let bytes = writer.finish()?.into_inner();
+///
+/// let files = extract_skill_archive(&bytes)?;
+/// assert!(files.contains_key("SKILL.md"));
+/// # Ok(())
+/// # }
+/// ```
+///
+/// # Errors
+///
+/// Returns a distinct [`SkillError`] variant for each violated rule listed
+/// in the module documentation, or [`SkillError::ArchiveFormat`] when the
+/// bytes are not a well-formed zip archive.
+pub fn extract_skill_archive(bytes: &[u8]) -> SkillResult<BTreeMap<String, Vec<u8>>> {
+    if bytes.len() as u64 > MAX_ARCHIVE_BYTES {
+        return Err(SkillError::ArchiveTooLarge {
+            size: bytes.len() as u64,
+            limit: MAX_ARCHIVE_BYTES,
+        });
+    }
+
+    // The zip reader indexes entries by name and silently collapses exact
+    // duplicates (last entry wins), so the entry-count and duplicate rules
+    // are checked against the raw central directory instead.
+    let names = central_directory_names(bytes)?;
+    if names.len() > MAX_ENTRIES {
+        return Err(SkillError::ArchiveTooManyEntries { count: names.len(), limit: MAX_ENTRIES });
+    }
+    let mut seen = std::collections::BTreeSet::new();
+    for name in &names {
+        // `a/` and `a` also collide: extraction to a directory could not
+        // materialize both.
+        let normalized = name.trim_end_matches(['/', '\\']);
+        if !seen.insert(normalized) {
+            return Err(SkillError::ArchiveDuplicateEntry { name: name.clone() });
+        }
+    }
+
+    let mut archive = ZipArchive::new(Cursor::new(bytes)).map_err(format_error)?;
+
+    // Phase 1: central-directory validation, no decompression.
+    let mut declared_total: u64 = 0;
+    for index in 0..archive.len() {
+        let entry = archive.by_index_raw(index).map_err(format_error)?;
+        let name = entry.name().to_string();
+        validate_entry_name(&name)?;
+        if entry.is_symlink() {
+            return Err(SkillError::ArchiveSymlink { name });
+        }
+        if entry.is_dir() {
+            continue;
+        }
+        let declared = entry.size();
+        declared_total = declared_total.saturating_add(declared);
+        if declared_total > MAX_UNCOMPRESSED_BYTES {
+            return Err(SkillError::ArchiveUncompressedTooLarge {
+                total: declared_total,
+                limit: MAX_UNCOMPRESSED_BYTES,
+            });
+        }
+        let compressed = entry.compressed_size();
+        if compressed > 0 && declared > compressed.saturating_mul(MAX_COMPRESSION_RATIO) {
+            return Err(SkillError::ArchiveCompressionRatio {
+                name,
+                ratio: declared / compressed,
+                limit: MAX_COMPRESSION_RATIO,
+            });
+        }
+    }
+
+    // Phase 2: bounded content reads.
+    let mut files = BTreeMap::new();
+    for index in 0..archive.len() {
+        let mut entry = archive.by_index(index).map_err(format_error)?;
+        if entry.is_dir() {
+            continue;
+        }
+        let name = entry.name().to_string();
+        let declared = entry.size();
+        let mut contents = Vec::with_capacity(usize::try_from(declared).unwrap_or(0));
+        let read = std::io::copy(&mut (&mut entry).take(declared + 1), &mut contents)
+            .map_err(|error| SkillError::ArchiveFormat { message: error.to_string() })?;
+        if read != declared {
+            return Err(SkillError::ArchiveFormat {
+                message: format!(
+                    "entry `{name}` decompressed to {read} bytes but declared {declared}"
+                ),
+            });
+        }
+        files.insert(name, contents);
+    }
+    Ok(files)
+}
+
+/// Safely extracts a skill zip archive into a caller-provided directory.
+///
+/// Runs the same validation as [`extract_skill_archive`], then writes each
+/// file under `dir`, creating parent directories as needed. Returns the
+/// written paths in sorted order. Intended for future `pull`-style CLI
+/// tooling; extraction is fully validated in memory before anything touches
+/// the filesystem.
+///
+/// # Errors
+///
+/// Returns the same errors as [`extract_skill_archive`], plus
+/// [`SkillError::Io`] when a file or directory cannot be written.
+pub fn extract_skill_archive_to_dir(bytes: &[u8], dir: &Path) -> SkillResult<Vec<PathBuf>> {
+    let files = extract_skill_archive(bytes)?;
+    write_files_to_dir(&files, dir)
+}
+
+/// Writes an already-validated file map under `dir`.
+pub(crate) fn write_files_to_dir(
+    files: &BTreeMap<String, Vec<u8>>,
+    dir: &Path,
+) -> SkillResult<Vec<PathBuf>> {
+    let mut written = Vec::with_capacity(files.len());
+    for (name, contents) in files {
+        // Validated names are relative with no `..` components, so the join
+        // cannot escape `dir`.
+        let path = dir.join(name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(&path, contents)?;
+        written.push(path);
+    }
+    Ok(written)
+}
+
+fn format_error(error: zip::result::ZipError) -> SkillError {
+    SkillError::ArchiveFormat { message: error.to_string() }
+}
+
+/// Reads every entry name from the raw central directory.
+///
+/// The zip reader indexes entries by name, so exact duplicates and the true
+/// entry count are only observable in the raw record stream.
+fn central_directory_names(bytes: &[u8]) -> SkillResult<Vec<String>> {
+    const EOCD_SIGNATURE: [u8; 4] = [0x50, 0x4b, 0x05, 0x06];
+    const CENTRAL_HEADER_SIGNATURE: [u8; 4] = [0x50, 0x4b, 0x01, 0x02];
+    const EOCD_LEN: usize = 22;
+    const CENTRAL_HEADER_LEN: usize = 46;
+    const MAX_COMMENT_LEN: usize = u16::MAX as usize;
+
+    let read_u16 = |offset: usize| u16::from_le_bytes([bytes[offset], bytes[offset + 1]]) as usize;
+    let read_u32 = |offset: usize| {
+        u32::from_le_bytes([bytes[offset], bytes[offset + 1], bytes[offset + 2], bytes[offset + 3]])
+            as usize
+    };
+
+    if bytes.len() < EOCD_LEN {
+        return Err(SkillError::ArchiveFormat {
+            message: "missing end-of-central-directory record".to_string(),
+        });
+    }
+    let search_start = bytes.len().saturating_sub(EOCD_LEN + MAX_COMMENT_LEN);
+    let eocd = (search_start..=bytes.len() - EOCD_LEN)
+        .rev()
+        .find(|&offset| bytes[offset..offset + 4] == EOCD_SIGNATURE)
+        .ok_or_else(|| SkillError::ArchiveFormat {
+            message: "missing end-of-central-directory record".to_string(),
+        })?;
+
+    let total_entries = read_u16(eocd + 10);
+    let directory_size = read_u32(eocd + 12);
+    let directory_offset = read_u32(eocd + 16);
+    if total_entries == u16::MAX as usize
+        || directory_size == u32::MAX as usize
+        || directory_offset == u32::MAX as usize
+    {
+        // Zip64 markers. Archives within MAX_ARCHIVE_BYTES never need zip64,
+        // so anything carrying the markers is rejected outright.
+        return Err(SkillError::ArchiveFormat {
+            message: "zip64 archives are not supported; repackage without zip64".to_string(),
+        });
+    }
+    let directory_end = directory_offset
+        .checked_add(directory_size)
+        .filter(|end| *end <= bytes.len())
+        .ok_or_else(|| SkillError::ArchiveFormat {
+            message: "central directory extends past the end of the archive".to_string(),
+        })?;
+
+    let truncated =
+        || SkillError::ArchiveFormat { message: "truncated central directory record".to_string() };
+    let mut names = Vec::with_capacity(total_entries.min(MAX_ENTRIES + 1));
+    let mut cursor = directory_offset;
+    for _ in 0..total_entries {
+        if cursor + CENTRAL_HEADER_LEN > directory_end {
+            return Err(truncated());
+        }
+        if bytes[cursor..cursor + 4] != CENTRAL_HEADER_SIGNATURE {
+            return Err(SkillError::ArchiveFormat {
+                message: "malformed central directory header".to_string(),
+            });
+        }
+        let name_len = read_u16(cursor + 28);
+        let extra_len = read_u16(cursor + 30);
+        let comment_len = read_u16(cursor + 32);
+        let name_start = cursor + CENTRAL_HEADER_LEN;
+        let name_end = name_start + name_len;
+        if name_end > directory_end {
+            return Err(truncated());
+        }
+        names.push(String::from_utf8_lossy(&bytes[name_start..name_end]).into_owned());
+        cursor = name_end + extra_len + comment_len;
+    }
+    Ok(names)
+}
+
+fn validate_entry_name(name: &str) -> SkillResult<()> {
+    if name.is_empty() {
+        return Err(SkillError::ArchiveFormat { message: "entry with an empty name".to_string() });
+    }
+    if name.starts_with('/') || name.starts_with('\\') {
+        return Err(SkillError::ArchiveAbsolutePath { name: name.to_string() });
+    }
+    let components: Vec<&str> =
+        name.split(['/', '\\']).filter(|component| !component.is_empty()).collect();
+    if components.contains(&"..") {
+        return Err(SkillError::ArchivePathTraversal { name: name.to_string() });
+    }
+    // Directory entries end in a separator; their last component is itself a
+    // directory level. For files, the last component is the file name.
+    let is_dir_entry = name.ends_with('/') || name.ends_with('\\');
+    let depth = if is_dir_entry { components.len() } else { components.len().saturating_sub(1) };
+    if depth > MAX_DIRECTORY_DEPTH {
+        return Err(SkillError::ArchiveDepthExceeded {
+            name: name.to_string(),
+            depth,
+            limit: MAX_DIRECTORY_DEPTH,
+        });
+    }
+    Ok(())
+}

--- a/adk-skill/src/registry/mod.rs
+++ b/adk-skill/src/registry/mod.rs
@@ -1,0 +1,46 @@
+//! Read-only client for the Vertex AI **Skill Registry** (v1beta1, Preview).
+//!
+//! The Skill Registry is the Gemini Enterprise Agent Platform **Build**
+//! pillar service that stores versioned `SKILL.md` packages as zip archives
+//! on `aiplatform.googleapis.com`. It is served from **regional** endpoints
+//! (`https://{location}-aiplatform.googleapis.com`) under **v1beta1 only**,
+//! and is currently available in three regions: `us-central1`,
+//! `europe-west4`, and `us-east5`.
+//!
+//! > **Note:** do not confuse the Skill Registry with the **Agent Registry**.
+//! > The Agent Registry is a separate Govern-pillar service for cataloging
+//! > agents; the Skill Registry (this module) stores `SKILL.md` skill
+//! > packages under `projects/*/locations/*/skills/*`.
+//!
+//! # Scope
+//!
+//! This client is **read-only**: get, list, semantic search, revision
+//! listing/get, and content download. Lifecycle operations (create, update,
+//! delete) are intentionally unimplemented — platform tooling owns them.
+//!
+//! Content download is [`SkillRegistryClient::fetch_skill_content`], which
+//! decodes the base64 `zippedFilesystem` payload returned by `skills.get`
+//! (there is no separate `:download` endpoint), verifies its SHA-256 digest
+//! against the registry's `sha256` field, and safely extracts the archive
+//! in memory — mirroring the server-side zip validation rules as
+//! defense-in-depth (see [`extract`]).
+//!
+//! # Frontmatter parity
+//!
+//! Only `name` (as `displayName`), `description`, `license`, and
+//! `compatibility` are first-class registry fields. Everything else in the
+//! `SKILL.md` frontmatter — e.g. `metadata.category` and `allowed-tools` —
+//! survives only inside the zip payload and is recovered by parsing the
+//! extracted `SKILL.md`.
+
+mod client;
+pub mod extract;
+
+pub use client::{
+    ListSkillRevisionsResponse, ListSkillsResponse, RetrievedSkill, Skill, SkillContent,
+    SkillRegistryClient, SkillRegistryConfig, SkillRevision, SkillSource, SkillState,
+};
+pub use extract::{
+    MAX_ARCHIVE_BYTES, MAX_COMPRESSION_RATIO, MAX_DIRECTORY_DEPTH, MAX_ENTRIES,
+    MAX_UNCOMPRESSED_BYTES, extract_skill_archive, extract_skill_archive_to_dir,
+};

--- a/adk-skill/tests/skill_registry_contract.rs
+++ b/adk-skill/tests/skill_registry_contract.rs
@@ -1,0 +1,700 @@
+//! Contract tests for the Skill Registry v1beta1 read-only client.
+//!
+//! A mock Axum server captures every request's query string and body and
+//! returns fixture JSON, so the tests pin both directions of the wire
+//! contract: the client sends exactly the documented GET requests and parses
+//! the documented responses. Extraction safety tests craft hostile zips
+//! violating each server-side validation rule and assert the matching typed
+//! error.
+
+#![cfg(feature = "vertex-skill-registry")]
+
+use adk_skill::SkillError;
+use adk_skill::registry::{
+    MAX_ARCHIVE_BYTES, MAX_ENTRIES, RetrievedSkill, SkillRegistryClient, SkillRegistryConfig,
+    SkillState, extract_skill_archive,
+};
+use axum::{
+    Json, Router,
+    body::Bytes,
+    extract::{Query, State},
+    http::StatusCode,
+    routing::get,
+};
+use base64::Engine as _;
+use google_cloud_auth::credentials::api_key_credentials;
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::io::Write;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use zip::write::SimpleFileOptions;
+use zip::{CompressionMethod, ZipWriter};
+
+// ===== Mock server =====
+
+/// A captured request: its query params and its body length.
+type CapturedRequest = (HashMap<String, String>, usize);
+
+#[derive(Clone, Default)]
+struct MockRegistryState {
+    /// Captured requests keyed by op name.
+    requests: Arc<Mutex<HashMap<String, Vec<CapturedRequest>>>>,
+    /// Fixture responses keyed by op name.
+    responses: Arc<Mutex<HashMap<String, (StatusCode, Value)>>>,
+}
+
+async fn handle_op(
+    state: MockRegistryState,
+    op: String,
+    query: HashMap<String, String>,
+    body: Bytes,
+) -> (StatusCode, Json<Value>) {
+    state.requests.lock().await.entry(op.clone()).or_default().push((query, body.len()));
+    match state.responses.lock().await.get(&op) {
+        Some((status, value)) => (*status, Json(value.clone())),
+        None => (StatusCode::NOT_FOUND, Json(json!({ "error": "no fixture registered" }))),
+    }
+}
+
+fn op_route(
+    state: &MockRegistryState,
+    op: &'static str,
+) -> axum::routing::MethodRouter<MockRegistryState> {
+    let _ = state;
+    get(
+        move |State(state): State<MockRegistryState>,
+              Query(query): Query<HashMap<String, String>>,
+              body: Bytes| handle_op(state, op.to_string(), query, body),
+    )
+}
+
+async fn test_client() -> (MockRegistryState, SkillRegistryClient, tokio::task::JoinHandle<()>) {
+    let state = MockRegistryState::default();
+    let parent = "/v1beta1/projects/test-project/locations/us-central1";
+    let app = Router::new()
+        .route(&format!("{parent}/skills"), op_route(&state, "list"))
+        // `skills:retrieve` is a single path segment; the static `skills`
+        // segment above takes priority for plain list requests.
+        .route(&format!("{parent}/{{skills_verb}}"), op_route(&state, "retrieve"))
+        .route(&format!("{parent}/skills/{{skill}}"), op_route(&state, "get"))
+        .route(&format!("{parent}/skills/{{skill}}/revisions"), op_route(&state, "list_revisions"))
+        .route(
+            &format!("{parent}/skills/{{skill}}/revisions/{{revision}}"),
+            op_route(&state, "get_revision"),
+        )
+        .with_state(state.clone());
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("bind test listener");
+    let addr = listener.local_addr().expect("listener addr");
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("mock skill registry server should run");
+    });
+
+    let config = SkillRegistryConfig::new("test-project", "us-central1")
+        .with_endpoint(format!("http://{addr}"));
+    let credentials = api_key_credentials::Builder::new("test-api-key").build();
+    let client = SkillRegistryClient::with_credentials(config, credentials)
+        .expect("build test skill registry client");
+
+    (state, client, server)
+}
+
+async fn register_fixture(state: &MockRegistryState, op: &str, status: StatusCode, body: Value) {
+    state.responses.lock().await.insert(op.to_string(), (status, body));
+}
+
+async fn captured_requests(state: &MockRegistryState, op: &str) -> Vec<CapturedRequest> {
+    state.requests.lock().await.get(op).cloned().unwrap_or_default()
+}
+
+// ===== Zip fixtures =====
+
+const SKILL_MD: &str = "---\nname: demo-skill\ndescription: A demo skill for contract tests.\nlicense: Apache-2.0\n---\nUse the demo tool wisely.\n";
+
+fn build_zip(entries: &[(&str, &[u8])]) -> Vec<u8> {
+    let mut writer = ZipWriter::new(std::io::Cursor::new(Vec::new()));
+    for (name, data) in entries {
+        writer.start_file(*name, SimpleFileOptions::default()).expect("start zip entry");
+        writer.write_all(data).expect("write zip entry");
+    }
+    writer.finish().expect("finish zip").into_inner()
+}
+
+fn skill_fixture_json(zip_bytes: &[u8]) -> Value {
+    let encoded = base64::engine::general_purpose::STANDARD.encode(zip_bytes);
+    let digest = format!("{:x}", Sha256::digest(zip_bytes));
+    json!({
+        "name": "projects/test-project/locations/us-central1/skills/demo-skill",
+        "displayName": "demo-skill",
+        "description": "A demo skill for contract tests.",
+        "license": "Apache-2.0",
+        "zippedFilesystem": encoded,
+        "state": "ACTIVE",
+        "labels": { "env": "test" },
+        "sha256": digest,
+        "skillSource": "USER",
+        "createTime": "2026-01-01T00:00:00Z",
+        "updateTime": "2026-01-02T00:00:00Z",
+    })
+}
+
+// ===== Wire contract =====
+
+#[tokio::test]
+async fn test_get_skill_parses_full_resource_including_payload() {
+    let (state, client, server) = test_client().await;
+    let zip_bytes = build_zip(&[("SKILL.md", SKILL_MD.as_bytes())]);
+    register_fixture(&state, "get", StatusCode::OK, skill_fixture_json(&zip_bytes)).await;
+
+    let skill = client.get_skill("demo-skill").await.expect("get should succeed");
+
+    let requests = captured_requests(&state, "get").await;
+    assert_eq!(requests.len(), 1);
+    assert!(requests[0].0.is_empty(), "get sends no query params: {:?}", requests[0].0);
+
+    assert_eq!(skill.name, "projects/test-project/locations/us-central1/skills/demo-skill");
+    assert_eq!(skill.display_name, "demo-skill");
+    assert_eq!(skill.state, Some(SkillState::Active));
+    assert_eq!(skill.labels.get("env").map(String::as_str), Some("test"));
+    assert!(skill.zipped_filesystem.is_some(), "get returns the payload");
+    assert!(skill.sha256.is_some());
+
+    server.abort();
+    let _ = server.await;
+}
+
+#[tokio::test]
+async fn test_list_skills_sends_pagination_and_tolerates_elided_payload() {
+    let (state, client, server) = test_client().await;
+    register_fixture(
+        &state,
+        "list",
+        StatusCode::OK,
+        json!({
+            "skills": [
+                {
+                    "name": "projects/test-project/locations/us-central1/skills/demo-skill",
+                    "displayName": "demo-skill",
+                    "description": "A demo skill.",
+                    "state": "ACTIVE",
+                },
+            ],
+            "nextPageToken": "page-2",
+        }),
+    )
+    .await;
+
+    let response = client.list_skills(Some(25), Some("page-1")).await.expect("list should succeed");
+
+    let requests = captured_requests(&state, "list").await;
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0].0,
+        HashMap::from([
+            ("pageSize".to_string(), "25".to_string()),
+            ("pageToken".to_string(), "page-1".to_string()),
+        ]),
+    );
+
+    assert_eq!(response.skills.len(), 1);
+    // zippedFilesystem may be elided on list responses.
+    assert!(response.skills[0].zipped_filesystem.is_none());
+    assert_eq!(response.next_page_token.as_deref(), Some("page-2"));
+
+    server.abort();
+    let _ = server.await;
+}
+
+#[tokio::test]
+async fn test_search_skills_sends_query_params_with_empty_body_and_keeps_order() {
+    let (state, client, server) = test_client().await;
+    register_fixture(
+        &state,
+        "retrieve",
+        StatusCode::OK,
+        json!({
+            "retrievedSkills": [
+                {
+                    "skillName": "projects/test-project/locations/us-central1/skills/first",
+                    "description": "Best match.",
+                },
+                {
+                    "skillName": "projects/test-project/locations/us-central1/skills/second",
+                    "description": "Second match.",
+                },
+            ],
+        }),
+    )
+    .await;
+
+    let results =
+        client.search_skills("data analysis", Some(2)).await.expect("search should succeed");
+
+    let requests = captured_requests(&state, "retrieve").await;
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0].0,
+        HashMap::from([
+            ("query".to_string(), "data analysis".to_string()),
+            ("topK".to_string(), "2".to_string()),
+        ]),
+    );
+    // skills:retrieve takes an EMPTY request body.
+    assert_eq!(requests[0].1, 0, "retrieve must send no body");
+
+    // No scores on the wire: ranking is array order.
+    assert_eq!(
+        results,
+        vec![
+            RetrievedSkill {
+                skill_name: "projects/test-project/locations/us-central1/skills/first".to_string(),
+                description: "Best match.".to_string(),
+            },
+            RetrievedSkill {
+                skill_name: "projects/test-project/locations/us-central1/skills/second".to_string(),
+                description: "Second match.".to_string(),
+            },
+        ],
+    );
+
+    server.abort();
+    let _ = server.await;
+}
+
+#[tokio::test]
+async fn test_search_skills_rejects_top_k_over_the_documented_maximum() {
+    let (state, client, server) = test_client().await;
+
+    let error = client.search_skills("q", Some(101)).await.expect_err("topK over 100 must fail");
+    assert_eq!(error.code, "skill.registry.invalid_input");
+    assert!(captured_requests(&state, "retrieve").await.is_empty(), "no request must be sent");
+
+    server.abort();
+    let _ = server.await;
+}
+
+#[tokio::test]
+async fn test_list_skill_revisions_sends_filter_and_tolerates_undocumented_fields() {
+    let (state, client, server) = test_client().await;
+    register_fixture(
+        &state,
+        "list_revisions",
+        StatusCode::OK,
+        json!({
+            "skillRevisions": [
+                {
+                    "name": "projects/test-project/locations/us-central1/skills/demo-skill/revisions/2",
+                    "createTime": "2026-01-02T00:00:00Z",
+                    "state": "ACTIVE",
+                    // Undocumented field observed in real responses.
+                    "updateTime": "2026-01-02T00:00:00Z",
+                },
+            ],
+            "nextPageToken": "rev-page-2",
+        }),
+    )
+    .await;
+
+    let response = client
+        .list_skill_revisions("demo-skill", Some(10), Some("rev-page-1"), Some("labels.env=test"))
+        .await
+        .expect("list revisions should succeed");
+
+    let requests = captured_requests(&state, "list_revisions").await;
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0].0,
+        HashMap::from([
+            ("pageSize".to_string(), "10".to_string()),
+            ("pageToken".to_string(), "rev-page-1".to_string()),
+            ("filter".to_string(), "labels.env=test".to_string()),
+        ]),
+    );
+
+    assert_eq!(response.skill_revisions.len(), 1);
+    assert_eq!(response.skill_revisions[0].state, Some(SkillState::Active));
+    // The embedded skill snapshot is optional.
+    assert!(response.skill_revisions[0].skill.is_none());
+    assert_eq!(response.next_page_token.as_deref(), Some("rev-page-2"));
+
+    server.abort();
+    let _ = server.await;
+}
+
+#[tokio::test]
+async fn test_get_skill_revision_parses_embedded_snapshot() {
+    let (state, client, server) = test_client().await;
+    register_fixture(
+        &state,
+        "get_revision",
+        StatusCode::OK,
+        json!({
+            "name": "projects/test-project/locations/us-central1/skills/demo-skill/revisions/1",
+            "createTime": "2026-01-01T00:00:00Z",
+            "state": "ACTIVE",
+            "skill": {
+                "name": "projects/test-project/locations/us-central1/skills/demo-skill",
+                "displayName": "demo-skill",
+                "description": "A demo skill.",
+                // zippedFilesystem population on revisions is undocumented;
+                // this fixture elides it.
+            },
+        }),
+    )
+    .await;
+
+    let revision =
+        client.get_skill_revision("demo-skill", "1").await.expect("get revision should succeed");
+
+    assert_eq!(
+        revision.name,
+        "projects/test-project/locations/us-central1/skills/demo-skill/revisions/1",
+    );
+    let snapshot = revision.skill.expect("fixture embeds a snapshot");
+    assert_eq!(snapshot.display_name, "demo-skill");
+    assert!(snapshot.zipped_filesystem.is_none());
+
+    server.abort();
+    let _ = server.await;
+}
+
+#[tokio::test]
+async fn test_fetch_skill_content_roundtrips_payload_with_sha256_verification() {
+    let (state, client, server) = test_client().await;
+    let zip_bytes = build_zip(&[
+        ("SKILL.md", SKILL_MD.as_bytes()),
+        ("references/data.json", br#"{"answer": 42}"#),
+    ]);
+    register_fixture(&state, "get", StatusCode::OK, skill_fixture_json(&zip_bytes)).await;
+
+    let content = client.fetch_skill_content("demo-skill").await.expect("fetch should succeed");
+
+    // The base64 payload is consumed into the extracted file map.
+    assert!(content.skill.zipped_filesystem.is_none());
+    assert_eq!(content.sha256, format!("{:x}", Sha256::digest(&zip_bytes)));
+    assert_eq!(content.files.keys().collect::<Vec<_>>(), vec!["SKILL.md", "references/data.json"],);
+    assert_eq!(content.files["references/data.json"], br#"{"answer": 42}"#.to_vec());
+
+    // The SKILL.md bytes feed the existing parser path unchanged.
+    let skill_md = content.skill_md().expect("SKILL.md at the archive root");
+    let parsed = adk_skill::parse_skill_markdown(
+        std::path::Path::new("SKILL.md"),
+        std::str::from_utf8(skill_md).expect("SKILL.md is UTF-8"),
+    )
+    .expect("registry SKILL.md parses through the standard path");
+    assert_eq!(parsed.name, "demo-skill");
+    assert_eq!(parsed.license.as_deref(), Some("Apache-2.0"));
+
+    server.abort();
+    let _ = server.await;
+}
+
+#[tokio::test]
+async fn test_fetch_skill_content_rejects_sha256_mismatch() {
+    let (state, client, server) = test_client().await;
+    let zip_bytes = build_zip(&[("SKILL.md", SKILL_MD.as_bytes())]);
+    let mut fixture = skill_fixture_json(&zip_bytes);
+    fixture["sha256"] = json!("0".repeat(64));
+    register_fixture(&state, "get", StatusCode::OK, fixture).await;
+
+    let error =
+        client.fetch_skill_content("demo-skill").await.expect_err("digest mismatch must fail");
+    assert_eq!(error.code, "skill.registry.checksum_mismatch");
+
+    server.abort();
+    let _ = server.await;
+}
+
+#[tokio::test]
+async fn test_fetch_skill_content_rejects_missing_and_undecodable_payloads() {
+    let (state, client, server) = test_client().await;
+    let mut fixture = skill_fixture_json(&build_zip(&[("SKILL.md", SKILL_MD.as_bytes())]));
+    fixture["zippedFilesystem"] = Value::Null;
+    register_fixture(&state, "get", StatusCode::OK, fixture.clone()).await;
+
+    let error =
+        client.fetch_skill_content("demo-skill").await.expect_err("missing payload must fail");
+    assert_eq!(error.code, "skill.registry.invalid_response");
+
+    fixture["zippedFilesystem"] = json!("not-valid-base64!!!");
+    register_fixture(&state, "get", StatusCode::OK, fixture).await;
+    let error =
+        client.fetch_skill_content("demo-skill").await.expect_err("undecodable payload must fail");
+    assert_eq!(error.code, "skill.registry.payload_decode");
+
+    server.abort();
+    let _ = server.await;
+}
+
+#[tokio::test]
+async fn test_upstream_error_statuses_map_to_adk_error_categories() {
+    let (state, client, server) = test_client().await;
+    register_fixture(
+        &state,
+        "get",
+        StatusCode::NOT_FOUND,
+        json!({ "error": { "code": 404, "message": "skill not found" } }),
+    )
+    .await;
+
+    let error = client.get_skill("missing-skill").await.expect_err("404 must surface as an error");
+    assert!(error.is_not_found(), "unexpected error: {error:?}");
+    assert_eq!(error.details.upstream_status_code, Some(404));
+
+    server.abort();
+    let _ = server.await;
+}
+
+// ===== Extraction safety =====
+
+#[test]
+fn test_extract_rejects_path_traversal() {
+    let bytes = build_zip(&[("../evil.txt", b"boom")]);
+    let error = extract_skill_archive(&bytes).expect_err("traversal must be rejected");
+    assert!(
+        matches!(&error, SkillError::ArchivePathTraversal { name } if name == "../evil.txt"),
+        "unexpected error: {error}",
+    );
+}
+
+#[test]
+fn test_extract_rejects_nested_path_traversal() {
+    let bytes = build_zip(&[("safe/../../evil.txt", b"boom")]);
+    let error = extract_skill_archive(&bytes).expect_err("nested traversal must be rejected");
+    assert!(matches!(error, SkillError::ArchivePathTraversal { .. }), "unexpected error: {error}");
+}
+
+#[test]
+fn test_extract_rejects_absolute_paths() {
+    for name in ["/etc/passwd", r"\windows\system32"] {
+        let bytes = build_zip(&[(name, b"boom")]);
+        let error = extract_skill_archive(&bytes).expect_err("absolute path must be rejected");
+        assert!(
+            matches!(error, SkillError::ArchiveAbsolutePath { .. }),
+            "unexpected error for `{name}`: {error}",
+        );
+    }
+}
+
+#[test]
+fn test_extract_rejects_symlinks() {
+    let mut writer = ZipWriter::new(std::io::Cursor::new(Vec::new()));
+    writer.start_file("SKILL.md", SimpleFileOptions::default()).expect("start entry");
+    writer.write_all(SKILL_MD.as_bytes()).expect("write entry");
+    writer
+        .add_symlink("link.md", "/etc/passwd", SimpleFileOptions::default())
+        .expect("add symlink");
+    let bytes = writer.finish().expect("finish zip").into_inner();
+
+    let error = extract_skill_archive(&bytes).expect_err("symlink must be rejected");
+    assert!(
+        matches!(&error, SkillError::ArchiveSymlink { name } if name == "link.md"),
+        "unexpected error: {error}",
+    );
+}
+
+#[test]
+fn test_extract_rejects_too_many_entries() {
+    let stored = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+    let mut writer = ZipWriter::new(std::io::Cursor::new(Vec::new()));
+    for index in 0..=MAX_ENTRIES {
+        writer.start_file(format!("f{index}"), stored).expect("start entry");
+    }
+    let bytes = writer.finish().expect("finish zip").into_inner();
+
+    let error = extract_skill_archive(&bytes).expect_err("entry count must be rejected");
+    assert!(
+        matches!(
+            error,
+            SkillError::ArchiveTooManyEntries { count, limit }
+                if count == MAX_ENTRIES + 1 && limit == MAX_ENTRIES
+        ),
+        "unexpected error: {error}",
+    );
+}
+
+#[test]
+fn test_extract_rejects_excessive_directory_depth() {
+    // Nine directory levels for a file entry; the limit is eight.
+    let bytes = build_zip(&[("a/b/c/d/e/f/g/h/i/file.txt", b"deep")]);
+    let error = extract_skill_archive(&bytes).expect_err("depth must be rejected");
+    assert!(
+        matches!(error, SkillError::ArchiveDepthExceeded { depth: 9, limit: 8, .. }),
+        "unexpected error: {error}",
+    );
+}
+
+#[test]
+fn test_extract_accepts_the_maximum_directory_depth() {
+    let bytes = build_zip(&[("a/b/c/d/e/f/g/h/file.txt", b"ok"), ("SKILL.md", b"x")]);
+    let files = extract_skill_archive(&bytes).expect("eight levels are allowed");
+    assert_eq!(files.len(), 2);
+}
+
+#[test]
+fn test_extract_rejects_duplicate_entry_names() {
+    // ZipWriter refuses duplicate names, so forge them: write two entries
+    // with same-length names, then byte-patch both names (in the local
+    // headers and the central directory) to the same value.
+    let mut bytes = build_zip(&[("dup0.txt", b"first"), ("dup1.txt", b"second")]);
+    replace_all(&mut bytes, b"dup0.txt", b"dupX.txt");
+    replace_all(&mut bytes, b"dup1.txt", b"dupX.txt");
+
+    let error = extract_skill_archive(&bytes).expect_err("duplicates must be rejected");
+    assert!(
+        matches!(&error, SkillError::ArchiveDuplicateEntry { name } if name == "dupX.txt"),
+        "unexpected error: {error}",
+    );
+}
+
+/// Replaces every occurrence of `from` with the same-length `to` in place.
+fn replace_all(bytes: &mut [u8], from: &[u8], to: &[u8]) {
+    assert_eq!(from.len(), to.len(), "replacement must preserve offsets");
+    let mut start = 0;
+    while start + from.len() <= bytes.len() {
+        if &bytes[start..start + from.len()] == from {
+            bytes[start..start + from.len()].copy_from_slice(to);
+        }
+        start += 1;
+    }
+}
+
+#[test]
+fn test_extract_rejects_excessive_compression_ratio() {
+    // 5 MB of zeros deflates to a few KB — a ratio far beyond 100.
+    let bytes = build_zip(&[("zeros.bin", vec![0u8; 5 * 1024 * 1024].as_slice())]);
+    let error = extract_skill_archive(&bytes).expect_err("zip bomb must be rejected");
+    assert!(
+        matches!(error, SkillError::ArchiveCompressionRatio { limit: 100, .. }),
+        "unexpected error: {error}",
+    );
+}
+
+#[test]
+fn test_extract_rejects_uncompressed_total_over_the_limit() {
+    // Six 90 MB entries (540 MB total) built from 1 KB of pseudo-random
+    // bytes followed by 89 KB of zeros per unit: each entry's own ratio
+    // stays under 100, the archive stays under 10 MB, and the declared
+    // total crosses 500 MB — so the size rule is what trips.
+    let mut unit = pseudo_random_bytes(1024);
+    unit.resize(90 * 1024, 0);
+    let entry: Vec<u8> = unit.iter().copied().cycle().take(90 * 1024 * 1024).collect();
+
+    let mut writer = ZipWriter::new(std::io::Cursor::new(Vec::new()));
+    for index in 0..6 {
+        writer
+            .start_file(format!("bulk{index}.bin"), SimpleFileOptions::default())
+            .expect("start entry");
+        writer.write_all(&entry).expect("write entry");
+    }
+    let bytes = writer.finish().expect("finish zip").into_inner();
+    assert!(bytes.len() as u64 <= MAX_ARCHIVE_BYTES, "fixture archive must stay under 10 MB");
+
+    let error = extract_skill_archive(&bytes).expect_err("uncompressed total must be rejected");
+    assert!(
+        matches!(
+            error,
+            SkillError::ArchiveUncompressedTooLarge { total, limit }
+                if total > limit && limit == 500 * 1024 * 1024
+        ),
+        "unexpected error: {error}",
+    );
+}
+
+#[test]
+fn test_extract_rejects_oversized_archives_before_parsing() {
+    let bytes = vec![0u8; usize::try_from(MAX_ARCHIVE_BYTES).unwrap() + 1];
+    let error = extract_skill_archive(&bytes).expect_err("oversized archive must be rejected");
+    assert!(
+        matches!(
+            error,
+            SkillError::ArchiveTooLarge { size, limit }
+                if size == MAX_ARCHIVE_BYTES + 1 && limit == MAX_ARCHIVE_BYTES
+        ),
+        "unexpected error: {error}",
+    );
+}
+
+#[test]
+fn test_extract_rejects_garbage_bytes_as_invalid_format() {
+    let error = extract_skill_archive(b"not a zip archive").expect_err("garbage must be rejected");
+    assert!(matches!(error, SkillError::ArchiveFormat { .. }), "unexpected error: {error}");
+}
+
+#[test]
+fn test_extract_to_dir_writes_validated_files_only() {
+    let bytes = build_zip(&[
+        ("SKILL.md", SKILL_MD.as_bytes()),
+        ("references/data.json", br#"{"answer": 42}"#),
+    ]);
+    let dir = tempfile::tempdir().expect("create temp dir");
+
+    let written = adk_skill::registry::extract_skill_archive_to_dir(&bytes, dir.path())
+        .expect("extraction to dir should succeed");
+
+    assert_eq!(written, vec![dir.path().join("SKILL.md"), dir.path().join("references/data.json")],);
+    assert_eq!(std::fs::read(dir.path().join("SKILL.md")).unwrap(), SKILL_MD.as_bytes());
+}
+
+/// Deterministic incompressible-ish bytes without a rand dependency.
+fn pseudo_random_bytes(len: usize) -> Vec<u8> {
+    let mut state: u64 = 0x9E37_79B9_7F4A_7C15;
+    let mut bytes = Vec::with_capacity(len);
+    while bytes.len() < len {
+        // xorshift64*
+        state ^= state >> 12;
+        state ^= state << 25;
+        state ^= state >> 27;
+        bytes.extend_from_slice(&state.wrapping_mul(0x2545_F491_4F6C_DD1D).to_le_bytes());
+    }
+    bytes.truncate(len);
+    bytes
+}
+
+// ===== Live (ignored) =====
+
+/// Live read-only test against a real Skill Registry.
+///
+/// Requires ADC (`gcloud auth application-default login`) and:
+///
+/// - `GOOGLE_CLOUD_PROJECT` — the Google Cloud project ID
+/// - `GOOGLE_CLOUD_LOCATION` — `us-central1`, `europe-west4`, or `us-east5`
+/// - `VERTEX_SKILL_NAME` — a skill ID or full resource name to read
+///
+/// Never creates, updates, or deletes skills.
+#[tokio::test]
+#[ignore = "requires ADC credentials and a provisioned skill (GOOGLE_CLOUD_PROJECT, GOOGLE_CLOUD_LOCATION, VERTEX_SKILL_NAME)"]
+async fn skill_registry_live_read_only_roundtrip() {
+    let skill_name =
+        std::env::var("VERTEX_SKILL_NAME").expect("VERTEX_SKILL_NAME must name an existing skill");
+    let config = SkillRegistryConfig::from_env().expect("skill registry env vars must be set");
+    let client = SkillRegistryClient::new_with_adc(config).expect("build ADC client");
+
+    let listed = client.list_skills(Some(10), None).await.expect("list should succeed");
+    assert!(!listed.skills.is_empty(), "expected at least one skill in the registry");
+
+    let skill = client.get_skill(&skill_name).await.expect("get should succeed");
+    assert!(!skill.display_name.is_empty());
+
+    let revisions = client
+        .list_skill_revisions(&skill_name, Some(5), None, None)
+        .await
+        .expect("list revisions should succeed");
+    if let Some(revision) = revisions.skill_revisions.first() {
+        let revision_id =
+            revision.name.rsplit('/').next().expect("revision names end in an ID").to_string();
+        client
+            .get_skill_revision(&skill_name, &revision_id)
+            .await
+            .expect("get revision should succeed");
+    }
+
+    let results =
+        client.search_skills(&skill.description, Some(5)).await.expect("search should succeed");
+    assert!(results.len() <= 5);
+
+    let content = client.fetch_skill_content(&skill_name).await.expect("fetch should succeed");
+    assert!(content.skill_md().is_some(), "expected SKILL.md at the archive root");
+}


### PR DESCRIPTION
## What

Adds a read-only client for the Vertex AI **Skill Registry** (Build pillar,
`SKILL.md` packages on `aiplatform.googleapis.com` v1beta1, Preview) behind a
new `vertex-skill-registry` feature on `adk-skill`, plus defense-in-depth zip
extraction that mirrors the server-side archive validation rules.

- `adk_skill::registry::SkillRegistryConfig` — project/location/endpoint
  config with `from_env` (`GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`).
- `adk_skill::registry::SkillRegistryClient` — built on
  `adk_gcp::GcpHttpClient` (api version `v1beta1`, error codes
  `skill.registry.*`, subject "skill registry"), following the
  `adk-tool/src/example_store/client.rs` consumption pattern. Read-only ops:
  `get_skill`, `list_skills`, `search_skills` (query + optional `topK`,
  max 100, empty request body, rank-by-array-order), `list_skill_revisions`
  (labels-equality filter), `get_skill_revision`, and `fetch_skill_content`
  (get → base64-decode → SHA-256 verify → safe in-memory extraction).
- `adk_skill::registry::extract` — safe extraction into a
  `BTreeMap<String, Vec<u8>>` plus a directory-writing helper for future
  `pull` CLI tooling. Enforces every server-side rule as defense-in-depth:
  ≤10,000 entries, no `..` components, no absolute names, no symlinks, no
  duplicate names, ≤500 MB uncompressed, per-entry compression ratio ≤100,
  ≤8 directory levels, archive ≤10 MB. Each violation is a distinct
  `SkillError` variant (feature-gated) with actionable guidance.
- `SkillContent::skill_md()` surfaces the raw `SKILL.md` bytes so PR 4.9 can
  feed them through the existing `parse_skill_markdown`/`SkillDocument` path
  unchanged (the parser is untouched; the contract test proves the
  round-trip).
- Rustdoc disambiguates the Skill Registry (Build pillar) from the Agent
  Registry (Govern pillar), documents the three served regions
  (`us-central1`, `europe-west4`, `us-east5`), the lazily provisioned
  built-in `gcp-skill-registry` system skill, and that lifecycle operations
  are intentionally unimplemented — platform tooling owns them.

## Why

Wave 4 of the Agent Engine plan brings the Gemini Enterprise Agent Platform
Build-pillar services into the workspace. The Skill Registry client lets
agents discover and consume centrally governed `SKILL.md` packages; PR 4.9
builds the runtime integration on top of `fetch_skill_content`.

## How

- New `vertex-skill-registry` feature on `adk-skill` enabling optional
  `adk-gcp`, `google-cloud-auth`, `reqwest`, `base64`, and `zip` deps.
- `zip = { version = "7.2", default-features = false, features = ["deflate"] }`
  pinned in root `[workspace.dependencies]` — 7.2.0 already resolves in
  `Cargo.lock` via candle-core, so no new transitive resolution.
- All DTOs deserialize leniently (`#[serde(default)]`, `#[serde(other)]`
  fallback enum variants) because the service returns undocumented fields;
  `zippedFilesystem` is `Option` everywhere (elided on list, undocumented on
  revision snapshots).
- Extraction validates the raw central directory before decompressing
  anything: the zip reader indexes entries by name and silently collapses
  exact duplicates, so the duplicate-name and entry-count rules are checked
  against the raw record stream. Content reads are bounded by declared size.
- Contract tests run a mock Axum server pinning all six ops (captured query
  strings, empty `skills:retrieve` body, base64 zip payload round-trip with
  SHA-256), plus one crafted hostile zip per extraction rule asserting the
  matching typed error, plus an `#[ignore]` live read-only test gated on
  `GOOGLE_CLOUD_PROJECT`/`GOOGLE_CLOUD_LOCATION`/`VERTEX_SKILL_NAME` that
  never creates skills.

### Notes for reviewers

- **Approved deviation (consolidated forwarding):** umbrella
  (`adk-rust/*`) feature forwarding, `ci.yml` feature-coverage, `AGENTS.md`,
  and `CHANGELOG.md` are deliberately not touched here — Track D docs fold
  into PR 4.9 and umbrella forwarding + changelog consolidate in a separate
  forwarding PR.
- **ErrorComponent choice:** `adk-core` has no `Skill` component;
  `ErrorComponent::Tool` is used because `adk-skill`'s existing
  `From<SkillError> for AdkError` already stamps `Tool`, keeping every error
  from this crate under one component.
- **zip version:** pinned to `7.2` (current stable major), default features
  off, `deflate` only.
- Decode/checksum failures map to `ErrorCategory::Internal` (corrupt
  upstream payload); archive-rule violations map to
  `ErrorCategory::InvalidInput` (rejected input data), matching the crate's
  existing `Validation` mapping.

## Verification

| Gate | Result |
|------|--------|
| `cargo fmt --all -- --check` | pass |
| `cargo clippy -p adk-skill --features vertex-skill-registry --all-targets -- -D warnings` | pass |
| `cargo nextest run -p adk-skill --features vertex-skill-registry` | 90 passed, 1 skipped (live `#[ignore]`) |
| `cargo nextest run -p adk-skill` (default features) | 64 passed |
| `cargo test -p adk-skill --features vertex-skill-registry --doc` | 11 passed, 4 ignored (`no_run`) |
| `RUSTDOCFLAGS='-D warnings' cargo doc -p adk-skill --no-deps --features vertex-skill-registry` | pass |
| `cargo check --workspace` | pass |
| `./scripts/check-publish-order.sh` | OK (43 publishable crates, 9 dependency tiers, order computable) |

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024)
- [x] `devenv shell clippy` — zero warnings (-D warnings)
- [x] `devenv shell test` — all non-ignored tests pass
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [ ] CHANGELOG.md updated for user-facing changes — deferred to the
      consolidated forwarding PR (approved deviation)
- [ ] README updated if crate capabilities changed — Track D docs fold into
      PR 4.9 (approved deviation)
- [x] Examples added or updated for new features — rustdoc `# Example`
      sections plus contract-test coverage
