### PR TITLE
fix(telemetry): keep span parenting across suspension points

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-subscriber",
  "uuid 1.25.0",
 ]
 

--- a/adk-agent/Cargo.toml
+++ b/adk-agent/Cargo.toml
@@ -71,4 +71,9 @@ anyhow = "1"
 dotenvy = "0.15"
 proptest = "1.5"
 tempfile = "3"
-tokio = { workspace = true, features = ["rt", "macros"] }
+# `rt-multi-thread`: the span-parenting regression test must run on a
+# multi-threaded runtime — a current-thread runtime can mask the thread-affinity
+# half of the bug it covers.
+tokio = { workspace = true, features = ["rt", "macros", "rt-multi-thread"] }
+# Capture layer for the span-parenting regression test.
+tracing-subscriber = { workspace = true }

--- a/adk-agent/src/llm_agent.rs
+++ b/adk-agent/src/llm_agent.rs
@@ -2671,7 +2671,16 @@ impl Agent for LlmAgent {
                         "gcp.vertex.agent.llm_request" = %trace_request_json,
                         "gcp.vertex.agent.llm_response" = tracing::field::Empty  // Placeholder for later recording
                     );
-                    let _llm_guard = llm_span.enter();
+                    // NOTE: do not `llm_span.enter()` here. This is an
+                    // `async_stream` generator body: an entered guard is tied to the
+                    // current thread, not the task, so it is neither exited when the
+                    // generator suspends at an `.await`/`yield` nor re-entered when
+                    // it resumes (possibly on another worker thread). That both
+                    // detaches everything after the first suspension point from
+                    // `call_llm` and leaks the entry onto the worker thread, where
+                    // unrelated tasks then inherit it as a parent. Instrument the
+                    // individual futures instead — `Instrumented::poll` enters the
+                    // span per poll, so it is correct across suspension.
 
                     // Check streaming mode from run config
                     use adk_core::StreamingMode;
@@ -2680,7 +2689,10 @@ impl Agent for LlmAgent {
                         && output_guardrails.is_empty();
 
                     // Always use streaming internally for LLM calls
-                    let mut response_stream = model.generate_content(request, true).await?;
+                    let mut response_stream = model
+                        .generate_content(request, true)
+                        .instrument(llm_span.clone())
+                        .await?;
 
                     use futures::StreamExt;
 
@@ -2688,12 +2700,16 @@ impl Agent for LlmAgent {
                     let mut last_chunk: Option<LlmResponse> = None;
 
                     // Stream and process chunks with AfterModel callbacks
-                    while let Some(chunk_result) = response_stream.next().await {
+                    while let Some(chunk_result) =
+                        response_stream.next().instrument(llm_span.clone()).await
+                    {
                         // Cooperative cancellation: stop consuming the model
                         // stream promptly when the invocation is cancelled. This
                         // drops `response_stream`, releasing the provider connection.
                         if ctx.is_cancelled() {
-                            tracing::info!(agent.name = %agent_name, "invocation cancelled during LLM streaming");
+                            llm_span.in_scope(|| {
+                                tracing::info!(agent.name = %agent_name, "invocation cancelled during LLM streaming")
+                            });
                             return;
                         }
                         let mut chunk = match chunk_result {
@@ -2707,7 +2723,10 @@ impl Agent for LlmAgent {
                         // ===== AFTER MODEL CALLBACKS (per chunk) =====
                         // Callbacks can modify each streaming chunk
                         for callback in after_model_callbacks.as_ref() {
-                            match callback(ctx.clone() as Arc<dyn CallbackContext>, chunk.clone()).await {
+                            match callback(ctx.clone() as Arc<dyn CallbackContext>, chunk.clone())
+                                .instrument(llm_span.clone())
+                                .await
+                            {
                                 Ok(Some(modified_chunk)) => {
                                     // Callback modified this chunk
                                     chunk = modified_chunk;
@@ -2779,7 +2798,9 @@ impl Agent for LlmAgent {
                             let content = if has_function_calls {
                                 content
                             } else {
-                                Self::apply_output_guardrails(output_guardrails.as_ref(), content).await?
+                                Self::apply_output_guardrails(output_guardrails.as_ref(), content)
+                                    .instrument(llm_span.clone())
+                                    .await?
                             };
                             accumulated_content = Some(content);
                         }
@@ -2819,12 +2840,14 @@ impl Agent for LlmAgent {
                             .error_message
                             .clone()
                             .unwrap_or_else(|| "provider reported a terminal error".to_string());
-                        tracing::error!(
-                            error.code = %code,
-                            error.message = %message,
-                            agent = %agent_name,
-                            "model reported a terminal error"
-                        );
+                        llm_span.in_scope(|| {
+                            tracing::error!(
+                                error.code = %code,
+                                error.message = %message,
+                                agent = %agent_name,
+                                "model reported a terminal error"
+                            )
+                        });
                         // The provider's own code is preserved in the ADK error code
                         // so retry policy and telemetry can key on it.
                         // Built before the yield point: a borrow may not cross it.

--- a/adk-agent/tests/span_parenting_test.rs
+++ b/adk-agent/tests/span_parenting_test.rs
@@ -1,0 +1,325 @@
+//! Regression tests for span parenting across suspension points.
+//!
+//! Two distinct defects are covered:
+//!
+//! 1. `LlmAgent::run` used to hold a `call_llm` span guard (`Span::enter()`)
+//!    across the `.await`/`yield` points of its `async_stream` generator. An
+//!    entered guard is bound to the *thread*, not the task, so it was not exited
+//!    when the generator suspended nor re-entered when it resumed. Everything
+//!    created after the first suspension point silently detached from `call_llm`.
+//!
+//! 2. `Runner` used to `.instrument()` only the future that *constructs* the
+//!    agent stream, not the polling of it. Since the entire agent execution
+//!    happens while the stream is drained, every span it produced was created
+//!    outside `agent.execute`.
+//!
+//! Both are invisible without an assertion on the span *tree* — the spans are
+//! still emitted, with correct names and durations, just attached to the wrong
+//! parent. Hence these tests inspect parentage rather than span presence.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use adk_agent::LlmAgentBuilder;
+use adk_core::{
+    Agent, Content, FinishReason, InvocationContext, Llm, LlmRequest, LlmResponse,
+    LlmResponseStream, Part, Result, RunConfig, Session, State,
+};
+use async_trait::async_trait;
+use futures::StreamExt;
+use serde_json::Value;
+use tracing::span::{Attributes, Id};
+use tracing::{Instrument, Subscriber};
+use tracing_subscriber::layer::{Context, Layer, SubscriberExt};
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::util::SubscriberInitExt;
+
+// --- Span capture ---
+
+/// Records `(span name, contextual parent name)` at span creation.
+///
+/// `lookup_current()` in `on_new_span` is precisely the signal both bugs
+/// corrupt: the span is created, but the ambient parent at creation time is
+/// wrong (or absent).
+/// A span's name paired with the name of its contextual parent, if any.
+type ParentEdge = (String, Option<String>);
+
+#[derive(Clone, Default)]
+struct Capture(Arc<Mutex<Vec<ParentEdge>>>);
+
+impl Capture {
+    fn drain(&self) -> Vec<ParentEdge> {
+        std::mem::take(&mut *self.0.lock().unwrap())
+    }
+}
+
+impl<S> Layer<S> for Capture
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, _id: &Id, ctx: Context<'_, S>) {
+        let parent = ctx.lookup_current().map(|s| s.name().to_string());
+        self.0.lock().unwrap().push((attrs.metadata().name().to_string(), parent));
+    }
+}
+
+/// One global subscriber for the whole test binary — a thread-local subscriber
+/// (`with_default`) would miss spans created on other runtime workers, which is
+/// exactly where these bugs manifest.
+fn capture() -> &'static Capture {
+    static CAPTURE: OnceLock<Capture> = OnceLock::new();
+    CAPTURE.get_or_init(|| {
+        let c = Capture::default();
+        tracing_subscriber::registry().with(c.clone()).init();
+        c
+    })
+}
+
+/// Contextual parent recorded for the first span named `name`.
+fn parent_of<'a>(spans: &'a [ParentEdge], name: &str) -> Option<&'a Option<String>> {
+    spans.iter().find(|(n, _)| n == name).map(|(_, p)| p)
+}
+
+// --- Mocks ---
+
+fn chunk(text: &str, final_chunk: bool) -> LlmResponse {
+    LlmResponse {
+        content: Some(Content {
+            role: "model".to_string(),
+            parts: vec![Part::Text { text: text.to_string() }],
+        }),
+        usage_metadata: None,
+        finish_reason: final_chunk.then_some(FinishReason::Stop),
+        citation_metadata: None,
+        partial: !final_chunk,
+        turn_complete: final_chunk,
+        interrupted: false,
+        error_code: None,
+        error_message: None,
+        provider_metadata: None,
+        interaction_id: None,
+    }
+}
+
+/// Streams two chunks with a real suspension between them, and creates a probe
+/// span *after* that suspension.
+///
+/// The probe is created while the agent is polling this stream, so a correctly
+/// instrumented agent must have `call_llm` as its ambient parent. Before the fix
+/// the guard had already been torn off the thread stack by the first suspension,
+/// so the probe attached to the caller instead.
+struct SuspendingModel;
+
+#[async_trait]
+impl Llm for SuspendingModel {
+    fn name(&self) -> &str {
+        "suspending-mock"
+    }
+
+    async fn generate_content(&self, _req: LlmRequest, _stream: bool) -> Result<LlmResponseStream> {
+        let s = async_stream::stream! {
+            yield Ok(chunk("first", false));
+
+            // Force the generator to return `Pending` at least once. Without a
+            // genuine suspension neither bug can be observed.
+            tokio::task::yield_now().await;
+
+            let _probe = tracing::info_span!("probe_after_suspension");
+            yield Ok(chunk("second", true));
+        };
+        Ok(Box::pin(s))
+    }
+}
+
+struct MockSession;
+impl Session for MockSession {
+    fn id(&self) -> &str {
+        "session-456"
+    }
+    fn app_name(&self) -> &str {
+        "test-app"
+    }
+    fn user_id(&self) -> &str {
+        "user-123"
+    }
+    fn state(&self) -> &dyn State {
+        &MockState
+    }
+    fn conversation_history(&self) -> Vec<Content> {
+        Vec::new()
+    }
+}
+
+struct MockState;
+impl State for MockState {
+    fn get(&self, _key: &str) -> Option<Value> {
+        None
+    }
+    fn set(&mut self, _key: String, _value: Value) {}
+    fn all(&self) -> HashMap<String, Value> {
+        HashMap::new()
+    }
+}
+
+struct MockContext {
+    session: MockSession,
+    user_content: Content,
+}
+
+impl MockContext {
+    fn new() -> Self {
+        Self {
+            session: MockSession,
+            user_content: Content {
+                role: "user".to_string(),
+                parts: vec![Part::Text { text: "hello".to_string() }],
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl adk_core::ReadonlyContext for MockContext {
+    fn invocation_id(&self) -> &str {
+        "inv-1"
+    }
+    fn agent_name(&self) -> &str {
+        "test-agent"
+    }
+    fn user_id(&self) -> &str {
+        "user-123"
+    }
+    fn app_name(&self) -> &str {
+        "test-app"
+    }
+    fn session_id(&self) -> &str {
+        "session-456"
+    }
+    fn branch(&self) -> &str {
+        "main"
+    }
+    fn user_content(&self) -> &Content {
+        &self.user_content
+    }
+}
+
+#[async_trait]
+impl adk_core::CallbackContext for MockContext {
+    fn artifacts(&self) -> Option<Arc<dyn adk_core::Artifacts>> {
+        None
+    }
+}
+
+#[async_trait]
+impl InvocationContext for MockContext {
+    fn agent(&self) -> Arc<dyn Agent> {
+        unimplemented!()
+    }
+    fn memory(&self) -> Option<Arc<dyn adk_core::Memory>> {
+        None
+    }
+    fn session(&self) -> &dyn Session {
+        &self.session
+    }
+    fn run_config(&self) -> &RunConfig {
+        static RUN_CONFIG: OnceLock<RunConfig> = OnceLock::new();
+        RUN_CONFIG.get_or_init(RunConfig::default)
+    }
+    fn end_invocation(&self) {}
+    fn ended(&self) -> bool {
+        false
+    }
+}
+
+// --- Tests ---
+
+/// Both scenarios share one global subscriber, so they run in a single test
+/// function on one multi-threaded runtime rather than racing each other.
+#[test]
+fn spans_keep_their_parents_across_suspension_points() {
+    let capture = capture();
+    let rt =
+        tokio::runtime::Builder::new_multi_thread().worker_threads(4).enable_all().build().unwrap();
+
+    // --- Bug 1: a span created after a suspension still nests under `call_llm`.
+    rt.block_on(async {
+        let agent =
+            LlmAgentBuilder::new("test-agent").model(Arc::new(SuspendingModel)).build().unwrap();
+
+        // The caller instruments the whole drain, which is the documented
+        // correct usage — so any misparenting below is the library's, not ours.
+        async {
+            let mut stream = agent.run(Arc::new(MockContext::new())).await.unwrap();
+            while stream.next().await.is_some() {}
+        }
+        .instrument(tracing::info_span!("caller"))
+        .await;
+    });
+
+    // Collected now, asserted at the end, so that both scenarios always run and
+    // a reviewer sees both defects rather than only the first to trip.
+    let agent_spans = capture.drain();
+
+    // --- Bug 2: `call_llm` nests under `agent.execute`, not the caller.
+    rt.block_on(async {
+        let agent =
+            LlmAgentBuilder::new("test-agent").model(Arc::new(SuspendingModel)).build().unwrap();
+
+        let sessions: Arc<dyn adk_session::SessionService> =
+            Arc::new(adk_session::InMemorySessionService::new());
+        sessions
+            .create(adk_session::CreateRequest {
+                app_name: "test-app".into(),
+                user_id: "user-123".into(),
+                session_id: Some("session-456".into()),
+                state: HashMap::new(),
+            })
+            .await
+            .unwrap();
+
+        let runner = adk_runner::Runner::builder()
+            .app_name("test-app")
+            .agent(Arc::new(agent))
+            .session_service(sessions)
+            .build()
+            .unwrap();
+
+        async {
+            let mut stream = runner
+                .run(
+                    adk_core::UserId::new("user-123").unwrap(),
+                    adk_core::SessionId::new("session-456").unwrap(),
+                    Content::new("user").with_text("hello"),
+                )
+                .await
+                .unwrap();
+            while stream.next().await.is_some() {}
+        }
+        .instrument(tracing::info_span!("caller"))
+        .await;
+    });
+
+    let runner_spans = capture.drain();
+
+    // --- Assertions ---
+
+    let probe = parent_of(&agent_spans, "probe_after_suspension")
+        .expect("probe span was never created — the model stream did not run to completion");
+    assert_eq!(
+        probe.as_deref(),
+        Some("call_llm"),
+        "a span created after the model stream suspended must still nest under \
+         `call_llm`; got {probe:?}. This means the `call_llm` guard was torn off \
+         the thread stack at the first suspension point (captured: {agent_spans:?})"
+    );
+
+    let call_llm = parent_of(&runner_spans, "call_llm")
+        .expect("`call_llm` span was never created — the runner did not reach the model");
+    assert_eq!(
+        call_llm.as_deref(),
+        Some("agent.execute"),
+        "`call_llm` must nest under `agent.execute`; got {call_llm:?}. This means \
+         the runner instrumented only the construction of the agent stream and \
+         not the draining of it (captured: {runner_spans:?})"
+    );
+}

--- a/adk-runner/src/runner.rs
+++ b/adk-runner/src/runner.rs
@@ -809,7 +809,7 @@ impl Runner {
                             ctx.mutable_session().replace_events(compacted);
                             tracing::info!("context compaction succeeded after token limit error, retrying agent");
                             // Retry the agent call with compacted context
-                            match agent_to_run.run(ctx.clone()).instrument(agent_span).await {
+                            match agent_to_run.run(ctx.clone()).instrument(agent_span.clone()).await {
                                 Ok(s) => s,
                                 Err(retry_err) => {
                                     #[cfg(feature = "plugins")]
@@ -863,10 +863,15 @@ impl Runner {
                                 }
                                 return;
                             }
-                            result = agent_stream.next() => result,
+                            // Instrument the poll, not just the construction of the
+                            // stream: `agent_to_run.run(..)` merely builds the
+                            // stream, so without this every span created while the
+                            // stream is drained — i.e. the whole agent execution —
+                            // is created outside `agent_span`.
+                            result = agent_stream.next().instrument(agent_span.clone()) => result,
                         }
                     }
-                    None => agent_stream.next().await,
+                    None => agent_stream.next().instrument(agent_span.clone()).await,
                 }
             } {
                 match result {


### PR DESCRIPTION
Fixes #641

Two independent defects caused agent and LLM spans to detach from their parents, so one logical invocation was exported as several disconnected traces. Neither affects span names, attributes or durations — only parentage, which is why nothing looks wrong in logs.

## Changes

**`adk-agent/src/llm_agent.rs`** — remove the `call_llm` guard held across the generator's `.await`/`yield` points, and instrument the individual futures instead:

```diff
-                    let _llm_guard = llm_span.enter();
-                    let mut response_stream = model.generate_content(request, true).await?;
+                    let mut response_stream = model
+                        .generate_content(request, true)
+                        .instrument(llm_span.clone())
+                        .await?;
```

plus the same on the chunk poll, the after-model callback and the output-guardrail call. `Instrumented::poll` enters the span per poll, so it is correct across suspension by construction, and no `yield` point moves. The two `tracing` events inside the former guard region are wrapped in `llm_span.in_scope(..)` so they stay attached to the call they describe.

The `apply_output_guardrails` call in the cached-response branch is outside the guard region and is deliberately left alone.

**`adk-runner/src/runner.rs`** — instrument the drain, not just the construction:

```diff
-                            result = agent_stream.next() => result,
+                            result = agent_stream.next().instrument(agent_span.clone()) => result,
...
-                    None => agent_stream.next().await,
+                    None => agent_stream.next().instrument(agent_span.clone()).await,
```

The retry site at `:812` moved `agent_span`, so it becomes `.clone()` to keep the span alive for the drain. `tokio::select!` semantics and cancellation behaviour are unchanged — `Instrumented` is a transparent future wrapper.

`use tracing::Instrument` was already imported in both files, so there is no new dependency.

## Test

`adk-agent/tests/span_parenting_test.rs` installs a capture `Layer` recording `lookup_current()` at span creation, then drives two scenarios on a multi-threaded runtime:

1. a model stream yielding two chunks with a real suspension between them, asserting a span created after that suspension still nests under `call_llm`;
2. a full `Runner` invocation, asserting `call_llm` nests under `agent.execute`.

Both scenarios run before either assertion, so a reviewer sees both defects rather than only the first to trip. Without this change the test fails with:

```
assertion `left == right` failed: a span created after the model stream suspended must
still nest under `call_llm`; got Some("caller"). ... (captured: [("caller", None),
("run", Some("caller")), ("call_llm", Some("caller")), ("probe_after_suspension", Some("caller"))])
```

Everything flattens onto the caller. `adk-agent`'s dev-dependencies gain `tracing-subscriber` (for the capture layer) and tokio's `rt-multi-thread` — a current-thread runtime can mask the thread-affinity half of the first defect.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy -p adk-agent -p adk-runner --all-targets -- -D warnings` clean
- `cargo test -p adk-agent -p adk-runner` all green; no existing test changed behaviour
- `adk-runner` also builds with `--features context-compaction`, which gates the `:812` site

## Not included

Three related sites are described in #641 and left for a follow-up: `adk-agent/src/team.rs:1774` and `:1471` take the same one-line treatment, while `adk-server/src/rest/controllers/runtime.rs:1239` needs the SSE stream itself to carry the span. Enabling `clippy::await_holding_span_guard` would stop the first defect recurring — happy to add it here or separately, whichever you prefer.

Generated with Claude Code