### PR TITLE
fix(model): emit DeepSeek stream content exactly once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **DeepSeek streaming emitted every response twice** (`adk-model`): the
+  terminal SSE chunk replayed the accumulated text and reasoning buffers on top
+  of the deltas it had already yielded as partial chunks. Consumers accumulate
+  the parts of every chunk — `LlmAgent` does, to build conversation history — so
+  they saw the whole response twice. With `output_schema` set that is
+  `{...}{...}`, which fails JSON parsing ("Response is not valid JSON: trailing
+  characters") and burns every schema-validation retry, so structured output was
+  unusable on DeepSeek. The terminal chunk now contributes only its own `delta`,
+  plus reasoning that was buffered but never streamed (thinking disabled), and a
+  `delta.content` arriving in the same chunk as `finish_reason` is no longer
+  dropped.
+
 ## [2.2.0] - 2026-09-01
 
 ### Added

--- a/adk-model/src/deepseek/client.rs
+++ b/adk-model/src/deepseek/client.rs
@@ -275,7 +275,6 @@ impl Llm for DeepSeekClient {
                 let mut tool_call_accumulators: std::collections::HashMap<u32, (String, String, String)> =
                     std::collections::HashMap::new();
                 let mut reasoning_buffer = String::new();
-                let mut text_buffer = String::new();
 
                 while let Some(chunk_result) = byte_stream.next().await {
                     let chunk = chunk_result
@@ -368,11 +367,10 @@ impl Llm for DeepSeekClient {
                                                         (id, name, args)
                                                     })
                                                     .collect();
-                                                let tool_reasoning = if thinking_enabled {
-                                                    Some(std::mem::take(&mut reasoning_buffer))
-                                                } else {
-                                                    None
-                                                };
+                                                let tool_reasoning = convert::pending_reasoning(
+                                                    &mut reasoning_buffer,
+                                                    thinking_enabled,
+                                                );
                                                 yield convert::create_tool_call_response(
                                                     tool_calls,
                                                     finish_reason,
@@ -381,18 +379,11 @@ impl Llm for DeepSeekClient {
                                                 continue;
                                             }
 
-                                            let mut parts = Vec::new();
-                                            if !reasoning_buffer.is_empty() {
-                                                parts.push(Part::Thinking {
-                                                    thinking: std::mem::take(&mut reasoning_buffer),
-                                                    signature: None,
-                                                });
-                                            }
-                                            if !text_buffer.is_empty() {
-                                                parts.push(Part::Text {
-                                                    text: std::mem::take(&mut text_buffer),
-                                                });
-                                            }
+                                            let parts = convert::final_chunk_parts(
+                                                choice.delta.as_ref(),
+                                                &mut reasoning_buffer,
+                                                thinking_enabled,
+                                            );
 
                                             let content = if parts.is_empty() {
                                                 None
@@ -430,7 +421,6 @@ impl Llm for DeepSeekClient {
                                             if let Some(delta) = &choice.delta
                                                 && let Some(text) = &delta.content
                                                     && !text.is_empty() {
-                                                        text_buffer.push_str(text);
                                                         yield LlmResponse {
                                                             content: Some(adk_core::Content {
                                                                 role: "model".to_string(),

--- a/adk-model/src/deepseek/convert.rs
+++ b/adk-model/src/deepseek/convert.rs
@@ -276,6 +276,57 @@ pub fn content_to_message(content: &Content) -> Message {
     }
 }
 
+/// Reasoning that the terminal chunk still owes the consumer.
+///
+/// With thinking enabled, each `reasoning_content` delta is yielded as a
+/// partial `Part::Thinking` while it arrives, so the terminal chunk must not
+/// replay `buffer`. With thinking disabled the deltas are buffered and never
+/// yielded, so the terminal chunk is the only place they can surface.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// // thinking enabled: already streamed, nothing left to emit
+/// assert!(pending_reasoning(&mut buffer, true).is_none());
+/// ```
+pub fn pending_reasoning(buffer: &mut String, thinking_enabled: bool) -> Option<String> {
+    if thinking_enabled || buffer.is_empty() {
+        return None;
+    }
+    Some(std::mem::take(buffer))
+}
+
+/// Parts the terminal chunk of a stream contributes, on top of everything its
+/// earlier chunks already yielded.
+///
+/// ADK accumulates the parts of *every* chunk it receives, partial ones
+/// included, so each piece of a response must be emitted exactly once across
+/// the stream. The terminal chunk therefore carries only its own `delta` —
+/// plus any reasoning that was buffered but never streamed.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// // The usual DeepSeek finish chunk has an empty delta and contributes nothing.
+/// assert!(final_chunk_parts(None, &mut String::new(), false).is_empty());
+/// ```
+pub fn final_chunk_parts(
+    delta: Option<&DeltaMessage>,
+    reasoning_buffer: &mut String,
+    thinking_enabled: bool,
+) -> Vec<Part> {
+    let mut parts = Vec::new();
+    if let Some(thinking) = pending_reasoning(reasoning_buffer, thinking_enabled) {
+        parts.push(Part::Thinking { thinking, signature: None });
+    }
+    if let Some(text) = delta.and_then(|d| d.content.as_deref())
+        && !text.is_empty()
+    {
+        parts.push(Part::Text { text: text.to_string() });
+    }
+    parts
+}
+
 /// Convert ADK tools to DeepSeek tools.
 ///
 /// When `strict` is `true`, each tool definition includes `"strict": true`
@@ -431,6 +482,44 @@ pub fn create_tool_call_response(
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn pending_reasoning_is_owed_only_when_it_was_never_streamed() {
+        // Thinking enabled: the deltas were yielded as they arrived.
+        let mut buffer = String::from("because");
+        assert_eq!(pending_reasoning(&mut buffer, true), None);
+        assert_eq!(buffer, "because", "buffer must not be consumed");
+
+        // Thinking disabled: the terminal chunk is the only place it can surface.
+        assert_eq!(pending_reasoning(&mut buffer, false), Some("because".to_string()));
+        assert!(buffer.is_empty(), "buffer is drained once emitted");
+        assert_eq!(pending_reasoning(&mut buffer, false), None);
+    }
+
+    #[test]
+    fn final_chunk_carries_only_its_own_delta() {
+        // Regression: the terminal chunk used to replay the accumulated text
+        // buffer on top of the deltas it had already yielded, so consumers that
+        // accumulate every chunk saw the whole response twice.
+        let delta = DeltaMessage { content: Some("tail".into()), ..Default::default() };
+        let parts = final_chunk_parts(Some(&delta), &mut String::new(), false);
+        assert_eq!(parts.len(), 1);
+        assert!(matches!(&parts[0], Part::Text { text } if text == "tail"));
+
+        // The usual DeepSeek finish chunk has an empty delta.
+        assert!(final_chunk_parts(None, &mut String::new(), false).is_empty());
+        let empty = DeltaMessage { content: Some(String::new()), ..Default::default() };
+        assert!(final_chunk_parts(Some(&empty), &mut String::new(), false).is_empty());
+    }
+
+    #[test]
+    fn final_chunk_orders_unstreamed_reasoning_before_text() {
+        let delta = DeltaMessage { content: Some("answer".into()), ..Default::default() };
+        let mut buffer = String::from("because");
+        let parts = final_chunk_parts(Some(&delta), &mut buffer, false);
+        assert!(matches!(&parts[0], Part::Thinking { thinking, .. } if thinking == "because"));
+        assert!(matches!(&parts[1], Part::Text { text } if text == "answer"));
+    }
+
     use super::*;
 
     #[test]

--- a/adk-model/tests/deepseek_stream_duplicate_text_tests.rs
+++ b/adk-model/tests/deepseek_stream_duplicate_text_tests.rs
@@ -1,0 +1,205 @@
+//! Regression tests for the DeepSeek SSE streaming path.
+//!
+//! ADK accumulates the parts of *every* chunk a provider yields — partial
+//! chunks included (`adk-agent/src/llm_agent.rs`, "Accumulate content for
+//! conversation history"). A provider must therefore emit each piece of the
+//! response exactly once across the stream.
+//!
+//! These tests exercise the real streaming code path in
+//! `adk-model/src/deepseek/client.rs`: a `wiremock` server returns a DeepSeek
+//! streaming (SSE) response, the client parses it, and we assert that
+//! concatenating every emitted `Part::Text` reproduces the source text once —
+//! not twice.
+
+#![cfg(feature = "deepseek")]
+
+use adk_core::{Content, Llm, LlmRequest, Part};
+use adk_model::deepseek::{DeepSeekClient, DeepSeekConfig, ThinkingMode};
+use futures::StreamExt;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn make_client(base_url: &str) -> DeepSeekClient {
+    let config = DeepSeekConfig::new("test-key", "deepseek-chat")
+        .with_base_url(base_url)
+        .with_thinking_mode(ThinkingMode::Disabled);
+    DeepSeekClient::new(config).expect("client creation should succeed")
+}
+
+fn make_request() -> LlmRequest {
+    LlmRequest::new("deepseek-chat", vec![Content::new("user").with_text("Hello")])
+}
+
+/// One SSE `chat.completion.chunk` carrying a `delta.content` fragment.
+fn content_chunk(content: &str) -> String {
+    let v = serde_json::json!({
+        "id": "chatcmpl-1",
+        "object": "chat.completion.chunk",
+        "created": 0,
+        "model": "deepseek-chat",
+        "choices": [{
+            "index": 0,
+            "delta": { "content": content },
+            "finish_reason": null
+        }]
+    });
+    format!("data: {}\n\n", serde_json::to_string(&v).unwrap())
+}
+
+/// The terminal chunk: empty delta plus `finish_reason` and usage.
+fn finish_chunk() -> String {
+    let v = serde_json::json!({
+        "id": "chatcmpl-1",
+        "object": "chat.completion.chunk",
+        "created": 0,
+        "model": "deepseek-chat",
+        "choices": [{
+            "index": 0,
+            "delta": {},
+            "finish_reason": "stop"
+        }],
+        "usage": { "prompt_tokens": 5, "completion_tokens": 5, "total_tokens": 10 }
+    });
+    format!("data: {}\n\n", serde_json::to_string(&v).unwrap())
+}
+
+fn sse_body(fragments: &[&str]) -> String {
+    let mut body = String::new();
+    for f in fragments {
+        body.push_str(&content_chunk(f));
+    }
+    body.push_str(&finish_chunk());
+    body.push_str("data: [DONE]\n\n");
+    body
+}
+
+/// Concatenate every `Part::Text` across every chunk of the stream, the way
+/// `LlmAgent` accumulates them into the final content.
+async fn collect_text(body: String) -> String {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_raw(body, "text/event-stream")
+                .insert_header("content-type", "text/event-stream"),
+        )
+        .mount(&server)
+        .await;
+
+    let client = make_client(&server.uri());
+    let mut stream =
+        client.generate_content(make_request(), true).await.expect("stream should start");
+
+    let mut text = String::new();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.expect("chunk should not error");
+        if let Some(content) = chunk.content {
+            for part in content.parts {
+                if let Part::Text { text: t } = part {
+                    text.push_str(&t);
+                }
+            }
+        }
+    }
+    text
+}
+
+#[tokio::test]
+async fn streamed_text_is_emitted_exactly_once() {
+    // The finish chunk used to re-emit the whole accumulated text buffer on top
+    // of the deltas it had already yielded, so every consumer that accumulates
+    // all chunks saw the response twice.
+    let text = collect_text(sse_body(&["Hello", ", ", "world!"])).await;
+    assert_eq!(text, "Hello, world!");
+}
+
+#[tokio::test]
+async fn structured_json_output_stays_parsable() {
+    // The concrete symptom: with `output_schema` set, a doubled response is
+    // `{...}{...}`, which fails JSON parsing ("trailing characters") and burns
+    // every schema-validation retry.
+    let text = collect_text(sse_body(&["{\"tags\"", ":[\"jazz\"],", "\"price_min\":50}"])).await;
+    assert_eq!(text, "{\"tags\":[\"jazz\"],\"price_min\":50}");
+    serde_json::from_str::<serde_json::Value>(&text).expect("streamed JSON should parse");
+}
+
+#[tokio::test]
+async fn final_content_delta_is_not_dropped() {
+    // Some providers put the last token in the same chunk as `finish_reason`.
+    // That delta must still be emitted.
+    let mut body = content_chunk("partial");
+    let v = serde_json::json!({
+        "id": "chatcmpl-1",
+        "object": "chat.completion.chunk",
+        "created": 0,
+        "model": "deepseek-chat",
+        "choices": [{
+            "index": 0,
+            "delta": { "content": " tail" },
+            "finish_reason": "stop"
+        }]
+    });
+    body.push_str(&format!("data: {}\n\n", serde_json::to_string(&v).unwrap()));
+    body.push_str("data: [DONE]\n\n");
+
+    assert_eq!(collect_text(body).await, "partial tail");
+}
+
+/// Same contract for reasoning: with thinking enabled the deltas are yielded as
+/// they arrive, so the finish chunk must not replay the accumulated buffer.
+#[tokio::test]
+async fn streamed_reasoning_is_emitted_exactly_once() {
+    let server = MockServer::start().await;
+    let mut body = String::new();
+    for r in ["think", "ing"] {
+        let v = serde_json::json!({
+            "id": "chatcmpl-1",
+            "object": "chat.completion.chunk",
+            "created": 0,
+            "model": "deepseek-reasoner",
+            "choices": [{
+                "index": 0,
+                "delta": { "reasoning_content": r },
+                "finish_reason": null
+            }]
+        });
+        body.push_str(&format!("data: {}\n\n", serde_json::to_string(&v).unwrap()));
+    }
+    body.push_str(&content_chunk("answer"));
+    body.push_str(&finish_chunk());
+    body.push_str("data: [DONE]\n\n");
+
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_raw(body, "text/event-stream")
+                .insert_header("content-type", "text/event-stream"),
+        )
+        .mount(&server)
+        .await;
+
+    let config = DeepSeekConfig::new("test-key", "deepseek-reasoner")
+        .with_base_url(server.uri())
+        .with_thinking_mode(ThinkingMode::Enabled);
+    let client = DeepSeekClient::new(config).expect("client creation should succeed");
+    let mut stream = client
+        .generate_content(
+            LlmRequest::new("deepseek-reasoner", vec![Content::new("user").with_text("Hi")]),
+            true,
+        )
+        .await
+        .expect("stream should start");
+
+    let mut thinking = String::new();
+    while let Some(chunk) = stream.next().await {
+        for part in chunk.expect("chunk should not error").content.into_iter().flat_map(|c| c.parts)
+        {
+            if let Part::Thinking { thinking: t, .. } = part {
+                thinking.push_str(&t);
+            }
+        }
+    }
+    assert_eq!(thinking, "thinking");
+}


### PR DESCRIPTION
## What

The DeepSeek SSE stream emitted the whole response twice. Its terminal chunk
(the one with `finish_reason`) replayed the accumulated `text_buffer` and
`reasoning_buffer` on top of the deltas it had already yielded as partial
chunks, and every consumer that accumulates the parts of each chunk — `LlmAgent`
does, to build conversation history — ended up with the response duplicated.

With `output_schema` set that is `{...}{...}`: not valid JSON, so validation
fails, and the correction retries fail identically. Every structured-output call
on DeepSeek ended as
`agent.internal: output schema validation failed after 3 attempts`. Without a
schema it silently doubled the text and `Part::Thinking` parts in history on
every turn.

## Why

Link to the issue this addresses: Fixes #656

## How

`convert::final_chunk_parts` builds what the terminal chunk still owes the
consumer: only that chunk's own `delta`, plus reasoning that was buffered but
never streamed. This is the contract `openai_compatible.rs` already follows —
its terminal chunk emits its own delta and nothing more.

Two smaller bugs in the same branch fall out of the same rule:

- `delta.content` arriving in the *same* chunk as `finish_reason` was dropped,
  because it was only read in the non-finish arm. `"partial" + " tail"` came out
  as `"partialpartial"`.
- The tool-call arm had the reasoning condition inverted — it replayed
  `reasoning_buffer` when thinking was *enabled* (already streamed, so
  duplicated) and dropped it when disabled (never streamed, so lost). Both arms
  now share `convert::pending_reasoning`.

`text_buffer` is gone; nothing reads it any more.

Tests: three unit tests on the two new helpers, plus
`adk-model/tests/deepseek_stream_duplicate_text_tests.rs` — wiremock SSE
coverage, modelled on the existing `whitespace_stream_deltas_e2e.rs`, for text
emitted once, streamed JSON staying parsable, the final delta not being dropped,
and reasoning emitted once. All four fail on `main` (f2edb385) and pass here.

## PR Checklist

### Quality Gates (all required)

- [x] `devenv shell fmt` — code is formatted (Edition 2024) — ran `cargo fmt --all -- --check`
- [x] `devenv shell clippy` — zero warnings (-D warnings) — ran `cargo clippy --workspace --all-targets -- -D warnings`, plus `-p adk-model --all-targets --all-features`
- [x] `devenv shell test` — all non-ignored tests pass — ran `cargo test -p adk-model --all-features` (nextest not installed locally; CI covers the workspace run)
- [x] `devenv shell check` — fast workspace compilation check

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [x] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [x] CHANGELOG.md updated for user-facing changes
- [ ] README updated if crate capabilities changed — n/a
- [ ] Examples added or updated for new features — n/a
