### PR TITLE
fix(model): release false-positive tool-call buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Text tool-call buffering** (`adk-model`): ordinary text that begins like a
+  split tool-call prefix is released as soon as later chunks disambiguate it, so
+  Markdown links and similar content do not remain buffered until stream end.
 - **OpenAI-compatible streaming usage** (`adk-model`): usage-only terminal
   chunks with empty `choices` attach token counts to the final response.
 - **Span parenting across suspension points** (`adk-agent`, `adk-runner`): one

--- a/adk-model/src/tool_call_parser.rs
+++ b/adk-model/src/tool_call_parser.rs
@@ -413,6 +413,10 @@ impl ToolCallBuffer {
             if self.has_complete_tool_call() {
                 return self.try_parse_and_emit();
             }
+            // A prefix-like chunk can become ordinary text once more data arrives.
+            if !self.starts_tool_call_prefix() && !self.has_partial_prefix() {
+                return self.flush_as_emit();
+            }
             // Safety valve: if buffer is too large, flush as text
             if self.buffer.len() > MAX_BUFFER_SIZE {
                 return self.flush_as_emit();
@@ -742,6 +746,46 @@ mod tests {
                 assert!(matches!(&parts[0], Part::FunctionCall { name, .. } if name == "x"));
             }
             BufferAction::Buffering => panic!("should emit"),
+        }
+    }
+
+    #[test]
+    fn test_buffer_markdown_link_is_not_mistaken_for_tool_call() {
+        let mut buf = ToolCallBuffer::new();
+
+        assert!(matches!(buf.push("["), BufferAction::Buffering));
+
+        match buf.push("documentation](https://example.com) trailing text") {
+            BufferAction::Emit(parts) => {
+                assert_eq!(
+                    parts,
+                    vec![Part::Text {
+                        text: "[documentation](https://example.com) trailing text".to_string()
+                    }]
+                );
+            }
+            BufferAction::Buffering => panic!("markdown link must not stay buffered"),
+        }
+
+        assert!(buf.flush().is_empty());
+    }
+
+    #[test]
+    fn test_buffer_mistral_prefix_can_still_span_chunks() {
+        let mut buf = ToolCallBuffer::new();
+
+        assert!(matches!(buf.push("["), BufferAction::Buffering));
+        assert!(matches!(buf.push("TOOL"), BufferAction::Buffering));
+
+        match buf.push(r#"_CALLS][{"name":"search","arguments":{"q":"rust"}}]"#) {
+            BufferAction::Emit(parts) => {
+                assert_eq!(parts.len(), 1);
+                assert!(matches!(
+                    &parts[0],
+                    Part::FunctionCall { name, .. } if name == "search"
+                ));
+            }
+            BufferAction::Buffering => panic!("should emit parsed tool call"),
         }
     }
 


### PR DESCRIPTION
## What

Releases buffered streaming text as soon as it can no longer be a supported tool-call prefix.

This prevents Markdown links and similar ordinary text beginning with `[` from remaining hidden until the model response finishes.

## Why

Fixes #650 

`ToolCallBuffer` correctly buffers ambiguous prefixes such as `[`, because they may become Mistral's `[TOOL_CALLS]` marker across later chunks.

The existing implementation checks whether the accumulated buffer contains a complete tool call, but it does not check whether later content has disqualified the buffer from every supported prefix.

Consequently, once buffering starts, ordinary text can remain buffered until end-of-stream.

## How

While a buffer is active:

1. Continue parsing if it contains a complete tool call.
2. Continue buffering if it still matches a supported full or partial prefix.
3. Otherwise, immediately flush the accumulated content as ordinary text.

The existing maximum-buffer safety valve remains unchanged.

Two regression tests are included:

- A Markdown link beginning with `[` is emitted as soon as the second chunk disambiguates it.
- A genuine Mistral `[TOOL_CALLS]` marker can still span three chunks and is parsed as a function call.

## Deterministic Streaming Experiment

Input:

1. `[`
2. `documentation](https://example.com) trailing text`

| Step | Upstream | This fix |
|---|---|---|
| First chunk | `Buffering` | `Buffering` |
| Second chunk | Still `Buffering` | Immediately emits the complete Markdown text |
| End-of-stream `flush()` | Emits delayed text | Empty |

The previous delay lasts until the response ends, so its wall-clock duration depends on the remaining generation time. The experiment therefore reports the deterministic buffer state rather than an artificial timing number.

The valid split-prefix regression uses:

1. `[`
2. `TOOL`
3. `_CALLS][{"name":"search","arguments":{"q":"rust"}}]`

It remains buffered for the first two chunks and emits a parsed function call after the third.

## Validation

The following checks passed:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo nextest run --workspace`
- `cargo check --workspace`
- Markdown false-positive regression test
- Split Mistral tool-call prefix regression test

## PR Checklist

### Quality Gates (all required)

- [x] Format check passed
- [x] Clippy passed with zero warnings
- [x] All non-ignored workspace tests passed
- [x] Workspace compilation check passed

### Code Quality

- [x] New code has regression tests
- [x] Public API documentation is unchanged because no public API was added
- [x] No `println!` or `eprintln!` was added to library code
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts
- [x] No unrelated formatting, refactoring, or feature changes
- [x] Branch naming follows the `fix/` convention
- [x] Commit message follows the conventional commit format
- [x] PR targets the upstream `main` branch
- [x] PR references and closes #650 

### Documentation

- [x] `CHANGELOG.md` updated
- [x] README changes are not required because no public capability changed
- [x] Additional examples are not required because regression tests cover the behavior
