### PR TITLE
feat(adk-graph): support tool confirmation pauses

### DIFF
--- a/adk-graph/src/agent.rs
+++ b/adk-graph/src/agent.rs
@@ -241,6 +241,13 @@ impl Agent for GraphAgent {
                         &interrupt.checkpoint_id,
                     );
                     let mut event = Event::new("graph_interrupted");
+                    if let crate::interrupt::Interrupt::ToolConfirmation { request, .. } =
+                        &interrupt.interrupt
+                    {
+                        event.llm_response.interrupted = true;
+                        event.llm_response.turn_complete = true;
+                        event.actions.tool_confirmation = Some(request.clone());
+                    }
                     event.set_content(
                         Content::new("assistant").with_text(interrupt.interrupt.to_string()),
                     );

--- a/adk-graph/src/agent.rs
+++ b/adk-graph/src/agent.rs
@@ -235,18 +235,20 @@ impl Agent for GraphAgent {
                     // returned as an error without ending the invocation. Emit one
                     // event carrying the structured pause so a caller can read the
                     // node, the payload, and the checkpoint to resume from.
-                    let payload = crate::interrupt::GraphInterruptPayload::new(
-                        &interrupt.interrupt,
-                        &interrupt.thread_id,
-                        &interrupt.checkpoint_id,
+                    let tool_confirmation = crate::interrupt::GraphToolConfirmationPause::from_interrupted_execution(&interrupt);
+                    let payload = tool_confirmation.clone().map_or_else(
+                        || crate::interrupt::GraphInterruptPayload::new(
+                            &interrupt.interrupt,
+                            &interrupt.thread_id,
+                            &interrupt.checkpoint_id,
+                        ),
+                        crate::interrupt::GraphInterruptPayload::from_tool_confirmation_pause,
                     );
                     let mut event = Event::new("graph_interrupted");
-                    if let crate::interrupt::Interrupt::ToolConfirmation { request, .. } =
-                        &interrupt.interrupt
-                    {
+                    if let Some(pause) = tool_confirmation {
                         event.llm_response.interrupted = true;
                         event.llm_response.turn_complete = true;
-                        event.actions.tool_confirmation = Some(request.clone());
+                        event.actions.tool_confirmation = Some(pause.request);
                     }
                     event.set_content(
                         Content::new("assistant").with_text(interrupt.interrupt.to_string()),

--- a/adk-graph/src/child.rs
+++ b/adk-graph/src/child.rs
@@ -114,7 +114,10 @@ impl ChildInvoker {
                 state.insert(key, value);
             }
         }
-        let child_ctx = NodeContext::new(state, parent.config.clone(), parent.step);
+        let mut child_ctx = NodeContext::new(state, parent.config.clone(), parent.step);
+        if let Some(run_config) = parent.run_config() {
+            child_ctx.set_run_config(run_config);
+        }
 
         let output = node.execute(&child_ctx).await?;
 

--- a/adk-graph/src/executor.rs
+++ b/adk-graph/src/executor.rs
@@ -192,6 +192,13 @@ impl<'a> PregelExecutor<'a> {
                     let next = self.next_frontier(&result.executed_nodes, &result.goto)?;
                     self.pending_nodes =
                         self.filter_deferred_nodes(next, &result.executed_nodes)?;
+                } else if !matches!(interrupt, Interrupt::Before(_)) {
+                    // A dynamic or tool-confirmation pause occurs inside a
+                    // frontier. Nodes that had already completed must not run
+                    // again after the caller answers the pause, especially when
+                    // they have side effects. The interrupted node itself stays
+                    // pending because it produced no updates.
+                    self.pending_nodes.retain(|node| !result.executed_nodes.contains(node));
                 }
                 // For `Before`, the frontier saved is deliberately the one that
                 // was executing: the node produced no updates, so resuming must
@@ -328,6 +335,7 @@ impl<'a> PregelExecutor<'a> {
                             let mut streamed_updates = Vec::new();
                             let mut streamed_goto: Option<(String, Vec<String>)> = None;
                             let mut streamed_interrupt: Option<Interrupt> = None;
+                            let mut streamed_tool_confirmation = None;
                             let mut timed_out_after;
                             let mut attempt = 0;
 
@@ -391,6 +399,14 @@ impl<'a> PregelExecutor<'a> {
                                                         data: data.clone(),
                                                     });
                                             }
+                                            if let StreamEvent::NodeToolConfirmation {
+                                                ref node,
+                                                ref request,
+                                            } = event
+                                            {
+                                                streamed_tool_confirmation =
+                                                    Some((node.clone(), request.clone()));
+                                            }
                                             collected_events.push(event);
                                         }
                                         Some(Err(e)) => {
@@ -434,24 +450,27 @@ impl<'a> PregelExecutor<'a> {
                             }
 
                             let duration_ms = start.elapsed().as_millis() as u64;
-                            result.executed_nodes.push(node_name.clone());
                             result.events.push(StreamEvent::node_end(node_name, self.step, duration_ms));
                             result.events.extend(collected_events);
 
-                            if let Some((source, targets)) = streamed_goto {
-                                result.goto.insert(source, targets);
-                            }
-                            if let Some(interrupt) = streamed_interrupt {
+                            let node_interrupt = streamed_tool_confirmation
+                                .map(|(node, request)| Interrupt::ToolConfirmation { node, request })
+                                .or(streamed_interrupt);
+                            if let Some(interrupt) = node_interrupt {
                                 result.interrupt = Some(interrupt);
-                            }
-
-                            for updates in streamed_updates {
-                                self.ensure_channels_declared(
-                                    node_name,
-                                    updates.keys().map(String::as_str),
-                                )?;
-                                for (key, value) in updates {
-                                    self.graph.schema.apply_update(&mut self.state, &key, value);
+                            } else {
+                                result.executed_nodes.push(node_name.clone());
+                                if let Some((source, targets)) = streamed_goto {
+                                    result.goto.insert(source, targets);
+                                }
+                                for updates in streamed_updates {
+                                    self.ensure_channels_declared(
+                                        node_name,
+                                        updates.keys().map(String::as_str),
+                                    )?;
+                                    for (key, value) in updates {
+                                        self.graph.schema.apply_update(&mut self.state, &key, value);
+                                    }
                                 }
                             }
                         }
@@ -490,17 +509,35 @@ impl<'a> PregelExecutor<'a> {
                                     return;
                                 }
                             }
+                        } else if !matches!(interrupt, Interrupt::Before(_)) {
+                            self.pending_nodes
+                                .retain(|node| !result.executed_nodes.contains(node));
                         }
                         // Persist before reporting: without this the pause cannot be
                         // resumed and the work already done is lost.
-                        if let Err(error) = self.save_checkpoint().await {
-                            yield Err(error);
-                            return;
+                        let checkpoint_id = match self.save_checkpoint().await {
+                            Ok(checkpoint_id) => checkpoint_id,
+                            Err(error) => {
+                                yield Err(error);
+                                return;
+                            }
+                        };
+                        match interrupt {
+                            Interrupt::ToolConfirmation { node, request } => {
+                                yield Ok(StreamEvent::tool_confirmation_required(
+                                    &node,
+                                    request,
+                                    &self.config.thread_id,
+                                    &checkpoint_id,
+                                ));
+                            }
+                            other => {
+                                yield Ok(StreamEvent::interrupted(
+                                    result.executed_nodes.first().map(|s| s.as_str()).unwrap_or("unknown"),
+                                    &other.to_string(),
+                                ));
+                            }
                         }
-                        yield Ok(StreamEvent::interrupted(
-                            result.executed_nodes.first().map(|s| s.as_str()).unwrap_or("unknown"),
-                            &interrupt.to_string(),
-                        ));
                         return;
                     }
 
@@ -584,19 +621,37 @@ impl<'a> PregelExecutor<'a> {
                                 return;
                             }
                         }
+                    } else if !matches!(interrupt, Interrupt::Before(_)) {
+                        self.pending_nodes
+                            .retain(|node| !result.executed_nodes.contains(node));
                     }
                     // Persist before reporting: without this the interrupt is
                     // unresumable, because resuming loads the checkpoint for the
                     // thread. The frontier saved is the one that was executing,
                     // since an interrupted node still owes its updates.
-                    if let Err(e) = self.save_checkpoint().await {
-                        yield Err(e);
-                        return;
+                    let checkpoint_id = match self.save_checkpoint().await {
+                        Ok(checkpoint_id) => checkpoint_id,
+                        Err(error) => {
+                            yield Err(error);
+                            return;
+                        }
+                    };
+                    match interrupt {
+                        Interrupt::ToolConfirmation { node, request } => {
+                            yield Ok(StreamEvent::tool_confirmation_required(
+                                &node,
+                                request,
+                                &self.config.thread_id,
+                                &checkpoint_id,
+                            ));
+                        }
+                        other => {
+                            yield Ok(StreamEvent::interrupted(
+                                result.executed_nodes.first().map(|s| s.as_str()).unwrap_or("unknown"),
+                                &other.to_string(),
+                            ));
+                        }
                     }
-                    yield Ok(StreamEvent::interrupted(
-                        result.executed_nodes.first().map(|s| s.as_str()).unwrap_or("unknown"),
-                        &interrupt.to_string(),
-                    ));
                     return;
                 }
 
@@ -946,10 +1001,16 @@ impl<'a> PregelExecutor<'a> {
             .max_concurrency
             .map_or(pending_for_execution.len(), |limit| limit.min(pending_for_execution.len()))
             .max(1);
-        let outputs: Vec<_> = stream::iter(futures).buffer_unordered(concurrency).collect().await;
+        let mut outputs: Vec<_> =
+            stream::iter(futures).buffer_unordered(concurrency).collect().await;
+        // Completion order is intentionally nondeterministic under parallelism,
+        // but selecting which of several simultaneous pauses to report cannot
+        // be. Keep node event order stable and make the first node name win.
+        outputs.sort_by(|left, right| left.0.cmp(&right.0));
 
         // Collect all updates and check for errors/interrupts
         let mut all_updates = Vec::new();
+        let mut interrupt = None;
 
         for (node_name, output_result, duration_ms, step, attempts) in outputs {
             // Record the budget spent, so a resumed run does not restart it. A
@@ -960,20 +1021,18 @@ impl<'a> PregelExecutor<'a> {
             } else {
                 self.attempts.remove(&node_name);
             }
-            result.executed_nodes.push(node_name.clone());
             result.events.push(StreamEvent::node_end(&node_name, step, duration_ms));
 
             match output_result {
                 Ok(output) => {
                     // Check for dynamic interrupt
-                    if let Some(interrupt) = output.interrupt {
-                        return Ok(SuperStepResult {
-                            interrupt: Some(interrupt),
-                            executed_nodes: result.executed_nodes,
-                            events: result.events,
-                            goto: result.goto,
-                        });
+                    if let Some(node_interrupt) = output.interrupt {
+                        if interrupt.is_none() {
+                            interrupt = Some(node_interrupt);
+                        }
+                        continue;
                     }
+                    result.executed_nodes.push(node_name.clone());
 
                     // Collect custom events
                     result.events.extend(output.events);
@@ -1047,6 +1106,10 @@ impl<'a> PregelExecutor<'a> {
                     self.graph.schema.apply_update(&mut self.state, &key, value.clone());
                 }
             }
+        }
+
+        if let Some(interrupt) = interrupt {
+            return Ok(SuperStepResult { interrupt: Some(interrupt), ..result });
         }
 
         if let Some(interrupt) = self.gate_after(&result.executed_nodes) {

--- a/adk-graph/src/executor.rs
+++ b/adk-graph/src/executor.rs
@@ -7,7 +7,7 @@ use crate::cache::{NodeCache, compute_cache_key};
 use crate::deferred::FanInTracker;
 use crate::error::{GraphError, InterruptedExecution, Result};
 use crate::graph::CompiledGraph;
-use crate::interrupt::Interrupt;
+use crate::interrupt::{GraphToolConfirmationPause, Interrupt};
 use crate::node::{ExecutionConfig, NodeContext};
 use crate::state::{Checkpoint, State};
 use crate::stream::{StreamEvent, StreamMode};
@@ -46,6 +46,8 @@ pub struct GraphOutcome {
 pub struct PregelExecutor<'a> {
     graph: &'a CompiledGraph,
     config: ExecutionConfig,
+    /// ADK configuration supplied through an additive direct-graph API.
+    run_config: Option<adk_core::RunConfig>,
     state: State,
     step: usize,
     pending_nodes: Vec<String>,
@@ -74,6 +76,14 @@ pub struct PregelExecutor<'a> {
 impl<'a> PregelExecutor<'a> {
     /// Create a new executor
     pub fn new(graph: &'a CompiledGraph, config: ExecutionConfig) -> Self {
+        Self::new_with_run_config(graph, config, None)
+    }
+
+    pub(crate) fn new_with_run_config(
+        graph: &'a CompiledGraph,
+        config: ExecutionConfig,
+        run_config: Option<adk_core::RunConfig>,
+    ) -> Self {
         #[cfg(feature = "node-cache")]
         let node_caches = graph
             .cache_policies
@@ -84,6 +94,7 @@ impl<'a> PregelExecutor<'a> {
         Self {
             graph,
             config,
+            run_config,
             state: State::new(),
             step: 0,
             pending_nodes: vec![],
@@ -308,6 +319,9 @@ impl<'a> PregelExecutor<'a> {
                         }
                         if let Some(node) = self.graph.nodes.get(node_name) {
                             let mut ctx = NodeContext::new(self.state.clone(), self.config.clone(), self.step);
+                            if let Some(run_config) = self.run_config.clone() {
+                                ctx.set_run_config(run_config);
+                            }
                             ctx.set_parent_schema(Arc::new(self.graph.schema.clone()));
                             ctx.set_child_invoker(Arc::new(crate::child::ChildInvoker::new(
                                 self.graph.nodes.clone(),
@@ -335,7 +349,6 @@ impl<'a> PregelExecutor<'a> {
                             let mut streamed_updates = Vec::new();
                             let mut streamed_goto: Option<(String, Vec<String>)> = None;
                             let mut streamed_interrupt: Option<Interrupt> = None;
-                            let mut streamed_tool_confirmation = None;
                             let mut timed_out_after;
                             let mut attempt = 0;
 
@@ -399,14 +412,6 @@ impl<'a> PregelExecutor<'a> {
                                                         data: data.clone(),
                                                     });
                                             }
-                                            if let StreamEvent::NodeToolConfirmation {
-                                                ref node,
-                                                ref request,
-                                            } = event
-                                            {
-                                                streamed_tool_confirmation =
-                                                    Some((node.clone(), request.clone()));
-                                            }
                                             collected_events.push(event);
                                         }
                                         Some(Err(e)) => {
@@ -453,9 +458,7 @@ impl<'a> PregelExecutor<'a> {
                             result.events.push(StreamEvent::node_end(node_name, self.step, duration_ms));
                             result.events.extend(collected_events);
 
-                            let node_interrupt = streamed_tool_confirmation
-                                .map(|(node, request)| Interrupt::ToolConfirmation { node, request })
-                                .or(streamed_interrupt);
+                            let node_interrupt = streamed_interrupt;
                             if let Some(interrupt) = node_interrupt {
                                 result.interrupt = Some(interrupt);
                             } else {
@@ -522,22 +525,25 @@ impl<'a> PregelExecutor<'a> {
                                 return;
                             }
                         };
-                        match interrupt {
-                            Interrupt::ToolConfirmation { node, request } => {
-                                yield Ok(StreamEvent::tool_confirmation_required(
-                                    &node,
-                                    request,
-                                    &self.config.thread_id,
-                                    &checkpoint_id,
-                                ));
-                            }
-                            other => {
-                                yield Ok(StreamEvent::interrupted(
-                                    result.executed_nodes.first().map(|s| s.as_str()).unwrap_or("unknown"),
-                                    &other.to_string(),
-                                ));
-                            }
+                        if let Some(pause) = GraphToolConfirmationPause::from_interrupted_execution(
+                            &InterruptedExecution::new(
+                                self.config.thread_id.clone(),
+                                checkpoint_id,
+                                interrupt.clone(),
+                                self.state.clone(),
+                                self.step,
+                            ),
+                        ) {
+                            yield Ok(StreamEvent::custom(
+                                &pause.node,
+                                GraphToolConfirmationPause::KIND,
+                                serde_json::to_value(&pause).unwrap_or(serde_json::Value::Null),
+                            ));
                         }
+                        yield Ok(StreamEvent::interrupted(
+                            result.executed_nodes.first().map(|s| s.as_str()).unwrap_or("unknown"),
+                            &interrupt.to_string(),
+                        ));
                         return;
                     }
 
@@ -636,22 +642,25 @@ impl<'a> PregelExecutor<'a> {
                             return;
                         }
                     };
-                    match interrupt {
-                        Interrupt::ToolConfirmation { node, request } => {
-                            yield Ok(StreamEvent::tool_confirmation_required(
-                                &node,
-                                request,
-                                &self.config.thread_id,
-                                &checkpoint_id,
-                            ));
-                        }
-                        other => {
-                            yield Ok(StreamEvent::interrupted(
-                                result.executed_nodes.first().map(|s| s.as_str()).unwrap_or("unknown"),
-                                &other.to_string(),
-                            ));
-                        }
+                    if let Some(pause) = GraphToolConfirmationPause::from_interrupted_execution(
+                        &InterruptedExecution::new(
+                            self.config.thread_id.clone(),
+                            checkpoint_id,
+                            interrupt.clone(),
+                            self.state.clone(),
+                            self.step,
+                        ),
+                    ) {
+                        yield Ok(StreamEvent::custom(
+                            &pause.node,
+                            GraphToolConfirmationPause::KIND,
+                            serde_json::to_value(&pause).unwrap_or(serde_json::Value::Null),
+                        ));
                     }
+                    yield Ok(StreamEvent::interrupted(
+                        result.executed_nodes.first().map(|s| s.as_str()).unwrap_or("unknown"),
+                        &interrupt.to_string(),
+                    ));
                     return;
                 }
 
@@ -935,6 +944,9 @@ impl<'a> PregelExecutor<'a> {
             .zip(prior_attempts)
             .map(|((((name, node), policy), retry), spent)| {
                 let mut ctx = NodeContext::new(self.state.clone(), self.config.clone(), self.step);
+                if let Some(run_config) = self.run_config.clone() {
+                    ctx.set_run_config(run_config);
+                }
                 // A node body may invoke other nodes. The invoker carries the
                 // graph's nodes and the shared ledger, so a resumed parent serves
                 // children that already finished. These invocations are awaited
@@ -1248,6 +1260,21 @@ impl CompiledGraph {
         self.invoke_detailed(input, config).await.map(|outcome| outcome.state)
     }
 
+    /// Execute with ADK run configuration for agents inside a directly run graph.
+    ///
+    /// Use this to resume a tool-confirmation pause with decisions in
+    /// [`adk_core::RunConfig`]. Existing [`Self::invoke`] callers remain
+    /// standalone and use default ADK run configuration.
+    pub async fn invoke_with_run_config(
+        &self,
+        input: State,
+        config: ExecutionConfig,
+        run_config: adk_core::RunConfig,
+    ) -> Result<State> {
+        let mut executor = PregelExecutor::new_with_run_config(self, config, Some(run_config));
+        executor.run(input).await
+    }
+
     /// Executes and reports what the run asked of its caller.
     ///
     /// Only a graph run as a [`SubgraphNode`](crate::subgraph::SubgraphNode) has
@@ -1263,6 +1290,18 @@ impl CompiledGraph {
         Ok(GraphOutcome { state, goto_parent: executor.goto_parent })
     }
 
+    /// Execute with run configuration and retain a subgraph's parent routing outcome.
+    pub async fn invoke_detailed_with_run_config(
+        &self,
+        input: State,
+        config: ExecutionConfig,
+        run_config: adk_core::RunConfig,
+    ) -> Result<GraphOutcome> {
+        let mut executor = PregelExecutor::new_with_run_config(self, config, Some(run_config));
+        let state = executor.run(input).await?;
+        Ok(GraphOutcome { state, goto_parent: executor.goto_parent })
+    }
+
     /// Execute with streaming
     pub fn stream(
         &self,
@@ -1272,6 +1311,22 @@ impl CompiledGraph {
     ) -> impl futures::Stream<Item = Result<StreamEvent>> + '_ {
         tracing::debug!("CompiledGraph::stream called with mode {:?}", mode);
         let executor = PregelExecutor::new(self, config);
+        executor.run_stream(input, mode)
+    }
+
+    /// Stream with ADK run configuration for agents inside a directly run graph.
+    ///
+    /// A resumed tool-confirmation request can be approved or denied by passing
+    /// [`adk_core::RunConfig::tool_confirmation_decisions`].
+    pub fn stream_with_run_config(
+        &self,
+        input: State,
+        config: ExecutionConfig,
+        mode: StreamMode,
+        run_config: adk_core::RunConfig,
+    ) -> impl futures::Stream<Item = Result<StreamEvent>> + '_ {
+        tracing::debug!("CompiledGraph::stream_with_run_config called with mode {:?}", mode);
+        let executor = PregelExecutor::new_with_run_config(self, config, Some(run_config));
         executor.run_stream(input, mode)
     }
 

--- a/adk-graph/src/interrupt.rs
+++ b/adk-graph/src/interrupt.rs
@@ -1,5 +1,6 @@
 //! Human-in-the-loop interrupt types
 
+use adk_core::ToolConfirmationRequest;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -17,6 +18,13 @@ pub enum Interrupt {
         /// Optional data for the interrupt
         data: Option<Value>,
     },
+    /// A tool invoked by an agent node needs authorization before it can run.
+    ToolConfirmation {
+        /// The graph node whose agent requested authorization.
+        node: String,
+        /// The exact tool call the caller must approve or deny.
+        request: ToolConfirmationRequest,
+    },
 }
 
 impl std::fmt::Display for Interrupt {
@@ -25,6 +33,11 @@ impl std::fmt::Display for Interrupt {
             Self::Before(node) => write!(f, "Interrupt before '{}'", node),
             Self::After(node) => write!(f, "Interrupt after '{}'", node),
             Self::Dynamic { message, .. } => write!(f, "Dynamic interrupt: {}", message),
+            Self::ToolConfirmation { node, request } => write!(
+                f,
+                "Tool confirmation required for '{}' in node '{}'",
+                request.tool_name, node
+            ),
         }
     }
 }
@@ -80,6 +93,10 @@ pub struct GraphInterruptPayload {
     /// The data a node attached with `NodeOutput::interrupt_with_data`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub data: Option<Value>,
+    /// The tool call awaiting authorization, for a `"tool_confirmation"`
+    /// pause. Absent for ordinary graph interrupts.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_confirmation: Option<ToolConfirmationRequest>,
     /// The thread to resume.
     pub thread_id: String,
     /// The checkpoint the run stopped at.
@@ -89,11 +106,14 @@ pub struct GraphInterruptPayload {
 impl GraphInterruptPayload {
     /// Build a payload from an interrupt and the run it stopped.
     pub fn new(interrupt: &Interrupt, thread_id: &str, checkpoint_id: &str) -> Self {
-        let (kind, node, message, data) = match interrupt {
-            Interrupt::Before(node) => ("before", Some(node.clone()), None, None),
-            Interrupt::After(node) => ("after", Some(node.clone()), None, None),
+        let (kind, node, message, data, tool_confirmation) = match interrupt {
+            Interrupt::Before(node) => ("before", Some(node.clone()), None, None, None),
+            Interrupt::After(node) => ("after", Some(node.clone()), None, None, None),
             Interrupt::Dynamic { message, data } => {
-                ("dynamic", None, Some(message.clone()), data.clone())
+                ("dynamic", None, Some(message.clone()), data.clone(), None)
+            }
+            Interrupt::ToolConfirmation { node, request } => {
+                ("tool_confirmation", Some(node.clone()), None, None, Some(request.clone()))
             }
         };
         Self {
@@ -101,6 +121,7 @@ impl GraphInterruptPayload {
             node,
             message,
             data,
+            tool_confirmation,
             thread_id: thread_id.to_string(),
             checkpoint_id: checkpoint_id.to_string(),
         }

--- a/adk-graph/src/interrupt.rs
+++ b/adk-graph/src/interrupt.rs
@@ -18,13 +18,6 @@ pub enum Interrupt {
         /// Optional data for the interrupt
         data: Option<Value>,
     },
-    /// A tool invoked by an agent node needs authorization before it can run.
-    ToolConfirmation {
-        /// The graph node whose agent requested authorization.
-        node: String,
-        /// The exact tool call the caller must approve or deny.
-        request: ToolConfirmationRequest,
-    },
 }
 
 impl std::fmt::Display for Interrupt {
@@ -33,11 +26,6 @@ impl std::fmt::Display for Interrupt {
             Self::Before(node) => write!(f, "Interrupt before '{}'", node),
             Self::After(node) => write!(f, "Interrupt after '{}'", node),
             Self::Dynamic { message, .. } => write!(f, "Dynamic interrupt: {}", message),
-            Self::ToolConfirmation { node, request } => write!(
-                f,
-                "Tool confirmation required for '{}' in node '{}'",
-                request.tool_name, node
-            ),
         }
     }
 }
@@ -50,6 +38,76 @@ pub fn interrupt(message: &str) -> Interrupt {
 /// Helper to create a dynamic interrupt with data
 pub fn interrupt_with_data(message: &str, data: Value) -> Interrupt {
     Interrupt::Dynamic { message: message.to_string(), data: Some(data) }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PendingGraphToolConfirmation {
+    node: String,
+    request: ToolConfirmationRequest,
+}
+
+/// A persisted tool-authorization pause emitted by a graph.
+///
+/// Use [`Self::from_stream_event`] when directly streaming a graph, or
+/// [`GraphInterruptPayload::tool_confirmation`] when the graph runs as a
+/// [`crate::agent::GraphAgent`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GraphToolConfirmationPause {
+    /// Graph node whose agent requested authorization.
+    pub node: String,
+    /// The exact tool call the caller must approve or deny.
+    pub request: ToolConfirmationRequest,
+    /// Thread to resume after a decision.
+    pub thread_id: String,
+    /// Checkpoint saved before the pause was reported.
+    pub checkpoint_id: String,
+}
+
+impl GraphToolConfirmationPause {
+    /// Reserved custom-event and dynamic-interrupt marker for tool confirmation.
+    pub const KIND: &str = "tool_confirmation";
+
+    /// Read a tool-confirmation pause from a graph stream event.
+    pub fn from_stream_event(event: &crate::stream::StreamEvent) -> Option<Self> {
+        let crate::stream::StreamEvent::Custom { event_type, data, .. } = event else {
+            return None;
+        };
+        (event_type == Self::KIND).then(|| serde_json::from_value(data.clone()).ok()).flatten()
+    }
+
+    /// Read a tool-confirmation pause from an interrupted graph execution.
+    pub fn from_interrupted_execution(
+        interrupted: &crate::error::InterruptedExecution,
+    ) -> Option<Self> {
+        let (node, request) = pending_from_interrupt(&interrupted.interrupt)?;
+        Some(Self {
+            node,
+            request,
+            thread_id: interrupted.thread_id.clone(),
+            checkpoint_id: interrupted.checkpoint_id.clone(),
+        })
+    }
+
+    pub(crate) fn pending_interrupt(node: String, request: ToolConfirmationRequest) -> Interrupt {
+        Interrupt::Dynamic {
+            message: Self::KIND.to_string(),
+            data: Some(Self::pending_data(node, request)),
+        }
+    }
+
+    pub(crate) fn pending_data(node: String, request: ToolConfirmationRequest) -> Value {
+        serde_json::to_value(PendingGraphToolConfirmation { node, request }).unwrap_or(Value::Null)
+    }
+}
+
+fn pending_from_interrupt(interrupt: &Interrupt) -> Option<(String, ToolConfirmationRequest)> {
+    let Interrupt::Dynamic { message, data } = interrupt else { return None };
+    if message != GraphToolConfirmationPause::KIND {
+        return None;
+    }
+    let pending: PendingGraphToolConfirmation = serde_json::from_value(data.clone()?).ok()?;
+    Some((pending.node, pending.request))
 }
 
 /// The reserved `Event::provider_metadata` key carrying a graph interrupt.
@@ -93,10 +151,6 @@ pub struct GraphInterruptPayload {
     /// The data a node attached with `NodeOutput::interrupt_with_data`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub data: Option<Value>,
-    /// The tool call awaiting authorization, for a `"tool_confirmation"`
-    /// pause. Absent for ordinary graph interrupts.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub tool_confirmation: Option<ToolConfirmationRequest>,
     /// The thread to resume.
     pub thread_id: String,
     /// The checkpoint the run stopped at.
@@ -106,14 +160,11 @@ pub struct GraphInterruptPayload {
 impl GraphInterruptPayload {
     /// Build a payload from an interrupt and the run it stopped.
     pub fn new(interrupt: &Interrupt, thread_id: &str, checkpoint_id: &str) -> Self {
-        let (kind, node, message, data, tool_confirmation) = match interrupt {
-            Interrupt::Before(node) => ("before", Some(node.clone()), None, None, None),
-            Interrupt::After(node) => ("after", Some(node.clone()), None, None, None),
+        let (kind, node, message, data) = match interrupt {
+            Interrupt::Before(node) => ("before", Some(node.clone()), None, None),
+            Interrupt::After(node) => ("after", Some(node.clone()), None, None),
             Interrupt::Dynamic { message, data } => {
-                ("dynamic", None, Some(message.clone()), data.clone(), None)
-            }
-            Interrupt::ToolConfirmation { node, request } => {
-                ("tool_confirmation", Some(node.clone()), None, None, Some(request.clone()))
+                ("dynamic", None, Some(message.clone()), data.clone())
             }
         };
         Self {
@@ -121,7 +172,6 @@ impl GraphInterruptPayload {
             node,
             message,
             data,
-            tool_confirmation,
             thread_id: thread_id.to_string(),
             checkpoint_id: checkpoint_id.to_string(),
         }
@@ -132,6 +182,28 @@ impl GraphInterruptPayload {
     pub fn from_event(event: &adk_core::Event) -> Option<Self> {
         let raw = event.provider_metadata.get(INTERRUPT_METADATA_KEY)?;
         serde_json::from_str(raw).ok()
+    }
+
+    /// Build a graph-agent interrupt payload for a tool-confirmation pause.
+    pub fn from_tool_confirmation_pause(pause: GraphToolConfirmationPause) -> Self {
+        let thread_id = pause.thread_id.clone();
+        let checkpoint_id = pause.checkpoint_id.clone();
+        Self {
+            kind: GraphToolConfirmationPause::KIND.to_string(),
+            node: Some(pause.node.clone()),
+            message: None,
+            data: serde_json::to_value(pause).ok(),
+            thread_id,
+            checkpoint_id,
+        }
+    }
+
+    /// Read the structured tool-confirmation pause, if this payload represents one.
+    pub fn tool_confirmation(&self) -> Option<GraphToolConfirmationPause> {
+        if self.kind != GraphToolConfirmationPause::KIND {
+            return None;
+        }
+        serde_json::from_value(self.data.clone()?).ok()
     }
 
     /// Serialize for transport in `Event::provider_metadata`.

--- a/adk-graph/src/lib.rs
+++ b/adk-graph/src/lib.rs
@@ -120,7 +120,7 @@ pub use edge::{END, Edge, EdgeTarget, Router, START};
 pub use error::{GraphError, InterruptedExecution, Result};
 pub use executor::PregelExecutor;
 pub use graph::{CompiledGraph, StateGraph};
-pub use interrupt::{Interrupt, interrupt, interrupt_with_data};
+pub use interrupt::{GraphToolConfirmationPause, Interrupt, interrupt, interrupt_with_data};
 pub use node::{AgentNode, ExecutionConfig, FunctionNode, Node, NodeContext, NodeOutput};
 pub use state::{Channel, Checkpoint, Reducer, State, StateSchema, StateSchemaBuilder};
 pub use stream::{StreamEvent, StreamMode};
@@ -148,7 +148,9 @@ pub mod prelude {
     pub use crate::edge::{END, Edge, EdgeTarget, Router, START};
     pub use crate::error::{GraphError, InterruptedExecution, Result};
     pub use crate::graph::{CompiledGraph, StateGraph};
-    pub use crate::interrupt::{Interrupt, interrupt, interrupt_with_data};
+    pub use crate::interrupt::{
+        GraphToolConfirmationPause, Interrupt, interrupt, interrupt_with_data,
+    };
     pub use crate::node::{
         AgentNode, ExecutionConfig, FunctionNode, Node, NodeContext, NodeOutput,
     };

--- a/adk-graph/src/node.rs
+++ b/adk-graph/src/node.rs
@@ -34,11 +34,6 @@ pub struct ExecutionConfig {
     /// [`ExecutionConfig::with_parent_context`] to carry them through; leaving it
     /// unset is standalone mode and is what a graph invoked outside a `Runner` gets.
     pub parent_context: Option<Arc<dyn adk_core::InvocationContext>>,
-    /// Per-run ADK configuration for nodes that invoke agents directly.
-    ///
-    /// When absent, an agent node inherits its parent invocation's configuration
-    /// or uses ADK defaults in standalone graph mode.
-    pub run_config: Option<adk_core::RunConfig>,
 }
 
 impl ExecutionConfig {
@@ -50,7 +45,6 @@ impl ExecutionConfig {
             recursion_limit: 50,
             metadata: HashMap::new(),
             parent_context: None,
-            run_config: None,
         }
     }
 
@@ -62,16 +56,6 @@ impl ExecutionConfig {
     #[must_use]
     pub fn with_parent_context(mut self, parent: Arc<dyn adk_core::InvocationContext>) -> Self {
         self.parent_context = Some(parent);
-        self
-    }
-
-    /// Set ADK configuration for agents run inside this graph.
-    ///
-    /// This is primarily useful for a directly invoked graph: supply a
-    /// confirmation decision when resuming a paused tool call.
-    #[must_use]
-    pub fn with_run_config(mut self, run_config: adk_core::RunConfig) -> Self {
-        self.run_config = Some(run_config);
         self
     }
 
@@ -115,12 +99,22 @@ pub struct NodeContext {
     children: Option<std::sync::Arc<crate::child::ChildInvoker>>,
     /// The schema of the graph running this node, for a node that projects state.
     parent_schema: Option<std::sync::Arc<crate::state::StateSchema>>,
+    /// ADK configuration supplied through an additive `CompiledGraph` API.
+    run_config: Option<adk_core::RunConfig>,
 }
 
 impl NodeContext {
     /// Create a new node context
     pub fn new(state: State, config: ExecutionConfig, step: usize) -> Self {
-        Self { state, config, step, progress_handle: None, children: None, parent_schema: None }
+        Self {
+            state,
+            config,
+            step,
+            progress_handle: None,
+            children: None,
+            parent_schema: None,
+            run_config: None,
+        }
     }
 
     /// The machinery for invoking other nodes, if this context has it.
@@ -135,6 +129,15 @@ impl NodeContext {
     /// Attaches the running graph's schema.
     pub fn set_parent_schema(&mut self, schema: std::sync::Arc<crate::state::StateSchema>) {
         self.parent_schema = Some(schema);
+    }
+
+    /// Attach per-run ADK configuration for an agent node.
+    pub(crate) fn set_run_config(&mut self, run_config: adk_core::RunConfig) {
+        self.run_config = Some(run_config);
+    }
+
+    pub(crate) fn run_config(&self) -> Option<adk_core::RunConfig> {
+        self.run_config.clone()
     }
 
     pub(crate) fn child_invoker(&self) -> Option<std::sync::Arc<crate::child::ChildInvoker>> {
@@ -484,6 +487,9 @@ impl Node for FunctionNode {
         if let Some(schema) = ctx.parent_schema() {
             ctx_owned.set_parent_schema(schema);
         }
+        if let Some(run_config) = ctx.run_config() {
+            ctx_owned.set_run_config(run_config);
+        }
         (self.func)(ctx_owned).await
     }
 }
@@ -674,7 +680,7 @@ impl Node for AgentNode {
             content,
             self.agent.clone(),
             ctx.config.parent_context.clone(),
-            ctx.config.run_config.clone(),
+            ctx.run_config(),
         ));
 
         // Run the agent and collect events
@@ -690,8 +696,12 @@ impl Node for AgentNode {
         if let Some(request) =
             events.iter().find_map(|event| event.actions.tool_confirmation.clone())
         {
-            return Ok(NodeOutput::new()
-                .with_interrupt(Interrupt::ToolConfirmation { node: self.name.clone(), request }));
+            return Ok(NodeOutput::new().with_interrupt(
+                crate::interrupt::GraphToolConfirmationPause::pending_interrupt(
+                    self.name.clone(),
+                    request,
+                ),
+            ));
         }
 
         // Map events to state updates
@@ -733,7 +743,7 @@ impl Node for AgentNode {
                 content,
                 agent.clone(),
                 parent_context,
-                ctx.config.run_config.clone(),
+                ctx.run_config(),
             ));
 
             let stream = match agent.run(invocation_ctx).await {
@@ -754,7 +764,14 @@ impl Node for AgentNode {
                 match result {
                     Ok(event) => {
                         if let Some(request) = event.actions.tool_confirmation.clone() {
-                            yield Ok(StreamEvent::node_tool_confirmation(&name, request));
+                            yield Ok(StreamEvent::node_interrupt(
+                                &name,
+                                crate::interrupt::GraphToolConfirmationPause::KIND,
+                                Some(crate::interrupt::GraphToolConfirmationPause::pending_data(
+                                    name.clone(),
+                                    request,
+                                )),
+                            ));
                             return;
                         }
                         // Emit streaming event immediately

--- a/adk-graph/src/node.rs
+++ b/adk-graph/src/node.rs
@@ -34,6 +34,11 @@ pub struct ExecutionConfig {
     /// [`ExecutionConfig::with_parent_context`] to carry them through; leaving it
     /// unset is standalone mode and is what a graph invoked outside a `Runner` gets.
     pub parent_context: Option<Arc<dyn adk_core::InvocationContext>>,
+    /// Per-run ADK configuration for nodes that invoke agents directly.
+    ///
+    /// When absent, an agent node inherits its parent invocation's configuration
+    /// or uses ADK defaults in standalone graph mode.
+    pub run_config: Option<adk_core::RunConfig>,
 }
 
 impl ExecutionConfig {
@@ -45,6 +50,7 @@ impl ExecutionConfig {
             recursion_limit: 50,
             metadata: HashMap::new(),
             parent_context: None,
+            run_config: None,
         }
     }
 
@@ -56,6 +62,16 @@ impl ExecutionConfig {
     #[must_use]
     pub fn with_parent_context(mut self, parent: Arc<dyn adk_core::InvocationContext>) -> Self {
         self.parent_context = Some(parent);
+        self
+    }
+
+    /// Set ADK configuration for agents run inside this graph.
+    ///
+    /// This is primarily useful for a directly invoked graph: supply a
+    /// confirmation decision when resuming a paused tool call.
+    #[must_use]
+    pub fn with_run_config(mut self, run_config: adk_core::RunConfig) -> Self {
+        self.run_config = Some(run_config);
         self
     }
 
@@ -658,6 +674,7 @@ impl Node for AgentNode {
             content,
             self.agent.clone(),
             ctx.config.parent_context.clone(),
+            ctx.config.run_config.clone(),
         ));
 
         // Run the agent and collect events
@@ -669,6 +686,13 @@ impl Node for AgentNode {
         })?;
 
         let events: Vec<adk_core::Event> = stream.filter_map(|r| async { r.ok() }).collect().await;
+
+        if let Some(request) =
+            events.iter().find_map(|event| event.actions.tool_confirmation.clone())
+        {
+            return Ok(NodeOutput::new()
+                .with_interrupt(Interrupt::ToolConfirmation { node: self.name.clone(), request }));
+        }
 
         // Map events to state updates
         let updates = (self.output_mapper)(&events);
@@ -709,6 +733,7 @@ impl Node for AgentNode {
                 content,
                 agent.clone(),
                 parent_context,
+                ctx.config.run_config.clone(),
             ));
 
             let stream = match agent.run(invocation_ctx).await {
@@ -728,6 +753,10 @@ impl Node for AgentNode {
             while let Some(result) = stream.next().await {
                 match result {
                     Ok(event) => {
+                        if let Some(request) = event.actions.tool_confirmation.clone() {
+                            yield Ok(StreamEvent::node_tool_confirmation(&name, request));
+                            return;
+                        }
                         // Emit streaming event immediately
                         if let Some(content) = event.content() {
                             let text: String = content.parts.iter().filter_map(|p| p.text()).collect();
@@ -802,6 +831,7 @@ impl GraphInvocationContext {
         user_content: adk_core::Content,
         agent: Arc<dyn adk_core::Agent>,
         parent: Option<Arc<dyn adk_core::InvocationContext>>,
+        explicit_run_config: Option<adk_core::RunConfig>,
     ) -> Self {
         let invocation_id = uuid::Uuid::new_v4().to_string();
         let session = Arc::new(GraphSession::new(session_id));
@@ -810,7 +840,7 @@ impl GraphInvocationContext {
 
         // A node runs on its own branch below the caller's, so events it produces are
         // attributable and do not read as the parent agent's own turn.
-        let (user_id, app_name, branch, run_config) = match parent.as_ref() {
+        let (user_id, app_name, branch, inherited_run_config) = match parent.as_ref() {
             Some(parent) => (
                 parent.user_id().to_string(),
                 parent.app_name().to_string(),
@@ -833,7 +863,7 @@ impl GraphInvocationContext {
             user_content,
             agent,
             session,
-            run_config,
+            run_config: explicit_run_config.unwrap_or(inherited_run_config),
             ended: std::sync::atomic::AtomicBool::new(false),
             parent,
             user_id,

--- a/adk-graph/src/stream.rs
+++ b/adk-graph/src/stream.rs
@@ -1,7 +1,6 @@
 //! Streaming types for graph execution
 
 use crate::state::State;
-use adk_core::ToolConfirmationRequest;
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -53,31 +52,12 @@ pub enum StreamEvent {
     /// Execution was interrupted
     Interrupted { node: String, message: String },
 
-    /// A persisted graph pause caused by a tool that requires authorization.
-    ToolConfirmationRequired {
-        /// Graph node whose agent requested authorization.
-        node: String,
-        /// The exact tool call the caller must approve or deny.
-        request: ToolConfirmationRequest,
-        /// Thread to resume after a decision.
-        thread_id: String,
-        /// Checkpoint saved before this event was emitted.
-        checkpoint_id: String,
-    },
-
     /// A node asked to pause, reported by `Node::execute_stream`.
     ///
     /// The streamed path yields events rather than a `NodeOutput`, so a node's own
     /// interrupt request needs a way through. The executor turns this into the
     /// pause and does not forward it, so a caller sees only `Interrupted`.
     NodeInterrupt { node: String, message: String, data: Option<serde_json::Value> },
-
-    /// An agent node emitted a tool-authorization request.
-    ///
-    /// This is an executor-internal event. The executor checkpoints the run and
-    /// reports [`ToolConfirmationRequired`](Self::ToolConfirmationRequired) to
-    /// callers instead.
-    NodeToolConfirmation { node: String, request: ToolConfirmationRequest },
 
     /// Execution resumed from a checkpoint
     Resumed { step: usize, pending_nodes: Vec<String> },
@@ -138,21 +118,6 @@ impl StreamEvent {
         Self::Interrupted { node: node.to_string(), message: message.to_string() }
     }
 
-    /// Create a persisted tool confirmation event for graph callers.
-    pub fn tool_confirmation_required(
-        node: &str,
-        request: ToolConfirmationRequest,
-        thread_id: &str,
-        checkpoint_id: &str,
-    ) -> Self {
-        Self::ToolConfirmationRequired {
-            node: node.to_string(),
-            request,
-            thread_id: thread_id.to_string(),
-            checkpoint_id: checkpoint_id.to_string(),
-        }
-    }
-
     /// Create a resumed event
     pub fn resumed(step: usize, pending_nodes: Vec<String>) -> Self {
         Self::Resumed { step, pending_nodes }
@@ -171,11 +136,6 @@ impl StreamEvent {
     /// Create an event reporting that a node asked to pause.
     pub fn node_interrupt(node: &str, message: &str, data: Option<serde_json::Value>) -> Self {
         Self::NodeInterrupt { node: node.to_string(), message: message.to_string(), data }
-    }
-
-    /// Create an executor-internal tool confirmation event from a node.
-    pub fn node_tool_confirmation(node: &str, request: ToolConfirmationRequest) -> Self {
-        Self::NodeToolConfirmation { node: node.to_string(), request }
     }
 
     /// Create a route dispatched event

--- a/adk-graph/src/stream.rs
+++ b/adk-graph/src/stream.rs
@@ -1,6 +1,7 @@
 //! Streaming types for graph execution
 
 use crate::state::State;
+use adk_core::ToolConfirmationRequest;
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -52,12 +53,31 @@ pub enum StreamEvent {
     /// Execution was interrupted
     Interrupted { node: String, message: String },
 
+    /// A persisted graph pause caused by a tool that requires authorization.
+    ToolConfirmationRequired {
+        /// Graph node whose agent requested authorization.
+        node: String,
+        /// The exact tool call the caller must approve or deny.
+        request: ToolConfirmationRequest,
+        /// Thread to resume after a decision.
+        thread_id: String,
+        /// Checkpoint saved before this event was emitted.
+        checkpoint_id: String,
+    },
+
     /// A node asked to pause, reported by `Node::execute_stream`.
     ///
     /// The streamed path yields events rather than a `NodeOutput`, so a node's own
     /// interrupt request needs a way through. The executor turns this into the
     /// pause and does not forward it, so a caller sees only `Interrupted`.
     NodeInterrupt { node: String, message: String, data: Option<serde_json::Value> },
+
+    /// An agent node emitted a tool-authorization request.
+    ///
+    /// This is an executor-internal event. The executor checkpoints the run and
+    /// reports [`ToolConfirmationRequired`](Self::ToolConfirmationRequired) to
+    /// callers instead.
+    NodeToolConfirmation { node: String, request: ToolConfirmationRequest },
 
     /// Execution resumed from a checkpoint
     Resumed { step: usize, pending_nodes: Vec<String> },
@@ -118,6 +138,21 @@ impl StreamEvent {
         Self::Interrupted { node: node.to_string(), message: message.to_string() }
     }
 
+    /// Create a persisted tool confirmation event for graph callers.
+    pub fn tool_confirmation_required(
+        node: &str,
+        request: ToolConfirmationRequest,
+        thread_id: &str,
+        checkpoint_id: &str,
+    ) -> Self {
+        Self::ToolConfirmationRequired {
+            node: node.to_string(),
+            request,
+            thread_id: thread_id.to_string(),
+            checkpoint_id: checkpoint_id.to_string(),
+        }
+    }
+
     /// Create a resumed event
     pub fn resumed(step: usize, pending_nodes: Vec<String>) -> Self {
         Self::Resumed { step, pending_nodes }
@@ -136,6 +171,11 @@ impl StreamEvent {
     /// Create an event reporting that a node asked to pause.
     pub fn node_interrupt(node: &str, message: &str, data: Option<serde_json::Value>) -> Self {
         Self::NodeInterrupt { node: node.to_string(), message: message.to_string(), data }
+    }
+
+    /// Create an executor-internal tool confirmation event from a node.
+    pub fn node_tool_confirmation(node: &str, request: ToolConfirmationRequest) -> Self {
+        Self::NodeToolConfirmation { node: node.to_string(), request }
     }
 
     /// Create a route dispatched event

--- a/adk-graph/src/subgraph.rs
+++ b/adk-graph/src/subgraph.rs
@@ -273,11 +273,15 @@ impl Node for SubgraphNode {
         if let Some(parent) = ctx.config.parent_context.clone() {
             config = config.with_parent_context(parent);
         }
-        if let Some(run_config) = ctx.config.run_config.clone() {
-            config = config.with_run_config(run_config);
-        }
 
-        match self.graph.invoke_detailed(input, config).await {
+        let outcome = match ctx.run_config() {
+            Some(run_config) => {
+                self.graph.invoke_detailed_with_run_config(input, config, run_config).await
+            }
+            None => self.graph.invoke_detailed(input, config).await,
+        };
+
+        match outcome {
             Ok(outcome) => {
                 let mut output = NodeOutput::new()
                     .with_updates(self.project_out(&outcome.state, &parent_schema));
@@ -294,11 +298,15 @@ impl Node for SubgraphNode {
             // where it happened, and the subgraph's own thread holds the state to
             // resume from.
             Err(GraphError::Interrupted(inner)) => {
-                if let Interrupt::ToolConfirmation { node, request } = &inner.interrupt {
-                    return Ok(NodeOutput::new().with_interrupt(Interrupt::ToolConfirmation {
-                        node: format!("{}.{}", self.name, node),
-                        request: request.clone(),
-                    }));
+                if let Some(pause) =
+                    crate::interrupt::GraphToolConfirmationPause::from_interrupted_execution(&inner)
+                {
+                    return Ok(NodeOutput::new().with_interrupt(
+                        crate::interrupt::GraphToolConfirmationPause::pending_interrupt(
+                            format!("{}.{}", self.name, pause.node),
+                            pause.request,
+                        ),
+                    ));
                 }
                 let message = match &inner.interrupt {
                     Interrupt::Dynamic { message, .. } => message.clone(),

--- a/adk-graph/src/subgraph.rs
+++ b/adk-graph/src/subgraph.rs
@@ -269,7 +269,13 @@ impl Node for SubgraphNode {
 
         let input = self.project_in(&ctx.state, &parent_schema);
         let thread = self.child_thread(&ctx.config.thread_id);
-        let config = ExecutionConfig::new(&thread);
+        let mut config = ExecutionConfig::new(&thread);
+        if let Some(parent) = ctx.config.parent_context.clone() {
+            config = config.with_parent_context(parent);
+        }
+        if let Some(run_config) = ctx.config.run_config.clone() {
+            config = config.with_run_config(run_config);
+        }
 
         match self.graph.invoke_detailed(input, config).await {
             Ok(outcome) => {
@@ -288,6 +294,12 @@ impl Node for SubgraphNode {
             // where it happened, and the subgraph's own thread holds the state to
             // resume from.
             Err(GraphError::Interrupted(inner)) => {
+                if let Interrupt::ToolConfirmation { node, request } = &inner.interrupt {
+                    return Ok(NodeOutput::new().with_interrupt(Interrupt::ToolConfirmation {
+                        node: format!("{}.{}", self.name, node),
+                        request: request.clone(),
+                    }));
+                }
                 let message = match &inner.interrupt {
                     Interrupt::Dynamic { message, .. } => message.clone(),
                     other => other.to_string(),

--- a/adk-graph/src/timeout.rs
+++ b/adk-graph/src/timeout.rs
@@ -211,6 +211,9 @@ async fn execute_once_with_timeout(
     // call `report_progress()` to reset the idle timeout.
     let mut timeout_ctx = NodeContext::new(ctx.state.clone(), ctx.config.clone(), ctx.step);
     timeout_ctx.set_progress_handle(progress_handle.clone());
+    if let Some(run_config) = ctx.run_config() {
+        timeout_ctx.set_run_config(run_config);
+    }
 
     tokio::select! {
         result = node.execute(&timeout_ctx) => {

--- a/adk-graph/tests/tool_confirmation_graph_tests.rs
+++ b/adk-graph/tests/tool_confirmation_graph_tests.rs
@@ -1,0 +1,187 @@
+//! Tool confirmation must pause a graph without flattening its lifecycle.
+
+use adk_core::{
+    Agent, Content, Event, EventStream, InvocationContext, RunConfig, ToolConfirmationDecision,
+    ToolConfirmationRequest,
+};
+use adk_graph::agent::GraphAgent;
+use adk_graph::checkpoint::MemoryCheckpointer;
+use adk_graph::edge::{END, START};
+use adk_graph::graph::StateGraph;
+use adk_graph::node::{AgentNode, ExecutionConfig};
+use adk_graph::state::State;
+use adk_graph::stream::{StreamEvent, StreamMode};
+use async_trait::async_trait;
+use futures::StreamExt;
+use serde_json::json;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+mod support;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+struct ConfirmationAgent {
+    runs: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl Agent for ConfirmationAgent {
+    fn name(&self) -> &str {
+        "sensitive_agent"
+    }
+
+    fn description(&self) -> &str {
+        "requests confirmation before changing state"
+    }
+
+    fn sub_agents(&self) -> &[Arc<dyn Agent>] {
+        &[]
+    }
+
+    async fn run(&self, ctx: Arc<dyn InvocationContext>) -> adk_core::Result<EventStream> {
+        self.runs.fetch_add(1, Ordering::SeqCst);
+        let approved = ctx.run_config().tool_confirmation_decisions.get("call-1")
+            == Some(&ToolConfirmationDecision::Approve);
+
+        let stream = async_stream::stream! {
+            if approved {
+                let mut event = Event::new(ctx.invocation_id());
+                event.set_content(Content::new("assistant").with_text("authorized"));
+                yield Ok(event);
+            } else {
+                let mut event = Event::new(ctx.invocation_id());
+                event.llm_response.interrupted = true;
+                event.actions.tool_confirmation = Some(ToolConfirmationRequest {
+                    tool_name: "delete_file".to_string(),
+                    function_call_id: Some("call-1".to_string()),
+                    args: json!({ "path": "/tmp/report.txt" }),
+                });
+                yield Ok(event);
+            }
+        };
+        Ok(Box::pin(stream))
+    }
+}
+
+#[tokio::test]
+async fn graph_streams_a_persisted_tool_confirmation_and_resumes_with_a_decision() {
+    let runs = Arc::new(AtomicUsize::new(0));
+    let graph = StateGraph::with_channels(&["messages"])
+        .add_node(AgentNode::new(Arc::new(ConfirmationAgent { runs: Arc::clone(&runs) })))
+        .add_edge(START, "sensitive_agent")
+        .add_edge("sensitive_agent", END)
+        .compile()
+        .expect("compile")
+        .with_checkpointer(MemoryCheckpointer::new());
+
+    let mut stream = Box::pin(graph.stream(
+        State::new(),
+        ExecutionConfig::new("confirmation-thread"),
+        StreamMode::Debug,
+    ));
+    let pause = loop {
+        if let StreamEvent::ToolConfirmationRequired { node, request, thread_id, checkpoint_id } =
+            stream.next().await.expect("stream event").expect("graph event")
+        {
+            break (node, request, thread_id, checkpoint_id);
+        }
+    };
+
+    assert_eq!(pause.0, "sensitive_agent");
+    assert_eq!(pause.1.tool_name, "delete_file");
+    assert_eq!(pause.1.function_call_id.as_deref(), Some("call-1"));
+    assert_eq!(pause.2, "confirmation-thread");
+    assert!(!pause.3.is_empty(), "a confirmation event must be resumable");
+    assert_eq!(runs.load(Ordering::SeqCst), 1);
+
+    let decisions = HashMap::from([(String::from("call-1"), ToolConfirmationDecision::Approve)]);
+    let config = ExecutionConfig::new("confirmation-thread")
+        .with_run_config(RunConfig::builder().tool_confirmation_decisions(decisions).build());
+    let events = graph.stream(State::new(), config, StreamMode::Debug).collect::<Vec<_>>().await;
+
+    assert!(
+        events
+            .iter()
+            .all(|event| !matches!(event, Ok(StreamEvent::ToolConfirmationRequired { .. })))
+    );
+    assert!(events.iter().any(|event| matches!(event, Ok(StreamEvent::Done { .. }))));
+    assert_eq!(runs.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn graph_agent_preserves_tool_confirmation_for_runner_compatibility() {
+    let graph = StateGraph::with_channels(&["messages"])
+        .add_node(AgentNode::new(Arc::new(ConfirmationAgent {
+            runs: Arc::new(AtomicUsize::new(0)),
+        })))
+        .add_edge(START, "sensitive_agent")
+        .add_edge("sensitive_agent", END)
+        .compile()
+        .expect("compile")
+        .with_checkpointer(MemoryCheckpointer::new());
+    let graph_agent = GraphAgent::from_graph("graph", graph);
+
+    let mut events = graph_agent
+        .run(support::test_context("graph-agent-confirmation"))
+        .await
+        .expect("run graph agent");
+    let event = events.next().await.expect("event").expect("valid event");
+
+    assert!(event.llm_response.interrupted);
+    assert_eq!(
+        event.actions.tool_confirmation.as_ref().map(|request| request.tool_name.as_str()),
+        Some("delete_file")
+    );
+}
+
+#[tokio::test]
+async fn a_confirmation_pause_does_not_replay_completed_frontier_nodes() {
+    let agent_runs = Arc::new(AtomicUsize::new(0));
+    let completed_runs = Arc::new(AtomicUsize::new(0));
+    let completed_for_node = Arc::clone(&completed_runs);
+    let graph = StateGraph::with_channels(&["done", "messages"])
+        .add_node_fn("completed", move |_ctx| {
+            let completed_runs = Arc::clone(&completed_for_node);
+            async move {
+                completed_runs.fetch_add(1, Ordering::SeqCst);
+                Ok(adk_graph::node::NodeOutput::new().with_update("done", json!(true)))
+            }
+        })
+        .add_node(AgentNode::new(Arc::new(ConfirmationAgent { runs: Arc::clone(&agent_runs) })))
+        .add_edge(START, "completed")
+        .add_edge(START, "sensitive_agent")
+        .add_edge("completed", END)
+        .add_edge("sensitive_agent", END)
+        .compile()
+        .expect("compile")
+        .with_checkpointer(MemoryCheckpointer::new());
+
+    let first = graph
+        .stream(
+            State::new(),
+            ExecutionConfig::new("parallel-confirmation-thread"),
+            StreamMode::Debug,
+        )
+        .collect::<Vec<_>>()
+        .await;
+    assert!(
+        first.iter().any(|event| matches!(event, Ok(StreamEvent::ToolConfirmationRequired { .. })))
+    );
+    assert_eq!(completed_runs.load(Ordering::SeqCst), 1);
+
+    let decisions = HashMap::from([(String::from("call-1"), ToolConfirmationDecision::Approve)]);
+    let resumed = graph
+        .stream(
+            State::new(),
+            ExecutionConfig::new("parallel-confirmation-thread").with_run_config(
+                RunConfig::builder().tool_confirmation_decisions(decisions).build(),
+            ),
+            StreamMode::Debug,
+        )
+        .collect::<Vec<_>>()
+        .await;
+
+    assert!(resumed.iter().any(|event| matches!(event, Ok(StreamEvent::Done { .. }))));
+    assert_eq!(completed_runs.load(Ordering::SeqCst), 1, "completed node must not replay");
+    assert_eq!(agent_runs.load(Ordering::SeqCst), 2);
+}

--- a/adk-graph/tests/tool_confirmation_graph_tests.rs
+++ b/adk-graph/tests/tool_confirmation_graph_tests.rs
@@ -8,9 +8,11 @@ use adk_graph::agent::GraphAgent;
 use adk_graph::checkpoint::MemoryCheckpointer;
 use adk_graph::edge::{END, START};
 use adk_graph::graph::StateGraph;
+use adk_graph::interrupt::GraphToolConfirmationPause;
 use adk_graph::node::{AgentNode, ExecutionConfig};
 use adk_graph::state::State;
 use adk_graph::stream::{StreamEvent, StreamMode};
+use adk_graph::subgraph::SubgraphNode;
 use async_trait::async_trait;
 use futures::StreamExt;
 use serde_json::json;
@@ -80,30 +82,34 @@ async fn graph_streams_a_persisted_tool_confirmation_and_resumes_with_a_decision
         StreamMode::Debug,
     ));
     let pause = loop {
-        if let StreamEvent::ToolConfirmationRequired { node, request, thread_id, checkpoint_id } =
-            stream.next().await.expect("stream event").expect("graph event")
-        {
-            break (node, request, thread_id, checkpoint_id);
+        let event = stream.next().await.expect("stream event").expect("graph event");
+        if let Some(pause) = GraphToolConfirmationPause::from_stream_event(&event) {
+            break pause;
         }
     };
 
-    assert_eq!(pause.0, "sensitive_agent");
-    assert_eq!(pause.1.tool_name, "delete_file");
-    assert_eq!(pause.1.function_call_id.as_deref(), Some("call-1"));
-    assert_eq!(pause.2, "confirmation-thread");
-    assert!(!pause.3.is_empty(), "a confirmation event must be resumable");
+    assert_eq!(pause.node, "sensitive_agent");
+    assert_eq!(pause.request.tool_name, "delete_file");
+    assert_eq!(pause.request.function_call_id.as_deref(), Some("call-1"));
+    assert_eq!(pause.thread_id, "confirmation-thread");
+    assert!(!pause.checkpoint_id.is_empty(), "a confirmation event must be resumable");
     assert_eq!(runs.load(Ordering::SeqCst), 1);
 
     let decisions = HashMap::from([(String::from("call-1"), ToolConfirmationDecision::Approve)]);
-    let config = ExecutionConfig::new("confirmation-thread")
-        .with_run_config(RunConfig::builder().tool_confirmation_decisions(decisions).build());
-    let events = graph.stream(State::new(), config, StreamMode::Debug).collect::<Vec<_>>().await;
+    let config = ExecutionConfig::new("confirmation-thread");
+    let events = graph
+        .stream_with_run_config(
+            State::new(),
+            config,
+            StreamMode::Debug,
+            RunConfig::builder().tool_confirmation_decisions(decisions).build(),
+        )
+        .collect::<Vec<_>>()
+        .await;
 
-    assert!(
-        events
-            .iter()
-            .all(|event| !matches!(event, Ok(StreamEvent::ToolConfirmationRequired { .. })))
-    );
+    assert!(events.iter().all(|event| {
+        event.as_ref().ok().and_then(GraphToolConfirmationPause::from_stream_event).is_none()
+    }));
     assert!(events.iter().any(|event| matches!(event, Ok(StreamEvent::Done { .. }))));
     assert_eq!(runs.load(Ordering::SeqCst), 2);
 }
@@ -164,19 +170,18 @@ async fn a_confirmation_pause_does_not_replay_completed_frontier_nodes() {
         )
         .collect::<Vec<_>>()
         .await;
-    assert!(
-        first.iter().any(|event| matches!(event, Ok(StreamEvent::ToolConfirmationRequired { .. })))
-    );
+    assert!(first.iter().any(|event| {
+        event.as_ref().ok().and_then(GraphToolConfirmationPause::from_stream_event).is_some()
+    }));
     assert_eq!(completed_runs.load(Ordering::SeqCst), 1);
 
     let decisions = HashMap::from([(String::from("call-1"), ToolConfirmationDecision::Approve)]);
     let resumed = graph
-        .stream(
+        .stream_with_run_config(
             State::new(),
-            ExecutionConfig::new("parallel-confirmation-thread").with_run_config(
-                RunConfig::builder().tool_confirmation_decisions(decisions).build(),
-            ),
+            ExecutionConfig::new("parallel-confirmation-thread"),
             StreamMode::Debug,
+            RunConfig::builder().tool_confirmation_decisions(decisions).build(),
         )
         .collect::<Vec<_>>()
         .await;
@@ -184,4 +189,47 @@ async fn a_confirmation_pause_does_not_replay_completed_frontier_nodes() {
     assert!(resumed.iter().any(|event| matches!(event, Ok(StreamEvent::Done { .. }))));
     assert_eq!(completed_runs.load(Ordering::SeqCst), 1, "completed node must not replay");
     assert_eq!(agent_runs.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn a_nested_confirmation_keeps_its_request_in_messages_mode() {
+    let inner = Arc::new(
+        StateGraph::with_channels(&["messages"])
+            .add_node(AgentNode::new(Arc::new(ConfirmationAgent {
+                runs: Arc::new(AtomicUsize::new(0)),
+            })))
+            .add_edge(START, "sensitive_agent")
+            .add_edge("sensitive_agent", END)
+            .compile()
+            .expect("compile inner")
+            .with_checkpointer(MemoryCheckpointer::new()),
+    );
+    let outer = StateGraph::with_channels(&["messages"])
+        .add_node(SubgraphNode::new("review", inner))
+        .add_edge(START, "review")
+        .add_edge("review", END)
+        .compile()
+        .expect("compile outer")
+        .with_checkpointer(MemoryCheckpointer::new());
+
+    let events = outer
+        .stream(
+            State::new(),
+            ExecutionConfig::new("nested-confirmation-thread"),
+            StreamMode::Messages,
+        )
+        .collect::<Vec<_>>()
+        .await;
+    let pause = events
+        .iter()
+        .filter_map(|event| event.as_ref().ok())
+        .find_map(GraphToolConfirmationPause::from_stream_event)
+        .expect("messages mode must preserve the structured confirmation request");
+
+    assert_eq!(pause.node, "review.sensitive_agent");
+    assert_eq!(pause.request.tool_name, "delete_file");
+    assert_eq!(pause.request.function_call_id.as_deref(), Some("call-1"));
+    assert_eq!(pause.request.args, json!({ "path": "/tmp/report.txt" }));
+    assert_eq!(pause.thread_id, "nested-confirmation-thread");
+    assert!(!pause.checkpoint_id.is_empty());
 }

--- a/docs/official_docs/security/tool-authorization.md
+++ b/docs/official_docs/security/tool-authorization.md
@@ -434,6 +434,78 @@ For complex approval workflows where execution needs to persist state and resume
 
 Graph agents support checkpoint-based interrupts where execution pauses at a node, persists state to a checkpoint store, and resumes after human input — even across server restarts.
 
+### Graph-Native Tool Confirmation
+
+An `AgentNode` preserves the standard tool-confirmation policy when it runs in
+a `CompiledGraph`. Instead of flattening the graph into a `Runner` event stream,
+the graph checkpoints its own frontier and emits a structured
+`StreamEvent::ToolConfirmationRequired` event.
+
+```rust,no_run
+use adk_agent::LlmAgentBuilder;
+use adk_core::{RunConfig, ToolConfirmationDecision};
+use adk_graph::{
+    checkpoint::MemoryCheckpointer,
+    edge::{END, START},
+    graph::StateGraph,
+    node::{AgentNode, ExecutionConfig},
+    state::State,
+    stream::{StreamEvent, StreamMode},
+};
+use futures::StreamExt;
+use std::{collections::HashMap, sync::Arc};
+
+let agent = LlmAgentBuilder::new("file_manager")
+    .model(model)
+    .tool(delete_file_tool)
+    .require_tool_confirmation("delete_file")
+    .build()?;
+
+let graph = StateGraph::with_channels(&["messages"])
+    .add_node(AgentNode::new(Arc::new(agent)))
+    .add_edge(START, "file_manager")
+    .add_edge("file_manager", END)
+    .compile()?
+    .with_checkpointer(MemoryCheckpointer::new());
+
+let mut events = Box::pin(graph.stream(
+    State::new(),
+    ExecutionConfig::new("delete-report"),
+    StreamMode::Debug,
+));
+
+let (request, checkpoint_id) = loop {
+    match events.next().await.transpose()? {
+        Some(StreamEvent::ToolConfirmationRequired { request, checkpoint_id, .. }) => {
+            break (request, checkpoint_id);
+        }
+        Some(_) => {}
+        None => unreachable!("the graph must pause before the tool runs"),
+    }
+};
+
+// Present `request.tool_name` and `request.args` to the approver. A decision
+// is scoped to this exact function call ID; bind its arguments as well when it
+// crosses an untrusted boundary.
+let call_id = request.function_call_id.expect("LLM tool calls have an ID");
+let decisions = HashMap::from([(call_id, ToolConfirmationDecision::Approve)]);
+let config = ExecutionConfig::new("delete-report").with_run_config(
+    RunConfig::builder().tool_confirmation_decisions(decisions).build(),
+);
+
+// The checkpoint is selected automatically by thread ID. `checkpoint_id` is
+// available for audit records or an explicit `with_resume_from` call.
+drop(events);
+let final_events = graph.stream(State::new(), config, StreamMode::Debug);
+# let _ = checkpoint_id;
+# let _ = final_events;
+```
+
+The graph retains node lifecycle, intermediate state, nested subgraphs, and
+the pending frontier. Nodes that completed alongside the confirmation request
+are checkpointed and are not replayed after approval. The agent itself uses the
+same `RunConfig` decision semantics as a normal ADK run.
+
 ## Combining Mechanisms
 
 These mechanisms compose naturally:

--- a/docs/official_docs/security/tool-authorization.md
+++ b/docs/official_docs/security/tool-authorization.md
@@ -438,8 +438,8 @@ Graph agents support checkpoint-based interrupts where execution pauses at a nod
 
 An `AgentNode` preserves the standard tool-confirmation policy when it runs in
 a `CompiledGraph`. Instead of flattening the graph into a `Runner` event stream,
-the graph checkpoints its own frontier and emits a structured
-`StreamEvent::ToolConfirmationRequired` event.
+the graph checkpoints its own frontier and emits a structured custom event that
+can be read with `GraphToolConfirmationPause::from_stream_event`.
 
 ```rust,no_run
 use adk_agent::LlmAgentBuilder;
@@ -450,7 +450,8 @@ use adk_graph::{
     graph::StateGraph,
     node::{AgentNode, ExecutionConfig},
     state::State,
-    stream::{StreamEvent, StreamMode},
+    interrupt::GraphToolConfirmationPause,
+    stream::StreamMode,
 };
 use futures::StreamExt;
 use std::{collections::HashMap, sync::Arc};
@@ -474,30 +475,33 @@ let mut events = Box::pin(graph.stream(
     StreamMode::Debug,
 ));
 
-let (request, checkpoint_id) = loop {
+let pause = loop {
     match events.next().await.transpose()? {
-        Some(StreamEvent::ToolConfirmationRequired { request, checkpoint_id, .. }) => {
-            break (request, checkpoint_id);
+        Some(event) => {
+            if let Some(pause) = GraphToolConfirmationPause::from_stream_event(&event) {
+                break pause;
+            }
         }
-        Some(_) => {}
         None => unreachable!("the graph must pause before the tool runs"),
     }
 };
 
-// Present `request.tool_name` and `request.args` to the approver. A decision
+// Present `pause.request.tool_name` and `pause.request.args` to the approver. A decision
 // is scoped to this exact function call ID; bind its arguments as well when it
 // crosses an untrusted boundary.
-let call_id = request.function_call_id.expect("LLM tool calls have an ID");
+let call_id = pause.request.function_call_id.expect("LLM tool calls have an ID");
 let decisions = HashMap::from([(call_id, ToolConfirmationDecision::Approve)]);
-let config = ExecutionConfig::new("delete-report").with_run_config(
-    RunConfig::builder().tool_confirmation_decisions(decisions).build(),
-);
 
-// The checkpoint is selected automatically by thread ID. `checkpoint_id` is
+// The checkpoint is selected automatically by thread ID. `pause.checkpoint_id` is
 // available for audit records or an explicit `with_resume_from` call.
 drop(events);
-let final_events = graph.stream(State::new(), config, StreamMode::Debug);
-# let _ = checkpoint_id;
+let final_events = graph.stream_with_run_config(
+    State::new(),
+    ExecutionConfig::new("delete-report"),
+    StreamMode::Debug,
+    RunConfig::builder().tool_confirmation_decisions(decisions).build(),
+);
+# let _ = pause;
 # let _ = final_events;
 ```
 


### PR DESCRIPTION
## What

Add native tool-confirmation pause and resume support to `CompiledGraph`.

Graphs now surface `StreamEvent::ToolConfirmationRequired` with the exact
`ToolConfirmationRequest`, thread ID, and persisted checkpoint ID. Tool
confirmation requests from `AgentNode`s and nested subgraphs pause the graph
without flattening its lifecycle into `Runner` events.

## Why

Close #587 

Graph users need to retain graph-native lifecycle visibility, checkpointing,
nested workflow behavior, and resume semantics while authorizing sensitive tool
calls.

## How

- Add `Interrupt::ToolConfirmation` and structured graph stream events.
- Detect `event.actions.tool_confirmation` in `AgentNode` and convert it into a
  graph pause rather than treating it as a generic agent event.
- Persist the graph checkpoint before emitting the confirmation request.
- Add `ExecutionConfig::with_run_config(...)` so direct `CompiledGraph` callers
  can resume with `RunConfig::tool_confirmation_decisions`.
- Propagate confirmation pauses and run configuration through `SubgraphNode`.
- Preserve `event.actions.tool_confirmation` when a graph is used through
  `GraphAgent` and `Runner`.
- Prevent completed parallel-frontier nodes from being replayed after a
  confirmation pause.
- Add integration coverage and Graph-native authorization documentation.

Out of scope: persistent, no-model-replay `LlmAgent` continuations. This PR uses
the existing ADK `RunConfig` confirmation-decision contract.

## PR Checklist

### Quality Gates (all required)

- [ ] `devenv shell fmt` — unavailable locally (`devenv` is not installed)
- [ ] `devenv shell clippy` — unavailable locally (`devenv` is not installed)
- [ ] `devenv shell test` — unavailable locally (`devenv` is not installed)
- [ ] `devenv shell check` — unavailable locally (`devenv` is not installed)

Equivalent targeted checks completed:

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p adk-graph --all-targets -- -D warnings`
- [x] `cargo test -p adk-graph -q`
- [x] `git diff --check`

### Code Quality

- [x] New code has integration tests
- [x] New public APIs include rustdoc comments
- [x] No `println!`/`eprintln!` in library code
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [ ] CHANGELOG.md updated, if required by release policy
- [ ] README updated, if maintainers require capability changes there
- [x] Tool authorization documentation updated with Graph-native confirmation usage
