### PR TITLE
chore(release): 2.2.0

### DIFF
--- a/.skills/skills/adk-rust-app-bootstrap/references/bootstrap-checklist.md
+++ b/.skills/skills/adk-rust-app-bootstrap/references/bootstrap-checklist.md
@@ -1,7 +1,7 @@
 # Bootstrap Checklist
 
 ## Cargo setup
-- Add `adk-rust = "2.1.0"` for broad usage.
+- Add `adk-rust = "2.2.0"` for broad usage.
 - Or add targeted crates (`adk-agent`, `adk-model`, `adk-runner`, etc.).
 
 ## Provider selection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-09-01
+
 ### Added
 
 - **Wave 4 platform services (round two)** — the Govern-pillar invocation
@@ -59,6 +61,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `GeminiModel::with_vertex_rag_store(...)`, Studio-backend requests fail
   with a structured error, and grounding responses surface
   `retrievedContext` including `ragChunk` provenance.
+
+### Fixed
+
+- **Span parenting across suspension points** (`adk-agent`, `adk-runner`): one
+  logical invocation was exported as several disconnected traces. `LlmAgent`
+  held a `call_llm` span guard across the `.await`/`yield` points of its
+  `async_stream` generator — an entered guard is bound to the thread, not the
+  task, so it was neither exited on suspension nor re-entered on resumption, and
+  everything after the first suspension detached from `call_llm`. `Runner`
+  instrumented only the future that constructs the agent stream, not the
+  draining of it, so every span the agent produced was created outside
+  `agent.execute`. Both now instrument the individual futures, which is correct
+  across suspension by construction. Span names, attributes and durations are
+  unchanged — only parentage.
+- **`adk-realtime` with `livekit` compiles again**: livekit 0.8.1 requires
+  `livekit-data-stream = "0.1"`, and 0.1.2 changed `incoming::Manager::new`'s
+  arity and added a `topic` field, which broke livekit's own source. The
+  workspace now pins `=0.1.1`.
+- **`adk-audio` ONNX features compile again**: `ort` 2.0.0-rc.13 moved the CUDA
+  and CoreML execution providers out of `ort::execution_providers`, so the
+  floating pre-release requirement broke every ONNX model feature. Pinned to
+  `=2.0.0-rc.11`.
 
 ## [2.1.0] - 2026-08-25
 
@@ -4290,7 +4314,8 @@ Initial release - Published to crates.io.
 - Tokio async runtime
 - Google API key for Gemini
 
-[Unreleased]: https://github.com/zavora-ai/adk-rust/compare/v2.1.0...HEAD
+[Unreleased]: https://github.com/zavora-ai/adk-rust/compare/v2.2.0...HEAD
+[2.2.0]: https://github.com/zavora-ai/adk-rust/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/zavora-ai/adk-rust/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/zavora-ai/adk-rust/compare/v1.0.0...v2.0.0
 [0.3.0]: https://github.com/zavora-ai/adk-rust/compare/v0.2.0...v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Progressive skill disclosure** (`adk-skill`, `skills-progressive-disclosure`):
+  a Google ADK-style `SkillToolset` exposing `list_skills`, `load_skill` and
+  `load_skill_resource`, so an agent discovers a skill index first and pulls full
+  skill bodies and resources only when it needs them, rather than carrying every
+  skill in the prompt. `ResourceAccessPolicy` bounds which resources a loaded
+  skill may read, and `ReadonlyContext::state()` is a new defaulted trait method
+  letting dynamic toolsets read session state without mutable access —
+  third-party context implementations stay source-compatible.
+
 - **Wave 4 platform services (round two)** — the Govern-pillar invocation
   and consumption features, closing out the Agent Engine plan:
   - `vertex-remote-engine` (adk-server): `RemoteReasoningEngineAgent` —

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "adk-acp"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-runner",
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "adk-action"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "proptest",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-devtools",
@@ -132,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "adk-anthropic"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gcp",
@@ -170,7 +170,7 @@ dependencies = [
 
 [[package]]
 name = "adk-audio"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-realtime",
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "adk-auth"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-server",
@@ -239,7 +239,7 @@ dependencies = [
 
 [[package]]
 name = "adk-awp"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "arc-swap",
@@ -267,7 +267,7 @@ dependencies = [
 
 [[package]]
 name = "adk-bench"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-core",
@@ -291,7 +291,7 @@ dependencies = [
 
 [[package]]
 name = "adk-browser"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "adk-cli"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-artifact",
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "adk-code"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gcp",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "adk-codeact-monty"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-code",
@@ -387,7 +387,7 @@ dependencies = [
 
 [[package]]
 name = "adk-computer-use"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-auth",
@@ -414,7 +414,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -432,7 +432,7 @@ dependencies = [
 
 [[package]]
 name = "adk-deploy"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gcp",
@@ -459,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "adk-devtools"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -477,7 +477,7 @@ dependencies = [
 
 [[package]]
 name = "adk-enterprise"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -497,7 +497,7 @@ dependencies = [
 
 [[package]]
 name = "adk-eval"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gcp",
@@ -526,7 +526,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gcp"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "axum",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -572,7 +572,7 @@ dependencies = [
 
 [[package]]
 name = "adk-graph"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-action",
  "adk-agent",
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "adk-guardrail"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "adk-managed"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-core",
@@ -647,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "adk-memory"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gcp",
@@ -671,7 +671,7 @@ dependencies = [
 
 [[package]]
 name = "adk-mistralrs"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-telemetry",
@@ -697,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-anthropic",
  "adk-core",
@@ -732,7 +732,7 @@ dependencies = [
 
 [[package]]
 name = "adk-payments"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-auth",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rag"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gcp",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "adk-realtime"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -821,6 +821,7 @@ dependencies = [
  "libwebrtc",
  "livekit",
  "livekit-api",
+ "livekit-data-stream",
  "livekit-datatrack",
  "parking_lot",
  "proptest",
@@ -843,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "adk-retry-reflect"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -857,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -883,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-acp",
  "adk-action",
@@ -929,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -944,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "adk-sandbox"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -968,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "adk-server"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "a2a-protocol-types",
  "adk-agent",
@@ -1019,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gcp",
@@ -1049,7 +1050,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gcp",
@@ -1073,7 +1074,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "google-cloud-auth 1.15.0",
  "http 1.5.0",
@@ -1093,7 +1094,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-code",
  "adk-core",
@@ -2237,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "awp-types"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "chrono",
  "proptest",
@@ -3890,7 +3891,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-adk"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-bench",
  "adk-deploy",
@@ -11243,9 +11244,9 @@ dependencies = [
 
 [[package]]
 name = "livekit-data-stream"
-version = "0.1.2"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfdf91af5f2dade508e2f81c7f63c79f77461f3d15cabe6b7059fe5f2839d58"
+checksum = "23af4bf8a38def67095d248a57eca35425dcdf2ca7876a178237fb1268d502f2"
 dependencies = [
  "async-compression",
  "bmrng",
@@ -13325,9 +13326,9 @@ dependencies = [
 
 [[package]]
 name = "ort"
-version = "2.0.0-rc.13"
+version = "2.0.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4336a1e2b38848325241c72889086886004e589b7c74f335e60a8e8db5138a0b"
+checksum = "4a5df903c0d2c07b56950f1058104ab0c8557159f2741782223704de9be73c3c"
 dependencies = [
  "ndarray 0.17.2",
  "ort-sys",
@@ -13338,9 +13339,9 @@ dependencies = [
 
 [[package]]
 name = "ort-sys"
-version = "2.0.0-rc.13"
+version = "2.0.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf211e3776eea6aec988552fa118dd746d70e1b1e5e244058d1c98015f3e5872"
+checksum = "06503bb33f294c5f1ba484011e053bfa6ae227074bdb841e9863492dc5960d4b"
 dependencies = [
  "hmac-sha256",
  "lzma-rust2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,7 @@ strip = false
 opt-level = 2
 
 [workspace.package]
-version = "2.1.0"
+version = "2.2.0"
 edition = "2024"
 rust-version = "1.95"
 license = "Apache-2.0"
@@ -155,49 +155,53 @@ flate2 = "1.0"
 tar = "0.4"
 zip = { version = "7.2", default-features = false, features = ["deflate"] }
 livekit = { version = "=0.8.1", default-features = false, features = ["tokio", "native-tls"] }
+# livekit 0.8.1 declares `livekit-data-stream = "0.1"`, and 0.1.2 changed
+# `incoming::Manager::new`'s arity and added a `topic` field, so livekit's own
+# source stops compiling. Pinned here until the livekit 0.8.4 stack lands.
+livekit-data-stream = { version = "=0.1.1", default-features = false }
 livekit-api = { version = "=0.6.1", default-features = false, features = ["services-tokio", "access-token"] }
 livekit-datatrack = { version = "=0.1.13", default-features = false }
 libwebrtc = { version = "=0.3.43", default-features = false }
 webrtc-sys = { version = "=0.3.40", default-features = false }
 
 # ADK internal crates (use { workspace = true } in member crates)
-adk-core = { path = "adk-core", version = "2.1.0" }
-adk-rust-macros = { path = "adk-rust-macros", version = "2.1.0" }
-adk-agent = { path = "adk-agent", version = "2.1.0", default-features = false }
-adk-model = { path = "adk-model", version = "2.1.0", default-features = false }
-adk-tool = { path = "adk-tool", version = "2.1.0" }
-adk-runner = { path = "adk-runner", version = "2.1.0", default-features = false }
-adk-server = { path = "adk-server", version = "2.1.0" }
-adk-session = { path = "adk-session", version = "2.1.0" }
-adk-artifact = { path = "adk-artifact", version = "2.1.0" }
-adk-memory = { path = "adk-memory", version = "2.1.0" }
-adk-cli = { path = "adk-cli", version = "2.1.0", default-features = false }
-adk-realtime = { path = "adk-realtime", version = "2.1.0" }
-adk-graph = { path = "adk-graph", version = "2.1.0" }
-adk-browser = { path = "adk-browser", version = "2.1.0" }
-adk-computer-use = { path = "adk-computer-use", version = "2.1.0" }
-adk-eval = { path = "adk-eval", version = "2.1.0" }
-adk-telemetry = { path = "adk-telemetry", version = "2.1.0" }
-adk-guardrail = { path = "adk-guardrail", version = "2.1.0" }
-adk-auth = { path = "adk-auth", version = "2.1.0" }
-adk-plugin = { path = "adk-plugin", version = "2.1.0" }
-adk-skill = { path = "adk-skill", version = "2.1.0" }
-adk-gemini = { path = "adk-gemini", version = "2.1.0" }
-adk-gcp = { path = "adk-gcp", version = "2.1.0" }
-adk-code = { path = "adk-code", version = "2.1.0" }
-adk-codeact-monty = { path = "adk-codeact-monty", version = "2.1.0" }
-adk-devtools = { path = "adk-devtools", version = "2.1.0" }
-adk-sandbox = { path = "adk-sandbox", version = "2.1.0" }
-adk-rag = { path = "adk-rag", version = "2.1.0" }
-adk-audio = { path = "adk-audio", version = "2.1.0" }
-adk-mistralrs = { path = "adk-mistralrs", version = "2.1.0", default-features = false }
-adk-deploy = { path = "adk-deploy", version = "2.1.0" }
-adk-payments = { path = "adk-payments", version = "2.1.0" }
-adk-action = { path = "adk-action", version = "2.1.0" }
-adk-anthropic = { path = "adk-anthropic", version = "2.1.0" }
-adk-managed = { path = "adk-managed", version = "2.1.0", default-features = false }
-adk-enterprise = { path = "adk-enterprise", version = "2.1.0" }
-adk-bench = { path = "adk-bench", version = "2.1.0" }
-awp-types = { path = "awp-types", version = "2.1.0" }
-adk-awp = { path = "adk-awp", version = "2.1.0" }
-adk-acp = { path = "adk-acp", version = "2.1.0" }
+adk-core = { path = "adk-core", version = "2.2.0" }
+adk-rust-macros = { path = "adk-rust-macros", version = "2.2.0" }
+adk-agent = { path = "adk-agent", version = "2.2.0", default-features = false }
+adk-model = { path = "adk-model", version = "2.2.0", default-features = false }
+adk-tool = { path = "adk-tool", version = "2.2.0" }
+adk-runner = { path = "adk-runner", version = "2.2.0", default-features = false }
+adk-server = { path = "adk-server", version = "2.2.0" }
+adk-session = { path = "adk-session", version = "2.2.0" }
+adk-artifact = { path = "adk-artifact", version = "2.2.0" }
+adk-memory = { path = "adk-memory", version = "2.2.0" }
+adk-cli = { path = "adk-cli", version = "2.2.0", default-features = false }
+adk-realtime = { path = "adk-realtime", version = "2.2.0" }
+adk-graph = { path = "adk-graph", version = "2.2.0" }
+adk-browser = { path = "adk-browser", version = "2.2.0" }
+adk-computer-use = { path = "adk-computer-use", version = "2.2.0" }
+adk-eval = { path = "adk-eval", version = "2.2.0" }
+adk-telemetry = { path = "adk-telemetry", version = "2.2.0" }
+adk-guardrail = { path = "adk-guardrail", version = "2.2.0" }
+adk-auth = { path = "adk-auth", version = "2.2.0" }
+adk-plugin = { path = "adk-plugin", version = "2.2.0" }
+adk-skill = { path = "adk-skill", version = "2.2.0" }
+adk-gemini = { path = "adk-gemini", version = "2.2.0" }
+adk-gcp = { path = "adk-gcp", version = "2.2.0" }
+adk-code = { path = "adk-code", version = "2.2.0" }
+adk-codeact-monty = { path = "adk-codeact-monty", version = "2.2.0" }
+adk-devtools = { path = "adk-devtools", version = "2.2.0" }
+adk-sandbox = { path = "adk-sandbox", version = "2.2.0" }
+adk-rag = { path = "adk-rag", version = "2.2.0" }
+adk-audio = { path = "adk-audio", version = "2.2.0" }
+adk-mistralrs = { path = "adk-mistralrs", version = "2.2.0", default-features = false }
+adk-deploy = { path = "adk-deploy", version = "2.2.0" }
+adk-payments = { path = "adk-payments", version = "2.2.0" }
+adk-action = { path = "adk-action", version = "2.2.0" }
+adk-anthropic = { path = "adk-anthropic", version = "2.2.0" }
+adk-managed = { path = "adk-managed", version = "2.2.0", default-features = false }
+adk-enterprise = { path = "adk-enterprise", version = "2.2.0" }
+adk-bench = { path = "adk-bench", version = "2.2.0" }
+awp-types = { path = "awp-types", version = "2.2.0" }
+adk-awp = { path = "adk-awp", version = "2.2.0" }
+adk-acp = { path = "adk-acp", version = "2.2.0" }

--- a/README.md
+++ b/README.md
@@ -11,16 +11,16 @@
 A production-ready Rust framework for building AI agents. Model-agnostic, type-safe
 and async, across 43 publishable crates for agent orchestration.
 
-> **v2.1.0 Released!** This API-compatible minor release
-> adds portable, validated teams with exact handoff and delegation semantics; a
-> Gemini Enterprise Agent Platform path spanning Agent Engine runtime and BYOC
-> deployment, Vertex sessions and Memory Bank, GCS artifacts, Example Store,
-> Cloud telemetry, and managed code sandboxes; hardened ambient scheduling,
-> runtime skill writing, and argument-level tool guardrails; plus Anthropic
-> request customization and typed safety-refusal fallback; and a new ADK-Rust-owned
-> responsive runtime UI for conversations, exact team topology, event timelines,
-> shared state, artifacts, sessions, and UI-protocol discovery. All 43 crates are
-> available on [crates.io](https://crates.io/crates/adk-rust/2.1.0).
+> **v2.2.0 Released!** This API-compatible minor release completes the Gemini
+> Enterprise Agent Platform consumption path: the Gen AI Evaluation Service
+> bridge, Vertex AI RAG Engine retrieval and grounding, an Agent Retrieval
+> vector store, Agent Registry discovery and registration, Skill Registry
+> consumption with remote skill loading, and remote ReasoningEngine agents you
+> can call as sub-agents — every one opt-in and composable with any preset, and
+> all appended to `gemini-agent-platform`. Graph workflows gain native tool
+> confirmation pauses. Tracing is fixed so one invocation exports as one trace
+> rather than several disconnected ones. All 43 crates are available on
+> [crates.io](https://crates.io/crates/adk-rust/2.2.0).
 >
 > **Milestone:** ADK-Rust has crossed **500K total crates.io downloads** across
 > the workspace crates.
@@ -149,8 +149,8 @@ with tool, graph, and team agents.
 
 ```toml
 [dependencies]
-adk-rust = "2.1.0"                                        # Gemini, agents, runner, sessions
-# adk-rust = { version = "2.1.0", features = ["standard"] }  # + server, auth, graph, eval
+adk-rust = "2.2.0"                                        # Gemini, agents, runner, sessions
+# adk-rust = { version = "2.2.0", features = ["standard"] }  # + server, auth, graph, eval
 ```
 
 | Tier | Includes | Use case |
@@ -426,7 +426,7 @@ per-platform tool matrix and the CI cost tiers.
 
 ## Project
 
-- [ROADMAP.md](ROADMAP.md) — **v2.1.0** (current). Longer-term direction and
+- [ROADMAP.md](ROADMAP.md) — **v2.2.0** (current). Longer-term direction and
   why both orchestration APIs are supported
 - [CHANGELOG.md](CHANGELOG.md) — every release
 - [CONTRIBUTORS.md](CONTRIBUTORS.md) — the people who built this

--- a/adk-acp/README.md
+++ b/adk-acp/README.md
@@ -27,10 +27,10 @@ not mean ACP protocol v2.
 
 ```toml
 [dependencies]
-adk-acp = "2.1.0"
+adk-acp = "2.2.0"
 
 # Add the server feature only when exposing an ADK-Rust agent to a client.
-adk-acp = { version = "2.1.0", features = ["server"] }
+adk-acp = { version = "2.2.0", features = ["server"] }
 ```
 
 ## Use an ACP agent as an ADK-Rust tool

--- a/adk-action/README.md
+++ b/adk-action/README.md
@@ -41,7 +41,7 @@ Action nodes are programmatic graph nodes that perform specific operations — H
 
 ```toml
 [dependencies]
-adk-action = "2.1.0"
+adk-action = "2.2.0"
 ```
 
 ## Usage

--- a/adk-agent/README.md
+++ b/adk-agent/README.md
@@ -33,14 +33,14 @@ Agent implementations for ADK-Rust (LLM, Custom, Workflow agents).
 
 ```toml
 [dependencies]
-adk-agent = "2.1.0"
+adk-agent = "2.2.0"
 ```
 
 Or use the umbrella crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "2.1.0", features = ["agents"] }
+adk-rust = { version = "2.2.0", features = ["agents"] }
 ```
 
 ## Quick Start

--- a/adk-artifact/README.md
+++ b/adk-artifact/README.md
@@ -31,9 +31,9 @@ Auto-assigned versions start at `0` (matching adk-python; the in-memory and file
 
 ```toml
 [dependencies]
-adk-artifact = { version = "2.1.0", features = ["gcs"] }
+adk-artifact = { version = "2.2.0", features = ["gcs"] }
 # or via the umbrella crate:
-adk-rust = { version = "2.1.0", features = ["minimal", "gcs-artifacts"] }
+adk-rust = { version = "2.2.0", features = ["minimal", "gcs-artifacts"] }
 ```
 
 ```rust,no_run
@@ -49,14 +49,14 @@ fn main() -> adk_core::Result<()> {
 
 ```toml
 [dependencies]
-adk-artifact = "2.1.0"
+adk-artifact = "2.2.0"
 ```
 
 Or via the umbrella crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "2.1.0", features = ["artifacts"] }
+adk-rust = { version = "2.2.0", features = ["artifacts"] }
 ```
 
 ## Quick Start

--- a/adk-audio/Cargo.toml
+++ b/adk-audio/Cargo.toml
@@ -50,7 +50,9 @@ base64 = { version = "0.22", optional = true }
 # a C VAD into the dependency graph.
 
 # Local inference (optional)
-ort = { version = "2.0.0-rc.11", optional = true }
+# Pinned exactly: rc.13 moved the CUDA and CoreML execution providers out of
+# `ort::execution_providers`, so a floating pre-release breaks every ONNX feature.
+ort = { version = "=2.0.0-rc.11", optional = true }
 tokenizers = { version = "0.22", optional = true }
 hf-hub = { version = "0.5", optional = true }
 

--- a/adk-audio/README.md
+++ b/adk-audio/README.md
@@ -8,14 +8,14 @@ Provides unified traits for Text-to-Speech (TTS), Speech-to-Text (STT), music ge
 
 ```toml
 [dependencies]
-adk-audio = "2.1.0"
+adk-audio = "2.2.0"
 ```
 
 Or via the umbrella crate (experimental):
 
 ```toml
 [dependencies]
-adk-rust = { version = "2.1.0", features = ["audio"] }
+adk-rust = { version = "2.2.0", features = ["audio"] }
 ```
 
 ## Feature Flags

--- a/adk-audio/src/onnx/stt/mod.rs
+++ b/adk-audio/src/onnx/stt/mod.rs
@@ -315,7 +315,7 @@ impl OnnxSttProvider {
             message: format!("failed to create {session_name} session builder: {e}"),
         })?;
 
-        let mut builder = Self::apply_execution_provider(builder, ep, session_name);
+        let builder = Self::apply_execution_provider(builder, ep, session_name);
 
         builder.commit_from_file(onnx_path).map_err(|e| AudioError::Stt {
             provider: "ONNX".into(),

--- a/adk-auth/README.md
+++ b/adk-auth/README.md
@@ -20,13 +20,13 @@ Access control and authentication for Rust Agent Development Kit (ADK-Rust).
 
 ```toml
 [dependencies]
-adk-auth = "2.1.0"
+adk-auth = "2.2.0"
 
 # With SSO/JWT validation
-adk-auth = { version = "2.1.0", features = ["sso"] }
+adk-auth = { version = "2.2.0", features = ["sso"] }
 
 # With auth bridge for adk-server identity flow (implies sso)
-adk-auth = { version = "2.1.0", features = ["auth-bridge"] }
+adk-auth = { version = "2.2.0", features = ["auth-bridge"] }
 ```
 
 ## Features

--- a/adk-auth/src/sso/mod.rs
+++ b/adk-auth/src/sso/mod.rs
@@ -8,7 +8,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-auth = { version = "2.1.0", features = ["sso"] }
+//! adk-auth = { version = "2.2.0", features = ["sso"] }
 //! ```
 //!
 //! # Quick Start

--- a/adk-browser/README.md
+++ b/adk-browser/README.md
@@ -6,14 +6,14 @@ Browser automation tools for ADK-Rust agents using WebDriver (via [thirtyfour](h
 
 ```toml
 [dependencies]
-adk-browser = "2.1.0"
+adk-browser = "2.2.0"
 ```
 
 Or via the umbrella crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "2.1.0", features = ["browser"] }
+adk-rust = { version = "2.2.0", features = ["browser"] }
 ```
 
 ## Overview

--- a/adk-codeact-monty/README.md
+++ b/adk-codeact-monty/README.md
@@ -25,8 +25,8 @@ read-only or read-write paths and an explicit environment map (see
 
 ```toml
 [dependencies]
-adk-agent = { version = "2.1.0", features = ["codeact"] }
-adk-codeact-monty = "2.1.0"
+adk-agent = { version = "2.2.0", features = ["codeact"] }
+adk-codeact-monty = "2.2.0"
 ```
 
 > **Note:** this crate is **Experimental** (see [STABILITY.md](../STABILITY.md)) —

--- a/adk-core/README.md
+++ b/adk-core/README.md
@@ -26,14 +26,14 @@ This crate is model-agnostic and contains no LLM-specific code.
 
 ```toml
 [dependencies]
-adk-core = "2.1.0"
+adk-core = "2.2.0"
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = "2.1.0"
+adk-rust = "2.2.0"
 ```
 
 ## Core Traits

--- a/adk-deploy/README.md
+++ b/adk-deploy/README.md
@@ -19,7 +19,7 @@ Deployment manifest, bundling, and control-plane client for ADK-Rust agents.
 
 ```toml
 [dependencies]
-adk-deploy = "2.1.0"
+adk-deploy = "2.2.0"
 ```
 
 ## Manifest Format

--- a/adk-enterprise/README.md
+++ b/adk-enterprise/README.md
@@ -48,7 +48,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-enterprise = "2.1.0"
+adk-enterprise = "2.2.0"
 futures = "0.3"
 tokio = { version = "1", features = ["full"] }
 ```
@@ -57,7 +57,7 @@ Or via the umbrella crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "2.1.0", features = ["enterprise-client"] }
+adk-rust = { version = "2.2.0", features = ["enterprise-client"] }
 ```
 
 ## Quick Start

--- a/adk-eval/README.md
+++ b/adk-eval/README.md
@@ -260,7 +260,7 @@ async fn test_my_agent() {
 
 ```toml
 [dependencies]
-adk-eval = { version = "2.1.0", features = ["embedding", "ci-helpers", "statistics"] }
+adk-eval = { version = "2.2.0", features = ["embedding", "ci-helpers", "statistics"] }
 ```
 
 | Feature | Dependency | Capability |

--- a/adk-gemini/README.md
+++ b/adk-gemini/README.md
@@ -34,14 +34,14 @@ Rust client library for Google's Gemini API — content generation, streaming, f
 
 ```toml
 [dependencies]
-adk-gemini = "2.1.0"
+adk-gemini = "2.2.0"
 ```
 
 Or through `adk-model`:
 
 ```toml
 [dependencies]
-adk-model = { version = "2.1.0", features = ["gemini"] }
+adk-model = { version = "2.2.0", features = ["gemini"] }
 ```
 
 ## Quick Start

--- a/adk-graph/README.md
+++ b/adk-graph/README.md
@@ -57,10 +57,10 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-graph = { version = "2.1.0", features = ["sqlite"] }
-adk-agent = "2.1.0"
-adk-model = "2.1.0"
-adk-core = "2.1.0"
+adk-graph = { version = "2.2.0", features = ["sqlite"] }
+adk-agent = "2.2.0"
+adk-model = "2.2.0"
+adk-core = "2.2.0"
 ```
 
 ### Basic Graph with AgentNode
@@ -641,7 +641,7 @@ The Functional API (feature: `functional`) provides a higher-level programming m
 
 ```toml
 [dependencies]
-adk-graph = { version = "2.1.0", features = ["functional"] }
+adk-graph = { version = "2.2.0", features = ["functional"] }
 ```
 
 ```rust

--- a/adk-guardrail/README.md
+++ b/adk-guardrail/README.md
@@ -19,10 +19,10 @@ Guardrails framework for ADK agents - input/output validation, content filtering
 
 ```toml
 [dependencies]
-adk-guardrail = "2.1.0"
+adk-guardrail = "2.2.0"
 
 # With JSON schema validation (default)
-adk-guardrail = { version = "2.1.0", features = ["schema"] }
+adk-guardrail = { version = "2.2.0", features = ["schema"] }
 ```
 
 ## Quick Start
@@ -63,7 +63,7 @@ let filter = ContentFilter::blocked_keywords(vec!["forbidden".into()]);
 Requires `guardrails` feature on `adk-agent`:
 
 ```toml
-adk-agent = { version = "2.1.0", features = ["guardrails"] }
+adk-agent = { version = "2.2.0", features = ["guardrails"] }
 ```
 
 ```rust

--- a/adk-managed/README.md
+++ b/adk-managed/README.md
@@ -61,9 +61,9 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-managed = "2.1.0"
-adk-session = "2.1.0"
-adk-core = "2.1.0"
+adk-managed = "2.2.0"
+adk-session = "2.2.0"
+adk-core = "2.2.0"
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
 async-trait = "0.1"
@@ -73,7 +73,7 @@ Or via the umbrella crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "2.1.0", features = ["managed-runtime"] }
+adk-rust = { version = "2.2.0", features = ["managed-runtime"] }
 ```
 
 ### Minimal Example

--- a/adk-memory/README.md
+++ b/adk-memory/README.md
@@ -26,14 +26,14 @@ Semantic memory and search for Rust Agent Development Kit (ADK-Rust) agents.
 
 ```toml
 [dependencies]
-adk-memory = "2.1.0"
+adk-memory = "2.2.0"
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "2.1.0", features = ["memory"] }
+adk-rust = { version = "2.2.0", features = ["memory"] }
 ```
 
 ## Quick Start
@@ -183,10 +183,10 @@ validate_project_id(&"x".repeat(257))?; // Err: exceeds 256 chars
 
 ```toml
 # SQLite
-adk-memory = { version = "2.1.0", features = ["sqlite-memory"] }
+adk-memory = { version = "2.2.0", features = ["sqlite-memory"] }
 
 # PostgreSQL + pgvector
-adk-memory = { version = "2.1.0", features = ["database-memory"] }
+adk-memory = { version = "2.2.0", features = ["database-memory"] }
 ```
 
 ## Schema Migrations

--- a/adk-mistralrs/README.md
+++ b/adk-mistralrs/README.md
@@ -10,26 +10,26 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-mistralrs = "2.1.0"
+adk-mistralrs = "2.2.0"
 ```
 
 ### With Hardware Acceleration
 
 ```toml
 # macOS with Metal
-adk-mistralrs = { version = "2.1.0", features = ["metal"] }
+adk-mistralrs = { version = "2.2.0", features = ["metal"] }
 
 # NVIDIA GPU with CUDA
-adk-mistralrs = { version = "2.1.0", features = ["cuda"] }
+adk-mistralrs = { version = "2.2.0", features = ["cuda"] }
 
 # CUDA with Flash Attention
-adk-mistralrs = { version = "2.1.0", features = ["flash-attn"] }
+adk-mistralrs = { version = "2.2.0", features = ["flash-attn"] }
 
 # Multi-GPU via NCCL
-adk-mistralrs = { version = "2.1.0", features = ["nccl"] }
+adk-mistralrs = { version = "2.2.0", features = ["nccl"] }
 
 # Intel MKL
-adk-mistralrs = { version = "2.1.0", features = ["mkl"] }
+adk-mistralrs = { version = "2.2.0", features = ["mkl"] }
 ```
 
 ## Features
@@ -50,9 +50,9 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-core = "2.1.0"
-adk-agent = "2.1.0"
-adk-mistralrs = "2.1.0"
+adk-core = "2.2.0"
+adk-agent = "2.2.0"
+adk-mistralrs = "2.2.0"
 ```
 
 ### Feature Flags

--- a/adk-mistralrs/src/lib.rs
+++ b/adk-mistralrs/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-mistralrs = "2.1.0"
+//! adk-mistralrs = "2.2.0"
 //! ```
 //!
 //! ## Features
@@ -145,7 +145,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-mistralrs = { version = "2.1.0", features = ["cuda"] }
+//! adk-mistralrs = { version = "2.2.0", features = ["cuda"] }
 //! ```
 //!
 //! Available features:

--- a/adk-model/README.md
+++ b/adk-model/README.md
@@ -35,21 +35,21 @@ The crate implements the `Llm` trait from `adk-core`, allowing models to be used
 
 ```toml
 [dependencies]
-adk-model = "2.1.0"
+adk-model = "2.2.0"
 ```
 
 Enable provider-specific features as needed:
 
 ```toml
 [dependencies]
-adk-model = { version = "2.1.0", features = ["openrouter"] }
+adk-model = { version = "2.2.0", features = ["openrouter"] }
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "2.1.0", features = ["models"] }
+adk-rust = { version = "2.2.0", features = ["models"] }
 ```
 
 ## Quick Start
@@ -714,24 +714,24 @@ Enable specific providers with feature flags:
 ```toml
 [dependencies]
 # All providers (default)
-adk-model = { version = "2.1.0", features = ["all-providers"] }
+adk-model = { version = "2.2.0", features = ["all-providers"] }
 
 # Individual providers
-adk-model = { version = "2.1.0", features = ["gemini"] }
-adk-model = { version = "2.1.0", features = ["openai"] }
-adk-model = { version = "2.1.0", features = ["xai"] }
-adk-model = { version = "2.1.0", features = ["anthropic"] }
-adk-model = { version = "2.1.0", features = ["deepseek"] }
-adk-model = { version = "2.1.0", features = ["groq"] }
-adk-model = { version = "2.1.0", features = ["ollama"] }
-adk-model = { version = "2.1.0", features = ["fireworks"] }
-adk-model = { version = "2.1.0", features = ["together"] }
-adk-model = { version = "2.1.0", features = ["mistral"] }
-adk-model = { version = "2.1.0", features = ["perplexity"] }
-adk-model = { version = "2.1.0", features = ["cerebras"] }
-adk-model = { version = "2.1.0", features = ["sambanova"] }
-adk-model = { version = "2.1.0", features = ["bedrock"] }
-adk-model = { version = "2.1.0", features = ["azure-ai"] }
+adk-model = { version = "2.2.0", features = ["gemini"] }
+adk-model = { version = "2.2.0", features = ["openai"] }
+adk-model = { version = "2.2.0", features = ["xai"] }
+adk-model = { version = "2.2.0", features = ["anthropic"] }
+adk-model = { version = "2.2.0", features = ["deepseek"] }
+adk-model = { version = "2.2.0", features = ["groq"] }
+adk-model = { version = "2.2.0", features = ["ollama"] }
+adk-model = { version = "2.2.0", features = ["fireworks"] }
+adk-model = { version = "2.2.0", features = ["together"] }
+adk-model = { version = "2.2.0", features = ["mistral"] }
+adk-model = { version = "2.2.0", features = ["perplexity"] }
+adk-model = { version = "2.2.0", features = ["cerebras"] }
+adk-model = { version = "2.2.0", features = ["sambanova"] }
+adk-model = { version = "2.2.0", features = ["bedrock"] }
+adk-model = { version = "2.2.0", features = ["azure-ai"] }
 ```
 
 ## Related Crates

--- a/adk-payments/README.md
+++ b/adk-payments/README.md
@@ -54,17 +54,17 @@ Choose only the features you need:
 
 ```toml
 [dependencies]
-adk-payments = { version = "2.1.0", features = ["acp"] }
+adk-payments = { version = "2.2.0", features = ["acp"] }
 ```
 
 ```toml
 [dependencies]
-adk-payments = { version = "2.1.0", features = ["ap2", "ap2-a2a", "ap2-mcp"] }
+adk-payments = { version = "2.2.0", features = ["ap2", "ap2-a2a", "ap2-mcp"] }
 ```
 
 ```toml
 [dependencies]
-adk-payments = { version = "2.1.0", features = ["acp", "acp-experimental", "ap2"] }
+adk-payments = { version = "2.2.0", features = ["acp", "acp-experimental", "ap2"] }
 ```
 
 ## Core Concepts

--- a/adk-plugin/README.md
+++ b/adk-plugin/README.md
@@ -31,7 +31,7 @@ Plugin system for ADK-Rust agents.
 
 ```toml
 [dependencies]
-adk-plugin = "2.1.0"
+adk-plugin = "2.2.0"
 ```
 
 ## Quick Start

--- a/adk-rag/README.md
+++ b/adk-rag/README.md
@@ -24,7 +24,7 @@ The fastest way to get a working RAG pipeline. Uses Gemini for embeddings (free 
 
 ```toml
 [dependencies]
-adk-rag = { version = "2.1.0", features = ["gemini"] }
+adk-rag = { version = "2.2.0", features = ["gemini"] }
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -70,10 +70,10 @@ The practical use case — an agent that searches your knowledge base to answer 
 
 ```toml
 [dependencies]
-adk-rag = { version = "2.1.0", features = ["gemini"] }
-adk-agent = "2.1.0"
-adk-model = "2.1.0"
-adk-cli = "2.1.0"
+adk-rag = { version = "2.2.0", features = ["gemini"] }
+adk-agent = "2.2.0"
+adk-model = "2.2.0"
+adk-cli = "2.2.0"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -149,7 +149,7 @@ The `RagPipeline` wires these together. The `RagTool` wraps the pipeline as an `
 Uses Google's `gemini-embedding-2` model (3072 dimensions). Free tier available.
 
 ```toml
-adk-rag = { version = "2.1.0", features = ["gemini"] }
+adk-rag = { version = "2.2.0", features = ["gemini"] }
 ```
 
 ```rust
@@ -161,7 +161,7 @@ let provider = GeminiEmbeddingProvider::new(&api_key)?;
 Uses `text-embedding-3-small` (1536 dimensions) by default. Supports dimension truncation via Matryoshka.
 
 ```toml
-adk-rag = { version = "2.1.0", features = ["openai"] }
+adk-rag = { version = "2.2.0", features = ["openai"] }
 ```
 
 ```rust
@@ -217,7 +217,7 @@ let store = InMemoryVectorStore::new();
 Production-ready vector database with filtering, snapshots, and clustering.
 
 ```toml
-adk-rag = { version = "2.1.0", features = ["qdrant"] }
+adk-rag = { version = "2.2.0", features = ["qdrant"] }
 ```
 
 ```rust
@@ -229,7 +229,7 @@ let store = QdrantVectorStore::new("http://localhost:6334").await?;
 Embedded vector database with no server required. Data persists to disk.
 
 ```toml
-adk-rag = { version = "2.1.0", features = ["lancedb"] }
+adk-rag = { version = "2.2.0", features = ["lancedb"] }
 ```
 
 > Requires `protoc` installed: `brew install protobuf` (macOS), `apt install protobuf-compiler` (Ubuntu).
@@ -243,7 +243,7 @@ let store = LanceDBVectorStore::new("/tmp/my-vectors").await?;
 Use your existing PostgreSQL database for vector search.
 
 ```toml
-adk-rag = { version = "2.1.0", features = ["pgvector"] }
+adk-rag = { version = "2.2.0", features = ["pgvector"] }
 ```
 
 ```rust
@@ -255,7 +255,7 @@ let store = PgVectorStore::new("postgres://user:pass@localhost/mydb").await?;
 Embedded or remote multi-model database with built-in vector search.
 
 ```toml
-adk-rag = { version = "2.1.0", features = ["surrealdb"] }
+adk-rag = { version = "2.2.0", features = ["surrealdb"] }
 ```
 
 ```rust
@@ -273,7 +273,7 @@ retrieval tool (corpus creation and file import stay in the Vertex AI console
 or management APIs):
 
 ```toml
-adk-rag = { version = "2.1.0", features = ["vertex-rag"] }
+adk-rag = { version = "2.2.0", features = ["vertex-rag"] }
 ```
 
 ```rust
@@ -337,7 +337,7 @@ The default `NoOpReranker` passes results through unchanged. Write your own to i
 
 ```toml
 [dependencies]
-adk-rag = { version = "2.1.0", features = ["gemini"] }
+adk-rag = { version = "2.2.0", features = ["gemini"] }
 async-trait = "0.1"
 tokio = { version = "1", features = ["full"] }
 ```
@@ -390,19 +390,19 @@ let pipeline = RagPipeline::builder()
 
 ```toml
 # Core only (in-memory store, all chunkers, no external deps)
-adk-rag = "2.1.0"
+adk-rag = "2.2.0"
 
 # With Gemini embeddings (recommended)
-adk-rag = { version = "2.1.0", features = ["gemini"] }
+adk-rag = { version = "2.2.0", features = ["gemini"] }
 
 # With OpenAI embeddings
-adk-rag = { version = "2.1.0", features = ["openai"] }
+adk-rag = { version = "2.2.0", features = ["openai"] }
 
 # With a persistent vector store
-adk-rag = { version = "2.1.0", features = ["gemini", "qdrant"] }
+adk-rag = { version = "2.2.0", features = ["gemini", "qdrant"] }
 
 # Everything
-adk-rag = { version = "2.1.0", features = ["full"] }
+adk-rag = { version = "2.2.0", features = ["full"] }
 ```
 
 | Feature | Enables | Extra dependency |

--- a/adk-realtime/Cargo.toml
+++ b/adk-realtime/Cargo.toml
@@ -69,6 +69,9 @@ google-cloud-auth = { version = "1.4", optional = true, default-features = false
 livekit = { workspace = true, optional = true }
 livekit-api = { workspace = true, optional = true }
 livekit-datatrack = { workspace = true, optional = true }
+# Not used directly: declared only so the workspace pin constrains what
+# livekit 0.8.1 resolves for its own `livekit-data-stream = "0.1"` requirement.
+livekit-data-stream = { workspace = true, optional = true }
 libwebrtc = { workspace = true, optional = true }
 webrtc-sys = { workspace = true, optional = true }
 
@@ -166,7 +169,7 @@ gemini = ["dep:tokio-tungstenite", "dep:adk-gemini"]
 # Enable Vertex AI Live API support (requires gemini + OAuth2/ADC auth)
 vertex-live = ["gemini", "dep:google-cloud-auth"]
 # Enable LiveKit WebRTC bridge
-livekit = ["dep:livekit", "dep:livekit-api", "dep:tokio-tungstenite", "dep:libwebrtc", "dep:webrtc-sys", "dep:livekit-datatrack"]
+livekit = ["dep:livekit", "dep:livekit-api", "dep:tokio-tungstenite", "dep:libwebrtc", "dep:webrtc-sys", "dep:livekit-datatrack", "dep:livekit-data-stream"]
 # Enable OpenAI WebRTC transport (requires openai + Sans-IO WebRTC + Opus codec)
 openai-webrtc = ["openai", "dep:str0m", "dep:audiopus", "dep:reqwest"]
 # Enable video avatar support for realtime sessions

--- a/adk-realtime/README.md
+++ b/adk-realtime/README.md
@@ -73,7 +73,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-realtime = { version = "2.1.0", features = ["openai"] }
+adk-realtime = { version = "2.2.0", features = ["openai"] }
 ```
 
 ### Using RealtimeAgent (Recommended)
@@ -138,7 +138,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 Connect to Gemini Live API via Vertex AI with Application Default Credentials:
 
 ```toml
-adk-realtime = { version = "2.1.0", features = ["vertex-live"] }
+adk-realtime = { version = "2.2.0", features = ["vertex-live"] }
 ```
 
 ```rust
@@ -168,7 +168,7 @@ Prerequisites:
 Lower-latency audio transport using Sans-IO WebRTC with Opus codec:
 
 ```toml
-adk-realtime = { version = "2.1.0", features = ["openai-webrtc"] }
+adk-realtime = { version = "2.2.0", features = ["openai-webrtc"] }
 ```
 
 ```rust
@@ -190,7 +190,7 @@ export CMAKE_POLICY_VERSION_MINIMUM=3.5
 Bridge any `EventHandler` to a LiveKit room for production voice apps:
 
 ```toml
-adk-realtime = { version = "2.1.0", features = ["livekit", "openai"] }
+adk-realtime = { version = "2.2.0", features = ["livekit", "openai"] }
 ```
 
 #### LiveKitConfig and LiveKitRoomBuilder

--- a/adk-runner/README.md
+++ b/adk-runner/README.md
@@ -24,14 +24,14 @@ Agent execution runtime for ADK-Rust.
 
 ```toml
 [dependencies]
-adk-runner = "2.1.0"
+adk-runner = "2.2.0"
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "2.1.0", features = ["runner"] }
+adk-rust = { version = "2.2.0", features = ["runner"] }
 ```
 
 ## Quick Start

--- a/adk-rust-macros/README.md
+++ b/adk-rust-macros/README.md
@@ -10,8 +10,8 @@ This crate provides the `#[tool]` attribute macro that turns an async function i
 
 ```toml
 [dependencies]
-adk-rust-macros = "2.1.0"
-adk-tool = "2.1.0"
+adk-rust-macros = "2.2.0"
+adk-tool = "2.2.0"
 schemars = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/adk-rust/README.md
+++ b/adk-rust/README.md
@@ -39,7 +39,7 @@ cargo new my_agent && cd my_agent
 
 ```toml
 [dependencies]
-adk-rust = "2.1.0"
+adk-rust = "2.2.0"
 tokio = { version = "1.40", features = ["full"] }
 dotenvy = "0.15"
 ```
@@ -308,32 +308,32 @@ cargo run -- serve --port 8080
 
 ```toml
 # Minimal (default) — agents, Gemini, runner, sessions (fastest build)
-adk-rust = "2.1.0"
+adk-rust = "2.2.0"
 
 # Standard — minimal + tools, memory, OpenAI, Anthropic, server, auth,
 # graph, eval, guardrails, skills, plugins, artifacts, telemetry
-adk-rust = { version = "2.1.0", features = ["standard"] }
+adk-rust = { version = "2.2.0", features = ["standard"] }
 
 # Enterprise — standard + realtime, browser, rag, payments, awp
-adk-rust = { version = "2.1.0", features = ["enterprise"] }
+adk-rust = { version = "2.2.0", features = ["enterprise"] }
 
 # Full — enterprise + experimental crates (audio, code, sandbox, code-tools)
-adk-rust = { version = "2.1.0", features = ["full"] }
+adk-rust = { version = "2.2.0", features = ["full"] }
 
 # Gemini Enterprise Agent Platform — every Vertex/EAP integration except
 # realtime transports; composable with any tier. The right default for
 # ReasoningEngine BYOC deployments. Deploy-time tooling is host-side and
 # not included.
-adk-rust = { version = "2.1.0", features = ["standard", "gemini-agent-platform"] }
+adk-rust = { version = "2.2.0", features = ["standard", "gemini-agent-platform"] }
 
 # gemini-agent-platform + Vertex AI Live API (pulls in the realtime WebSocket/audio stack)
-adk-rust = { version = "2.1.0", features = ["standard", "gemini-agent-platform-full"] }
+adk-rust = { version = "2.2.0", features = ["standard", "gemini-agent-platform-full"] }
 
 # Custom
-adk-rust = { version = "2.1.0", default-features = false, features = ["agents", "gemini", "tools"] }
+adk-rust = { version = "2.2.0", default-features = false, features = ["agents", "gemini", "tools"] }
 
 # With new providers (forwarded to adk-model)
-adk-model = { version = "2.1.0", features = ["fireworks", "together", "mistral", "perplexity", "cerebras", "sambanova", "bedrock", "azure-ai"] }
+adk-model = { version = "2.2.0", features = ["fireworks", "together", "mistral", "perplexity", "cerebras", "sambanova", "bedrock", "azure-ai"] }
 ```
 
 ## Documentation

--- a/adk-rust/src/lib.rs
+++ b/adk-rust/src/lib.rs
@@ -40,7 +40,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-rust = "2.1.0"
+//! adk-rust = "2.2.0"
 //! tokio = { version = "1.40", features = ["full"] }
 //! dotenvy = "0.15"  # For loading .env files
 //! ```
@@ -49,20 +49,20 @@
 //!
 //! ```toml
 //! # Minimal (default) — agents, Gemini, runner, sessions (fastest build)
-//! adk-rust = "2.1.0"
+//! adk-rust = "2.2.0"
 //!
 //! # Standard — minimal + tools, memory, OpenAI, Anthropic, server, auth,
 //! # graph, eval, guardrails, skills, plugins, artifacts, telemetry
-//! adk-rust = { version = "2.1.0", features = ["standard"] }
+//! adk-rust = { version = "2.2.0", features = ["standard"] }
 //!
 //! # Enterprise — standard + realtime, browser, rag, payments, awp
-//! adk-rust = { version = "2.1.0", features = ["enterprise"] }
+//! adk-rust = { version = "2.2.0", features = ["enterprise"] }
 //!
 //! # Full — enterprise + experimental crates (audio, code, sandbox)
-//! adk-rust = { version = "2.1.0", features = ["full"] }
+//! adk-rust = { version = "2.2.0", features = ["full"] }
 //!
 //! # Custom — pick exactly what you need
-//! adk-rust = { version = "2.1.0", default-features = false, features = [
+//! adk-rust = { version = "2.2.0", default-features = false, features = [
 //!     "agents", "gemini", "tools", "sessions", "openai", "openrouter"
 //! ] }
 //! ```

--- a/adk-server/README.md
+++ b/adk-server/README.md
@@ -29,14 +29,14 @@ HTTP server and A2A v1.0.0 protocol for Rust Agent Development Kit (ADK-Rust) ag
 
 ```toml
 [dependencies]
-adk-server = "2.1.0"
+adk-server = "2.2.0"
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "2.1.0", features = ["server"] }
+adk-rust = { version = "2.2.0", features = ["server"] }
 ```
 
 ## Quick Start

--- a/adk-session/README.md
+++ b/adk-session/README.md
@@ -24,14 +24,14 @@ Session management and state persistence for Rust Agent Development Kit (ADK-Rus
 
 ```toml
 [dependencies]
-adk-session = "2.1.0"
+adk-session = "2.2.0"
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "2.1.0", features = ["sessions"] }
+adk-rust = { version = "2.2.0", features = ["sessions"] }
 ```
 
 ## Quick Start
@@ -80,19 +80,19 @@ let name = session.state().get("user:name");
 
 ```toml
 # SQLite
-adk-session = { version = "2.1.0", features = ["sqlite"] }
+adk-session = { version = "2.2.0", features = ["sqlite"] }
 
 # PostgreSQL
-adk-session = { version = "2.1.0", features = ["postgres"] }
+adk-session = { version = "2.2.0", features = ["postgres"] }
 
 # Redis
-adk-session = { version = "2.1.0", features = ["redis"] }
+adk-session = { version = "2.2.0", features = ["redis"] }
 
 # Encrypted sessions
-adk-session = { version = "2.1.0", features = ["encrypted-session"] }
+adk-session = { version = "2.2.0", features = ["encrypted-session"] }
 
 # Vertex AI sessions through the umbrella crate
-adk-rust = { version = "2.1.0", features = ["vertex-session"] }
+adk-rust = { version = "2.2.0", features = ["vertex-session"] }
 ```
 
 ## Vertex AI Sessions

--- a/adk-telemetry/README.md
+++ b/adk-telemetry/README.md
@@ -26,14 +26,14 @@ OpenTelemetry integration for Rust Agent Development Kit (ADK-Rust) agent observ
 
 ```toml
 [dependencies]
-adk-telemetry = "2.1.0"
+adk-telemetry = "2.2.0"
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "2.1.0", features = ["telemetry"] }
+adk-rust = { version = "2.2.0", features = ["telemetry"] }
 ```
 
 ## Quick Start
@@ -88,7 +88,7 @@ deploy. Enable the `sqlite` feature (`adk-rust` forwards it as
 `telemetry-sqlite`):
 
 ```toml
-adk-telemetry = { version = "2.1.0", features = ["sqlite"] }
+adk-telemetry = { version = "2.2.0", features = ["sqlite"] }
 ```
 
 ```rust
@@ -133,7 +133,7 @@ Logging-parseable JSON logs. `adk-rust` forwards it as `gcp-telemetry`,
 and the `gemini-agent-platform` meta-feature includes it:
 
 ```toml
-adk-telemetry = { version = "2.1.0", features = ["gcp"] }
+adk-telemetry = { version = "2.2.0", features = ["gcp"] }
 ```
 
 ```rust

--- a/adk-telemetry/src/span_exporter.rs
+++ b/adk-telemetry/src/span_exporter.rs
@@ -76,7 +76,7 @@ impl AdkSpanExporter {
         let trace_dict = self.trace_dict.read().unwrap_or_else(|e| e.into_inner());
 
         let mut spans = Vec::new();
-        for (_event_id, attributes) in trace_dict.iter() {
+        for attributes in trace_dict.values() {
             // Check if this span belongs to the session
             if let Some(span_session_id) = attributes.get("gcp.vertex.agent.session_id")
                 && span_session_id == session_id

--- a/adk-tool/README.md
+++ b/adk-tool/README.md
@@ -32,20 +32,20 @@ Tool system for Rust Agent Development Kit (ADK-Rust) agents (FunctionTool, MCP,
 
 ```toml
 [dependencies]
-adk-tool = "2.1.0"
+adk-tool = "2.2.0"
 
 # For local MCP servers via stdio:
-adk-tool = { version = "2.1.0", features = ["mcp"] }
+adk-tool = { version = "2.2.0", features = ["mcp"] }
 
 # For remote MCP servers via HTTP:
-adk-tool = { version = "2.1.0", features = ["mcp", "http-transport"] }
+adk-tool = { version = "2.2.0", features = ["mcp", "http-transport"] }
 ```
 
 Or use the meta-crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "2.1.0", features = ["tools"] }
+adk-rust = { version = "2.2.0", features = ["tools"] }
 ```
 
 ## Quick Start

--- a/awp-types/README.md
+++ b/awp-types/README.md
@@ -78,7 +78,7 @@ Use `awp-types` when you need to:
 
 ```toml
 [dependencies]
-awp-types = "2.1.0"
+awp-types = "2.2.0"
 ```
 
 ```rust

--- a/cargo-adk/README.md
+++ b/cargo-adk/README.md
@@ -247,7 +247,7 @@ Current version: **1.0.0**
 
 ```toml
 [dependencies]
-cargo-adk = "2.1.0"
+cargo-adk = "2.2.0"
 ```
 
 ## Part of ADK-Rust

--- a/docs/official_docs/acp/client.md
+++ b/docs/official_docs/acp/client.md
@@ -9,7 +9,7 @@ offered to the coding agent.
 
 ```toml
 [dependencies]
-adk-acp = "2.1.0"
+adk-acp = "2.2.0"
 ```
 
 The default feature set is the client implementation. The `server` feature is

--- a/docs/official_docs/acp/server.md
+++ b/docs/official_docs/acp/server.md
@@ -10,7 +10,7 @@ ACP.
 
 ```toml
 [dependencies]
-adk-acp = { version = "2.1.0", features = ["server"] }
+adk-acp = { version = "2.2.0", features = ["server"] }
 ```
 
 ## Build and serve an agent

--- a/docs/official_docs/agents/ambient-agents.md
+++ b/docs/official_docs/agents/ambient-agents.md
@@ -90,7 +90,7 @@ Requires the `ambient` feature:
 
 ```toml
 [dependencies]
-adk-agent = { version = "2.1.0", features = ["ambient"] }
+adk-agent = { version = "2.2.0", features = ["ambient"] }
 ```
 
 ## Event sources

--- a/docs/official_docs/agents/code-agent.md
+++ b/docs/official_docs/agents/code-agent.md
@@ -181,15 +181,15 @@ kernel, which pins the `monty` crates in one place; rustc 1.95+ is required.
 
 ```toml
 [dependencies]
-adk-agent = { version = "2.1.0", features = ["codeact"] }
-adk-codeact-monty = "2.1.0"
+adk-agent = { version = "2.2.0", features = ["codeact"] }
+adk-codeact-monty = "2.2.0"
 ```
 
 Or through the umbrella crate (re-exported as `adk_rust::codeact_monty`):
 
 ```toml
 [dependencies]
-adk-rust = { version = "2.1.0", features = ["minimal", "codeact-monty"] }
+adk-rust = { version = "2.2.0", features = ["minimal", "codeact-monty"] }
 ```
 
 ```rust,ignore

--- a/docs/official_docs/agents/desktop-audio.md
+++ b/docs/official_docs/agents/desktop-audio.md
@@ -17,7 +17,7 @@ All components use the `cpal` crate for cross-platform audio (CoreAudio on macOS
 ```toml
 [dependencies]
 # Cross-platform (macOS, Linux, Windows) via cpal
-adk-audio = { version = "2.1.0", features = ["desktop-audio"] }
+adk-audio = { version = "2.2.0", features = ["desktop-audio"] }
 ```
 
 The `desktop-audio` feature implies `vad` (for `VadProcessor`) and adds `cpal` as a dependency. It is intentionally excluded from the `all` feature to avoid pulling platform-specific audio dependencies into CI builds.

--- a/docs/official_docs/agents/functional-api.md
+++ b/docs/official_docs/agents/functional-api.md
@@ -17,8 +17,8 @@ The Functional API (`functional` feature in `adk-graph`) provides a higher-level
 
 ```toml
 [dependencies]
-adk-graph = { version = "2.1.0", features = ["functional"] }
-adk-rust-macros = "2.1.0"
+adk-graph = { version = "2.2.0", features = ["functional"] }
+adk-rust-macros = "2.2.0"
 ```
 
 ## Core Types

--- a/docs/official_docs/agents/graph-agents.md
+++ b/docs/official_docs/agents/graph-agents.md
@@ -154,10 +154,10 @@ Add dependencies to `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-graph = { version = "2.1.0", features = ["sqlite"] }
-adk-agent = "2.1.0"
-adk-model = "2.1.0"
-adk-core = "2.1.0"
+adk-graph = { version = "2.2.0", features = ["sqlite"] }
+adk-agent = "2.2.0"
+adk-model = "2.2.0"
+adk-core = "2.2.0"
 tokio = { version = "1", features = ["full"] }
 dotenvy = "0.15"
 serde_json = "1.0"

--- a/docs/official_docs/agents/llm-agent.md
+++ b/docs/official_docs/agents/llm-agent.md
@@ -15,7 +15,7 @@ Add dependencies to `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-rust = "2.1.0"
+adk-rust = "2.2.0"
 tokio = { version = "1.40", features = ["full"] }
 dotenvy = "0.15"
 serde_json = "1.0"
@@ -297,7 +297,7 @@ Add dependencies to `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-rust = { version = "2.1.0", features = ["tools"] }
+adk-rust = { version = "2.2.0", features = ["tools"] }
 tokio = { version = "1.40", features = ["full"] }
 dotenvy = "0.15"
 serde_json = "1.0"

--- a/docs/official_docs/agents/multi-agent.md
+++ b/docs/official_docs/agents/multi-agent.md
@@ -187,7 +187,7 @@ Add dependencies to `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-rust = "2.1.0"
+adk-rust = "2.2.0"
 tokio = { version = "1", features = ["full"] }
 dotenvy = "0.15"
 ```

--- a/docs/official_docs/agents/realtime-agents.md
+++ b/docs/official_docs/agents/realtime-agents.md
@@ -44,16 +44,16 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-realtime = { version = "2.1.0", features = ["openai"] }
+adk-realtime = { version = "2.2.0", features = ["openai"] }
 
 # For Vertex AI Live (Google Cloud with ADC auth)
-# adk-realtime = { version = "2.1.0", features = ["vertex-live"] }
+# adk-realtime = { version = "2.2.0", features = ["vertex-live"] }
 
 # For LiveKit WebRTC bridge
-# adk-realtime = { version = "2.1.0", features = ["livekit"] }
+# adk-realtime = { version = "2.2.0", features = ["livekit"] }
 
 # For all transports (except WebRTC which needs cmake)
-# adk-realtime = { version = "2.1.0", features = ["full"] }
+# adk-realtime = { version = "2.2.0", features = ["full"] }
 ```
 
 ### Basic Usage

--- a/docs/official_docs/agents/workflow-agents.md
+++ b/docs/official_docs/agents/workflow-agents.md
@@ -15,7 +15,7 @@ Add dependencies to `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-rust = "2.1.0"
+adk-rust = "2.2.0"
 tokio = { version = "1.40", features = ["full"] }
 dotenvy = "0.15"
 ```

--- a/docs/official_docs/coding-agent/index.md
+++ b/docs/official_docs/coding-agent/index.md
@@ -35,11 +35,11 @@ This is assembled from a few focused pieces rather than a monolithic framework:
 
 ```toml
 # The harness (pulls in the dev tools) + a model provider
-adk-agent = { version = "2.1.0", features = ["coding"] }
-adk-devtools = "2.1.0"
-adk-model = { version = "2.1.0", features = ["gemini"] }
-adk-runner = "2.1.0"
-adk-session = "2.1.0"
+adk-agent = { version = "2.2.0", features = ["coding"] }
+adk-devtools = "2.2.0"
+adk-model = { version = "2.2.0", features = ["gemini"] }
+adk-runner = "2.2.0"
+adk-session = "2.2.0"
 ```
 
 The dev tools are sandbox-first and have no heavy dependencies, so the footprint

--- a/docs/official_docs/compliance/vertex-only-deployments.md
+++ b/docs/official_docs/compliance/vertex-only-deployments.md
@@ -28,14 +28,14 @@ Compile the Vertex backend in — without it, the flag cannot be honored:
 
 ```toml
 [dependencies]
-adk-rust = { version = "2.1.0", features = ["minimal", "gemini-vertex"] }
+adk-rust = { version = "2.2.0", features = ["minimal", "gemini-vertex"] }
 ```
 
 Or use the platform preset, which includes it:
 
 ```toml
 [dependencies]
-adk-rust = { version = "2.1.0", features = ["minimal", "gemini-agent-platform"] }
+adk-rust = { version = "2.2.0", features = ["minimal", "gemini-agent-platform"] }
 ```
 
 ### 2. Set the environment flags

--- a/docs/official_docs/core/plugins.md
+++ b/docs/official_docs/core/plugins.md
@@ -17,10 +17,10 @@ Plugins run in a priority-ordered pipeline, enabling composable middleware stack
 
 ```toml
 [dependencies]
-adk-plugin = "2.1.0"
+adk-plugin = "2.2.0"
 
 # Or via umbrella crate (included in standard tier)
-adk-rust = { version = "2.1.0", features = ["standard"] }
+adk-rust = { version = "2.2.0", features = ["standard"] }
 ```
 
 ## Quick Start

--- a/docs/official_docs/core/runner.md
+++ b/docs/official_docs/core/runner.md
@@ -47,7 +47,7 @@ sequenceDiagram
 
 ```toml
 [dependencies]
-adk-runner = "2.1.0"
+adk-runner = "2.2.0"
 ```
 
 ## RunnerConfig

--- a/docs/official_docs/deployment/agent-engine.md
+++ b/docs/official_docs/deployment/agent-engine.md
@@ -26,7 +26,7 @@ meta-feature):
 
 ```toml
 [dependencies]
-adk-rust = { version = "2.1.0", features = ["minimal", "agent-engine"] }
+adk-rust = { version = "2.2.0", features = ["minimal", "agent-engine"] }
 ```
 
 For an agent that uses the full platform — managed sessions, Memory Bank,
@@ -35,7 +35,7 @@ and Skill Registries — one feature brings every integration:
 
 ```toml
 [dependencies]
-adk-rust = { version = "2.1.0", features = ["minimal", "gemini-agent-platform"] }
+adk-rust = { version = "2.2.0", features = ["minimal", "gemini-agent-platform"] }
 ```
 
 `serve_agent_engine` is the whole `main` of a deployable engine. It binds

--- a/docs/official_docs/deployment/agent-registry.md
+++ b/docs/official_docs/deployment/agent-registry.md
@@ -78,7 +78,7 @@ See `examples/agent_orchestrator` for the full pattern — registry search plus 
 
 ```toml
 [dependencies]
-adk-rust = { version = "2.1.0", features = ["minimal", "gemini-agent-platform"] }
+adk-rust = { version = "2.2.0", features = ["minimal", "gemini-agent-platform"] }
 ```
 
 The `gemini-agent-platform` meta-feature includes `vertex-agent-registry` and `vertex-remote-engine` along with every other platform integration.

--- a/docs/official_docs/development/cargo-adk-build.md
+++ b/docs/official_docs/development/cargo-adk-build.md
@@ -114,7 +114,7 @@ error[E0432]: unresolved import `adk_tool`
 
 ```toml
 [dependencies]
-adk-tool = { version = "2.1.0", features = ["mcp"] }
+adk-tool = { version = "2.2.0", features = ["mcp"] }
 ```
 
 ### Invalid project structure

--- a/docs/official_docs/evaluation/vertex-eval.md
+++ b/docs/official_docs/evaluation/vertex-eval.md
@@ -10,7 +10,7 @@ computation-based trajectory metrics. Every call is a single POST to
 
 ```toml
 [dependencies]
-adk-eval = { version = "2.1.0", features = ["vertex-eval"] }
+adk-eval = { version = "2.2.0", features = ["vertex-eval"] }
 ```
 
 Authentication uses Application Default Credentials

--- a/docs/official_docs/introduction.md
+++ b/docs/official_docs/introduction.md
@@ -16,7 +16,7 @@ Or add it to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-rust = "2.1.0"
+adk-rust = "2.2.0"
 tokio = { version = "1.40", features = ["full"] }
 ```
 
@@ -190,22 +190,22 @@ ADK-Rust uses Cargo features for modularity. Four presets control which crates a
 
 ```toml
 # Minimal (default) — Gemini, agents, runner, sessions
-adk-rust = "2.1.0"
+adk-rust = "2.2.0"
 
 # Standard — adds tools, memory, telemetry, server, auth, graph, eval, guardrail, plugins, artifacts, skills
-adk-rust = { version = "2.1.0", features = ["standard"] }
+adk-rust = { version = "2.2.0", features = ["standard"] }
 
 # Enterprise — standard + realtime, browser, RAG, payments, AWP
-adk-rust = { version = "2.1.0", features = ["enterprise"] }
+adk-rust = { version = "2.2.0", features = ["enterprise"] }
 
 # Full — enterprise + audio, code execution, sandbox
-adk-rust = { version = "2.1.0", features = ["full"] }
+adk-rust = { version = "2.2.0", features = ["full"] }
 
 # Equivalent explicit minimal selection
-adk-rust = { version = "2.1.0", default-features = false, features = ["minimal"] }
+adk-rust = { version = "2.2.0", default-features = false, features = ["minimal"] }
 
 # Custom: Pick what you need
-adk-rust = { version = "2.1.0", default-features = false, features = ["agents", "gemini", "tools"] }
+adk-rust = { version = "2.2.0", default-features = false, features = ["agents", "gemini", "tools"] }
 ```
 
 Available features:

--- a/docs/official_docs/managed-agents/runtime.md
+++ b/docs/official_docs/managed-agents/runtime.md
@@ -23,15 +23,15 @@ Add the feature to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-rust = { version = "2.1.0", features = ["managed-runtime"] }
+adk-rust = { version = "2.2.0", features = ["managed-runtime"] }
 ```
 
 Or use the `adk-managed` crate directly:
 
 ```toml
 [dependencies]
-adk-managed = "2.1.0"
-adk-session = "2.1.0"
+adk-managed = "2.2.0"
+adk-session = "2.2.0"
 ```
 
 ### Minimal Example (ScriptedLlm — no API key)

--- a/docs/official_docs/mcp/client.md
+++ b/docs/official_docs/mcp/client.md
@@ -8,13 +8,13 @@ workflow.
 
 ```toml
 [dependencies]
-adk-tool = { version = "2.1.0", features = ["mcp"] }
+adk-tool = { version = "2.2.0", features = ["mcp"] }
 ```
 
 For remote Streamable HTTP:
 
 ```toml
-adk-tool = { version = "2.1.0", features = ["mcp", "http-transport"] }
+adk-tool = { version = "2.2.0", features = ["mcp", "http-transport"] }
 ```
 
 ## Local stdio connection

--- a/docs/official_docs/memory/index.md
+++ b/docs/official_docs/memory/index.md
@@ -56,10 +56,10 @@ transcript-style recall or a clean, queryable model of the user.
 
 ```toml
 # Semantic store — pick the backend you need
-adk-memory = { version = "2.1.0", features = ["sqlite-memory"] }
+adk-memory = { version = "2.2.0", features = ["sqlite-memory"] }
 
 # Bi-temporal knowledge graph
-adk-memory = { version = "2.1.0", features = ["graph-memory"] }
+adk-memory = { version = "2.2.0", features = ["graph-memory"] }
 ```
 
 | Feature | Adds |

--- a/docs/official_docs/migration/1.0-to-2.0.md
+++ b/docs/official_docs/migration/1.0-to-2.0.md
@@ -9,7 +9,7 @@ Update every `adk-*` dependency together — the crates are versioned in lockste
 
 ```toml
 [dependencies]
-adk-rust = { version = "2.1.0", features = ["standard"] }
+adk-rust = { version = "2.2.0", features = ["standard"] }
 ```
 
 ## Quick reference
@@ -281,7 +281,7 @@ Tier composition is unchanged (`minimal` → `standard` → `enterprise` → `fu
 OTLP telemetry export remains a separate opt-in:
 
 ```toml
-adk-rust = { version = "2.1.0", features = ["standard", "telemetry-otlp"] }
+adk-rust = { version = "2.2.0", features = ["standard", "telemetry-otlp"] }
 ```
 
 ## Verifying your upgrade

--- a/docs/official_docs/models/gemini-interactions.md
+++ b/docs/official_docs/models/gemini-interactions.md
@@ -51,11 +51,11 @@ The ADK agent runtime (the `Llm` trait, tool loop, and `Runner`) uses `generateC
 
 ```toml
 # Direct client (adk-gemini)
-adk-gemini = { version = "2.1.0", features = ["interactions"] }
+adk-gemini = { version = "2.2.0", features = ["interactions"] }
 
 # Through the model facade / umbrella
-adk-model = { version = "2.1.0", features = ["gemini-interactions"] }
-adk-rust  = { version = "2.1.0", features = ["gemini-interactions"] }
+adk-model = { version = "2.2.0", features = ["gemini-interactions"] }
+adk-rust  = { version = "2.2.0", features = ["gemini-interactions"] }
 ```
 
 The feature adds **no new dependencies** and is fully additive to the existing `generateContent` API.
@@ -222,8 +222,8 @@ The transport is gated behind the `gemini-interactions` feature (forwarded from
 `adk-rust` → `adk-model` → `adk-gemini/interactions`):
 
 ```toml
-adk-model = { version = "2.1.0", features = ["gemini-interactions"] }
-adk-rust  = { version = "2.1.0", features = ["gemini-interactions"] }
+adk-model = { version = "2.2.0", features = ["gemini-interactions"] }
+adk-rust  = { version = "2.2.0", features = ["gemini-interactions"] }
 ```
 
 Flip the switch on the model and wrap it in a normal `LlmAgent` and `Runner` —

--- a/docs/official_docs/models/mistralrs.md
+++ b/docs/official_docs/models/mistralrs.md
@@ -31,9 +31,9 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-adk-mistralrs = "2.1.0"
-adk-agent = "2.1.0"
-adk-rust = "2.1.0"
+adk-mistralrs = "2.2.0"
+adk-agent = "2.2.0"
+adk-rust = "2.2.0"
 tokio = { version = "1", features = ["full"] }
 anyhow = "1.0"
 ```
@@ -42,10 +42,10 @@ For hardware acceleration, add feature flags:
 
 ```toml
 # macOS with Apple Silicon
-adk-mistralrs = { version = "2.1.0", features = ["metal"] }
+adk-mistralrs = { version = "2.2.0", features = ["metal"] }
 
 # NVIDIA GPU (requires CUDA toolkit)
-adk-mistralrs = { version = "2.1.0", features = ["cuda"] }
+adk-mistralrs = { version = "2.2.0", features = ["cuda"] }
 ```
 
 ---
@@ -282,7 +282,7 @@ ModelSource::gguf("/path/to/model.Q4_K_M.gguf")
 ### macOS (Apple Silicon)
 
 ```toml
-adk-mistralrs = { version = "2.1.0", features = ["metal"] }
+adk-mistralrs = { version = "2.2.0", features = ["metal"] }
 ```
 
 Metal acceleration is automatic on M1/M2/M3 Macs.
@@ -290,7 +290,7 @@ Metal acceleration is automatic on M1/M2/M3 Macs.
 ### NVIDIA GPU
 
 ```toml
-adk-mistralrs = { version = "2.1.0", features = ["cuda"] }
+adk-mistralrs = { version = "2.2.0", features = ["cuda"] }
 ```
 
 Requires CUDA toolkit 11.8+.

--- a/docs/official_docs/models/ollama.md
+++ b/docs/official_docs/models/ollama.md
@@ -98,7 +98,7 @@ ollama pull codellama:13b     # Code generation
 
 ```toml
 [dependencies]
-adk-model = { version = "2.1.0", features = ["ollama"] }
+adk-model = { version = "2.2.0", features = ["ollama"] }
 ```
 
 ---
@@ -158,7 +158,7 @@ async fn main() -> anyhow::Result<()> {
 
 ```toml
 [dependencies]
-adk-rust = { version = "2.1.0", features = ["ollama"] }
+adk-rust = { version = "2.2.0", features = ["ollama"] }
 tokio = { version = "1", features = ["full"] }
 dotenvy = "0.15"
 anyhow = "1.0"

--- a/docs/official_docs/models/openai-responses.md
+++ b/docs/official_docs/models/openai-responses.md
@@ -53,15 +53,15 @@ Use `OpenAIResponsesClient` when you need reasoning models with summaries, built
 
 ```toml
 [dependencies]
-adk-rust = { version = "2.1.0", features = ["openai"] }
-adk-tool = "2.1.0"
+adk-rust = { version = "2.2.0", features = ["openai"] }
+adk-tool = "2.2.0"
 ```
 
 Or with `adk-model` directly:
 
 ```toml
 [dependencies]
-adk-model = { version = "2.1.0", features = ["openai"] }
+adk-model = { version = "2.2.0", features = ["openai"] }
 ```
 
 Set your API key:

--- a/docs/official_docs/models/providers.md
+++ b/docs/official_docs/models/providers.md
@@ -41,14 +41,14 @@ Add the providers you need to your `Cargo.toml`:
 ```toml
 [dependencies]
 # Pick one or more providers:
-adk-model = { version = "2.1.0", features = ["gemini"] }        # Google Gemini (default)
-adk-model = { version = "2.1.0", features = ["openai"] }        # OpenAI GPT-5
-adk-model = { version = "2.1.0", features = ["anthropic"] }     # Anthropic Claude
-adk-model = { version = "2.1.0", features = ["deepseek"] }      # DeepSeek
-adk-model = { version = "2.1.0", features = ["groq"] }          # Groq (ultra-fast)
+adk-model = { version = "2.2.0", features = ["gemini"] }        # Google Gemini (default)
+adk-model = { version = "2.2.0", features = ["openai"] }        # OpenAI GPT-5
+adk-model = { version = "2.2.0", features = ["anthropic"] }     # Anthropic Claude
+adk-model = { version = "2.2.0", features = ["deepseek"] }      # DeepSeek
+adk-model = { version = "2.2.0", features = ["groq"] }          # Groq (ultra-fast)
 
 # Or all cloud providers at once:
-adk-model = { version = "2.1.0", features = ["all-providers"] }
+adk-model = { version = "2.2.0", features = ["all-providers"] }
 ```
 
 ## Step 2: Set Your API Key

--- a/docs/official_docs/observability/gcp.md
+++ b/docs/official_docs/observability/gcp.md
@@ -6,14 +6,14 @@ The `gcp` feature of `adk-telemetry` exports traces directly to Google Cloud Obs
 
 ```toml
 [dependencies]
-adk-telemetry = { version = "2.1.0", features = ["gcp"] }
+adk-telemetry = { version = "2.2.0", features = ["gcp"] }
 ```
 
 Or through the umbrella crate (`gcp-telemetry` is also part of the `gemini-agent-platform` meta-feature):
 
 ```toml
 [dependencies]
-adk-rust = { version = "2.1.0", features = ["minimal", "gcp-telemetry"] }
+adk-rust = { version = "2.2.0", features = ["minimal", "gcp-telemetry"] }
 ```
 
 ## Direct Export to Google Cloud

--- a/docs/official_docs/quickstart-a2ui.md
+++ b/docs/official_docs/quickstart-a2ui.md
@@ -7,8 +7,8 @@ This guide shows how to emit A2UI JSONL from an ADK agent and render it with the
 ```toml
 [dependencies]
 adk-ui = { git = "https://github.com/zavora-ai/adk-ui" }
-adk-agent = "2.1.0"
-adk-model = "2.1.0"
+adk-agent = "2.2.0"
+adk-model = "2.2.0"
 ```
 
 React renderer:

--- a/docs/official_docs/quickstart.md
+++ b/docs/official_docs/quickstart.md
@@ -191,7 +191,7 @@ The fastest way to add tools is the `#[tool]` macro. Add `adk-tool` to your depe
 
 ```toml
 [dependencies]
-adk-tool = "2.1.0"
+adk-tool = "2.2.0"
 schemars = "1"
 serde = { version = "1", features = ["derive"] }
 ```
@@ -265,7 +265,7 @@ Enable providers via feature flags. The default build stays Gemini-only for fast
 
 ```toml
 [dependencies]
-adk-rust = { version = "2.1.0", features = ["openai"] }
+adk-rust = { version = "2.2.0", features = ["openai"] }
 ```
 
 Or scaffold with a provider: `cargo adk new my-agent --provider openai`

--- a/docs/official_docs/rag/agent-retrieval.md
+++ b/docs/official_docs/rag/agent-retrieval.md
@@ -4,7 +4,7 @@ Agent Retrieval (formerly Vector Search 2.0) is Google's managed vector database
 
 ```toml
 [dependencies]
-adk-rag = { version = "2.1.0", features = ["agent-retrieval"] }
+adk-rag = { version = "2.2.0", features = ["agent-retrieval"] }
 ```
 
 ## Quick start

--- a/docs/official_docs/rag/vertex-rag-engine.md
+++ b/docs/official_docs/rag/vertex-rag-engine.md
@@ -26,7 +26,7 @@ or the `RagCorpora`/`RagFiles` management APIs.
 
 ```toml
 [dependencies]
-adk-rag = { version = "2.1.0", features = ["vertex-rag"] }
+adk-rag = { version = "2.2.0", features = ["vertex-rag"] }
 ```
 
 Authentication uses Application Default Credentials:

--- a/docs/official_docs/realtime/index.md
+++ b/docs/official_docs/realtime/index.md
@@ -60,7 +60,7 @@ Live — documented there.)
 
 ```toml
 # Voice + tools + the integration layer (recommended)
-adk-realtime = { version = "2.1.0", features = ["openai", "gemini", "integration"] }
+adk-realtime = { version = "2.2.0", features = ["openai", "gemini", "integration"] }
 ```
 
 | Feature | Adds |

--- a/docs/official_docs/realtime/providers.md
+++ b/docs/official_docs/realtime/providers.md
@@ -139,7 +139,7 @@ To diagnose drift with the frame in hand, compile `adk-realtime` with the
 
 ```toml
 [dependencies]
-adk-realtime = { version = "2.1.0", features = ["openai", "record-payloads"] }
+adk-realtime = { version = "2.2.0", features = ["openai", "record-payloads"] }
 ```
 
 The feature is off by default and is a deliberate choice per build, because schema drift is

--- a/docs/official_docs/sandbox/index.md
+++ b/docs/official_docs/sandbox/index.md
@@ -93,11 +93,11 @@ let result = backend.execute(request).await?;
 ```toml
 [dependencies]
 # Auto-detect platform enforcer
-adk-sandbox = { version = "2.1.0", features = ["process", "sandbox-native"] }
+adk-sandbox = { version = "2.2.0", features = ["process", "sandbox-native"] }
 
 # Or pick a specific platform
-adk-sandbox = { version = "2.1.0", features = ["process", "sandbox-macos"] }
-adk-sandbox = { version = "2.1.0", features = ["process", "sandbox-linux"] }
+adk-sandbox = { version = "2.2.0", features = ["process", "sandbox-macos"] }
+adk-sandbox = { version = "2.2.0", features = ["process", "sandbox-linux"] }
 ```
 
 ### SandboxPolicy

--- a/docs/official_docs/security/access-control.md
+++ b/docs/official_docs/security/access-control.md
@@ -126,10 +126,10 @@ sso.check_token(token, &permission).await?;
 
 ```toml
 [dependencies]
-adk-auth = "2.1.0"
+adk-auth = "2.2.0"
 
 # For SSO/OAuth support
-adk-auth = { version = "2.1.0", features = ["sso"] }
+adk-auth = { version = "2.2.0", features = ["sso"] }
 ```
 
 ## Core Components

--- a/docs/official_docs/security/guardrails.md
+++ b/docs/official_docs/security/guardrails.md
@@ -15,10 +15,10 @@ Guardrails validate and transform agent inputs and outputs to ensure safety, com
 
 ```toml
 [dependencies]
-adk-guardrail = "2.1.0"
+adk-guardrail = "2.2.0"
 
 # For JSON schema validation
-adk-guardrail = { version = "2.1.0", features = ["schema"] }
+adk-guardrail = { version = "2.2.0", features = ["schema"] }
 ```
 
 ## Core Concepts

--- a/docs/official_docs/security/memory.md
+++ b/docs/official_docs/security/memory.md
@@ -10,7 +10,7 @@ The memory system provides persistent, searchable storage for agent conversation
 
 ```toml
 [dependencies]
-adk-memory = "2.1.0"
+adk-memory = "2.2.0"
 ```
 
 ## Core Concepts

--- a/docs/official_docs/sessions/sessions.md
+++ b/docs/official_docs/sessions/sessions.md
@@ -161,7 +161,7 @@ ADK-Rust provides multiple session service implementations:
 
 ```toml
 [dependencies]
-adk-rust = { version = "2.1.0", features = ["vertex-session"] }
+adk-rust = { version = "2.2.0", features = ["vertex-session"] }
 ```
 
 ### VertexAiSessionService
@@ -425,7 +425,7 @@ async fn main() -> anyhow::Result<()> {
 
 > **Note**: The `SqliteSessionService` requires the `sqlite` feature flag:
 > ```toml
-> adk-session = { version = "2.1.0", features = ["sqlite"] }
+> adk-session = { version = "2.2.0", features = ["sqlite"] }
 > ```
 
 ### PostgresSessionService
@@ -458,7 +458,7 @@ async fn main() -> anyhow::Result<()> {
 
 > **Note**: Requires the `postgres` feature flag:
 > ```toml
-> adk-session = { version = "2.1.0", features = ["postgres"] }
+> adk-session = { version = "2.2.0", features = ["postgres"] }
 > ```
 
 ### MongoSessionService
@@ -503,7 +503,7 @@ async fn main() -> anyhow::Result<()> {
 
 > **Note**: Requires the `mongodb` feature flag:
 > ```toml
-> adk-session = { version = "2.1.0", features = ["mongodb"] }
+> adk-session = { version = "2.2.0", features = ["mongodb"] }
 > ```
 
 #### MongoDB deployment modes
@@ -557,7 +557,7 @@ async fn main() -> anyhow::Result<()> {
 
 > **Note**: Requires the `neo4j` feature flag:
 > ```toml
-> adk-session = { version = "2.1.0", features = ["neo4j"] }
+> adk-session = { version = "2.2.0", features = ["neo4j"] }
 > ```
 
 ### RedisSessionService
@@ -573,7 +573,7 @@ let session_service = RedisSessionService::new(config).await?;
 
 > **Note**: Requires the `redis` feature flag:
 > ```toml
-> adk-session = { version = "2.1.0", features = ["redis"] }
+> adk-session = { version = "2.2.0", features = ["redis"] }
 > ```
 
 ## Schema Migrations
@@ -585,7 +585,7 @@ All database-backed session services (SQLite, PostgreSQL, MongoDB, Neo4j) includ
 Wrap any `SessionService` with `EncryptedSession` to encrypt session state at rest using AES-256-GCM. Requires the `encrypted-session` feature flag.
 
 ```toml
-adk-session = { version = "2.1.0", features = ["encrypted-session"] }
+adk-session = { version = "2.2.0", features = ["encrypted-session"] }
 ```
 
 #### Basic Usage

--- a/docs/official_docs/skills/skill-registry.md
+++ b/docs/official_docs/skills/skill-registry.md
@@ -17,7 +17,7 @@ Enable the feature on `adk-skill` (and on `adk-cli` for the commands):
 
 ```toml
 [dependencies]
-adk-skill = { version = "2.1.0", features = ["vertex-skill-registry"] }
+adk-skill = { version = "2.2.0", features = ["vertex-skill-registry"] }
 ```
 
 Authentication uses Application Default Credentials
@@ -111,7 +111,7 @@ The `adk-rust` binary gains two read-only subcommands behind the
 
 ```toml
 [dependencies]
-adk-cli = { version = "2.1.0", features = ["vertex-skill-registry"] }
+adk-cli = { version = "2.2.0", features = ["vertex-skill-registry"] }
 ```
 
 ```bash

--- a/docs/official_docs/studio/studio.md
+++ b/docs/official_docs/studio/studio.md
@@ -356,13 +356,13 @@ The generated `Cargo.toml` automatically includes the correct `adk-model` featur
 
 ```toml
 # Only Gemini
-adk-model = { version = "2.1.0", default-features = false, features = ["gemini"] }
+adk-model = { version = "2.2.0", default-features = false, features = ["gemini"] }
 
 # Mixed providers (e.g., Gemini + Anthropic)
-adk-model = { version = "2.1.0", default-features = false, features = ["gemini", "anthropic"] }
+adk-model = { version = "2.2.0", default-features = false, features = ["gemini", "anthropic"] }
 
 # Ollama only (no API key needed)
-adk-model = { version = "2.1.0", default-features = false, features = ["ollama"] }
+adk-model = { version = "2.2.0", default-features = false, features = ["ollama"] }
 ```
 
 ### Generated Code with Action Nodes

--- a/docs/official_docs/tools/action-nodes.md
+++ b/docs/official_docs/tools/action-nodes.md
@@ -15,10 +15,10 @@ Action nodes are the building blocks of visual and programmatic workflow graphs.
 
 ```toml
 [dependencies]
-adk-action = "2.1.0"
+adk-action = "2.2.0"
 
 # Or specific action features via umbrella crate
-adk-rust = { version = "2.1.0", features = ["action"] }
+adk-rust = { version = "2.2.0", features = ["action"] }
 ```
 
 ## Node Types (14)

--- a/docs/official_docs/tools/browser-tools.md
+++ b/docs/official_docs/tools/browser-tools.md
@@ -19,9 +19,9 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-adk-browser = "2.1.0"
-adk-agent = "2.1.0"
-adk-model = "2.1.0"
+adk-browser = "2.2.0"
+adk-agent = "2.2.0"
+adk-model = "2.2.0"
 ```
 
 ### Prerequisites

--- a/docs/official_docs/tools/mcp-tools.md
+++ b/docs/official_docs/tools/mcp-tools.md
@@ -63,13 +63,13 @@ Local stdio MCP support is opt-in:
 
 ```toml
 [dependencies]
-adk-tool = { version = "2.1.0", features = ["mcp"] }
+adk-tool = { version = "2.2.0", features = ["mcp"] }
 ```
 
 Add Streamable HTTP when connecting to remote services:
 
 ```toml
-adk-tool = { version = "2.1.0", features = ["mcp", "http-transport"] }
+adk-tool = { version = "2.2.0", features = ["mcp", "http-transport"] }
 ```
 
 Legacy sampling callbacks require the separate `mcp-sampling` feature. The MCP

--- a/docs/official_docs/tools/memory-tools.md
+++ b/docs/official_docs/tools/memory-tools.md
@@ -45,8 +45,8 @@ let agent = LlmAgentBuilder::new("assistant")
 
 ```toml
 [dependencies]
-adk-tool = { version = "2.1.0", features = ["memory-tools"] }
-adk-memory = "2.1.0"
+adk-tool = { version = "2.2.0", features = ["memory-tools"] }
+adk-memory = "2.2.0"
 ```
 
 ## LoadMemoryTool

--- a/docs/official_docs/tools/python-code-execution.md
+++ b/docs/official_docs/tools/python-code-execution.md
@@ -19,14 +19,14 @@ construction.
 
 ```toml
 [dependencies]
-adk-tool = { version = "2.1.0", features = ["code-embedded-python"] }
+adk-tool = { version = "2.2.0", features = ["code-embedded-python"] }
 ```
 
 Or through the umbrella crate:
 
 ```toml
 [dependencies]
-adk-rust = { version = "2.1.0", features = ["minimal", "code-embedded-python"] }
+adk-rust = { version = "2.2.0", features = ["minimal", "code-embedded-python"] }
 ```
 
 ## One-shot vs. REPL

--- a/docs/official_docs/tools/rag.md
+++ b/docs/official_docs/tools/rag.md
@@ -29,10 +29,10 @@ This means your agent can answer questions about product docs, company policies,
 ```toml
 [dependencies]
 # Core only (in-memory store, all chunkers, no external deps)
-adk-rag = "2.1.0"
+adk-rag = "2.2.0"
 
 # With Gemini embeddings (recommended for getting started)
-adk-rag = { version = "2.1.0", features = ["gemini"] }
+adk-rag = { version = "2.2.0", features = ["gemini"] }
 ```
 
 ---
@@ -353,13 +353,13 @@ Only pull the dependencies you need:
 
 ```toml
 # Just core
-adk-rag = "2.1.0"
+adk-rag = "2.2.0"
 
 # With Gemini embeddings
-adk-rag = { version = "2.1.0", features = ["gemini"] }
+adk-rag = { version = "2.2.0", features = ["gemini"] }
 
 # Everything
-adk-rag = { version = "2.1.0", features = ["full"] }
+adk-rag = { version = "2.2.0", features = ["full"] }
 ```
 
 > **Note:** The `lancedb` feature requires `protoc` installed. Install with `brew install protobuf` (macOS) or `apt install protobuf-compiler` (Ubuntu).

--- a/docs/official_docs/tools/retry-reflect.md
+++ b/docs/official_docs/tools/retry-reflect.md
@@ -16,10 +16,10 @@ When a tool call fails, the default behavior is to return the error to the LLM a
 
 ```toml
 [dependencies]
-adk-retry-reflect = "2.1.0"
+adk-retry-reflect = "2.2.0"
 
 # Or via umbrella crate (included in standard tier)
-adk-rust = { version = "2.1.0", features = ["standard"] }
+adk-rust = { version = "2.2.0", features = ["standard"] }
 ```
 
 ## Quick Start

--- a/docs/official_docs/tools/ui-tools.md
+++ b/docs/official_docs/tools/ui-tools.md
@@ -115,8 +115,8 @@ Add to your `Cargo.toml`:
 ```toml
 [dependencies]
 adk-ui = { git = "https://github.com/zavora-ai/adk-ui" }
-adk-agent = "2.1.0"
-adk-model = "2.1.0"
+adk-agent = "2.2.0"
+adk-model = "2.2.0"
 ```
 
 ### Basic Usage

--- a/examples/a2a-research-agent/Cargo.lock
+++ b/examples/a2a-research-agent/Cargo.lock
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -132,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "adk-server"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "a2a-protocol-types",
  "adk-agent",
@@ -197,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/a2a-writing-agent/Cargo.lock
+++ b/examples/a2a-writing-agent/Cargo.lock
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -59,7 +59,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "adk-server"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "a2a-protocol-types",
  "adk-agent",
@@ -199,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/a2a_interceptors/Cargo.lock
+++ b/examples/a2a_interceptors/Cargo.lock
@@ -23,7 +23,7 @@ dependencies = [
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -44,7 +44,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -145,7 +145,7 @@ dependencies = [
 
 [[package]]
 name = "adk-server"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-artifact",
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/a2a_quickstart/Cargo.lock
+++ b/examples/a2a_quickstart/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "adk-anthropic"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "adk-auth"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "adk-computer-use"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-auth",
  "adk-core",
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -129,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "adk-eval"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-model",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "adk-graph"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -190,7 +190,7 @@ dependencies = [
 
 [[package]]
 name = "adk-guardrail"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "adk-memory"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -217,7 +217,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-anthropic",
  "adk-core",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-anthropic",
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "adk-server"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "a2a-protocol-types",
  "adk-agent",
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -385,7 +385,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/acp_client_host/Cargo.lock
+++ b/examples/acp_client_host/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 
 [[package]]
 name = "adk-acp"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "agent-client-protocol",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/examples/acp_full_protocol/Cargo.lock
+++ b/examples/acp_full_protocol/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "adk-acp"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-runner",
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -97,7 +97,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -150,7 +150,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -175,7 +175,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/acp_kiro/Cargo.lock
+++ b/examples/acp_kiro/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
 
 [[package]]
 name = "adk-acp"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "agent-client-protocol",
@@ -32,7 +32,7 @@ dependencies = [
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-telemetry",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-session",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-core",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -161,7 +161,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/acp_server/Cargo.lock
+++ b/examples/acp_server/Cargo.lock
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "adk-acp"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-runner",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -151,7 +151,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -172,7 +172,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/action_nodes/Cargo.lock
+++ b/examples/action_nodes/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
 
 [[package]]
 name = "adk-action"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "regex",
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "adk-graph"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-action",
  "adk-core",

--- a/examples/advanced_agents/Cargo.lock
+++ b/examples/advanced_agents/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "adk-memory"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-telemetry",
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "adk-realtime"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-openai",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "adk-server"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-artifact",
@@ -190,7 +190,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -203,7 +203,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/agent_orchestrator/Cargo.lock
+++ b/examples/agent_orchestrator/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gcp"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "google-cloud-auth",
@@ -62,7 +62,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "adk-memory"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -129,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -150,7 +150,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "adk-server"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-artifact",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gcp",

--- a/examples/agent_registry/Cargo.lock
+++ b/examples/agent_registry/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "adk-server"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-artifact",
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/ambient_cron_agent/Cargo.lock
+++ b/examples/ambient_cron_agent/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-telemetry",
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/anthropic_server_tools/Cargo.lock
+++ b/examples/anthropic_server_tools/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "adk-anthropic"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "adk-auth"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "adk-computer-use"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-auth",
  "adk-core",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "adk-eval"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-model",
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "adk-graph"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "adk-guardrail"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "adk-memory"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-anthropic",
  "adk-core",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-anthropic",
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "adk-server"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "a2a-protocol-types",
  "adk-agent",
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/awp_agent/Cargo.lock
+++ b/examples/awp_agent/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adk-awp"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "arc-swap",
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -152,7 +152,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -314,7 +314,7 @@ dependencies = [
 
 [[package]]
 name = "awp-types"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "chrono",
  "serde",

--- a/examples/background_runs/Cargo.lock
+++ b/examples/background_runs/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "adk-server"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-artifact",
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/bedrock_test/Cargo.lock
+++ b/examples/bedrock_test/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-telemetry",
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -87,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-session",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-core",
@@ -123,7 +123,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -132,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -145,7 +145,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/bigquery_toolset/Cargo.lock
+++ b/examples/bigquery_toolset/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/codeact_agent/Cargo.lock
+++ b/examples/codeact_agent/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/codeact_monty_agent/Cargo.lock
+++ b/examples/codeact_monty_agent/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adk-code"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-sandbox",
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "adk-codeact-monty"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-code",
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -79,7 +79,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "adk-sandbox"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/coding_agent/Cargo.lock
+++ b/examples/coding_agent/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-devtools",
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "adk-devtools"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/coding_goal/Cargo.lock
+++ b/examples/coding_goal/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-devtools",
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "adk-devtools"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/coding_graph/Cargo.lock
+++ b/examples/coding_graph/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-devtools",
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "adk-devtools"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "adk-graph"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -145,7 +145,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -179,7 +179,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/competitive_ergonomics/Cargo.lock
+++ b/examples/competitive_ergonomics/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "adk-anthropic"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "adk-auth"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "adk-computer-use"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-auth",
  "adk-core",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "adk-eval"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-model",
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "adk-graph"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "adk-guardrail"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "adk-memory"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-anthropic",
  "adk-core",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-anthropic",
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "adk-server"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "a2a-protocol-types",
  "adk-agent",
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "aes-gcm",
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -378,7 +378,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/competitive_graph_resume/Cargo.lock
+++ b/examples/competitive_graph_resume/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "adk-graph"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",

--- a/examples/competitive_tool_search/Cargo.lock
+++ b/examples/competitive_tool_search/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-anthropic"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "base64",
  "bytes",
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-anthropic",
  "adk-core",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "adk-realtime"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/context_compaction/Cargo.lock
+++ b/examples/context_compaction/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/crate_adoption_feedback/Cargo.lock
+++ b/examples/crate_adoption_feedback/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-guardrail",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "adk-anthropic"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "adk-auth"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "adk-computer-use"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-auth",
  "adk-core",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "adk-eval"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-model",
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "adk-graph"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "adk-guardrail"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "adk-memory"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-anthropic",
  "adk-core",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -244,7 +244,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -265,7 +265,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-anthropic",
@@ -296,7 +296,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "adk-server"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "a2a-protocol-types",
  "adk-agent",
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -381,7 +381,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/cron_scheduling/Cargo.lock
+++ b/examples/cron_scheduling/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "adk-server"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-artifact",
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/customer_service/Cargo.lock
+++ b/examples/customer_service/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "adk-memory"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "adk-realtime"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",

--- a/examples/customer_service/README.md
+++ b/examples/customer_service/README.md
@@ -87,7 +87,7 @@ Then **Connect**, press **Start mic** and/or **Start camera**, and try:
 ## Feature flags
 
 ```toml
-adk-realtime = { version = "2.1.0", features = ["openai", "gemini", "integration"] }
+adk-realtime = { version = "2.2.0", features = ["openai", "gemini", "integration"] }
 ```
 
 > Multimodal video input is provided by `RealtimeSession::send_video_frame`

--- a/examples/deepseek_v4/Cargo.lock
+++ b/examples/deepseek_v4/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -174,7 +174,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/deferred_nodes/Cargo.lock
+++ b/examples/deferred_nodes/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "adk-graph"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/delta_checkpoints/Cargo.lock
+++ b/examples/delta_checkpoints/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "adk-graph"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -129,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/desktop_agent/Cargo.lock
+++ b/examples/desktop_agent/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/desktop_audio/Cargo.lock
+++ b/examples/desktop_audio/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adk-audio"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -99,7 +99,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",

--- a/examples/developer_ergonomics/Cargo.lock
+++ b/examples/developer_ergonomics/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "adk-anthropic"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "adk-auth"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "adk-computer-use"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-auth",
  "adk-core",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "adk-eval"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-model",
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "adk-graph"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "adk-guardrail"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "adk-memory"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-anthropic",
  "adk-core",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-anthropic",
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "adk-server"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "a2a-protocol-types",
  "adk-agent",
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/enterprise_custom_tool/Cargo.lock
+++ b/examples/enterprise_custom_tool/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-enterprise"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/examples/enterprise_hello/Cargo.lock
+++ b/examples/enterprise_hello/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-enterprise"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/examples/eval_showcase/Cargo.lock
+++ b/examples/eval_showcase/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "adk-eval"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-memory",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "adk-memory"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-telemetry",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-session",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/example_store/Cargo.lock
+++ b/examples/example_store/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gcp"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "google-cloud-auth",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gcp",

--- a/examples/functional_workflow/Cargo.lock
+++ b/examples/functional_workflow/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "adk-graph"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",

--- a/examples/gemini3_builtin_tools/Cargo.lock
+++ b/examples/gemini3_builtin_tools/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "adk-anthropic"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "adk-auth"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "adk-computer-use"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-auth",
  "adk-core",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "adk-eval"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-model",
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "adk-graph"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "adk-guardrail"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "adk-memory"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-anthropic",
  "adk-core",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-anthropic",
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "adk-server"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "a2a-protocol-types",
  "adk-agent",
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/gemini_audio/Cargo.lock
+++ b/examples/gemini_audio/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "adk-anthropic"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "adk-audio"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -87,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "adk-auth"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "adk-computer-use"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-auth",
  "adk-core",
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "adk-eval"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-model",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "adk-graph"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "adk-guardrail"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -217,7 +217,7 @@ dependencies = [
 
 [[package]]
 name = "adk-memory"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -229,7 +229,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-anthropic",
  "adk-core",
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -285,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-anthropic",
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -325,7 +325,7 @@ dependencies = [
 
 [[package]]
 name = "adk-server"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "a2a-protocol-types",
  "adk-agent",
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -372,7 +372,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/gemini_interactions_agent/Cargo.lock
+++ b/examples/gemini_interactions_agent/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/gemini_managed_agents/Cargo.lock
+++ b/examples/gemini_managed_agents/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",

--- a/examples/gemini_search_bug/Cargo.lock
+++ b/examples/gemini_search_bug/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -79,7 +79,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -129,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -151,7 +151,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/graph_goto_routing/Cargo.lock
+++ b/examples/graph_goto_routing/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "adk-graph"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/graph_parity_openai/Cargo.lock
+++ b/examples/graph_parity_openai/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "adk-graph"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -152,7 +152,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/graph_resilient_research/Cargo.lock
+++ b/examples/graph_resilient_research/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "adk-graph"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -161,7 +161,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -177,7 +177,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/graph_subgraph_claims/Cargo.lock
+++ b/examples/graph_subgraph_claims/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "adk-graph"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/harness_pattern/Cargo.lock
+++ b/examples/harness_pattern/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/intra_compaction/Cargo.lock
+++ b/examples/intra_compaction/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/knowledge_graph_agent/Cargo.lock
+++ b/examples/knowledge_graph_agent/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "adk-memory"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -161,7 +161,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -177,7 +177,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-memory",

--- a/examples/knowledge_graph_agent/README.md
+++ b/examples/knowledge_graph_agent/README.md
@@ -91,6 +91,6 @@ have the agent remember the user across process restarts.
 ## Feature flags
 
 ```toml
-adk-memory = { version = "2.1.0", features = ["graph-memory"] }
-adk-tool   = { version = "2.1.0", features = ["graph-memory-tools"] }
+adk-memory = { version = "2.2.0", features = ["graph-memory"] }
+adk-tool   = { version = "2.2.0", features = ["graph-memory-tools"] }
 ```

--- a/examples/managed_agents_custom_tools/Cargo.lock
+++ b/examples/managed_agents_custom_tools/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-anthropic"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "base64",
  "bytes",

--- a/examples/managed_agents_files/Cargo.lock
+++ b/examples/managed_agents_files/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-anthropic"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "base64",
  "bytes",

--- a/examples/managed_agents_hello/Cargo.lock
+++ b/examples/managed_agents_hello/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-anthropic"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "base64",
  "bytes",

--- a/examples/managed_agents_memory/Cargo.lock
+++ b/examples/managed_agents_memory/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-anthropic"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "base64",
  "bytes",

--- a/examples/managed_agents_multiagent/Cargo.lock
+++ b/examples/managed_agents_multiagent/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-anthropic"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "base64",
  "bytes",

--- a/examples/managed_runtime_hello/Cargo.lock
+++ b/examples/managed_runtime_hello/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-telemetry",
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "adk-managed"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-core",
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-telemetry",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-session",
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/mcp_elicitation/Cargo.lock
+++ b/examples/mcp_elicitation/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-devtools",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "adk-anthropic"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "adk-auth"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "adk-cli"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-artifact",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "adk-computer-use"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-auth",
  "adk-core",
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -152,7 +152,7 @@ dependencies = [
 
 [[package]]
 name = "adk-deploy"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "adk-devtools"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -190,7 +190,7 @@ dependencies = [
 
 [[package]]
 name = "adk-eval"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-model",
@@ -208,7 +208,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "adk-graph"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "adk-guardrail"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -266,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "adk-memory"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-anthropic",
  "adk-core",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -334,7 +334,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-anthropic",
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "adk-server"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "a2a-protocol-types",
  "adk-agent",
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -437,7 +437,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -446,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/mcp_manager/Cargo.lock
+++ b/examples/mcp_manager/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/mcp_protocol_revisions/Cargo.lock
+++ b/examples/mcp_protocol_revisions/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/mcp_resources/Cargo.lock
+++ b/examples/mcp_resources/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-devtools",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "adk-anthropic"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "adk-auth"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "adk-cli"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-artifact",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "adk-computer-use"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-auth",
  "adk-core",
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -152,7 +152,7 @@ dependencies = [
 
 [[package]]
 name = "adk-deploy"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "adk-devtools"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -190,7 +190,7 @@ dependencies = [
 
 [[package]]
 name = "adk-eval"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-model",
@@ -208,7 +208,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "adk-graph"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "adk-guardrail"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -266,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "adk-memory"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-anthropic",
  "adk-core",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -334,7 +334,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-anthropic",
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "adk-server"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "a2a-protocol-types",
  "adk-agent",
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -437,7 +437,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -446,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/mcp_sampling/Cargo.lock
+++ b/examples/mcp_sampling/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-devtools",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "adk-anthropic"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "adk-auth"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "adk-cli"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-artifact",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "adk-computer-use"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-auth",
  "adk-core",
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -152,7 +152,7 @@ dependencies = [
 
 [[package]]
 name = "adk-deploy"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "adk-devtools"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -190,7 +190,7 @@ dependencies = [
 
 [[package]]
 name = "adk-eval"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-model",
@@ -208,7 +208,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "adk-graph"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "adk-guardrail"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -266,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "adk-memory"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-anthropic",
  "adk-core",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -334,7 +334,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-anthropic",
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "adk-server"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "a2a-protocol-types",
  "adk-agent",
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -437,7 +437,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -446,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/monty_python_code_tool/Cargo.lock
+++ b/examples/monty_python_code_tool/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adk-code"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-sandbox",
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -145,7 +145,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "adk-sandbox"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -170,7 +170,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -199,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -208,7 +208,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-code",
  "adk-core",

--- a/examples/multi_perspective_analysis/Cargo.lock
+++ b/examples/multi_perspective_analysis/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "adk-anthropic"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "adk-auth"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "adk-computer-use"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-auth",
  "adk-core",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "adk-eval"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-model",
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "adk-graph"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "adk-guardrail"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "adk-memory"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-anthropic",
  "adk-core",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-anthropic",
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "adk-server"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "a2a-protocol-types",
  "adk-agent",
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/multimodal_function_response/Cargo.lock
+++ b/examples/multimodal_function_response/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "adk-anthropic"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "adk-auth"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "adk-computer-use"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-auth",
  "adk-core",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "adk-eval"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-model",
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "adk-graph"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "adk-guardrail"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "adk-memory"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-anthropic",
  "adk-core",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-anthropic",
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "adk-server"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "a2a-protocol-types",
  "adk-agent",
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/node_caching/Cargo.lock
+++ b/examples/node_caching/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "adk-graph"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -129,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/node_timeouts/Cargo.lock
+++ b/examples/node_timeouts/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "adk-graph"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/ollama_qwen/Cargo.lock
+++ b/examples/ollama_qwen/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "adk-anthropic"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "adk-auth"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "adk-computer-use"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-auth",
  "adk-core",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "adk-eval"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-model",
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "adk-graph"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "adk-guardrail"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "adk-memory"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-anthropic",
  "adk-core",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -244,7 +244,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -265,7 +265,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-anthropic",
@@ -296,7 +296,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "adk-server"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "a2a-protocol-types",
  "adk-agent",
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/openai_background/Cargo.lock
+++ b/examples/openai_background/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-telemetry",
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-session",
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-core",
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/openai_builtin_tools/Cargo.lock
+++ b/examples/openai_builtin_tools/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-telemetry",
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-session",
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-core",
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/openai_conversations/Cargo.lock
+++ b/examples/openai_conversations/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-telemetry",
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-session",
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-core",
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/openai_deep_research/Cargo.lock
+++ b/examples/openai_deep_research/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-telemetry",
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-session",
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-core",
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/openai_open_responses/Cargo.lock
+++ b/examples/openai_open_responses/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-telemetry",
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-session",
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-core",
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/openai_responses/Cargo.lock
+++ b/examples/openai_responses/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-telemetry",
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-session",
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-core",
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/openai_server_tools/Cargo.lock
+++ b/examples/openai_server_tools/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "adk-anthropic"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "adk-auth"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "adk-computer-use"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-auth",
  "adk-core",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "adk-eval"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-model",
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "adk-graph"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "adk-guardrail"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "adk-memory"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-anthropic",
  "adk-core",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-anthropic",
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "adk-server"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "a2a-protocol-types",
  "adk-agent",
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/openai_vision_detail/Cargo.lock
+++ b/examples/openai_vision_detail/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/openai_ws_minimal/Cargo.lock
+++ b/examples/openai_ws_minimal/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-telemetry",
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-session",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-core",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/openrouter/Cargo.lock
+++ b/examples/openrouter/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-telemetry",
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-session",
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-core",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -152,7 +152,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/output_schema_agent/Cargo.lock
+++ b/examples/output_schema_agent/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/parallel_shared_state/Cargo.lock
+++ b/examples/parallel_shared_state/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/payments/Cargo.lock
+++ b/examples/payments/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "adk-auth"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "adk-guardrail"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "adk-memory"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "adk-payments"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-auth",
@@ -97,7 +97,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",

--- a/examples/plugin_system/Cargo.lock
+++ b/examples/plugin_system/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -174,7 +174,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/project_scoped_memory/Cargo.lock
+++ b/examples/project_scoped_memory/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "adk-memory"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",

--- a/examples/prompt_optimizer/Cargo.lock
+++ b/examples/prompt_optimizer/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "adk-eval"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-model",
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-session",
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/realtime_tools/Cargo.lock
+++ b/examples/realtime_tools/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "adk-memory"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "adk-realtime"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-memory",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",

--- a/examples/realtime_voice/Cargo.lock
+++ b/examples/realtime_voice/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "adk-memory"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "adk-realtime"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -99,7 +99,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-memory",

--- a/examples/realtime_voice/README.md
+++ b/examples/realtime_voice/README.md
@@ -155,7 +155,7 @@ cargo run --manifest-path examples/realtime_voice/Cargo.toml -- probe gemini
 ## Feature Flags
 
 ```toml
-adk-realtime = { version = "2.1.0", features = ["openai", "gemini", "integration"] }
-adk-memory   = { version = "2.1.0", features = ["graph-memory"] }
-adk-tool     = { version = "2.1.0", features = ["graph-memory-tools"] }
+adk-realtime = { version = "2.2.0", features = ["openai", "gemini", "integration"] }
+adk-memory   = { version = "2.2.0", features = ["graph-memory"] }
+adk-tool     = { version = "2.2.0", features = ["graph-memory-tools"] }
 ```

--- a/examples/retry_reflect/Cargo.lock
+++ b/examples/retry_reflect/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "adk-retry-reflect"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/runtime_ui_showcase/Cargo.lock
+++ b/examples/runtime_ui_showcase/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "adk-graph"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "adk-server"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-artifact",
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -229,7 +229,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/sandbox_agent/Cargo.lock
+++ b/examples/sandbox_agent/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "adk-sandbox"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -152,7 +152,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -190,7 +190,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/sandbox_workspace_agent/Cargo.lock
+++ b/examples/sandbox_workspace_agent/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "adk-sandbox"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/schema_normalization/Cargo.lock
+++ b/examples/schema_normalization/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-anthropic"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "base64",
  "bytes",
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-anthropic",
  "adk-core",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/secret_provider/Cargo.lock
+++ b/examples/secret_provider/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "adk-auth"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/server_builder/Cargo.lock
+++ b/examples/server_builder/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "adk-server"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-artifact",
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/skill_memory_improvements/Cargo.lock
+++ b/examples/skill_memory_improvements/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "adk-memory"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -151,7 +151,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/skills_multilingual/Cargo.lock
+++ b/examples/skills_multilingual/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-telemetry",
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-session",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-core",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/slack_toolset/Cargo.lock
+++ b/examples/slack_toolset/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/spanner_toolset/Cargo.lock
+++ b/examples/spanner_toolset/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/streaming_bash/Cargo.lock
+++ b/examples/streaming_bash/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "adk-devtools"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -172,7 +172,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/team_architectures/Cargo.lock
+++ b/examples/team_architectures/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -132,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "adk-server"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-artifact",
@@ -174,7 +174,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -203,7 +203,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/telemetry_sqlite_export/Cargo.lock
+++ b/examples/telemetry_sqlite_export/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "rusqlite",
  "serde_json",
@@ -175,7 +175,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",

--- a/examples/tier_examples/Cargo.lock
+++ b/examples/tier_examples/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "adk-anthropic"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "adk-audio"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -87,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "adk-auth"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "adk-awp"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "arc-swap",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "adk-browser"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -145,7 +145,7 @@ dependencies = [
 
 [[package]]
 name = "adk-code"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-sandbox",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "adk-computer-use"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-auth",
  "adk-core",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -197,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "adk-eval"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-model",
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "adk-graph"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -261,7 +261,7 @@ dependencies = [
 
 [[package]]
 name = "adk-guardrail"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "adk-memory"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -288,7 +288,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-anthropic",
  "adk-core",
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "adk-payments"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-auth",
@@ -333,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rag"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "adk-realtime"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-anthropic",
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "adk-sandbox"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "adk-server"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "a2a-protocol-types",
  "adk-agent",
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror 2.0.20",
  "tracing",
@@ -536,7 +536,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-code",
  "adk-core",
@@ -707,7 +707,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "awp-types"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "chrono",
  "serde",

--- a/examples/tier_examples/README.md
+++ b/examples/tier_examples/README.md
@@ -6,7 +6,7 @@ Validates that all README and quickstart code examples work across every feature
 
 ### Minimal (default — no features needed)
 
-These examples use `adk-rust = "2.1.0"` with **no explicit features**. The `minimal` default includes Gemini, agents, runner, sessions, and the lightweight launcher.
+These examples use `adk-rust = "2.2.0"` with **no explicit features**. The `minimal` default includes Gemini, agents, runner, sessions, and the lightweight launcher.
 
 | # | Example | What it validates | Source |
 |---|---------|-------------------|--------|
@@ -90,7 +90,7 @@ cargo run --bin 16-full-sandbox            # needs python3 and rustc
 
 ## Key Point
 
-All minimal/quickstart examples use `adk-rust = "2.1.0"` with **no explicit features** unless the example name is a provider opt-in. The `minimal` default includes the smallest useful agent stack: Gemini, agents, runner, sessions, and the lightweight launcher.
+All minimal/quickstart examples use `adk-rust = "2.2.0"` with **no explicit features** unless the example name is a provider opt-in. The `minimal` default includes the smallest useful agent stack: Gemini, agents, runner, sessions, and the lightweight launcher.
 
 Higher tiers add production and specialist capabilities:
 - **standard** → tools, memory, telemetry, server, auth, graph workflows, eval

--- a/examples/tier_examples/src/01_minimal_hello.rs
+++ b/examples/tier_examples/src/01_minimal_hello.rs
@@ -5,7 +5,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-rust = "2.1.0"
+//! adk-rust = "2.2.0"
 //! ```
 
 use adk_rust::run;

--- a/examples/tier_examples/src/02_minimal_launcher.rs
+++ b/examples/tier_examples/src/02_minimal_launcher.rs
@@ -5,7 +5,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-rust = "2.1.0"
+//! adk-rust = "2.2.0"
 //! ```
 
 use adk_rust::Launcher;

--- a/examples/tier_examples/src/03_minimal_openai.rs
+++ b/examples/tier_examples/src/03_minimal_openai.rs
@@ -5,7 +5,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-rust = { version = "2.1.0", features = ["openai"] }
+//! adk-rust = { version = "2.2.0", features = ["openai"] }
 //! ```
 
 use adk_rust::Launcher;

--- a/examples/tier_examples/src/04_minimal_anthropic.rs
+++ b/examples/tier_examples/src/04_minimal_anthropic.rs
@@ -5,7 +5,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-rust = { version = "2.1.0", features = ["anthropic"] }
+//! adk-rust = { version = "2.2.0", features = ["anthropic"] }
 //! ```
 
 use adk_rust::Launcher;

--- a/examples/tier_examples/src/05_minimal_tools.rs
+++ b/examples/tier_examples/src/05_minimal_tools.rs
@@ -5,8 +5,8 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-rust = "2.1.0"
-//! adk-tool = "2.1.0"
+//! adk-rust = "2.2.0"
+//! adk-tool = "2.2.0"
 //! ```
 
 use adk_rust::Launcher;

--- a/examples/tier_examples/src/06_minimal_multi_provider.rs
+++ b/examples/tier_examples/src/06_minimal_multi_provider.rs
@@ -5,7 +5,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-rust = "2.1.0"
+//! adk-rust = "2.2.0"
 //! ```
 
 use adk_rust::Launcher;

--- a/examples/tier_examples/src/07_minimal_memory.rs
+++ b/examples/tier_examples/src/07_minimal_memory.rs
@@ -5,7 +5,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-rust = "2.1.0"
+//! adk-rust = "2.2.0"
 //! ```
 
 use adk_rust::prelude::*;

--- a/examples/tier_examples/src/08_quickstart_scaffold.rs
+++ b/examples/tier_examples/src/08_quickstart_scaffold.rs
@@ -5,7 +5,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-rust = "2.1.0"
+//! adk-rust = "2.2.0"
 //! ```
 
 use adk_rust::Launcher;

--- a/examples/tier_examples/src/09_quickstart_tools.rs
+++ b/examples/tier_examples/src/09_quickstart_tools.rs
@@ -5,8 +5,8 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-rust = "2.1.0"
-//! adk-tool = "2.1.0"
+//! adk-rust = "2.2.0"
+//! adk-tool = "2.2.0"
 //! schemars = "1"
 //! serde = { version = "1", features = ["derive"] }
 //! ```

--- a/examples/tier_examples/src/10_quickstart_zero_config.rs
+++ b/examples/tier_examples/src/10_quickstart_zero_config.rs
@@ -5,7 +5,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-rust = "2.1.0"
+//! adk-rust = "2.2.0"
 //! ```
 
 use adk_rust::run;

--- a/examples/tier_examples/src/11_standard_graph.rs
+++ b/examples/tier_examples/src/11_standard_graph.rs
@@ -5,7 +5,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-rust = { version = "2.1.0", features = ["standard"] }
+//! adk-rust = { version = "2.2.0", features = ["standard"] }
 //! ```
 
 use adk_rust::graph::node::AgentNode;

--- a/examples/tier_examples/src/12_standard_sequential.rs
+++ b/examples/tier_examples/src/12_standard_sequential.rs
@@ -5,7 +5,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-rust = { version = "2.1.0", features = ["standard"] }
+//! adk-rust = { version = "2.2.0", features = ["standard"] }
 //! ```
 
 use adk_rust::prelude::*;

--- a/examples/tier_examples/src/13_standard_cli_launcher.rs
+++ b/examples/tier_examples/src/13_standard_cli_launcher.rs
@@ -7,7 +7,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-rust = { version = "2.1.0", features = ["standard"] }
+//! adk-rust = { version = "2.2.0", features = ["standard"] }
 //! ```
 
 use adk_rust::Launcher;

--- a/examples/tier_examples/src/14_enterprise_multi_agent.rs
+++ b/examples/tier_examples/src/14_enterprise_multi_agent.rs
@@ -6,7 +6,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-rust = { version = "2.1.0", features = ["enterprise"] }
+//! adk-rust = { version = "2.2.0", features = ["enterprise"] }
 //! ```
 
 use adk_rust::artifact::{ArtifactService, InMemoryArtifactService, SaveRequest};

--- a/examples/tier_examples/src/15_enterprise_parallel.rs
+++ b/examples/tier_examples/src/15_enterprise_parallel.rs
@@ -6,7 +6,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-rust = { version = "2.1.0", features = ["enterprise"] }
+//! adk-rust = { version = "2.2.0", features = ["enterprise"] }
 //! ```
 
 use adk_rust::prelude::*;

--- a/examples/tier_examples/src/16_full_sandbox.rs
+++ b/examples/tier_examples/src/16_full_sandbox.rs
@@ -5,7 +5,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! adk-rust = { version = "2.1.0", features = ["full"] }
+//! adk-rust = { version = "2.2.0", features = ["full"] }
 //! ```
 
 use adk_rust::sandbox::{ExecRequest, Language, ProcessBackend, ProcessConfig, SandboxBackend};

--- a/examples/time_travel/Cargo.lock
+++ b/examples/time_travel/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "adk-graph"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/tool_concurrency/Cargo.lock
+++ b/examples/tool_concurrency/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/tool_guardrails_openai/Cargo.lock
+++ b/examples/tool_guardrails_openai/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-guardrail",
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "adk-guardrail"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-telemetry",
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -99,7 +99,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/user_personas/Cargo.lock
+++ b/examples/user_personas/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "adk-eval"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-model",
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-session",
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/vertex_rag/Cargo.lock
+++ b/examples/vertex_rag/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gcp"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "google-cloud-auth",
@@ -62,7 +62,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rag"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gcp",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/examples/vertex_sandbox/Cargo.lock
+++ b/examples/vertex_sandbox/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-code"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gcp",
@@ -23,7 +23,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gcp"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "google-cloud-auth",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "adk-sandbox"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",

--- a/examples/video_avatar/Cargo.lock
+++ b/examples/video_avatar/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "adk-realtime"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",

--- a/examples/yaml_agent/Cargo.lock
+++ b/examples/yaml_agent/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adk-agent"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-skill",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "adk-artifact"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adk-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "adk-gemini"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-stream",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "adk-model"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-gemini",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "adk-plugin"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "serde_json",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "adk-runner"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-artifact",
  "adk-core",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "adk-rust-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "adk-server"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-agent",
  "adk-artifact",
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "adk-session"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "async-trait",
@@ -184,7 +184,7 @@ dependencies = [
 
 [[package]]
 name = "adk-skill"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-plugin",
@@ -200,7 +200,7 @@ dependencies = [
 
 [[package]]
 name = "adk-telemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "adk-tool"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "adk-core",
  "adk-rust-macros",


### PR DESCRIPTION
## What

Cuts 2.2.0: workspace version bump, `CHANGELOG.md` release heading, README banner and roadmap
marker, re-pinned standalone example lockfiles, and two dependency pins that unbreak feature
combinations the PR tier does not compile.

## Why

`main` carries 12 `feat` commits since `v2.1.0` — the Wave 4 Gemini Enterprise Agent Platform
consumption features and graph tool-confirmation pauses — so the release is a minor, not a patch.
Six new public feature flags on the umbrella crate alone.

Two feature combinations were failing in the nightly tier through dependency drift, in code paths
consumers reach through `adk-rust`'s `livekit` and ONNX audio features:

| Combination | Break | Fix |
|-------------|-------|-----|
| `adk-realtime --features livekit` | `livekit-data-stream` 0.1.2 changed `incoming::Manager::new`'s arity and added a `topic` field, so livekit 0.8.1's own source stops compiling | pin `=0.1.1` |
| `adk-audio --features all-onnx` | `ort` 2.0.0-rc.13 moved the CUDA and CoreML execution providers out of `ort::execution_providers` | pin `=2.0.0-rc.11` |

Both are external drift rather than regressions in this workspace: consumers of 2.1.0 hit them today
because they resolve fresh at install time.

## How

- `scripts/bump-version.sh 2.2.0` — 108 doc/source files, 291 snippets, plus `Cargo.toml`.
- `cargo metadata` per standalone example, which re-pins the `adk-*` path deps in 111 example
  lockfiles without touching registry deps.
- `livekit-data-stream` is declared on `adk-realtime` behind the `livekit` feature and unused
  directly — the declaration exists so the workspace pin constrains what livekit resolves for its
  own `"0.1"` requirement, for consumers and not merely in our lockfile.
- `adk-telemetry`'s span exporter uses `HashMap::values`, which clippy newer than the 1.95 pin
  requires. It was blocking the pre-commit hook on any toolchain ahead of the pin.

## Verification

Local, on the pinned 1.95.0 toolchain:

- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo nextest run --workspace` — 4505 passed, 88 skipped
- `cargo clippy -p adk-rust --features full --all-targets -- -D warnings` clean
- `cargo test -p adk-rust --features full --doc` — 11 passed
- `cargo check -p adk-realtime --features livekit` clean; `cargo clippy -p adk-audio --features whisper-onnx,chatterbox --all-targets -- -D warnings` clean
- `scripts/check-examples-compile.sh` — 112 checked, 0 failed
- `scripts/check-cargo-adk-templates.sh`, `check-publish-order.sh`, `check-doc-examples.sh`, `check-doc-versions.sh`, `check-release-consistency.sh` all OK

`adk-audio --features kokoro` remains unverified locally: `espeak-rs-sys` needs the espeak-ng
system library. The nightly `audio-all-onnx` job covers it.