### PR TITLE
fix(server): emit errors on wrapped SSE streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Runtime SSE errors** (`adk-server`): ADK UI and legacy wrapped transports
+  emit structured runtime error events instead of ending the stream silently;
+  protocol-native AG-UI continues to emit `RUN_ERROR`.
 - **OpenAI-compatible streaming usage** (`adk-model`): usage-only terminal
   chunks with empty `choices` attach token counts to the final response.
 - **Span parenting across suspension points** (`adk-agent`, `adk-runner`): one

--- a/adk-server/src/rest/controllers/runtime.rs
+++ b/adk-server/src/rest/controllers/runtime.rs
@@ -311,6 +311,13 @@ fn serialize_runtime_event(event: &adk_core::Event, profile: UiProfile) -> Optio
     .ok()
 }
 
+fn serialize_runtime_error(error: &adk_core::AdkError, profile: UiProfile) -> Option<String> {
+    let mut event = adk_core::Event::new(String::new());
+    event.llm_response.error_code = Some(error.code.to_string());
+    event.llm_response.error_message = Some(error.to_string());
+    serialize_runtime_event(&event, profile)
+}
+
 fn infer_sse_request_protocol(req: &RunSseRequest) -> Option<&str> {
     req.ui_protocol
         .as_deref()
@@ -1106,6 +1113,8 @@ where
                             "runId": run_id,
                             "message": error.to_string(),
                         }).to_string()));
+                    } else if let Some(payload) = serialize_runtime_error(&error, profile) {
+                        yield Ok(Event::default().data(payload));
                     }
                     return;
                 }

--- a/adk-server/tests/server_tests.rs
+++ b/adk-server/tests/server_tests.rs
@@ -187,6 +187,31 @@ impl adk_core::Agent for StreamingTestAgent {
     }
 }
 
+struct ErrorStreamingTestAgent;
+
+#[async_trait]
+impl adk_core::Agent for ErrorStreamingTestAgent {
+    fn name(&self) -> &str {
+        "error-stream-test-agent"
+    }
+
+    fn description(&self) -> &str {
+        "Streaming error test agent"
+    }
+
+    fn sub_agents(&self) -> &[Arc<dyn adk_core::Agent>] {
+        &[]
+    }
+
+    async fn run(
+        &self,
+        _ctx: Arc<dyn adk_core::InvocationContext>,
+    ) -> adk_core::Result<Pin<Box<dyn futures::Stream<Item = adk_core::Result<Event>> + Send>>>
+    {
+        Ok(Box::pin(stream::once(async { Err(adk_core::AdkError::model("provider unavailable")) })))
+    }
+}
+
 struct PartialReasoningStreamingTestAgent;
 
 #[async_trait]
@@ -1334,6 +1359,84 @@ async fn test_run_sse_compat_emits_profile_wrapped_event() {
     let body_str = String::from_utf8(body.to_vec()).unwrap();
     assert!(body_str.contains("\"ui_protocol\":\"ag_ui\""));
     assert!(body_str.contains("\"event\""));
+}
+
+#[tokio::test]
+async fn test_run_sse_adk_ui_emits_runtime_error_event() {
+    let agent = Arc::new(ErrorStreamingTestAgent);
+    let config = adk_server::ServerConfig::new(
+        Arc::new(adk_core::SingleAgentLoader::new(agent)),
+        Arc::new(adk_session::InMemorySessionService::new()),
+    );
+    let app = create_app(config);
+
+    let body = serde_json::json!({
+        "appName": "error-stream-test-agent",
+        "userId": "user1",
+        "sessionId": "session1",
+        "newMessage": {
+            "role": "user",
+            "parts": [{ "text": "hello" }]
+        }
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/run_sse")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_str = String::from_utf8(body.to_vec()).unwrap();
+    assert!(body_str.contains("provider unavailable"));
+    assert!(body_str.contains("error_code"));
+}
+
+#[tokio::test]
+async fn test_run_sse_wrapped_profile_emits_runtime_error_event() {
+    let agent = Arc::new(ErrorStreamingTestAgent);
+    let config = adk_server::ServerConfig::new(
+        Arc::new(adk_core::SingleAgentLoader::new(agent)),
+        Arc::new(adk_session::InMemorySessionService::new()),
+    );
+    let app = create_app(config);
+
+    let body = serde_json::json!({
+        "appName": "error-stream-test-agent",
+        "userId": "user1",
+        "sessionId": "session1",
+        "newMessage": {
+            "role": "user",
+            "parts": [{ "text": "hello" }]
+        },
+        "uiProtocol": "a2ui"
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/run_sse")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_str = String::from_utf8(body.to_vec()).unwrap();
+    assert!(body_str.contains("\"ui_protocol\":\"a2ui\""));
+    assert!(body_str.contains("provider unavailable"));
+    assert!(body_str.contains("error_code"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What

Emits structured runtime error events when an agent stream fails under the default ADK UI or a legacy wrapped SSE profile.

Protocol-native AG-UI continues to emit its existing `RUN_ERROR` event.

## Why

Fixes #652 

Once an SSE response has started, an agent-stream failure cannot be communicated through a new HTTP error status.

Native AG-UI already handles this by emitting `RUN_ERROR`. Other UI profiles previously returned from the stream without yielding an error event, causing clients to observe an apparently normal EOF.

## How

Adds a small `serialize_runtime_error` helper that:

1. Creates a standard ADK runtime `Event`.
2. Copies `AdkError::code` into `llm_response.error_code`.
3. Copies the formatted error into `llm_response.error_message`.
4. Passes the event through the existing `serialize_runtime_event` function for the selected `UiProfile`.

The stream error branch now behaves as follows:

- Native AG-UI: emit the existing `RUN_ERROR`.
- Other profiles: serialize and emit a standard runtime error event.
- Return after emitting the error.

No new protocol envelope or endpoint is introduced.

## Deterministic SSE Experiment

A test agent returns this as its first stream item:

```rust
Err(adk_core::AdkError::model("provider unavailable"))
```

The complete SSE response is collected for each profile:

| Profile | Before | After |
|---|---|---|
| Default ADK UI | No runtime error event | Event contains `error_code` and `provider unavailable` |
| Wrapped A2UI | No runtime error event | Wrapped event contains `ui_protocol: "a2ui"`, `error_code`, and `provider unavailable` |
| Native AG-UI | Protocol-native `RUN_ERROR` | Unchanged |

The HTTP response remains 200 because the SSE response has already started. The failure is now communicated through the stream itself.

## Tests

Two integration tests were added:

- `test_run_sse_adk_ui_emits_runtime_error_event`
- `test_run_sse_wrapped_profile_emits_runtime_error_event`

They execute a real Axum application, call `POST /api/run_sse`, collect the response body, and verify the error fields and profile wrapper.

## Validation

The following checks passed:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo nextest run --workspace`
- `cargo check --workspace`
- ADK UI runtime-error integration test
- Wrapped A2UI runtime-error integration test

## PR Checklist

### Quality Gates (all required)

- [x] Format check passed
- [x] Clippy passed with zero warnings
- [x] All non-ignored workspace tests passed
- [x] Workspace compilation check passed

### Code Quality

- [x] New code has integration test coverage
- [x] Public API documentation is unchanged because no public API was added
- [x] No `println!` or `eprintln!` was added to library code
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts
- [x] No unrelated formatting, refactoring, or feature changes
- [x] Branch naming follows the `fix/` convention
- [x] Commit message follows the conventional commit format
- [x] PR targets the upstream `main` branch
- [x] PR references and closes #652 

### Documentation

- [x] `CHANGELOG.md` updated
- [x] README changes are not required because no public capability changed
- [x] Additional examples are not required because integration tests cover the behavior
