### PR TITLE
fix(agent): omit full payloads from partial stream events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Bounded partial streaming events** (`adk-agent`): incremental LLM events
+  no longer repeat the complete request and response payload on every chunk.
+  Terminal events retain the existing debug payload, while long histories now
+  incur constant payload overhead instead of growing with the chunk count.
 - **OpenAI-compatible streaming usage** (`adk-model`): usage-only terminal
   chunks with empty `choices` attach token counts to the final response.
 - **Span parenting across suspension points** (`adk-agent`, `adk-runner`): one

--- a/adk-agent/src/llm_agent.rs
+++ b/adk-agent/src/llm_agent.rs
@@ -144,14 +144,20 @@ fn build_partial_llm_event(
 ) -> Event {
     let mut event = Event::with_id(event_id, invocation_id);
     event.author = agent_name.to_string();
-    event.llm_request = Some(request_json.to_string());
-    event
-        .provider_metadata
-        .insert("gcp.vertex.agent.llm_request".to_string(), request_json.to_string());
-    event.provider_metadata.insert(
-        "gcp.vertex.agent.llm_response".to_string(),
-        serde_json::to_string(chunk).unwrap_or_default(),
-    );
+    // Keep payload snapshots on the terminal chunk for backwards-compatible
+    // debug tooling, but never repeat the full request and response on every
+    // incremental chunk. Large histories otherwise turn streaming into
+    // O(request_size * chunk_count) serialization and transport work.
+    if !chunk.partial {
+        event.llm_request = Some(request_json.to_string());
+        event
+            .provider_metadata
+            .insert("gcp.vertex.agent.llm_request".to_string(), request_json.to_string());
+        event.provider_metadata.insert(
+            "gcp.vertex.agent.llm_response".to_string(),
+            serde_json::to_string(chunk).unwrap_or_default(),
+        );
+    }
     event.llm_response.partial = chunk.partial;
     event.llm_response.turn_complete = chunk.turn_complete;
     event.llm_response.finish_reason = chunk.finish_reason;
@@ -3434,5 +3440,40 @@ mod run_helper_tests {
         assert_eq!(calls[1].index, 1);
         assert_eq!(calls[1].name, "second");
         assert_eq!(calls[1].function_call_id, "provider-id");
+    }
+
+    #[test]
+    fn partial_stream_events_do_not_repeat_large_payloads() {
+        let marker = "PRIVATE-REQUEST-PAYLOAD";
+        let request_json = format!("{marker}{}", "x".repeat(128 * 1024));
+        let chunk = LlmResponse {
+            content: Some(Content::new("model").with_text("x")),
+            partial: true,
+            ..Default::default()
+        };
+        let mut serialized_bytes = 0;
+
+        for index in 0..64 {
+            let event = build_partial_llm_event(
+                &format!("event-{index}"),
+                "invocation",
+                "agent",
+                &request_json,
+                &chunk,
+                Vec::new(),
+            );
+            let serialized = serde_json::to_string(&event).expect("event should serialize");
+
+            assert!(!serialized.contains(marker));
+            assert!(event.llm_request.is_none());
+            assert!(!event.provider_metadata.contains_key("gcp.vertex.agent.llm_request"));
+            assert!(!event.provider_metadata.contains_key("gcp.vertex.agent.llm_response"));
+            serialized_bytes += serialized.len();
+        }
+
+        assert!(
+            serialized_bytes < 1024 * 1024,
+            "64 tiny chunks unexpectedly serialized to {serialized_bytes} bytes"
+        );
     }
 }

--- a/adk-agent/tests/streaming_test.rs
+++ b/adk-agent/tests/streaming_test.rs
@@ -242,9 +242,20 @@ async fn test_streaming_chunks() {
     let mut stream = agent.run(ctx).await.unwrap();
 
     let mut received_chunks = Vec::new();
+    let mut terminal_payloads = 0;
 
     while let Some(result) = stream.next().await {
         let event = result.unwrap();
+        if event.llm_response.partial {
+            assert!(event.llm_request.is_none());
+            assert!(!event.provider_metadata.contains_key("gcp.vertex.agent.llm_request"));
+            assert!(!event.provider_metadata.contains_key("gcp.vertex.agent.llm_response"));
+        } else {
+            terminal_payloads += 1;
+            assert!(event.llm_request.is_some());
+            assert!(event.provider_metadata.contains_key("gcp.vertex.agent.llm_request"));
+            assert!(event.provider_metadata.contains_key("gcp.vertex.agent.llm_response"));
+        }
         if let Some(content) = event.llm_response.content
             && let Some(Part::Text { text }) = content.parts.first()
         {
@@ -253,4 +264,5 @@ async fn test_streaming_chunks() {
     }
 
     assert_eq!(received_chunks, vec!["Hello", " ", "World", "!"]);
+    assert_eq!(terminal_payloads, 1);
 }


### PR DESCRIPTION
## What

Stops incremental LLM stream events from repeating the complete request and provider request/response payload snapshots on every partial chunk.

Terminal events retain the existing payload snapshots for backwards-compatible debugging and observability.

## Why

Fixes #648

A large request was previously serialized into every partial event, producing O(request size × chunk count) payload overhead.

This becomes particularly expensive for requests containing long conversation histories, system instructions, and tool definitions.

## How

- Omits `llm_request` when `chunk.partial == true`.
- Omits `gcp.vertex.agent.llm_request` and `gcp.vertex.agent.llm_response` from partial events.
- Preserves all three payload fields on the terminal event.
- Adds a regression test using a 128 KiB request and 64 partial chunks.
- Extends the streaming integration test to verify that partial payloads are absent and exactly one terminal payload remains.
- Updates the changelog.

This is intentionally a narrow fix. It does not change:

- `RunConfig::record_payloads` semantics
- Runtime wire-format policies
- Session event consolidation
- Public APIs or configuration

## Serialized Payload Measurement

The measurement serializes the `Event` values produced by `build_partial_llm_event` using a 131,086-byte synthetic request, 64 incremental partial chunks, and one terminal event.

| Measurement | Before | After | Reduction |
|---|---:|---:|---:|
| 64 partial events | 16,828,918 bytes (16.05 MiB) | 28,854 bytes (28.18 KiB) | 99.83% |
| Complete stream, including terminal event | 17,091,882 bytes (16.30 MiB) | 291,818 bytes (284.98 KiB) | 98.29% |
| Terminal event alone | 262,964 bytes | 262,964 bytes | Unchanged |

The complete serialized stream is approximately 58.6× smaller in this synthetic case.

The terminal-event size remains unchanged, confirming that the existing debug payload is preserved. This measures serialized JSON payload size rather than end-to-end latency or model throughput.

## Validation

The following checks passed locally:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo nextest run --workspace`
  - 4508 tests passed
  - 88 tests skipped
- `cargo check --workspace`
- Targeted unit regression test
- `adk-agent` streaming integration test

## PR Checklist

### Quality Gates (all required)

- [x] Format check passed
- [x] Clippy passed with zero warnings
- [x] All non-ignored workspace tests passed
- [x] Workspace compilation check passed

### Code Quality

- [x] New code has unit and integration regression tests
- [x] Public API documentation is unchanged because no public API was added
- [x] No `println!` or `eprintln!` was added to library code
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts
- [x] No unrelated formatting, refactoring, or feature changes
- [x] Branch naming follows the `fix/` convention
- [x] Commit message follows the conventional commit format
- [x] PR targets the upstream `main` branch
- [x] PR references and closes #648

### Documentation

- [x] `CHANGELOG.md` updated
- [x] README changes are not required because no public capability changed
- [x] Additional examples are not required because regression tests cover the behavior
