### PR TITLE
feat(adk-skill): add progressive disclosure toolset

### DIFF
--- a/adk-agent/Cargo.toml
+++ b/adk-agent/Cargo.toml
@@ -45,6 +45,9 @@ default = ["skills"]
 guardrails = ["adk-guardrail"]
 enhanced-plugins = ["dep:adk-plugin"]
 skills = ["dep:adk-skill"]
+# Google ADK-style L1/L2/L3 skill tools. Existing `skills` continues to use
+# prompt injection unless callers explicitly register a SkillToolset.
+skills-progressive-disclosure = ["skills", "adk-skill/progressive-disclosure"]
 sandbox = ["dep:adk-sandbox", "adk-sandbox/workspace"]
 coding = ["dep:adk-devtools"]
 codeact = []

--- a/adk-agent/src/llm_agent.rs
+++ b/adk-agent/src/llm_agent.rs
@@ -116,6 +116,24 @@ fn collect_function_calls(content: &Content, invocation_id: &str) -> Vec<Pending
         .collect()
 }
 
+fn collect_long_running_tool_ids(
+    tool_map: &HashMap<String, Arc<dyn Tool>>,
+    content: &Content,
+) -> Vec<String> {
+    content
+        .parts
+        .iter()
+        .filter_map(|part| {
+            if let Part::FunctionCall { name, .. } = part
+                && tool_map.get(name).is_some_and(|tool| tool.is_long_running())
+            {
+                return Some(name.clone());
+            }
+            None
+        })
+        .collect()
+}
+
 fn build_partial_llm_event(
     event_id: &str,
     invocation_id: &str,
@@ -2479,26 +2497,9 @@ impl Agent for LlmAgent {
                     return;
                 }
             };
-            let tool_map = resolved_tools.map;
-            let tool_declarations = resolved_tools.declarations;
-            let valid_transfer_targets = resolved_tools.transfer_targets;
-
-            let collect_long_running_ids = |content: &Content| -> Vec<String> {
-                content
-                    .parts
-                    .iter()
-                    .filter_map(|part| {
-                        if let Part::FunctionCall { name, .. } = part
-                            && let Some(tool) = tool_map.get(name)
-                            && tool.is_long_running()
-                        {
-                            return Some(name.clone());
-                        }
-                        None
-                    })
-                    .collect()
-            };
-
+            let mut tool_map = resolved_tools.map;
+            let mut tool_declarations = resolved_tools.declarations;
+            let mut valid_transfer_targets = resolved_tools.transfer_targets;
 
             // ===== CIRCUIT BREAKER STATE =====
             // Created fresh per invocation so it resets between runs.
@@ -2643,7 +2644,8 @@ impl Agent for LlmAgent {
 
                     // Populate long_running_tool_ids for function calls from long-running tools
                     if let Some(ref content) = accumulated_content {
-                        cached_event.long_running_tool_ids = collect_long_running_ids(content);
+                        cached_event.long_running_tool_ids =
+                            collect_long_running_tool_ids(&tool_map, content);
                     }
 
                     yield Ok(cached_event);
@@ -2741,7 +2743,7 @@ impl Agent for LlmAgent {
                             let long_running_tool_ids = chunk
                                 .content
                                 .as_ref()
-                                .map(&collect_long_running_ids)
+                                .map(|content| collect_long_running_tool_ids(&tool_map, content))
                                 .unwrap_or_default();
                             yield Ok(build_partial_llm_event(
                                 &llm_event_id,
@@ -2789,7 +2791,7 @@ impl Agent for LlmAgent {
                         }
                         let long_running_tool_ids = accumulated_content
                             .as_ref()
-                            .map(&collect_long_running_ids)
+                            .map(|content| collect_long_running_tool_ids(&tool_map, content))
                             .unwrap_or_default();
                         yield Ok(build_final_llm_event(
                             &llm_event_id,
@@ -3305,6 +3307,21 @@ impl Agent for LlmAgent {
 
                         conversation_history.push(result.content);
                     }
+
+                    // A tool can update session state as part of its response. Resolve
+                    // toolsets again before the next model turn so context-sensitive
+                    // toolsets (notably progressive skills) can expose newly activated
+                    // capabilities in the same invocation.
+                    let refreshed_tools = match tool_setup.resolve(&ctx).await {
+                        Ok(tools) => tools,
+                        Err(error) => {
+                            yield Err(error);
+                            return;
+                        }
+                    };
+                    tool_map = refreshed_tools.map;
+                    tool_declarations = refreshed_tools.declarations;
+                    valid_transfer_targets = refreshed_tools.transfer_targets;
                 }
 
                 // If all function calls were from long-running tools, we need ONE more model call

--- a/adk-agent/tests/progressive_skill_runner_tests.rs
+++ b/adk-agent/tests/progressive_skill_runner_tests.rs
@@ -1,0 +1,189 @@
+//! Runner-level regression coverage for progressive skill disclosure.
+//!
+//! This exercises the production state path: `load_skill` emits an event
+//! delta, the runner persists it into the mutable session, and the next model
+//! turn receives the skill's newly activated business tool declaration.
+#![cfg(feature = "skills-progressive-disclosure")]
+
+use adk_agent::LlmAgentBuilder;
+use adk_core::{
+    Agent, Content, FinishReason, Llm, LlmRequest, LlmResponse, LlmResponseStream, Part, Result,
+    SessionId, Tool, ToolContext, ToolRegistry, UserId,
+};
+use adk_runner::Runner;
+use adk_session::{CreateRequest, GetRequest, InMemorySessionService, SessionService};
+use adk_skill::{SkillToolset, SkillToolsetConfig, load_skill_index};
+use async_trait::async_trait;
+use futures::StreamExt;
+use serde_json::{Value, json};
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, Mutex};
+
+struct ScriptedModel {
+    requests: Arc<Mutex<Vec<LlmRequest>>>,
+    responses: Mutex<VecDeque<LlmResponse>>,
+}
+
+impl ScriptedModel {
+    fn new(responses: Vec<LlmResponse>) -> Self {
+        Self { requests: Arc::new(Mutex::new(Vec::new())), responses: Mutex::new(responses.into()) }
+    }
+
+    fn function_call(name: &str, args: Value) -> LlmResponse {
+        Self::response(Content {
+            role: "model".to_string(),
+            parts: vec![Part::FunctionCall {
+                name: name.to_string(),
+                args,
+                id: Some(format!("call-{name}")),
+                thought_signature: None,
+            }],
+        })
+    }
+
+    fn text(text: &str) -> LlmResponse {
+        Self::response(Content::new("model").with_text(text))
+    }
+
+    fn response(content: Content) -> LlmResponse {
+        LlmResponse {
+            content: Some(content),
+            usage_metadata: None,
+            finish_reason: Some(FinishReason::Stop),
+            citation_metadata: None,
+            partial: false,
+            turn_complete: true,
+            interrupted: false,
+            error_code: None,
+            error_message: None,
+            provider_metadata: None,
+            interaction_id: None,
+        }
+    }
+}
+
+#[async_trait]
+impl Llm for ScriptedModel {
+    fn name(&self) -> &str {
+        "scripted-model"
+    }
+
+    async fn generate_content(
+        &self,
+        request: LlmRequest,
+        _stream: bool,
+    ) -> Result<LlmResponseStream> {
+        self.requests.lock().expect("requests lock").push(request);
+        let response = self
+            .responses
+            .lock()
+            .expect("responses lock")
+            .pop_front()
+            .unwrap_or_else(|| Self::text("done"));
+        Ok(Box::pin(async_stream::stream! {
+            yield Ok(response);
+        }))
+    }
+}
+
+struct WeatherTool;
+
+#[async_trait]
+impl Tool for WeatherTool {
+    fn name(&self) -> &str {
+        "weather_lookup"
+    }
+
+    fn description(&self) -> &str {
+        "Looks up the weather."
+    }
+
+    async fn execute(&self, _ctx: Arc<dyn ToolContext>, _args: Value) -> Result<Value> {
+        Ok(json!({ "temperatureC": 22 }))
+    }
+}
+
+struct WeatherRegistry;
+
+impl ToolRegistry for WeatherRegistry {
+    fn resolve(&self, name: &str) -> Option<Arc<dyn Tool>> {
+        (name == "weather_lookup").then(|| Arc::new(WeatherTool) as Arc<dyn Tool>)
+    }
+}
+
+#[tokio::test]
+async fn runner_persists_skill_activation_before_the_next_model_turn() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let skill_dir = temp.path().join(".skills/weather");
+    std::fs::create_dir_all(&skill_dir).expect("skill directory");
+    std::fs::write(
+        skill_dir.join("SKILL.md"),
+        "---\nname: weather\ndescription: Answer weather questions\nallowed-tools: [weather_lookup]\n---\nUse weather_lookup for weather questions.\n",
+    )
+    .expect("skill file");
+
+    let model = Arc::new(ScriptedModel::new(vec![
+        ScriptedModel::function_call("load_skill", json!({ "skill_name": "weather" })),
+        ScriptedModel::function_call("weather_lookup", json!({ "city": "Shanghai" })),
+        ScriptedModel::text("It is 22°C in Shanghai."),
+    ]));
+    let toolset = SkillToolset::new(
+        Arc::new(load_skill_index(temp.path()).expect("skill index")),
+        Arc::new(WeatherRegistry),
+        SkillToolsetConfig::default(),
+    );
+    let agent = LlmAgentBuilder::new("weather-agent")
+        .model(model.clone())
+        .toolset(Arc::new(toolset))
+        .build()
+        .expect("agent builds");
+    let sessions = Arc::new(InMemorySessionService::new());
+    sessions
+        .create(CreateRequest {
+            app_name: "progressive-test".to_string(),
+            user_id: "user-1".to_string(),
+            session_id: Some("session-1".to_string()),
+            state: HashMap::new(),
+        })
+        .await
+        .expect("session creates");
+    let runner = Runner::builder()
+        .app_name("progressive-test")
+        .agent(Arc::new(agent) as Arc<dyn Agent>)
+        .session_service(sessions.clone() as Arc<dyn SessionService>)
+        .build()
+        .expect("runner builds");
+
+    let mut stream = runner
+        .run(
+            UserId::new("user-1").expect("user ID"),
+            SessionId::new("session-1").expect("session ID"),
+            Content::new("user").with_text("What is the weather in Shanghai?"),
+        )
+        .await
+        .expect("runner starts");
+    while let Some(event) = stream.next().await {
+        event.expect("runner event");
+    }
+
+    {
+        let requests = model.requests.lock().expect("requests lock");
+        assert_eq!(requests.len(), 3);
+        assert!(!requests[0].tools.contains_key("weather_lookup"));
+        assert!(requests[1].tools.contains_key("weather_lookup"));
+    }
+
+    let session = sessions
+        .get(GetRequest {
+            app_name: "progressive-test".to_string(),
+            user_id: "user-1".to_string(),
+            session_id: "session-1".to_string(),
+            num_recent_events: None,
+            after: None,
+        })
+        .await
+        .expect("session loads");
+    let key = SkillToolset::activation_state_key("weather-agent");
+    let activations = session.state().get(&key).expect("activation state persists");
+    assert_eq!(activations[0]["name"], "weather");
+}

--- a/adk-agent/tests/review_regression_tests.rs
+++ b/adk-agent/tests/review_regression_tests.rs
@@ -5,7 +5,7 @@ use adk_agent::{
 use adk_core::{
     Agent, CallbackContext, Content, Event, EventStream, FinishReason, InvocationContext, Llm,
     LlmRequest, LlmResponse, LlmResponseStream, Part, Result, RunConfig, Session, State, Tool,
-    ToolContext,
+    ToolContext, Toolset,
 };
 use async_trait::async_trait;
 use futures::StreamExt;
@@ -245,6 +245,70 @@ impl Tool for IdCapturingTool {
     }
 }
 
+/// A test-only dynamic toolset whose second capability becomes available after
+/// its activation tool runs. This models progressive skill disclosure without
+/// coupling the agent runtime test to a particular skill storage backend.
+struct ActivatingToolset {
+    activated: Arc<AtomicBool>,
+    business_calls: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl Toolset for ActivatingToolset {
+    fn name(&self) -> &str {
+        "activating"
+    }
+
+    async fn tools(&self, _ctx: Arc<dyn adk_core::ReadonlyContext>) -> Result<Vec<Arc<dyn Tool>>> {
+        let mut tools: Vec<Arc<dyn Tool>> =
+            vec![Arc::new(ActivateCapabilityTool { activated: self.activated.clone() })];
+        if self.activated.load(Ordering::SeqCst) {
+            tools.push(Arc::new(ActivatedCapabilityTool { calls: self.business_calls.clone() }));
+        }
+        Ok(tools)
+    }
+}
+
+struct ActivateCapabilityTool {
+    activated: Arc<AtomicBool>,
+}
+
+#[async_trait]
+impl Tool for ActivateCapabilityTool {
+    fn name(&self) -> &str {
+        "activate_capability"
+    }
+
+    fn description(&self) -> &str {
+        "Activates a deferred capability."
+    }
+
+    async fn execute(&self, _ctx: Arc<dyn ToolContext>, _args: Value) -> Result<Value> {
+        self.activated.store(true, Ordering::SeqCst);
+        Ok(json!({ "activated": true }))
+    }
+}
+
+struct ActivatedCapabilityTool {
+    calls: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl Tool for ActivatedCapabilityTool {
+    fn name(&self) -> &str {
+        "activated_capability"
+    }
+
+    fn description(&self) -> &str {
+        "A capability exposed after activation."
+    }
+
+    async fn execute(&self, _ctx: Arc<dyn ToolContext>, _args: Value) -> Result<Value> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Ok(json!({ "ok": true }))
+    }
+}
+
 struct ConcurrencyProbeTool {
     active: Arc<AtomicUsize>,
     max_active: Arc<AtomicUsize>,
@@ -416,6 +480,42 @@ async fn drain_stream(mut stream: EventStream) -> Result<Vec<Event>> {
         events.push(result?);
     }
     Ok(events)
+}
+
+#[tokio::test]
+async fn toolsets_are_refreshed_between_model_turns_after_a_tool_call() {
+    let model = Arc::new(RecordingModel::new(vec![
+        RecordingModel::function_calls(vec![Part::FunctionCall {
+            name: "activate_capability".to_string(),
+            args: json!({}),
+            id: Some("activate".to_string()),
+            thought_signature: None,
+        }]),
+        RecordingModel::function_calls(vec![Part::FunctionCall {
+            name: "activated_capability".to_string(),
+            args: json!({}),
+            id: Some("use-activated".to_string()),
+            thought_signature: None,
+        }]),
+        RecordingModel::text_response("done"),
+    ]));
+    let activated = Arc::new(AtomicBool::new(false));
+    let business_calls = Arc::new(AtomicUsize::new(0));
+    let toolset = Arc::new(ActivatingToolset { activated, business_calls: business_calls.clone() });
+    let agent = LlmAgentBuilder::new("refresh-agent")
+        .model(model.clone())
+        .toolset(toolset)
+        .build()
+        .expect("agent builds");
+
+    let stream = agent.run(Arc::new(TestContext::new("activate and use it"))).await.expect("run");
+    drain_stream(stream).await.expect("agent stream");
+
+    assert_eq!(business_calls.load(Ordering::SeqCst), 1);
+    let requests = model.requests.lock().unwrap_or_else(|error| error.into_inner());
+    assert_eq!(requests.len(), 3);
+    assert!(!requests[0].tools.contains_key("activated_capability"));
+    assert!(requests[1].tools.contains_key("activated_capability"));
 }
 
 #[tokio::test]

--- a/adk-core/src/context.rs
+++ b/adk-core/src/context.rs
@@ -97,7 +97,7 @@ pub trait ReadonlyContext: Send + Sync {
     ///
     /// The default keeps lightweight contexts and third-party implementations
     /// source-compatible. Consumers must gracefully handle contexts without
-    /// session state. Dynamic [`Toolset`](crate::Toolset) implementations use
+    /// session state. Dynamic [`Toolset`] implementations use
     /// this to determine their context-specific tool surface without requiring
     /// mutable access to the session.
     fn state(&self) -> Option<&dyn State> {

--- a/adk-core/src/context.rs
+++ b/adk-core/src/context.rs
@@ -93,6 +93,17 @@ pub trait ReadonlyContext: Send + Sync {
     /// Returns the user's input content for this invocation.
     fn user_content(&self) -> &Content;
 
+    /// Returns the session state when the runtime exposes it to dynamic toolsets.
+    ///
+    /// The default keeps lightweight contexts and third-party implementations
+    /// source-compatible. Consumers must gracefully handle contexts without
+    /// session state. Dynamic [`Toolset`](crate::Toolset) implementations use
+    /// this to determine their context-specific tool surface without requiring
+    /// mutable access to the session.
+    fn state(&self) -> Option<&dyn State> {
+        None
+    }
+
     /// Returns the application name as a typed [`AppName`].
     ///
     /// Parses the value returned by [`app_name()`](Self::app_name). Returns an

--- a/adk-runner/src/context.rs
+++ b/adk-runner/src/context.rs
@@ -508,6 +508,12 @@ impl ReadonlyContext for InvocationContext {
     fn user_content(&self) -> &Content {
         &self.user_content
     }
+
+    fn state(&self) -> Option<&dyn adk_core::State> {
+        // Expose the runner's mutable session view so a toolset can observe a
+        // state delta emitted by an earlier tool result on the next model turn.
+        Some(adk_core::Session::state(self.session.as_ref()))
+    }
 }
 
 #[async_trait]

--- a/adk-rust/Cargo.toml
+++ b/adk-rust/Cargo.toml
@@ -119,6 +119,8 @@ record-payloads = ["agents", "adk-agent/record-payloads"]
 models = ["dep:adk-model"]
 tools = ["dep:adk-tool", "adk-agent?/team-tools"]
 skills = ["dep:adk-skill"]
+# Google ADK-style progressive skill discovery and activation tools.
+skills-progressive-disclosure = ["skills", "adk-skill/progressive-disclosure", "adk-agent?/skills-progressive-disclosure"]
 sessions = ["dep:adk-session"]
 artifacts = ["dep:adk-artifact"]
 # GCS artifact backend, blob-name compatible with adk-python (forwarded to adk-artifact)

--- a/adk-rust/src/lib.rs
+++ b/adk-rust/src/lib.rs
@@ -1386,6 +1386,8 @@ pub mod prelude {
     // Skills
     #[cfg(feature = "skills")]
     pub use crate::skill::{SelectionPolicy, SkillInjector, SkillInjectorConfig, load_skill_index};
+    #[cfg(feature = "skills-progressive-disclosure")]
+    pub use crate::skill::{SkillToolset, SkillToolsetConfig};
 
     // Sessions
     #[cfg(feature = "sessions")]

--- a/adk-skill/Cargo.toml
+++ b/adk-skill/Cargo.toml
@@ -23,11 +23,15 @@ vertex-skill-registry = [
     "dep:base64",
     "dep:zip",
 ]
+# Google ADK-style skill discovery and on-demand loading tools. This stays
+# opt-in so existing prompt-injection users retain their current behavior.
+progressive-disclosure = ["dep:async-trait", "dep:tokio"]
 
 [dependencies]
 adk-core.workspace = true
 adk-gcp = { workspace = true, optional = true }
 async-trait = { workspace = true, optional = true }
+tokio = { workspace = true, optional = true, features = ["sync"] }
 adk-plugin.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/adk-skill/README.md
+++ b/adk-skill/README.md
@@ -354,6 +354,46 @@ let plugin_manager = injector.build_plugin_manager("skills");
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
+## Progressive Disclosure (Google ADK-style)
+
+Enable the optional `progressive-disclosure` feature to expose skills as a
+context-aware `Toolset` rather than injecting an instruction body into every
+matching user message. It provides three always-available tools:
+
+1. `list_skills` — L1: names and descriptions only.
+2. `load_skill` — L2: loads one skill's instructions and activates its declared
+   `allowed-tools` for the next model turn.
+3. `load_skill_resource` — L3: reads a file from an activated skill's
+   `references/`, `assets/`, or `scripts/` directory.
+
+The activation record contains the skill's content ID and hash, so a changed or
+removed skill cannot silently retain its old permissions. Resources require
+activation by default and reject path traversal. Set
+`ResourceAccessPolicy::GoogleCompatible` only when direct resource reads are
+required for interoperability.
+
+```rust,ignore
+use adk_core::ToolRegistry;
+use adk_skill::{SkillToolset, SkillToolsetConfig, load_skill_index};
+use std::sync::Arc;
+
+let index = Arc::new(load_skill_index(".")?);
+let skills = SkillToolset::new(index, Arc::new(my_tool_registry), SkillToolsetConfig::default());
+let agent = LlmAgent::builder().toolset(Arc::new(skills)).build()?;
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+Existing `SkillInjector` and `ContextCoordinator` APIs remain unchanged. The
+new toolset is opt-in and can coexist with them while applications migrate.
+
+When both `progressive-disclosure` and `vertex-skill-registry` are enabled,
+attach an existing `SkillRegistryClient` through
+`SkillToolset::with_registry_client`. This adds the registry's semantic
+`search_skills` tool and fetches a selected package only on `load_skill`.
+Local names still take precedence. Registry activations retain their fully
+qualified resource name and content hash, so they can be validated on later
+model turns.
+
 ## Error Model
 
 Main error type: `SkillError`
@@ -370,8 +410,9 @@ Type alias: `SkillResult<T> = Result<T, SkillError>`
 
 - No embedding/vector retrieval (lexical matching only).
 - No incremental file reload API yet.
-- No remote catalog (`skills-ref`/MCP) in this crate yet.
-- No script/file reference execution layer in this crate (selection + injection only).
+- Script execution is not provided by progressive disclosure yet; use an
+  `adk-sandbox` or `adk-code` integration rather than executing skill scripts
+  directly.
 - No standard CLI for skill management (use `adk-cli` wrapper if available).
 
 ## Application Integration Patterns

--- a/adk-skill/src/lib.rs
+++ b/adk-skill/src/lib.rs
@@ -31,6 +31,8 @@ mod index;
 mod injector;
 mod model;
 mod parser;
+#[cfg(feature = "progressive-disclosure")]
+mod progressive;
 #[cfg(feature = "vertex-skill-registry")]
 pub mod registry;
 mod select;
@@ -54,5 +56,7 @@ pub use model::{
     SkillSummary,
 };
 pub use parser::{parse_instruction_markdown, parse_skill_markdown};
+#[cfg(feature = "progressive-disclosure")]
+pub use progressive::{ActivatedSkill, ResourceAccessPolicy, SkillToolset, SkillToolsetConfig};
 pub use select::select_skills;
 pub use writer::{SkillDraft, SkillWriter, validate_skill_name};

--- a/adk-skill/src/progressive.rs
+++ b/adk-skill/src/progressive.rs
@@ -1,0 +1,845 @@
+//! Google ADK-style progressive disclosure for skills.
+//!
+//! [`SkillToolset`] exposes a small, always-available tool surface:
+//!
+//! - **L1** [`list_skills`](ListSkillsTool): names and descriptions only.
+//! - **L2** [`load_skill`](LoadSkillTool): instructions and frontmatter for one skill.
+//! - **L3** [`load_skill_resource`](LoadSkillResourceTool): a single bundled resource.
+//!
+//! Loading a skill records its content ID and hash in agent-scoped session state.
+//! Business tools declared by `allowed-tools` become visible only after that
+//! activation is persisted and the runtime begins the next model turn. This is
+//! intentionally compatible with Google ADK's `SkillToolset`, while retaining
+//! ADK-Rust's strict [`ValidationMode`] and content-hash provenance guarantees.
+
+use crate::{SkillDocument, SkillIndex, SkillSummary, ToolRegistry, ValidationMode};
+use adk_core::{AdkError, ReadonlyContext, Result, Tool, ToolContext, Toolset};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
+
+#[cfg(feature = "vertex-skill-registry")]
+use crate::registry::{SkillContent, SkillRegistryClient, SkillSearchTool};
+#[cfg(feature = "vertex-skill-registry")]
+use std::collections::{BTreeMap, HashMap};
+#[cfg(feature = "vertex-skill-registry")]
+use tokio::sync::RwLock;
+
+const STATE_KEY_PREFIX: &str = "skill:active:";
+#[cfg(feature = "vertex-skill-registry")]
+const MAX_REMOTE_CACHE_INVOCATIONS: usize = 16;
+
+/// Rules for reading bundled skill resources.
+///
+/// [`ActivatedOnly`](Self::ActivatedOnly) is the secure default: a model must
+/// first receive the skill's instructions before it can inspect its auxiliary
+/// files. [`GoogleCompatible`](Self::GoogleCompatible) exists for applications
+/// that need the more permissive behavior of Google ADK's current toolset.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ResourceAccessPolicy {
+    /// Require an earlier successful `load_skill` call for this agent.
+    #[default]
+    ActivatedOnly,
+    /// Permit direct reads of a known skill, matching Google ADK's current behavior.
+    GoogleCompatible,
+}
+
+/// Serialized activation provenance retained in agent-scoped session state.
+///
+/// The content hash pins an activation to the exact skill revision the model
+/// loaded. When a skill is edited or removed, [`SkillToolset`] discards the
+/// stale record rather than silently retaining its tools or resources.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ActivatedSkill {
+    /// Content-addressed document ID.
+    pub skill_id: String,
+    /// Canonical skill name.
+    pub name: String,
+    /// Content hash captured at activation time.
+    pub hash: String,
+    /// Source-specific address used to reload the skill.
+    ///
+    /// Local skills use their canonical name. Registry-backed skills retain
+    /// their fully-qualified resource name so a frontmatter name change does
+    /// not prevent a later model turn from validating the activation. Older
+    /// serialized activations omit this field and fall back to [`Self::name`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+}
+
+/// Configuration for [`SkillToolset`].
+///
+/// Defaults favor safe, bounded disclosure: resources require activation,
+/// missing declared tools reject an activation, and instructions/resources are
+/// character-limited before being returned to the model.
+///
+/// # Example
+///
+/// ```rust
+/// use adk_skill::{ResourceAccessPolicy, SkillToolsetConfig};
+///
+/// let config = SkillToolsetConfig {
+///     resource_access: ResourceAccessPolicy::ActivatedOnly,
+///     max_instruction_chars: 4_000,
+///     ..SkillToolsetConfig::default()
+/// };
+/// assert_eq!(config.max_instruction_chars, 4_000);
+/// ```
+#[derive(Debug, Clone)]
+pub struct SkillToolsetConfig {
+    /// Whether resources require activation first.
+    pub resource_access: ResourceAccessPolicy,
+    /// Reject or tolerate skills whose declared business tools cannot be resolved.
+    pub validation_mode: ValidationMode,
+    /// Maximum number of active skills for one agent.
+    pub max_active_skills: usize,
+    /// Maximum number of characters returned by `load_skill`.
+    pub max_instruction_chars: usize,
+    /// Maximum number of characters returned by `load_skill_resource`.
+    pub max_resource_chars: usize,
+}
+
+impl Default for SkillToolsetConfig {
+    fn default() -> Self {
+        Self {
+            resource_access: ResourceAccessPolicy::ActivatedOnly,
+            validation_mode: ValidationMode::Strict,
+            max_active_skills: 8,
+            max_instruction_chars: 8_000,
+            max_resource_chars: 16_000,
+        }
+    }
+}
+
+/// A context-aware toolset implementing L1/L2/L3 progressive disclosure.
+///
+/// Register this type with an [`adk_core::Toolset`] consumer, such as an
+/// `LlmAgentBuilder::toolset` integration. It always contributes the three
+/// discovery/loading tools. After `load_skill` succeeds, a subsequent call to
+/// [`Toolset::tools`] additionally returns that skill's validated
+/// `allowed-tools` from the supplied [`ToolRegistry`].
+///
+/// This is opt-in; it does not alter the behavior of [`crate::SkillInjector`]
+/// or [`crate::ContextCoordinator`].
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use adk_agent::LlmAgent;
+/// use adk_skill::{SkillToolset, SkillToolsetConfig, load_skill_index};
+/// use std::sync::Arc;
+///
+/// let index = Arc::new(load_skill_index(".")?);
+/// let skills = SkillToolset::new(index, Arc::new(tool_registry), SkillToolsetConfig::default());
+/// let agent = LlmAgent::builder().toolset(Arc::new(skills)).build()?;
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[derive(Clone)]
+pub struct SkillToolset {
+    index: Arc<SkillIndex>,
+    tool_registry: Arc<dyn ToolRegistry>,
+    config: SkillToolsetConfig,
+    #[cfg(feature = "vertex-skill-registry")]
+    registry_client: Option<Arc<SkillRegistryClient>>,
+    #[cfg(feature = "vertex-skill-registry")]
+    remote_cache: SharedRemoteSkillCache,
+}
+
+#[cfg(feature = "vertex-skill-registry")]
+#[derive(Clone)]
+struct RemoteSkill {
+    document: SkillDocument,
+    files: BTreeMap<String, Vec<u8>>,
+    locator: String,
+}
+
+#[cfg(feature = "vertex-skill-registry")]
+type RemoteSkillCache = HashMap<String, HashMap<String, Arc<RemoteSkill>>>;
+#[cfg(feature = "vertex-skill-registry")]
+type SharedRemoteSkillCache = Arc<RwLock<RemoteSkillCache>>;
+
+#[derive(Clone)]
+enum LoadedSkill {
+    Local(Arc<SkillDocument>),
+    #[cfg(feature = "vertex-skill-registry")]
+    Remote(Arc<RemoteSkill>),
+}
+
+impl LoadedSkill {
+    fn document(&self) -> &SkillDocument {
+        match self {
+            Self::Local(document) => document,
+            #[cfg(feature = "vertex-skill-registry")]
+            Self::Remote(skill) => &skill.document,
+        }
+    }
+
+    fn locator(&self) -> &str {
+        match self {
+            Self::Local(document) => &document.name,
+            #[cfg(feature = "vertex-skill-registry")]
+            Self::Remote(skill) => &skill.locator,
+        }
+    }
+
+    fn resource_content(&self, requested: &str) -> Result<String> {
+        match self {
+            Self::Local(skill) => {
+                let resource = SkillToolset::resource_path(skill, requested)?;
+                fs::read_to_string(&resource).map_err(|error| {
+                    AdkError::tool(format!("read skill resource '{requested}': {error}"))
+                })
+            }
+            #[cfg(feature = "vertex-skill-registry")]
+            Self::Remote(skill) => {
+                SkillToolset::validate_resource_path(requested)?;
+                let bytes = skill.files.get(requested).ok_or_else(|| {
+                    AdkError::tool(format!(
+                        "resource '{requested}' was not found in skill '{}'",
+                        skill.document.name
+                    ))
+                })?;
+                String::from_utf8(bytes.clone()).map_err(|_| {
+                    AdkError::tool(format!(
+                        "resource '{requested}' is binary and cannot be returned as text"
+                    ))
+                })
+            }
+        }
+    }
+}
+
+impl SkillToolset {
+    /// Creates a progressive skill toolset from an existing index.
+    ///
+    /// `tool_registry` is consulted at skill activation time and on each later
+    /// model turn. This permits a host to enforce availability, authorization,
+    /// or tenant-specific tool policies without placing provider logic in this
+    /// crate.
+    pub fn new(
+        index: Arc<SkillIndex>,
+        tool_registry: Arc<dyn ToolRegistry>,
+        config: SkillToolsetConfig,
+    ) -> Self {
+        Self {
+            index,
+            tool_registry,
+            config,
+            #[cfg(feature = "vertex-skill-registry")]
+            registry_client: None,
+            #[cfg(feature = "vertex-skill-registry")]
+            remote_cache: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Enables lazy loading and semantic discovery from Vertex Skill Registry.
+    ///
+    /// Remote packages are fetched only when the model calls `load_skill` or
+    /// `load_skill_resource`. Each verified package is cached per invocation;
+    /// the cache is discarded with the toolset, not persisted into sessions.
+    /// It also adds the registry's `search_skills` tool to the L1 surface.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use adk_skill::{SkillToolset, registry::SkillRegistryClient};
+    /// use std::sync::Arc;
+    ///
+    /// let toolset = SkillToolset::new(index, tool_registry, config)
+    ///     .with_registry_client(Arc::new(SkillRegistryClient::new(registry_config)?));
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    #[cfg(feature = "vertex-skill-registry")]
+    #[must_use]
+    pub fn with_registry_client(mut self, client: Arc<SkillRegistryClient>) -> Self {
+        self.registry_client = Some(client);
+        self
+    }
+
+    /// Returns the state key used to persist activations for an agent.
+    ///
+    /// This is public for hosts that need to inspect, migrate, or clear an
+    /// activation explicitly. The agent name is part of the key so transferred
+    /// or nested agents do not inherit another agent's selected skills.
+    pub fn activation_state_key(agent_name: &str) -> String {
+        format!("{STATE_KEY_PREFIX}{agent_name}")
+    }
+
+    fn core_tools(&self) -> Vec<Arc<dyn Tool>> {
+        vec![
+            Arc::new(ListSkillsTool { toolset: self.clone() }),
+            Arc::new(LoadSkillTool { toolset: self.clone() }),
+            Arc::new(LoadSkillResourceTool { toolset: self.clone() }),
+        ]
+    }
+
+    fn summaries(&self) -> Vec<SkillSummary> {
+        self.index.summaries()
+    }
+
+    async fn load_skill(&self, ctx: &dyn ReadonlyContext, name: &str) -> Result<LoadedSkill> {
+        if let Some(skill) = self.index.find_by_name(name) {
+            return Ok(LoadedSkill::Local(Arc::new(skill.clone())));
+        }
+
+        #[cfg(feature = "vertex-skill-registry")]
+        if let Some(client) = &self.registry_client {
+            return Ok(LoadedSkill::Remote(
+                self.fetch_remote_skill(client, ctx.invocation_id(), name).await?,
+            ));
+        }
+
+        #[cfg(not(feature = "vertex-skill-registry"))]
+        let _ = ctx;
+
+        Err(AdkError::tool(format!("skill '{name}' was not found")))
+    }
+
+    #[cfg(feature = "vertex-skill-registry")]
+    async fn fetch_remote_skill(
+        &self,
+        client: &SkillRegistryClient,
+        invocation_id: &str,
+        name: &str,
+    ) -> Result<Arc<RemoteSkill>> {
+        if let Some(skill) = self
+            .remote_cache
+            .read()
+            .await
+            .get(invocation_id)
+            .and_then(|skills| skills.get(name))
+            .cloned()
+        {
+            return Ok(skill);
+        }
+
+        let content = client.fetch_skill_content(name).await?;
+        let remote = Arc::new(Self::remote_skill_from_content(content)?);
+        let mut cache = self.remote_cache.write().await;
+        // Keep cache retention bounded even when a long-lived toolset serves
+        // many invocations. Each inner map may contain aliases for one package;
+        // eviction order is irrelevant because invocation caches are advisory.
+        if !cache.contains_key(invocation_id)
+            && cache.len() >= MAX_REMOTE_CACHE_INVOCATIONS
+            && let Some(evicted) = cache.keys().next().cloned()
+        {
+            cache.remove(&evicted);
+        }
+        let entries = cache.entry(invocation_id.to_string()).or_default();
+        entries.insert(name.to_string(), remote.clone());
+        entries.insert(remote.document.name.clone(), remote.clone());
+        Ok(remote)
+    }
+
+    #[cfg(feature = "vertex-skill-registry")]
+    fn remote_skill_from_content(content: SkillContent) -> Result<RemoteSkill> {
+        let document = crate::registry::load::document_from_content(&content)
+            .map_err(adk_core::AdkError::from)?;
+        let locator = content.skill.name;
+        Ok(RemoteSkill { document, files: content.files, locator })
+    }
+
+    fn activated_skills(&self, ctx: &dyn ReadonlyContext) -> Vec<ActivatedSkill> {
+        let key = Self::activation_state_key(ctx.agent_name());
+        ctx.state()
+            .and_then(|state| state.get(&key).and_then(|value| serde_json::from_value(value).ok()))
+            .unwrap_or_default()
+    }
+
+    async fn valid_activated_skills(&self, ctx: &dyn ReadonlyContext) -> Vec<LoadedSkill> {
+        let mut valid = Vec::new();
+        for activation in self.activated_skills(ctx) {
+            let source = activation.source.as_deref().unwrap_or(&activation.name);
+            let Ok(skill) = self.load_skill(ctx, source).await else {
+                continue;
+            };
+            let document = skill.document();
+            if document.id == activation.skill_id && document.hash == activation.hash {
+                valid.push(skill);
+            }
+        }
+        valid
+    }
+
+    async fn activate(&self, ctx: &dyn ToolContext, skill: &LoadedSkill) -> Result<()> {
+        let document = skill.document();
+        let mut active = self
+            .valid_activated_skills(ctx)
+            .await
+            .into_iter()
+            .map(|skill| ActivatedSkill {
+                skill_id: skill.document().id.clone(),
+                name: skill.document().name.clone(),
+                hash: skill.document().hash.clone(),
+                source: Some(skill.locator().to_string()),
+            })
+            .collect::<Vec<_>>();
+        if !active.iter().any(|item| item.skill_id == document.id) {
+            if active.len() >= self.config.max_active_skills {
+                return Err(AdkError::tool(format!(
+                    "cannot activate skill '{}': the {}-skill limit has been reached",
+                    document.name, self.config.max_active_skills
+                )));
+            }
+            active.push(ActivatedSkill {
+                skill_id: document.id.clone(),
+                name: document.name.clone(),
+                hash: document.hash.clone(),
+                source: Some(skill.locator().to_string()),
+            });
+        }
+
+        let mut actions = ctx.actions();
+        actions.state_delta.insert(
+            Self::activation_state_key(ctx.agent_name()),
+            serde_json::to_value(active)
+                .map_err(|error| AdkError::tool(format!("serialize skill activation: {error}")))?,
+        );
+        ctx.set_actions(actions);
+        Ok(())
+    }
+
+    fn validate_skill_tools(&self, skill: &SkillDocument) -> Result<()> {
+        if self.config.validation_mode != ValidationMode::Strict {
+            return Ok(());
+        }
+        let missing = skill
+            .allowed_tools
+            .iter()
+            .filter(|name| self.tool_registry.resolve(name).is_none())
+            .cloned()
+            .collect::<Vec<_>>();
+        if missing.is_empty() {
+            Ok(())
+        } else {
+            Err(AdkError::tool(format!(
+                "skill '{}' requires unavailable tools: {}",
+                skill.name,
+                missing.join(", ")
+            )))
+        }
+    }
+
+    fn resource_path(skill: &SkillDocument, requested: &str) -> Result<PathBuf> {
+        let relative = Self::validate_resource_path(requested)?;
+        let root = skill.path.parent().ok_or_else(|| {
+            AdkError::tool(format!("skill '{}' has no parent resource directory", skill.name))
+        })?;
+        let root = fs::canonicalize(root)
+            .map_err(|error| AdkError::tool(format!("resolve skill resource root: {error}")))?;
+        let candidate = fs::canonicalize(root.join(relative)).map_err(|error| {
+            AdkError::tool(format!("resource '{requested}' could not be resolved: {error}"))
+        })?;
+        if !candidate.starts_with(&root) {
+            return Err(AdkError::tool("resource path escapes the skill directory"));
+        }
+        Ok(candidate)
+    }
+
+    fn validate_resource_path(requested: &str) -> Result<&Path> {
+        let relative = Path::new(requested);
+        // Check lexical components before filesystem resolution. Canonicalization
+        // below then catches symlinks that would otherwise escape this package.
+        if !matches!(
+            relative.components().next(),
+            Some(Component::Normal(prefix))
+                if prefix == "references" || prefix == "assets" || prefix == "scripts"
+        ) || relative.is_absolute()
+            || relative.components().any(|component| matches!(component, Component::ParentDir))
+        {
+            return Err(AdkError::tool(
+                "resource path must be a relative path under references/, assets/, or scripts/",
+            ));
+        }
+        Ok(relative)
+    }
+
+    fn truncate(value: String, limit: usize) -> String {
+        if value.chars().count() <= limit {
+            return value;
+        }
+        let mut truncated = value.chars().take(limit).collect::<String>();
+        truncated.push_str("\n[... truncated]");
+        truncated
+    }
+
+    async fn resolve_business_tools(
+        &self,
+        ctx: &dyn ReadonlyContext,
+    ) -> Result<Vec<Arc<dyn Tool>>> {
+        let mut names = HashSet::new();
+        let mut tools = Vec::new();
+        let mut missing = Vec::new();
+
+        for active in self.valid_activated_skills(ctx).await {
+            for name in &active.document().allowed_tools {
+                if !names.insert(name.clone()) {
+                    continue;
+                }
+                match self.tool_registry.resolve(name) {
+                    Some(tool) => tools.push(tool),
+                    None => missing.push(name.clone()),
+                }
+            }
+        }
+
+        if !missing.is_empty() && self.config.validation_mode == ValidationMode::Strict {
+            return Err(AdkError::tool(format!(
+                "activated skills require unavailable tools: {}",
+                missing.join(", ")
+            )));
+        }
+        if !missing.is_empty() {
+            tracing::warn!(missing_tools = ?missing, "omitting unavailable skill tools");
+        }
+        Ok(tools)
+    }
+}
+
+#[async_trait]
+impl Toolset for SkillToolset {
+    fn name(&self) -> &str {
+        "skills"
+    }
+
+    async fn tools(&self, ctx: Arc<dyn ReadonlyContext>) -> Result<Vec<Arc<dyn Tool>>> {
+        let mut tools = self.core_tools();
+        #[cfg(feature = "vertex-skill-registry")]
+        if let Some(client) = &self.registry_client {
+            tools.push(Arc::new(SkillSearchTool::new(client.clone())));
+        }
+        tools.extend(self.resolve_business_tools(ctx.as_ref()).await?);
+        Ok(tools)
+    }
+}
+
+struct ListSkillsTool {
+    toolset: SkillToolset,
+}
+
+#[async_trait]
+impl Tool for ListSkillsTool {
+    fn name(&self) -> &str {
+        "list_skills"
+    }
+    fn description(&self) -> &str {
+        "Lists available skills with their names and descriptions."
+    }
+    fn is_read_only(&self) -> bool {
+        true
+    }
+    fn is_concurrency_safe(&self) -> bool {
+        true
+    }
+    fn parameters_schema(&self) -> Option<Value> {
+        Some(json!({"type": "object", "properties": {}}))
+    }
+    async fn execute(&self, _ctx: Arc<dyn ToolContext>, _args: Value) -> Result<Value> {
+        serde_json::to_value(self.toolset.summaries())
+            .map_err(|error| AdkError::tool(format!("serialize skill catalog: {error}")))
+    }
+}
+
+struct LoadSkillTool {
+    toolset: SkillToolset,
+}
+
+#[async_trait]
+impl Tool for LoadSkillTool {
+    fn name(&self) -> &str {
+        "load_skill"
+    }
+    fn description(&self) -> &str {
+        "Loads the SKILL.md instructions for a given skill."
+    }
+    fn parameters_schema(&self) -> Option<Value> {
+        Some(
+            json!({"type":"object","properties":{"skill_name":{"type":"string"}},"required":["skill_name"]}),
+        )
+    }
+    async fn execute(&self, ctx: Arc<dyn ToolContext>, args: Value) -> Result<Value> {
+        let name = args
+            .get("skill_name")
+            .and_then(Value::as_str)
+            .ok_or_else(|| AdkError::tool("missing required string argument 'skill_name'"))?;
+        let skill = self.toolset.load_skill(ctx.as_ref(), name).await?;
+        let document = skill.document();
+        self.toolset.validate_skill_tools(document)?;
+        self.toolset.activate(ctx.as_ref(), &skill).await?;
+        Ok(json!({
+            "skillName": document.name,
+            "skillId": document.id,
+            "hash": document.hash,
+            "instructions": SkillToolset::truncate(document.body.clone(), self.toolset.config.max_instruction_chars),
+            "frontmatter": SkillSummary::from(document),
+        }))
+    }
+}
+
+struct LoadSkillResourceTool {
+    toolset: SkillToolset,
+}
+
+#[async_trait]
+impl Tool for LoadSkillResourceTool {
+    fn name(&self) -> &str {
+        "load_skill_resource"
+    }
+    fn description(&self) -> &str {
+        "Loads a resource file from references/, assets/, or scripts/ within a skill."
+    }
+    fn is_read_only(&self) -> bool {
+        true
+    }
+    fn parameters_schema(&self) -> Option<Value> {
+        Some(
+            json!({"type":"object","properties":{"skill_name":{"type":"string"},"file_path":{"type":"string"}},"required":["skill_name","file_path"]}),
+        )
+    }
+    async fn execute(&self, ctx: Arc<dyn ToolContext>, args: Value) -> Result<Value> {
+        let name = args
+            .get("skill_name")
+            .and_then(Value::as_str)
+            .ok_or_else(|| AdkError::tool("missing required string argument 'skill_name'"))?;
+        let path = args
+            .get("file_path")
+            .and_then(Value::as_str)
+            .ok_or_else(|| AdkError::tool("missing required string argument 'file_path'"))?;
+        let skill = self.toolset.load_skill(ctx.as_ref(), name).await?;
+        let document = skill.document();
+        if self.toolset.config.resource_access == ResourceAccessPolicy::ActivatedOnly
+            && !self
+                .toolset
+                .valid_activated_skills(ctx.as_ref())
+                .await
+                .iter()
+                .any(|item| item.document().id == document.id)
+        {
+            return Err(AdkError::tool(format!(
+                "skill '{name}' must be loaded before reading its resources"
+            )));
+        }
+        let content = skill.resource_content(path)?;
+        Ok(json!({
+            "skillName": document.name,
+            "filePath": path,
+            "content": SkillToolset::truncate(content, self.toolset.config.max_resource_chars),
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use adk_core::{Artifacts, CallbackContext, Content, EventActions, MemoryEntry, State};
+    use async_trait::async_trait;
+    use std::{collections::HashMap, sync::Mutex};
+
+    #[derive(Default)]
+    struct TestState {
+        values: HashMap<String, Value>,
+    }
+
+    impl State for TestState {
+        fn get(&self, key: &str) -> Option<Value> {
+            self.values.get(key).cloned()
+        }
+
+        fn set(&mut self, key: String, value: Value) {
+            self.values.insert(key, value);
+        }
+
+        fn all(&self) -> HashMap<String, Value> {
+            self.values.clone()
+        }
+    }
+
+    struct TestContext {
+        state: TestState,
+        actions: Mutex<EventActions>,
+        user_content: Content,
+    }
+
+    impl TestContext {
+        fn new() -> Self {
+            Self {
+                state: TestState::default(),
+                actions: Mutex::new(EventActions::default()),
+                user_content: Content::new("user").with_text("test"),
+            }
+        }
+
+        fn with_state(key: String, value: Value) -> Self {
+            let mut state = TestState::default();
+            state.set(key, value);
+            Self {
+                state,
+                actions: Mutex::new(EventActions::default()),
+                user_content: Content::new("user").with_text("test"),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl ReadonlyContext for TestContext {
+        fn invocation_id(&self) -> &str {
+            "invocation"
+        }
+        fn agent_name(&self) -> &str {
+            "agent"
+        }
+        fn user_id(&self) -> &str {
+            "user"
+        }
+        fn app_name(&self) -> &str {
+            "app"
+        }
+        fn session_id(&self) -> &str {
+            "session"
+        }
+        fn branch(&self) -> &str {
+            ""
+        }
+        fn user_content(&self) -> &Content {
+            &self.user_content
+        }
+        fn state(&self) -> Option<&dyn State> {
+            Some(&self.state)
+        }
+    }
+
+    #[async_trait]
+    impl CallbackContext for TestContext {
+        fn artifacts(&self) -> Option<Arc<dyn Artifacts>> {
+            None
+        }
+    }
+
+    #[async_trait]
+    impl ToolContext for TestContext {
+        fn function_call_id(&self) -> &str {
+            "call"
+        }
+        fn actions(&self) -> EventActions {
+            self.actions.lock().expect("actions lock").clone()
+        }
+        fn set_actions(&self, actions: EventActions) {
+            *self.actions.lock().expect("actions lock") = actions;
+        }
+        async fn search_memory(&self, _query: &str) -> Result<Vec<MemoryEntry>> {
+            Ok(Vec::new())
+        }
+    }
+
+    struct DummyTool;
+
+    #[async_trait]
+    impl Tool for DummyTool {
+        fn name(&self) -> &str {
+            "weather_lookup"
+        }
+        fn description(&self) -> &str {
+            "Looks up weather."
+        }
+        async fn execute(&self, _ctx: Arc<dyn ToolContext>, _args: Value) -> Result<Value> {
+            Ok(Value::Null)
+        }
+    }
+
+    struct TestRegistry;
+
+    impl ToolRegistry for TestRegistry {
+        fn resolve(&self, tool_name: &str) -> Option<Arc<dyn Tool>> {
+            (tool_name == "weather_lookup").then(|| Arc::new(DummyTool) as Arc<dyn Tool>)
+        }
+    }
+
+    fn setup() -> (tempfile::TempDir, SkillToolset) {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let skill_dir = temp.path().join(".skills/weather");
+        fs::create_dir_all(skill_dir.join("references")).expect("skill directories");
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: weather\ndescription: Answer weather questions\nallowed-tools: [weather_lookup]\n---\nLoad references/units.md before answering.\n",
+        )
+        .expect("skill file");
+        fs::write(skill_dir.join("references/units.md"), "Use Celsius.").expect("reference");
+        let index = Arc::new(crate::load_skill_index(temp.path()).expect("skill index"));
+        (temp, SkillToolset::new(index, Arc::new(TestRegistry), SkillToolsetConfig::default()))
+    }
+
+    fn tool_by_name(tools: &[Arc<dyn Tool>], name: &str) -> Arc<dyn Tool> {
+        tools.iter().find(|tool| tool.name() == name).expect("tool present").clone()
+    }
+
+    #[tokio::test]
+    async fn loading_a_skill_activates_its_declared_tool_and_resource_access() {
+        let (_temp, toolset) = setup();
+        let first_context = Arc::new(TestContext::new());
+        let initial_tools = toolset.tools(first_context.clone()).await.expect("initial tools");
+        assert_eq!(initial_tools.len(), 3);
+        assert!(!initial_tools.iter().any(|tool| tool.name() == "weather_lookup"));
+
+        let load = tool_by_name(&initial_tools, "load_skill");
+        let loaded = load
+            .execute(first_context.clone(), json!({"skill_name": "weather"}))
+            .await
+            .expect("load skill");
+        assert_eq!(loaded["skillName"], "weather");
+        assert!(loaded["instructions"].as_str().expect("instructions").contains("units.md"));
+
+        let state_key = SkillToolset::activation_state_key("agent");
+        let activation =
+            first_context.actions().state_delta.remove(&state_key).expect("activation state");
+        let second_context = Arc::new(TestContext::with_state(state_key, activation));
+        let activated_tools = toolset.tools(second_context.clone()).await.expect("activated tools");
+        assert!(activated_tools.iter().any(|tool| tool.name() == "weather_lookup"));
+
+        let resource = tool_by_name(&activated_tools, "load_skill_resource");
+        let loaded_resource = resource
+            .execute(
+                second_context,
+                json!({"skill_name": "weather", "file_path": "references/units.md"}),
+            )
+            .await
+            .expect("load resource");
+        assert_eq!(loaded_resource["content"], "Use Celsius.");
+    }
+
+    #[tokio::test]
+    async fn resources_require_activation_and_reject_path_traversal() {
+        let (_temp, toolset) = setup();
+        let context = Arc::new(TestContext::new());
+        let tools = toolset.tools(context.clone()).await.expect("tools");
+        let resource = tool_by_name(&tools, "load_skill_resource");
+        assert!(
+            resource
+                .execute(
+                    context.clone(),
+                    json!({"skill_name": "weather", "file_path": "references/units.md"})
+                )
+                .await
+                .is_err()
+        );
+
+        let load = tool_by_name(&tools, "load_skill");
+        load.execute(context.clone(), json!({"skill_name": "weather"})).await.expect("load skill");
+        let state_key = SkillToolset::activation_state_key("agent");
+        let activation =
+            context.actions().state_delta.remove(&state_key).expect("activation state");
+        let active_context = Arc::new(TestContext::with_state(state_key, activation));
+        let error = resource
+            .execute(
+                active_context,
+                json!({"skill_name": "weather", "file_path": "references/../SKILL.md"}),
+            )
+            .await
+            .expect_err("traversal must fail");
+        assert!(error.to_string().contains("resource path"));
+    }
+}

--- a/adk-skill/src/registry/load.rs
+++ b/adk-skill/src/registry/load.rs
@@ -198,7 +198,11 @@ pub fn merge_skill_indexes(local: SkillIndex, remote: SkillIndex) -> SkillIndex 
 }
 
 /// Builds a [`SkillDocument`] from a fetched skill package.
-fn document_from_content(content: &SkillContent) -> SkillResult<SkillDocument> {
+/// Builds a document from a verified registry payload.
+///
+/// This is shared by eager index loading and progressive, invocation-scoped
+/// loading so both paths preserve the same parser and content-hash semantics.
+pub(crate) fn document_from_content(content: &SkillContent) -> SkillResult<SkillDocument> {
     let skill_md = content.skill_md().ok_or_else(|| {
         SkillError::Validation(format!(
             "skill `{}` package has no SKILL.md at its root; repackage the skill with SKILL.md at the top level",

--- a/adk-skill/src/registry/mod.rs
+++ b/adk-skill/src/registry/mod.rs
@@ -35,7 +35,7 @@
 
 mod client;
 pub mod extract;
-mod load;
+pub(crate) mod load;
 mod tool;
 
 pub use client::{


### PR DESCRIPTION
## What

Adds an opt-in Google ADK-style progressive disclosure mechanism for skills.

`SkillToolset` now exposes:

- L1 `list_skills` for compact skill discovery;
- L2 `load_skill` for on-demand instructions and activation;
- L3 `load_skill_resource` for bounded reads of bundled resources;
- optional Vertex Skill Registry search and lazy package loading.

An activated skill exposes its validated `allowed-tools` on the next model turn.
Existing `SkillInjector` and `ContextCoordinator` behavior remains unchanged.

## Why

Fixes #634

This avoids placing complete skill instructions and every skill capability into
each model request. It reduces prompt and tool-surface cost while preserving the
existing ADK-Rust skill APIs as a compatible opt-in extension.

## How

- Adds `progressive-disclosure` to `adk-skill` and
  `skills-progressive-disclosure` forwarding features to `adk-agent` and
  `adk-rust`.
- Adds `SkillToolset`, `SkillToolsetConfig`, activation provenance, L1/L2/L3
  tools, resource access policy, and bounded response sizes.
- Persists agent-scoped activation state with skill ID, content hash, and source
  locator. Stale, changed, or unavailable skills no longer retain permissions.
- Extends `ReadonlyContext` with optional state access without breaking
  existing third-party implementations.
- Refreshes dynamic toolsets after each tool batch, so `load_skill` affects the
  next model turn in the same invocation.
- Supports optional Vertex Skill Registry `search_skills` and lazy loading,
  while local skill names retain precedence.
- Enforces strict declared-tool validation, activation-before-resource access by
  default, text-only resource responses, traversal protection, and local
  symlink containment checks.
- Adds unit, dynamic-toolset regression, and Runner end-to-end coverage.

## Scope: `run_skill_script` is intentionally not included

This PR completes progressive disclosure, not code execution.

`scripts/` can be read with `load_skill_resource`, but are never automatically
executed and no `run_skill_script` tool is exposed. This keeps disclosure of
trusted skill content separate from granting code-execution authority.

A follow-up PR will add an opt-in `run_skill_script` capability aligned with
Google ADK Python. It will be backed by an injected
`adk-sandbox::SandboxBackend` or `adk-code::CodeExecutor`, and will:

- execute only scripts from an activated skill's validated `scripts/` path;
- materialize skill resources in an isolated temporary workspace;
- use explicit language allowlists, timeout and output limits;
- apply filesystem, network, environment-variable, and working-directory
  policy through the selected execution backend;
- return structured stdout, stderr, exit status, and timeout information;
- emit tracing/audit events and add failure-path regression coverage.

Keeping this as a separate PR avoids making progressive disclosure a default
code-execution capability or introducing a breaking API change.

## PR Checklist

### Quality Gates (all required)

- [x] Formatting passed via `cargo fmt --all -- --check` (`devenv` is not installed locally)
- [x] Clippy passed via `cargo clippy --workspace --all-targets -- -D warnings` (`devenv` is not installed locally)
- [ ] `devenv shell test` / `cargo nextest run --workspace` — `cargo-nextest` is not installed locally
- [x] Workspace compilation passed via `cargo check --workspace` (`devenv` is not installed locally)

### Code Quality

- [x] New code has unit, integration, dynamic-toolset, and Runner end-to-end tests
- [x] Public APIs have Rustdoc comments and examples where practical
- [x] No `println!`/`eprintln!` added to library code
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts are included
- [x] No unrelated changes are mixed in
- [x] Branch naming follows convention: `feat/skill-progressive-disclosure`
- [x] Commit message follows conventional format
- [x] PR targets `main`

### Documentation (if applicable)

- [ ] CHANGELOG.md not updated
- [x] `adk-skill/README.md` updated with progressive-disclosure usage and scope
- [ ] No standalone example added in this PR
