### PR TITLE
fix(openai): preserve compatible response, usage, and tool data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   also accepts compatible endpoints that omit output-message IDs, statuses, or
   empty `output_text.annotations`, and reconstructs final function arguments
   from their streaming events when the completed response omits them.
+- **OpenAI-compatible usage metadata** (`adk-model`): Chat Completions
+  streaming and non-streaming responses now use one normalization path,
+  preserve the complete provider-native `usage` object in `provider_usage`,
+  and project reported cache-write tokens alongside cache reads.
 
 ## [2.2.0] - 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   streaming and non-streaming responses now use one normalization path,
   preserve the complete provider-native `usage` object in `provider_usage`,
   and project reported cache-write tokens alongside cache reads.
+- **OpenAI tool request stability** (`adk-model`): Chat Completions and
+  Responses requests now serialize function tools in deterministic name order,
+  preserving identical cacheable prefixes across repeated executions.
 
 ## [2.2.0] - 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **OpenAI-compatible structured tool arguments** (`adk-model`): Chat
+  Completions streaming now preserves structured JSON `function.arguments`
+  emitted by compatible intermediaries, including repeated and empty snapshot
+  chunks, instead of converting the tool call to empty arguments.
+- **OpenAI Responses web search** (`adk-tool`): the stable built-in tool now
+  serializes as `web_search`, matching the OpenAI Responses API. The explicit
+  preview variant remains `web_search_preview_2025_03_11`. URL annotations from
+  response text are preserved as ADK citation metadata. Open Responses mode now
+  also accepts compatible endpoints that omit output-message IDs, statuses, or
+  empty `output_text.annotations`, and reconstructs final function arguments
+  from their streaming events when the completed response omits them.
+
 ## [2.2.0] - 2026-09-01
 
 ### Added

--- a/adk-core/src/model.rs
+++ b/adk-core/src/model.rs
@@ -254,7 +254,8 @@ pub struct UsageMetadata {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub is_byok: Option<bool>,
 
-    /// Provider-specific usage details (e.g., server tool use, video tokens).
+    /// Provider-native usage data retained when available, including fields
+    /// that are not yet projected into the normalized counters above.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub provider_usage: Option<serde_json::Value>,
 }

--- a/adk-core/src/tool.rs
+++ b/adk-core/src/tool.rs
@@ -32,7 +32,7 @@ pub trait Tool: Send + Sync {
     ///         "name": self.name(),
     ///         "description": self.description(),
     ///         "x-adk-openai-tool": {
-    ///             "type": "web_search_2025_08_26"
+    ///             "type": "web_search"
     ///         }
     ///     })
     /// }

--- a/adk-model/src/openai/convert.rs
+++ b/adk-model/src/openai/convert.rs
@@ -350,6 +350,36 @@ pub fn from_openai_response(resp: &CreateChatCompletionResponse) -> LlmResponse 
     }
 }
 
+/// Normalize one raw Chat Completions `usage` object while retaining the
+/// provider payload for diagnostics and future provider-specific projections.
+pub(crate) fn usage_metadata_from_raw(usage: &serde_json::Value) -> Option<UsageMetadata> {
+    let usage = usage.as_object()?;
+    let prompt_details = usage.get("prompt_tokens_details");
+    let completion_details = usage.get("completion_tokens_details");
+
+    Some(UsageMetadata {
+        prompt_token_count: json_i32(usage.get("prompt_tokens")).unwrap_or_default(),
+        candidates_token_count: json_i32(usage.get("completion_tokens")).unwrap_or_default(),
+        total_token_count: json_i32(usage.get("total_tokens")).unwrap_or_default(),
+        cache_read_input_token_count: prompt_details
+            .and_then(|details| json_i32(details.get("cached_tokens"))),
+        cache_creation_input_token_count: prompt_details
+            .and_then(|details| json_i32(details.get("cache_write_tokens"))),
+        thinking_token_count: completion_details
+            .and_then(|details| json_i32(details.get("reasoning_tokens"))),
+        audio_input_token_count: prompt_details
+            .and_then(|details| json_i32(details.get("audio_tokens"))),
+        audio_output_token_count: completion_details
+            .and_then(|details| json_i32(details.get("audio_tokens"))),
+        provider_usage: Some(serde_json::Value::Object(usage.clone())),
+        ..Default::default()
+    })
+}
+
+fn json_i32(value: Option<&serde_json::Value>) -> Option<i32> {
+    i32::try_from(value?.as_i64()?).ok()
+}
+
 /// Convert a raw OpenAI JSON response to ADK LlmResponse.
 ///
 /// Unlike [`from_openai_response`], this parses the raw JSON directly so it can
@@ -412,38 +442,7 @@ pub fn from_raw_openai_response(json: &serde_json::Value) -> LlmResponse {
     });
 
     // Parse usage metadata
-    let usage_metadata = json.get("usage").map(|u| {
-        let prompt_tokens = u.get("prompt_tokens").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
-        let completion_tokens =
-            u.get("completion_tokens").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
-        let total_tokens = u.get("total_tokens").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
-
-        let prompt_details = u.get("prompt_tokens_details");
-        let completion_details = u.get("completion_tokens_details");
-
-        UsageMetadata {
-            prompt_token_count: prompt_tokens,
-            candidates_token_count: completion_tokens,
-            total_token_count: total_tokens,
-            cache_read_input_token_count: prompt_details
-                .and_then(|d| d.get("cached_tokens"))
-                .and_then(|v| v.as_i64())
-                .map(|v| v as i32),
-            thinking_token_count: completion_details
-                .and_then(|d| d.get("reasoning_tokens"))
-                .and_then(|v| v.as_i64())
-                .map(|v| v as i32),
-            audio_input_token_count: prompt_details
-                .and_then(|d| d.get("audio_tokens"))
-                .and_then(|v| v.as_i64())
-                .map(|v| v as i32),
-            audio_output_token_count: completion_details
-                .and_then(|d| d.get("audio_tokens"))
-                .and_then(|v| v.as_i64())
-                .map(|v| v as i32),
-            ..Default::default()
-        }
-    });
+    let usage_metadata = json.get("usage").and_then(usage_metadata_from_raw);
 
     // Parse finish reason
     let finish_reason =
@@ -786,6 +785,45 @@ mod tests {
         let usage = resp.usage_metadata.unwrap();
         assert_eq!(usage.prompt_token_count, 5);
         assert_eq!(usage.candidates_token_count, 3);
+    }
+
+    #[test]
+    fn raw_response_preserves_complete_provider_usage() {
+        let provider_usage = serde_json::json!({
+            "prompt_tokens": 120,
+            "completion_tokens": 30,
+            "total_tokens": 150,
+            "prompt_tokens_details": {
+                "cached_tokens": 80,
+                "cache_write_tokens": 12,
+                "audio_tokens": 4
+            },
+            "completion_tokens_details": {
+                "reasoning_tokens": 18,
+                "audio_tokens": 2
+            },
+            "provider_meter": {"units": 9}
+        });
+        let json = serde_json::json!({
+            "choices": [{
+                "message": {"role": "assistant", "content": "done"},
+                "finish_reason": "stop"
+            }],
+            "usage": provider_usage.clone()
+        });
+
+        let response = from_raw_openai_response(&json);
+        let usage = response.usage_metadata.expect("usage should be parsed");
+
+        assert_eq!(usage.prompt_token_count, 120);
+        assert_eq!(usage.candidates_token_count, 30);
+        assert_eq!(usage.total_token_count, 150);
+        assert_eq!(usage.cache_read_input_token_count, Some(80));
+        assert_eq!(usage.cache_creation_input_token_count, Some(12));
+        assert_eq!(usage.thinking_token_count, Some(18));
+        assert_eq!(usage.audio_input_token_count, Some(4));
+        assert_eq!(usage.audio_output_token_count, Some(2));
+        assert_eq!(usage.provider_usage, Some(provider_usage));
     }
 
     #[test]

--- a/adk-model/src/openai/convert.rs
+++ b/adk-model/src/openai/convert.rs
@@ -239,8 +239,10 @@ pub fn convert_tools(
     adapter: &dyn SchemaAdapter,
     cache: &SchemaCache,
 ) -> Vec<ChatCompletionTools> {
+    let mut tools = tools.iter().collect::<Vec<_>>();
+    tools.sort_unstable_by_key(|(name, _)| *name);
     tools
-        .iter()
+        .into_iter()
         .map(|(name, decl)| {
             let description = decl.get("description").and_then(|d| d.as_str()).map(String::from);
 
@@ -852,6 +854,30 @@ mod tests {
             assert_eq!(tool.function.name, "get_weather");
         } else {
             panic!("Expected Function variant");
+        }
+    }
+
+    #[test]
+    fn convert_tools_has_deterministic_name_order() {
+        use super::super::schema_adapter::OpenAiSchemaAdapter;
+
+        let adapter = OpenAiSchemaAdapter;
+        let cache = SchemaCache::for_adapter(std::sync::Arc::new(OpenAiSchemaAdapter));
+        for _ in 0..32 {
+            let tools = HashMap::from([
+                ("zeta".to_string(), serde_json::json!({})),
+                ("alpha".to_string(), serde_json::json!({})),
+                ("middle".to_string(), serde_json::json!({})),
+            ]);
+            let names = convert_tools(&tools, &adapter, &cache)
+                .into_iter()
+                .map(|tool| match tool {
+                    ChatCompletionTools::Function(tool) => tool.function.name,
+                    ChatCompletionTools::Custom(_) => panic!("expected a function tool"),
+                })
+                .collect::<Vec<_>>();
+
+            assert_eq!(names, ["alpha", "middle", "zeta"]);
         }
     }
 

--- a/adk-model/src/openai/responses_client.rs
+++ b/adk-model/src/openai/responses_client.rs
@@ -44,6 +44,34 @@ pub struct OpenAIResponsesClient {
     open_responses_mode: bool,
 }
 
+fn completed_stream_response(full: LlmResponse) -> LlmResponse {
+    let trailing_parts = full
+        .content
+        .as_ref()
+        .map(|content| {
+            content
+                .parts
+                .iter()
+                .filter(|part| !matches!(part, Part::Text { .. } | Part::Thinking { .. }))
+                .cloned()
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let content = (!trailing_parts.is_empty())
+        .then_some(Content { role: "model".to_string(), parts: trailing_parts });
+
+    LlmResponse {
+        content,
+        usage_metadata: full.usage_metadata,
+        finish_reason: full.finish_reason,
+        citation_metadata: full.citation_metadata,
+        provider_metadata: full.provider_metadata,
+        partial: false,
+        turn_complete: true,
+        ..Default::default()
+    }
+}
+
 impl OpenAIResponsesClient {
     /// Create a new Responses API client from the given config.
     ///
@@ -106,8 +134,9 @@ impl OpenAIResponsesClient {
             openai_config = openai_config.with_api_base(base_url);
         }
         let client = async_openai::Client::with_config(openai_config);
-        let client = if matches!(reasoning_effort, Some(OpenAIReasoningEffort::Max)) {
-            with_max_reasoning_middleware(client)
+        let uses_max_reasoning = matches!(reasoning_effort, Some(OpenAIReasoningEffort::Max));
+        let client = if uses_max_reasoning || open_responses_mode {
+            with_responses_compatibility_middleware(client, uses_max_reasoning, open_responses_mode)
         } else {
             client
         };
@@ -176,8 +205,10 @@ impl OpenAIResponsesClient {
     }
 }
 
-fn with_max_reasoning_middleware(
+fn with_responses_compatibility_middleware(
     client: async_openai::Client<async_openai::config::OpenAIConfig>,
+    uses_max_reasoning: bool,
+    open_responses_mode: bool,
 ) -> async_openai::Client<async_openai::config::OpenAIConfig> {
     use async_openai::error::OpenAIError;
     use async_openai::middleware::retry::OpenAIRetryLayer;
@@ -195,7 +226,7 @@ fn with_max_reasoning_middleware(
                 let original = original.clone();
                 async move {
                     let mut request = original.build().await?;
-                    if request.url().path().ends_with("/responses") {
+                    if uses_max_reasoning && request.url().path().ends_with("/responses") {
                         let body =
                             request.body().and_then(|body| body.as_bytes()).ok_or_else(|| {
                                 OpenAIError::InvalidArgument(
@@ -217,15 +248,17 @@ fn with_max_reasoning_middleware(
                 }
             });
             let response = transport.oneshot(rewritten).await?;
-            normalize_max_reasoning_response(response).await
+            normalize_responses_response(response, uses_max_reasoning, open_responses_mode).await
         }
     });
 
     client.with_http_service(service)
 }
 
-async fn normalize_max_reasoning_response(
+async fn normalize_responses_response(
     response: reqwest_openai::Response,
+    uses_max_reasoning: bool,
+    open_responses_mode: bool,
 ) -> Result<reqwest_openai::Response, async_openai::error::OpenAIError> {
     use reqwest_openai::ResponseBuilderExt;
 
@@ -248,26 +281,42 @@ async fn normalize_max_reasoning_response(
         let mut upstream = response.bytes_stream();
         let normalized = async_stream::stream! {
             let mut pending = Vec::new();
+            let mut stream_state = OpenResponsesStreamState::default();
             while let Some(chunk) = upstream.next().await {
                 match chunk {
                     Ok(chunk) => {
                         pending.extend_from_slice(&chunk);
                         while let Some(line_end) = pending.iter().position(|byte| *byte == b'\n') {
                             let line: Vec<u8> = pending.drain(..=line_end).collect();
-                            yield Ok::<Vec<u8>, reqwest_openai::Error>(normalize_max_reasoning_bytes(&line));
+                            yield Ok::<Vec<u8>, reqwest_openai::Error>(normalize_responses_bytes(
+                                &line,
+                                uses_max_reasoning,
+                                open_responses_mode,
+                                Some(&mut stream_state),
+                            ));
                         }
                     }
                     Err(error) => yield Err(error),
                 }
             }
             if !pending.is_empty() {
-                yield Ok::<Vec<u8>, reqwest_openai::Error>(normalize_max_reasoning_bytes(&pending));
+                yield Ok::<Vec<u8>, reqwest_openai::Error>(normalize_responses_bytes(
+                    &pending,
+                    uses_max_reasoning,
+                    open_responses_mode,
+                    Some(&mut stream_state),
+                ));
             }
         };
         reqwest_openai::Body::wrap_stream(normalized)
     } else {
         let bytes = response.bytes().await.map_err(async_openai::error::OpenAIError::Reqwest)?;
-        reqwest_openai::Body::from(normalize_max_reasoning_bytes(&bytes))
+        reqwest_openai::Body::from(normalize_responses_bytes(
+            &bytes,
+            uses_max_reasoning,
+            open_responses_mode,
+            None,
+        ))
     };
 
     let mut rebuilt =
@@ -282,11 +331,139 @@ async fn normalize_max_reasoning_response(
     Ok(reqwest_openai::Response::from(rebuilt))
 }
 
-fn normalize_max_reasoning_bytes(bytes: &[u8]) -> Vec<u8> {
-    String::from_utf8_lossy(bytes)
-        .replace("\"effort\":\"max\"", "\"effort\":\"xhigh\"")
-        .replace("\"effort\": \"max\"", "\"effort\": \"xhigh\"")
-        .into_bytes()
+fn normalize_responses_bytes(
+    bytes: &[u8],
+    uses_max_reasoning: bool,
+    open_responses_mode: bool,
+    stream_state: Option<&mut OpenResponsesStreamState>,
+) -> Vec<u8> {
+    let normalized = if uses_max_reasoning {
+        String::from_utf8_lossy(bytes)
+            .replace("\"effort\":\"max\"", "\"effort\":\"xhigh\"")
+            .replace("\"effort\": \"max\"", "\"effort\": \"xhigh\"")
+            .into_bytes()
+    } else {
+        bytes.to_vec()
+    };
+    if !open_responses_mode {
+        return normalized;
+    }
+
+    let payload_start = normalized
+        .strip_prefix(b"data:")
+        .map_or(0, |payload| normalized.len() - payload.trim_ascii_start().len());
+    let payload_end = normalized.trim_ascii_end().len();
+    let Ok(mut value) =
+        serde_json::from_slice::<serde_json::Value>(&normalized[payload_start..payload_end])
+    else {
+        return normalized;
+    };
+    let message_status = value
+        .pointer("/response/status")
+        .or_else(|| value.get("status"))
+        .and_then(serde_json::Value::as_str)
+        .filter(|status| matches!(*status, "in_progress" | "completed" | "incomplete"))
+        .unwrap_or("in_progress")
+        .to_string();
+    if let Some(stream_state) = stream_state {
+        stream_state.normalize_event(&mut value);
+    }
+    add_open_responses_defaults(&mut value, &message_status);
+
+    let Ok(encoded) = serde_json::to_vec(&value) else {
+        return normalized;
+    };
+    let mut rebuilt = Vec::with_capacity(normalized.len().max(encoded.len()));
+    rebuilt.extend_from_slice(&normalized[..payload_start]);
+    rebuilt.extend_from_slice(&encoded);
+    rebuilt.extend_from_slice(&normalized[payload_end..]);
+    rebuilt
+}
+
+#[derive(Default)]
+struct OpenResponsesStreamState {
+    function_arguments: std::collections::BTreeMap<u64, String>,
+}
+
+impl OpenResponsesStreamState {
+    fn normalize_event(&mut self, event: &mut serde_json::Value) {
+        let event_type = event.get("type").and_then(serde_json::Value::as_str);
+        match event_type {
+            Some("response.function_call_arguments.delta") => {
+                if let (Some(output_index), Some(delta)) = (
+                    event.get("output_index").and_then(serde_json::Value::as_u64),
+                    event.get("delta").and_then(serde_json::Value::as_str),
+                ) {
+                    self.function_arguments.entry(output_index).or_default().push_str(delta);
+                }
+            }
+            Some("response.function_call_arguments.done") => {
+                if let Some(output_index) =
+                    event.get("output_index").and_then(serde_json::Value::as_u64)
+                {
+                    if let Some(arguments) =
+                        event.get("arguments").and_then(serde_json::Value::as_str)
+                    {
+                        self.function_arguments.insert(output_index, arguments.to_string());
+                    } else if let Some(arguments) = self.function_arguments.get(&output_index) {
+                        event["arguments"] = serde_json::Value::String(arguments.clone());
+                    }
+                }
+            }
+            Some("response.completed") => {
+                let mut streamed_arguments = self.function_arguments.values();
+                if let Some(output) =
+                    event.pointer_mut("/response/output").and_then(serde_json::Value::as_array_mut)
+                {
+                    for item in output {
+                        let is_function_call = item.get("type").and_then(serde_json::Value::as_str)
+                            == Some("function_call");
+                        if is_function_call {
+                            let arguments = streamed_arguments.next();
+                            if item.get("arguments").is_none()
+                                && let Some(arguments) = arguments
+                            {
+                                item["arguments"] = serde_json::Value::String(arguments.clone());
+                            }
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn add_open_responses_defaults(value: &mut serde_json::Value, message_status: &str) {
+    match value {
+        serde_json::Value::Array(items) => {
+            for item in items {
+                add_open_responses_defaults(item, message_status);
+            }
+        }
+        serde_json::Value::Object(fields) => {
+            match fields.get("type").and_then(serde_json::Value::as_str) {
+                Some("message") => {
+                    fields.entry("id").or_insert_with(|| {
+                        serde_json::Value::String("msg_open_responses".to_string())
+                    });
+                    fields
+                        .entry("status")
+                        .or_insert_with(|| serde_json::Value::String(message_status.to_string()));
+                }
+                Some("output_text") => {
+                    fields
+                        .entry("annotations")
+                        .or_insert_with(|| serde_json::Value::Array(Vec::new()));
+                }
+                _ => {}
+            }
+            for field in fields.values_mut() {
+                add_open_responses_defaults(field, message_status);
+            }
+        }
+        _ => {}
+    }
 }
 
 fn set_max_reasoning_effort(
@@ -458,43 +635,7 @@ impl Llm for OpenAIResponsesClient {
                             // via delta events) and mark the turn complete.
                             ResponseStreamEvent::ResponseCompleted(evt) => {
                                 let full = responses_convert::from_response(&evt.response);
-                                // Extract only non-textual protocol parts (text/thinking were already
-                                // streamed via delta events, but tool protocol items need to survive).
-                                let trailing_parts: Vec<Part> = full
-                                    .content
-                                    .as_ref()
-                                    .map(|c| {
-                                        c.parts
-                                            .iter()
-                                            .filter(|part| {
-                                                !matches!(
-                                                    part,
-                                                    Part::Text { .. } | Part::Thinking { .. }
-                                                )
-                                            })
-                                            .cloned()
-                                            .collect()
-                                    })
-                                    .unwrap_or_default();
-
-                                let content = if trailing_parts.is_empty() {
-                                    None
-                                } else {
-                                    Some(Content {
-                                        role: "model".to_string(),
-                                        parts: trailing_parts,
-                                    })
-                                };
-
-                                Some(Ok(LlmResponse {
-                                    content,
-                                    usage_metadata: full.usage_metadata,
-                                    finish_reason: full.finish_reason,
-                                    provider_metadata: full.provider_metadata,
-                                    partial: false,
-                                    turn_complete: true,
-                                    ..Default::default()
-                                }))
+                                Some(Ok(completed_stream_response(full)))
                             }
 
                             ResponseStreamEvent::ResponseFailed(evt) => {
@@ -577,6 +718,37 @@ mod tests {
     use crate::openai::config::OpenAIResponsesConfig;
     use async_openai::error::{ApiError, ApiErrorResponse, OpenAIError};
 
+    #[test]
+    fn completed_stream_response_preserves_citations() {
+        let full = LlmResponse {
+            content: Some(Content::new("model").with_text("answer")),
+            citation_metadata: Some(adk_core::CitationMetadata {
+                citation_sources: vec![adk_core::CitationSource {
+                    uri: Some("https://example.test".to_string()),
+                    title: Some("Example".to_string()),
+                    start_index: Some(0),
+                    end_index: Some(6),
+                    license: None,
+                    publication_date: None,
+                }],
+            }),
+            ..Default::default()
+        };
+
+        let completed = completed_stream_response(full);
+
+        assert!(completed.content.is_none());
+        assert_eq!(
+            completed
+                .citation_metadata
+                .expect("citations should survive stream completion")
+                .citation_sources[0]
+                .uri
+                .as_deref(),
+            Some("https://example.test")
+        );
+    }
+
     fn api_error(status_code: u16) -> OpenAIError {
         OpenAIError::ApiError(ApiErrorResponse {
             status_code: reqwest::StatusCode::from_u16(status_code)
@@ -607,11 +779,81 @@ mod tests {
         let compact = br#"{"reasoning":{"effort":"max"}}"#;
         let spaced = br#"data: {"response":{"reasoning":{"effort": "max"}}}\n\n"#;
 
-        assert_eq!(normalize_max_reasoning_bytes(compact), br#"{"reasoning":{"effort":"xhigh"}}"#);
         assert_eq!(
-            normalize_max_reasoning_bytes(spaced),
+            normalize_responses_bytes(compact, true, false, None),
+            br#"{"reasoning":{"effort":"xhigh"}}"#
+        );
+        assert_eq!(
+            normalize_responses_bytes(spaced, true, false, None),
             br#"data: {"response":{"reasoning":{"effort": "xhigh"}}}\n\n"#
         );
+    }
+
+    #[test]
+    fn open_responses_mode_defaults_omitted_output_message_fields() {
+        let event = br#"data: {"type":"response.completed","response":{"status":"completed","output":[{"type":"message","content":[{"type":"output_text","text":"done"}]}]}}
+
+"#;
+
+        let normalized = normalize_responses_bytes(event, false, true, None);
+        let payload = normalized
+            .strip_prefix(b"data: ")
+            .expect("SSE data prefix should survive")
+            .trim_ascii_end();
+        let value: serde_json::Value =
+            serde_json::from_slice(payload).expect("normalized event should remain JSON");
+
+        assert_eq!(
+            value["response"]["output"][0]["content"][0]["annotations"],
+            serde_json::json!([])
+        );
+        assert_eq!(value["response"]["output"][0]["id"], "msg_open_responses");
+        assert_eq!(value["response"]["output"][0]["status"], "completed");
+    }
+
+    #[test]
+    fn open_responses_mode_restores_streamed_function_arguments() {
+        let events = [
+            br#"data: {"type":"response.function_call_arguments.delta","output_index":1,"item_id":"fc_1","delta":"{\"command\":"}
+
+"#
+            .as_slice(),
+            br#"data: {"type":"response.function_call_arguments.delta","output_index":1,"item_id":"fc_1","delta":"\"pwd\"}"}
+
+"#
+            .as_slice(),
+            br#"data: {"type":"response.function_call_arguments.done","output_index":1,"item_id":"fc_1"}
+
+"#
+            .as_slice(),
+            br#"data: {"type":"response.completed","response":{"status":"completed","output":[{"type":"function_call","call_id":"call_1","name":"bash"}]}}
+
+"#
+            .as_slice(),
+        ];
+        let mut stream_state = OpenResponsesStreamState::default();
+        let normalized: Vec<Vec<u8>> = events
+            .iter()
+            .map(|event| normalize_responses_bytes(event, false, true, Some(&mut stream_state)))
+            .collect();
+
+        let done: serde_json::Value = serde_json::from_slice(
+            normalized[2]
+                .strip_prefix(b"data: ")
+                .expect("SSE data prefix should survive")
+                .trim_ascii_end(),
+        )
+        .expect("normalized arguments event should remain JSON");
+        let completed: serde_json::Value = serde_json::from_slice(
+            normalized[3]
+                .strip_prefix(b"data: ")
+                .expect("SSE data prefix should survive")
+                .trim_ascii_end(),
+        )
+        .expect("normalized completion event should remain JSON");
+
+        assert_eq!(done["arguments"], r#"{"command":"pwd"}"#);
+        assert_eq!(completed["response"]["output"][0]["arguments"], r#"{"command":"pwd"}"#);
     }
 
     #[test]

--- a/adk-model/src/openai/responses_convert.rs
+++ b/adk-model/src/openai/responses_convert.rs
@@ -5,11 +5,11 @@
 
 use crate::attachment;
 use adk_core::{
-    AdkError, Content, ErrorCategory, ErrorComponent, FinishReason, LlmRequest, LlmResponse, Part,
-    UsageMetadata,
+    AdkError, CitationMetadata, CitationSource, Content, ErrorCategory, ErrorComponent,
+    FinishReason, LlmRequest, LlmResponse, Part, UsageMetadata,
 };
 use async_openai::types::responses::{
-    ApplyPatchToolCallItemParam, ApplyPatchToolCallOutputItemParam, ConversationParam,
+    Annotation, ApplyPatchToolCallItemParam, ApplyPatchToolCallOutputItemParam, ConversationParam,
     CreateResponse, CreateResponseArgs, EasyInputContent, EasyInputMessage, FunctionCallOutput,
     FunctionCallOutputItemParam, FunctionShellCallItemParam, FunctionShellCallOutputItemParam,
     FunctionTool, FunctionToolCall, IncludeEnum, InputContent, InputImageContent, InputItem,
@@ -588,12 +588,53 @@ pub fn from_response(response: &Response) -> LlmResponse {
     let usage_metadata = response.usage.as_ref().map(convert_usage);
     let finish_reason = map_finish_reason(response);
     let provider_metadata = build_provider_metadata(response);
+    let citation_sources = response
+        .output
+        .iter()
+        .filter_map(|item| match item {
+            OutputItem::Message(message) => Some(&message.content),
+            _ => None,
+        })
+        .flatten()
+        .filter_map(|content| match content {
+            OutputMessageContent::OutputText(text) => Some(&text.annotations),
+            OutputMessageContent::Refusal(_) => None,
+        })
+        .flatten()
+        .filter_map(|annotation| match annotation {
+            Annotation::UrlCitation(citation) => {
+                let value = serde_json::to_value(citation).ok()?;
+                Some(CitationSource {
+                    uri: value.get("url").and_then(serde_json::Value::as_str).map(str::to_owned),
+                    title: value
+                        .get("title")
+                        .and_then(serde_json::Value::as_str)
+                        .map(str::to_owned),
+                    start_index: value
+                        .get("start_index")
+                        .and_then(serde_json::Value::as_u64)
+                        .and_then(|index| i32::try_from(index).ok()),
+                    end_index: value
+                        .get("end_index")
+                        .and_then(serde_json::Value::as_u64)
+                        .and_then(|index| i32::try_from(index).ok()),
+                    license: None,
+                    publication_date: None,
+                })
+            }
+            Annotation::FileCitation(_)
+            | Annotation::ContainerFileCitation(_)
+            | Annotation::FilePath(_) => None,
+        })
+        .collect::<Vec<_>>();
+    let citation_metadata =
+        (!citation_sources.is_empty()).then_some(CitationMetadata { citation_sources });
 
     LlmResponse {
         content,
         usage_metadata,
         finish_reason,
-        citation_metadata: None,
+        citation_metadata,
         partial: false,
         turn_complete: true,
         interrupted: false,
@@ -1060,7 +1101,7 @@ mod tests {
             "openai_web_search".to_string(),
             serde_json::json!({
                 "x-adk-openai-tool": {
-                    "type": "web_search_2025_08_26"
+                    "type": "web_search"
                 }
             }),
         );
@@ -1360,7 +1401,7 @@ mod tests {
             "openai".to_string(),
             serde_json::json!({
                 "built_in_tools": [
-                    { "type": "web_search_2025_08_26" },
+                    { "type": "web_search" },
                     { "type": "image_generation", "size": "1024x1024", "quality": "high" }
                 ]
             }),
@@ -1414,7 +1455,7 @@ mod tests {
                 "prompt_cache_retention": "24h",
                 "service_tier": "priority",
                 "built_in_tools": [
-                    { "type": "web_search_2025_08_26" }
+                    { "type": "web_search" }
                 ]
             }),
         );
@@ -1469,6 +1510,56 @@ mod tests {
         let metadata = llm_response.provider_metadata.expect("metadata should exist");
         assert_eq!(metadata["openai"]["response_id"], "resp_status_test");
         assert_eq!(metadata["openai"]["status"], "completed");
+    }
+
+    #[test]
+    fn test_from_response_maps_url_citations() {
+        let response: Response = serde_json::from_value(serde_json::json!({
+            "id": "resp_citation_test",
+            "object": "response",
+            "created_at": 0,
+            "model": "gpt-5.4",
+            "status": "completed",
+            "output": [{
+                "type": "message",
+                "id": "msg_citation_test",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{
+                    "type": "output_text",
+                    "text": "OpenAI",
+                    "annotations": [{
+                        "type": "url_citation",
+                        "start_index": 0,
+                        "end_index": 6,
+                        "title": "OpenAI",
+                        "url": "https://openai.com"
+                    }]
+                }]
+            }],
+            "usage": {
+                "input_tokens": 10,
+                "input_tokens_details": { "cached_tokens": 0 },
+                "output_tokens": 5,
+                "output_tokens_details": { "reasoning_tokens": 0 },
+                "total_tokens": 15
+            }
+        }))
+        .expect("response should deserialize");
+
+        let llm_response = from_response(&response);
+        let citations = llm_response.citation_metadata.expect("citation metadata should exist");
+        assert_eq!(
+            citations.citation_sources,
+            vec![adk_core::CitationSource {
+                uri: Some("https://openai.com".to_string()),
+                title: Some("OpenAI".to_string()),
+                start_index: Some(0),
+                end_index: Some(6),
+                license: None,
+                publication_date: None,
+            }]
+        );
     }
 
     #[test]

--- a/adk-model/src/openai/responses_convert.rs
+++ b/adk-model/src/openai/responses_convert.rs
@@ -231,8 +231,10 @@ fn content_to_input_items(content: &Content) -> Vec<InputItem> {
 /// If the type is not recognized (e.g., `tool_search`, `skill`), the tool falls back to
 /// being treated as a regular function tool.
 pub fn convert_tools(tools: &HashMap<String, serde_json::Value>) -> Result<Vec<Tool>, AdkError> {
+    let mut tools = tools.iter().collect::<Vec<_>>();
+    tools.sort_unstable_by_key(|(name, _)| *name);
     tools
-        .iter()
+        .into_iter()
         .map(|(name, decl)| {
             if let Some(provider_tool) = decl.get("x-adk-openai-tool") {
                 convert_native_tool(name, decl, provider_tool)
@@ -1006,6 +1008,29 @@ mod tests {
         assert_eq!(converted.len(), 1);
         let value = serde_json::to_value(&converted[0]).expect("tool should serialize");
         assert_eq!(value["type"], "local_shell");
+    }
+
+    #[test]
+    fn convert_tools_has_deterministic_name_order() {
+        for _ in 0..32 {
+            let tools = HashMap::from([
+                ("zeta".to_string(), serde_json::json!({})),
+                ("alpha".to_string(), serde_json::json!({})),
+                ("middle".to_string(), serde_json::json!({})),
+            ]);
+            let names = convert_tools(&tools)
+                .expect("tool conversion should succeed")
+                .into_iter()
+                .map(|tool| {
+                    serde_json::to_value(tool).expect("tool should serialize")["name"]
+                        .as_str()
+                        .expect("function tool should have a name")
+                        .to_string()
+                })
+                .collect::<Vec<_>>();
+
+            assert_eq!(names, ["alpha", "middle", "zeta"]);
+        }
     }
 
     #[test]

--- a/adk-model/src/openai_compatible.rs
+++ b/adk-model/src/openai_compatible.rs
@@ -376,14 +376,6 @@ pub(crate) fn build_request_json(
         body["reasoning_effort"] = serde_json::Value::String("max".to_string());
     }
 
-    // GPT-5.6 defaults to medium reasoning, while Chat Completions function
-    // tools require effective reasoning `none`. ADK's public reasoning enum
-    // predates that value, so preserve source compatibility and make the safe
-    // effective setting explicit only for this otherwise-invalid combination.
-    if model.starts_with("gpt-5.6") && !request.tools.is_empty() && reasoning_effort.is_none() {
-        body["reasoning_effort"] = serde_json::Value::String("none".to_string());
-    }
-
     // Merge provider-specific extensions from config.extensions["openai"] into
     // the request body.  This allows users to pass provider-specific fields
     // that the typed builder doesn't cover (e.g. provider-specific parameters
@@ -494,6 +486,24 @@ fn append_tool_call_arguments(accumulator: &mut String, arguments: &serde_json::
             }
         }
     }
+}
+
+fn parse_tool_call_arguments(
+    provider_name: &str,
+    tool_name: &str,
+    arguments: &str,
+) -> Result<serde_json::Value, AdkError> {
+    serde_json::from_str(arguments).map_err(|error| {
+        AdkError::new(
+            ErrorComponent::Model,
+            ErrorCategory::Internal,
+            "model.openai_compat.invalid_tool_arguments",
+            format!(
+                "{provider_name} returned invalid JSON arguments for tool '{tool_name}': {error}"
+            ),
+        )
+        .with_provider(provider_name)
+    })
 }
 
 /// Parse usage metadata from a raw SSE chunk JSON value.
@@ -685,17 +695,19 @@ impl Llm for OpenAICompatible {
                                     let parts: Vec<Part> = sorted_calls
                                         .into_iter()
                                         .map(|(_, (id, name, args_str))| {
-                                            let args: serde_json::Value =
-                                                serde_json::from_str(&args_str)
-                                                    .unwrap_or(serde_json::json!({}));
-                                            Part::FunctionCall {
+                                            let args = parse_tool_call_arguments(
+                                                &provider_name,
+                                                &name,
+                                                &args_str,
+                                            )?;
+                                            Ok(Part::FunctionCall {
                                                 name,
                                                 args,
                                                 id: Some(id),
                                                 thought_signature: None,
-                                            }
+                                            })
                                         })
-                                        .collect();
+                                        .collect::<Result<Vec<_>, AdkError>>()?;
 
                                     let response = LlmResponse {
                                         content: Some(Content {
@@ -925,7 +937,22 @@ mod tests {
     }
 
     #[test]
-    fn gpt_56_chat_tools_default_to_no_reasoning() {
+    fn streamed_tool_arguments_require_valid_json() {
+        let parsed =
+            parse_tool_call_arguments("compatible-provider", "bash", r#"{"command":"pwd"}"#)
+                .expect("valid arguments should parse");
+        assert_eq!(parsed["command"], "pwd");
+
+        let error = parse_tool_call_arguments("compatible-provider", "bash", "")
+            .expect_err("empty arguments are not a valid function call payload");
+        assert_eq!(error.component, ErrorComponent::Model);
+        assert_eq!(error.category, ErrorCategory::Internal);
+        assert_eq!(error.code, "model.openai_compat.invalid_tool_arguments");
+        assert_eq!(error.details.provider.as_deref(), Some("compatible-provider"));
+    }
+
+    #[test]
+    fn gpt_56_chat_tools_preserve_configured_reasoning() {
         let adapter = GenericSchemaAdapter;
         let cache = SchemaCache::for_adapter(Arc::new(GenericSchemaAdapter));
         let mut request = LlmRequest {
@@ -943,17 +970,23 @@ mod tests {
             }),
         );
 
-        let body = build_request_json(
-            crate::catalog::OPENAI_DEFAULT,
-            &request,
-            &None,
-            true,
-            &adapter,
-            &cache,
-        )
-        .expect("request should build");
+        for (configured_effort, expected) in [
+            (None, None),
+            (Some(OpenAIReasoningEffort::Medium), Some("medium")),
+            (Some(OpenAIReasoningEffort::Max), Some("max")),
+        ] {
+            let body = build_request_json(
+                crate::catalog::OPENAI_DEFAULT,
+                &request,
+                &configured_effort,
+                true,
+                &adapter,
+                &cache,
+            )
+            .expect("request should build");
 
-        assert_eq!(body["reasoning_effort"], "none");
+            assert_eq!(body.get("reasoning_effort").and_then(serde_json::Value::as_str), expected);
+        }
     }
 
     #[test]

--- a/adk-model/src/openai_compatible.rs
+++ b/adk-model/src/openai_compatible.rs
@@ -480,6 +480,22 @@ fn parse_finish_reason(fr: &str) -> FinishReason {
     }
 }
 
+/// Accumulate string deltas while treating structured values as complete snapshots.
+fn append_tool_call_arguments(accumulator: &mut String, arguments: &serde_json::Value) {
+    match arguments {
+        serde_json::Value::String(fragment) => accumulator.push_str(fragment),
+        serde_json::Value::Null => {}
+        structured => {
+            let empty_snapshot = matches!(structured, serde_json::Value::Object(fields) if fields.is_empty())
+                || matches!(structured, serde_json::Value::Array(items) if items.is_empty());
+            if accumulator.is_empty() || !empty_snapshot {
+                accumulator.clear();
+                accumulator.push_str(&structured.to_string());
+            }
+        }
+    }
+}
+
 /// Parse usage metadata from a raw SSE chunk JSON value.
 fn parse_usage_from_chunk(chunk: &serde_json::Value) -> Option<UsageMetadata> {
     let u = chunk.get("usage")?.as_object()?;
@@ -678,10 +694,8 @@ impl Llm for OpenAICompatible {
                                         if let Some(name) = func.get("name").and_then(|v| v.as_str()) {
                                             entry.1 = name.to_string();
                                         }
-                                        if let Some(args_chunk) =
-                                            func.get("arguments").and_then(|v| v.as_str())
-                                        {
-                                            entry.2.push_str(args_chunk);
+                                        if let Some(arguments) = func.get("arguments") {
+                                            append_tool_call_arguments(&mut entry.2, arguments);
                                         }
                                     }
                                 }

--- a/adk-model/src/openai_compatible.rs
+++ b/adk-model/src/openai_compatible.rs
@@ -498,36 +498,7 @@ fn append_tool_call_arguments(accumulator: &mut String, arguments: &serde_json::
 
 /// Parse usage metadata from a raw SSE chunk JSON value.
 fn parse_usage_from_chunk(chunk: &serde_json::Value) -> Option<UsageMetadata> {
-    let u = chunk.get("usage")?.as_object()?;
-    let prompt_tokens = u.get("prompt_tokens").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
-    let completion_tokens = u.get("completion_tokens").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
-    let total_tokens = u.get("total_tokens").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
-
-    let prompt_details = u.get("prompt_tokens_details");
-    let completion_details = u.get("completion_tokens_details");
-
-    Some(UsageMetadata {
-        prompt_token_count: prompt_tokens,
-        candidates_token_count: completion_tokens,
-        total_token_count: total_tokens,
-        cache_read_input_token_count: prompt_details
-            .and_then(|d| d.get("cached_tokens"))
-            .and_then(|v| v.as_i64())
-            .map(|v| v as i32),
-        thinking_token_count: completion_details
-            .and_then(|d| d.get("reasoning_tokens"))
-            .and_then(|v| v.as_i64())
-            .map(|v| v as i32),
-        audio_input_token_count: prompt_details
-            .and_then(|d| d.get("audio_tokens"))
-            .and_then(|v| v.as_i64())
-            .map(|v| v as i32),
-        audio_output_token_count: completion_details
-            .and_then(|d| d.get("audio_tokens"))
-            .and_then(|v| v.as_i64())
-            .map(|v| v as i32),
-        ..Default::default()
-    })
+    chunk.get("usage").and_then(convert::usage_metadata_from_raw)
 }
 
 #[async_trait]

--- a/adk-model/tests/openai_streaming_exploration_tests.rs
+++ b/adk-model/tests/openai_streaming_exploration_tests.rs
@@ -162,7 +162,7 @@ mod streaming_exploration {
         let sse_body = [
             "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"},\"finish_reason\":null}]}\n\n",
             "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":null}\n\n",
-            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[],\"usage\":{\"prompt_tokens\":11,\"completion_tokens\":5,\"total_tokens\":16}}\n\n",
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[],\"usage\":{\"prompt_tokens\":11,\"completion_tokens\":5,\"total_tokens\":16,\"prompt_tokens_details\":{\"cached_tokens\":7,\"cache_write_tokens\":2},\"provider_meter\":{\"units\":3}}}\n\n",
             "data: [DONE]\n\n",
         ]
         .join("");
@@ -199,6 +199,21 @@ mod streaming_exploration {
         assert_eq!(usage.prompt_token_count, 11);
         assert_eq!(usage.candidates_token_count, 5);
         assert_eq!(usage.total_token_count, 16);
+        assert_eq!(usage.cache_read_input_token_count, Some(7));
+        assert_eq!(usage.cache_creation_input_token_count, Some(2));
+        assert_eq!(
+            usage.provider_usage,
+            Some(serde_json::json!({
+                "prompt_tokens": 11,
+                "completion_tokens": 5,
+                "total_tokens": 16,
+                "prompt_tokens_details": {
+                    "cached_tokens": 7,
+                    "cache_write_tokens": 2
+                },
+                "provider_meter": {"units": 3}
+            }))
+        );
     }
 
     // ── Test 3: reasoning_content chunks yield Part::Thinking ────────────

--- a/adk-model/tests/openai_streaming_exploration_tests.rs
+++ b/adk-model/tests/openai_streaming_exploration_tests.rs
@@ -372,6 +372,106 @@ mod streaming_exploration {
         assert_eq!(usage.total_token_count, 25);
     }
 
+    #[tokio::test]
+    async fn structured_tool_call_arguments_are_preserved() {
+        let server = MockServer::start().await;
+
+        let sse_body = [
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"tool_calls\":[{\"index\":0,\"id\":\"call_abc\",\"type\":\"function\",\"function\":{\"name\":\"run_command\",\"arguments\":{\"command\":\"printf 'OK\\\\n'\"}}}]},\"finish_reason\":null}]}\n\n",
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}],\"usage\":null}\n\n",
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":15,\"total_tokens\":25}}\n\n",
+            "data: [DONE]\n\n",
+        ]
+        .join("");
+
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string(&sse_body)
+                    .insert_header("content-type", "text/event-stream"),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = make_client(&server.uri());
+        let mut stream = client
+            .generate_content(make_request(), true)
+            .await
+            .expect("generate_content should not error");
+
+        let mut function_call = None;
+        while let Some(item) = stream.next().await {
+            let response = item.expect("stream should not yield an error");
+            function_call = response
+                .content
+                .as_ref()
+                .into_iter()
+                .flat_map(|content| &content.parts)
+                .find_map(|part| match part {
+                    Part::FunctionCall { name, args, id, .. } => {
+                        Some((name.clone(), args.clone(), id.clone()))
+                    }
+                    _ => None,
+                })
+                .or(function_call);
+        }
+
+        let (name, args, id) = function_call.expect("expected a function call");
+        assert_eq!(name, "run_command");
+        assert_eq!(args["command"], "printf 'OK\\n'");
+        assert_eq!(id.as_deref(), Some("call_abc"));
+    }
+
+    #[tokio::test]
+    async fn repeated_structured_tool_call_snapshots_do_not_corrupt_arguments() {
+        let server = MockServer::start().await;
+
+        let sse_body = [
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"tool_calls\":[{\"index\":0,\"id\":\"call_abc\",\"type\":\"function\",\"function\":{\"name\":\"run_command\",\"arguments\":{\"command\":\"printf 'OK\\\\n'\"}}}]},\"finish_reason\":null}]}\n\n",
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":{}}}]},\"finish_reason\":null}]}\n\n",
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}],\"usage\":null}\n\n",
+            "data: [DONE]\n\n",
+        ]
+        .join("");
+
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string(&sse_body)
+                    .insert_header("content-type", "text/event-stream"),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = make_client(&server.uri());
+        let mut stream = client
+            .generate_content(make_request(), true)
+            .await
+            .expect("generate_content should not error");
+
+        let mut function_call = None;
+        while let Some(item) = stream.next().await {
+            let response = item.expect("stream should not yield an error");
+            function_call = response
+                .content
+                .as_ref()
+                .into_iter()
+                .flat_map(|content| &content.parts)
+                .find_map(|part| match part {
+                    Part::FunctionCall { args, .. } => Some(args.clone()),
+                    _ => None,
+                })
+                .or(function_call);
+        }
+
+        let args = function_call.expect("expected a function call");
+        assert_eq!(args["command"], "printf 'OK\\n'");
+    }
+
     /// Regression test for providers using "delta.reasoning" field instead of "delta.reasoning_content"
     /// (OpenRouter, Kilo Gateway, SambaNova, Cerebras, Groq).
     /// Without the fallback fix, this test would fail — reasoning silently dropped in streaming.

--- a/adk-tool/src/builtin/openai.rs
+++ b/adk-tool/src/builtin/openai.rs
@@ -57,14 +57,14 @@ impl OpenAIApproximateLocation {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum OpenAIWebSearchVariant {
     #[default]
-    Stable20250826,
+    Stable,
     Preview20250311,
 }
 
 impl OpenAIWebSearchVariant {
     fn as_wire(self) -> &'static str {
         match self {
-            Self::Stable20250826 => "web_search_2025_08_26",
+            Self::Stable => "web_search",
             Self::Preview20250311 => "web_search_preview_2025_03_11",
         }
     }

--- a/adk-tool/tests/builtin_tests.rs
+++ b/adk-tool/tests/builtin_tests.rs
@@ -106,7 +106,9 @@ fn test_native_declarations_are_exposed() {
     assert_eq!(gemini_decl["x-adk-gemini-tool"]["google_search"], json!({}));
 
     let openai_decl = OpenAIWebSearchTool::new().declaration();
-    assert_eq!(openai_decl["x-adk-openai-tool"]["type"], "web_search_2025_08_26");
+    assert_eq!(openai_decl["x-adk-openai-tool"]["type"], "web_search");
+    let openai_preview_decl = OpenAIWebSearchTool::new().preview().declaration();
+    assert_eq!(openai_preview_decl["x-adk-openai-tool"]["type"], "web_search_preview_2025_03_11");
 
     let anthropic_decl = WebSearchTool::new().declaration();
     assert_eq!(anthropic_decl["x-adk-anthropic-tool"]["type"], "web_search_20250305");


### PR DESCRIPTION
## Summary

- serialize the stable OpenAI Responses web search tool as `web_search`, with the semantic `OpenAIWebSearchVariant::Stable` name while keeping the dated preview variant explicit
- preserve Responses URL citations through streaming completion
- make opt-in Open Responses compatibility tolerate omitted output-message metadata and reconstruct omitted final function arguments from streaming events
- preserve string fragments and structured JSON tool arguments from Chat Completions-compatible providers; reject malformed or empty argument payloads instead of silently substituting `{}`
- preserve configured GPT-5.6 reasoning values instead of applying a model-specific implicit override
- normalize streaming and non-streaming Chat Completions usage through one path, including cache-read/cache-write counters and the complete provider-native usage object
- serialize Chat Completions and Responses function tools in deterministic name order so repeated requests keep a stable cacheable prefix

## Compatibility

Open Responses response normalization remains opt-in through the existing Open Responses mode. Official OpenAI behavior and other provider protocols are unchanged. Provider-native usage is retained in `UsageMetadata::provider_usage` so additional fields can be inspected and projected without another wire-format change.

## Validation

- `cargo test -p adk-model --features all-providers`
- `cargo test -p adk-tool`
- `cargo clippy -p adk-model --features all-providers --all-targets -- -D warnings`
- `cargo clippy -p adk-tool --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- downstream `cargo test -p sailry-code-agent`
- downstream `cargo clippy -p sailry-code-agent --all-targets -- -D warnings`
- downstream macOS deterministic E2E suite, including complete conversation rendering and restored-session interruption state

## Changelog

The Unreleased Fixed section documents stable web search, citation and structured argument preservation, provider usage metadata, and deterministic tool ordering.
