### PR TITLE
fix(model): preserve usage-only streaming chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with a structured error, and grounding responses surface
   `retrievedContext` including `ragChunk` provenance.
 
+### Fixed
+
+- **OpenAI-compatible streaming usage** (`adk-model`): usage-only terminal
+  chunks with empty `choices` attach token counts to the final response.
+
 ## [2.1.0] - 2026-08-25
 
 ### Added

--- a/adk-model/src/openai_compatible.rs
+++ b/adk-model/src/openai_compatible.rs
@@ -482,7 +482,7 @@ fn parse_finish_reason(fr: &str) -> FinishReason {
 
 /// Parse usage metadata from a raw SSE chunk JSON value.
 fn parse_usage_from_chunk(chunk: &serde_json::Value) -> Option<UsageMetadata> {
-    let u = chunk.get("usage")?;
+    let u = chunk.get("usage")?.as_object()?;
     let prompt_tokens = u.get("prompt_tokens").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
     let completion_tokens = u.get("completion_tokens").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
     let total_tokens = u.get("total_tokens").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
@@ -595,6 +595,7 @@ impl Llm for OpenAICompatible {
                 let mut tool_call_accumulators: HashMap<u32, (String, String, String)> =
                     HashMap::new();
                 let mut text_tool_buffer = crate::tool_call_parser::ToolCallBuffer::new();
+                let mut pending_final_response: Option<LlmResponse> = None;
 
                 while let Some(chunk_result) = byte_stream.next().await {
                     let chunk = chunk_result.map_err(|e| {
@@ -608,7 +609,14 @@ impl Llm for OpenAICompatible {
                         let line = buffer[..line_end].trim().to_string();
                         buffer = buffer[line_end + 1..].to_string();
 
-                        if line.is_empty() || line == "data: [DONE]" {
+                        if line.is_empty() {
+                            continue;
+                        }
+
+                        if line == "data: [DONE]" {
+                            if let Some(response) = pending_final_response.take() {
+                                yield response;
+                            }
                             continue;
                         }
 
@@ -622,10 +630,19 @@ impl Llm for OpenAICompatible {
                                     continue;
                                 }
                             };
+                            let usage_metadata = parse_usage_from_chunk(&chunk_json);
 
                             let choice = match chunk_json.get("choices").and_then(|c| c.get(0)) {
                                 Some(c) => c,
-                                None => continue,
+                                None => {
+                                    if let Some(usage_metadata) = usage_metadata
+                                        && let Some(mut response) = pending_final_response.take()
+                                    {
+                                        response.usage_metadata = Some(usage_metadata);
+                                        yield response;
+                                    }
+                                    continue;
+                                }
                             };
                             let delta = match choice.get("delta") {
                                 Some(d) => d,
@@ -673,7 +690,6 @@ impl Llm for OpenAICompatible {
                             // Check for finish_reason → emit final response.
                             if let Some(ref fr) = finish_reason_str {
                                 let finish_reason = Some(parse_finish_reason(fr));
-                                let usage_metadata = parse_usage_from_chunk(&chunk_json);
 
                                 // Emit accumulated tool calls if any.
                                 if !tool_call_accumulators.is_empty() {
@@ -696,7 +712,7 @@ impl Llm for OpenAICompatible {
                                         })
                                         .collect();
 
-                                    yield LlmResponse {
+                                    let response = LlmResponse {
                                         content: Some(Content {
                                             role: "model".to_string(),
                                             parts,
@@ -714,6 +730,11 @@ impl Llm for OpenAICompatible {
                                         provider_metadata: None,
                                         interaction_id: None,
                                     };
+                                    if response.usage_metadata.is_some() {
+                                        yield response;
+                                    } else {
+                                        pending_final_response = Some(response);
+                                    }
                                     continue;
                                 }
 
@@ -724,7 +745,7 @@ impl Llm for OpenAICompatible {
                                         parts.push(Part::Text { text: text.to_string() });
                                     }
 
-                                yield LlmResponse {
+                                let response = LlmResponse {
                                     content: if parts.is_empty() { None } else {
                                         Some(Content {
                                             role: "model".to_string(),
@@ -742,6 +763,11 @@ impl Llm for OpenAICompatible {
                                     provider_metadata: None,
                                     interaction_id: None,
                                 };
+                                if response.usage_metadata.is_some() {
+                                    yield response;
+                                } else {
+                                    pending_final_response = Some(response);
+                                }
                                 continue;
                             }
 
@@ -807,6 +833,10 @@ impl Llm for OpenAICompatible {
                                 }
                         }
                     }
+                }
+
+                if let Some(response) = pending_final_response.take() {
+                    yield response;
                 }
 
                 // Flush any remaining buffered content from the tool call buffer

--- a/adk-model/tests/openai_streaming_exploration_tests.rs
+++ b/adk-model/tests/openai_streaming_exploration_tests.rs
@@ -102,7 +102,7 @@ mod streaming_exploration {
         let sse_body = [
             "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"Hello\"},\"finish_reason\":null}]}\n\n",
             "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\" world\"},\"finish_reason\":null}]}\n\n",
-            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":2,\"total_tokens\":7}}\n\n",
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":null}\n\n",
             "data: [DONE]\n\n",
         ]
         .join("");
@@ -153,6 +153,52 @@ mod streaming_exploration {
         let final_resp = responses.last().unwrap();
         assert!(!final_resp.partial, "final response should have partial=false");
         assert!(final_resp.turn_complete, "final response should have turn_complete=true");
+    }
+
+    #[tokio::test]
+    async fn usage_only_chunk_is_attached_to_the_terminal_response() {
+        let server = MockServer::start().await;
+
+        let sse_body = [
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"},\"finish_reason\":null}]}\n\n",
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":null}\n\n",
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[],\"usage\":{\"prompt_tokens\":11,\"completion_tokens\":5,\"total_tokens\":16}}\n\n",
+            "data: [DONE]\n\n",
+        ]
+        .join("");
+
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string(&sse_body)
+                    .insert_header("content-type", "text/event-stream"),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = make_client(&server.uri());
+        let mut stream = client
+            .generate_content(make_request(), true)
+            .await
+            .expect("generate_content should not error");
+        let mut responses = Vec::new();
+
+        while let Some(item) = stream.next().await {
+            responses.push(item.expect("stream should not yield an error"));
+        }
+
+        let terminal_responses: Vec<_> =
+            responses.iter().filter(|response| response.turn_complete).collect();
+        assert_eq!(terminal_responses.len(), 1);
+        let usage = terminal_responses[0]
+            .usage_metadata
+            .as_ref()
+            .expect("usage-only chunk should be attached to the terminal response");
+        assert_eq!(usage.prompt_token_count, 11);
+        assert_eq!(usage.candidates_token_count, 5);
+        assert_eq!(usage.total_token_count, 16);
     }
 
     // ── Test 3: reasoning_content chunks yield Part::Thinking ────────────
@@ -249,8 +295,9 @@ mod streaming_exploration {
             "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"city\\\"\"}}]},\"finish_reason\":null}]}\n\n",
             // Third chunk: tool call index 0, more argument fragment
             "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\": \\\"Paris\\\"}\"}}]},\"finish_reason\":null}]}\n\n",
-            // Finish chunk
-            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":15,\"total_tokens\":25}}\n\n",
+            // Finish chunk followed by the usage-only chunk required by the OpenAI stream contract.
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}],\"usage\":null}\n\n",
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":15,\"total_tokens\":25}}\n\n",
             "data: [DONE]\n\n",
         ]
         .join("");
@@ -316,6 +363,13 @@ mod streaming_exploration {
             "final response carrying tool calls must have turn_complete=false — the turn \
              continues until tool results are processed (issue #401)"
         );
+        let usage = final_resp
+            .usage_metadata
+            .as_ref()
+            .expect("usage-only chunk should be attached to the tool-call response");
+        assert_eq!(usage.prompt_token_count, 10);
+        assert_eq!(usage.candidates_token_count, 15);
+        assert_eq!(usage.total_token_count, 25);
     }
 
     /// Regression test for providers using "delta.reasoning" field instead of "delta.reasoning_content"


### PR DESCRIPTION
## What

Preserve token usage from OpenAI-compatible streaming responses when the provider sends usage in a final chunk with an empty `choices` array.

## Why

OpenAI-compatible providers commonly send a `finish_reason` chunk with `usage: null`, followed by a usage-only chunk. The current parser treats `null` as zero usage, emits the terminal response, and skips the later empty-choices chunk. Runners stop polling after the terminal response, so the reported token counts are lost.

No linked issue.

## How

- Treat `usage: null` as absent usage.
- Hold a terminal response without usage until the usage-only chunk or stream end.
- Attach usage to the same terminal response for text and tool-call turns.
- Preserve terminal responses when a provider omits usage.
- Add regression coverage matching the provider SSE sequence.

## PR Checklist

### Quality Gates

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib --tests --bins`
- [x] `cargo check --workspace`

### Code Quality

- [x] New behavior has integration tests.
- [x] No public API changes.
- [x] No `println!` or `eprintln!` added.
- [x] No secrets, API keys, or local paths added.

### Hygiene

- [x] No local development artifacts.
- [x] No unrelated changes.
- [x] Branch and commit follow repository conventions.
- [x] PR targets `main`.

### Documentation

- [x] `CHANGELOG.md` updated.
- [x] README and examples are unchanged because the public API is unchanged.