### PR TITLE
feat(adk-skill): inject progressive disclosure guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Automatic progressive-skill guidance** (`adk-skill`, `adk-agent`):
+  `SkillToolset` now adds guidance for its currently available tools to each
+  model request through the new `Toolset::process_llm_request` hook. Guidance
+  is also applied to invocation-scoped toolsets.
+
 ## [2.2.0] - 2026-09-01
 
 ### Added

--- a/adk-agent/src/llm_agent.rs
+++ b/adk-agent/src/llm_agent.rs
@@ -485,6 +485,20 @@ impl ToolSetup {
 
         Ok(ResolvedTools { map, declarations, transfer_targets })
     }
+
+    /// Lets static and invocation-scoped toolsets enrich each LLM request.
+    async fn process_llm_request(
+        &self,
+        ctx: &Arc<dyn InvocationContext>,
+        request: &mut LlmRequest,
+    ) -> Result<()> {
+        for toolset in self.toolsets.iter().map(AsRef::as_ref).chain(
+            ctx.run_config().runtime_toolsets.iter().map(|runtime| runtime.toolset().as_ref()),
+        ) {
+            toolset.process_llm_request(ctx.clone() as Arc<dyn ReadonlyContext>, request).await?;
+        }
+        Ok(())
+    }
 }
 
 impl std::fmt::Debug for LlmAgent {
@@ -2540,7 +2554,7 @@ impl Agent for LlmAgent {
                     ctx.run_config().cached_content.as_deref(),
                 );
 
-                let request = LlmRequest {
+                let mut request = LlmRequest {
                     model: model.name().to_string(),
                     contents: conversation_history.clone(),
                     tools: tool_declarations.clone(),
@@ -2553,6 +2567,11 @@ impl Agent for LlmAgent {
                     // for providers that never populate `interaction_id`.
                     previous_response_id: last_interaction_id.clone(),
                 };
+
+                if let Err(error) = tool_setup.process_llm_request(&ctx, &mut request).await {
+                    yield Err(error);
+                    return;
+                }
 
                 // ===== ENHANCED PLUGIN: BEFORE MODEL CALL =====
                 // Enhanced plugins can modify the request or short-circuit the model call.

--- a/adk-agent/tests/progressive_skill_runner_tests.rs
+++ b/adk-agent/tests/progressive_skill_runner_tests.rs
@@ -12,7 +12,9 @@ use adk_core::{
 };
 use adk_runner::Runner;
 use adk_session::{CreateRequest, GetRequest, InMemorySessionService, SessionService};
-use adk_skill::{SkillToolset, SkillToolsetConfig, load_skill_index};
+use adk_skill::{
+    SkillToolset, SkillToolsetConfig, build_skill_system_instruction, load_skill_index,
+};
 use async_trait::async_trait;
 use futures::StreamExt;
 use serde_json::{Value, json};
@@ -169,6 +171,17 @@ async fn runner_persists_skill_activation_before_the_next_model_turn() {
     {
         let requests = model.requests.lock().expect("requests lock");
         assert_eq!(requests.len(), 3);
+        let expected_skill_instruction = build_skill_system_instruction(
+            None,
+            Some(&["list_skills", "load_skill", "load_skill_resource"]),
+            None,
+            false,
+        );
+        assert!(requests[0].contents.iter().any(|content| {
+            content.parts.iter().any(
+                |part| matches!(part, Part::Text { text } if text == &expected_skill_instruction),
+            )
+        }));
         assert!(!requests[0].tools.contains_key("weather_lookup"));
         assert!(requests[1].tools.contains_key("weather_lookup"));
     }

--- a/adk-agent/tests/progressive_skill_runner_tests.rs
+++ b/adk-agent/tests/progressive_skill_runner_tests.rs
@@ -7,8 +7,9 @@
 
 use adk_agent::LlmAgentBuilder;
 use adk_core::{
-    Agent, Content, FinishReason, Llm, LlmRequest, LlmResponse, LlmResponseStream, Part, Result,
-    SessionId, Tool, ToolContext, ToolRegistry, UserId,
+    Agent, Content, FinishReason, Llm, LlmRequest, LlmResponse, LlmResponseStream, Part,
+    ReadonlyContext, Result, RunConfig, RuntimeToolset, SessionId, Tool, ToolContext, ToolRegistry,
+    Toolset, UserId,
 };
 use adk_runner::Runner;
 use adk_session::{CreateRequest, GetRequest, InMemorySessionService, SessionService};
@@ -113,6 +114,28 @@ impl ToolRegistry for WeatherRegistry {
     }
 }
 
+struct RequestGuidanceToolset;
+
+#[async_trait]
+impl Toolset for RequestGuidanceToolset {
+    fn name(&self) -> &str {
+        "request-guidance"
+    }
+
+    async fn tools(&self, _ctx: Arc<dyn ReadonlyContext>) -> Result<Vec<Arc<dyn Tool>>> {
+        Ok(Vec::new())
+    }
+
+    async fn process_llm_request(
+        &self,
+        _ctx: Arc<dyn ReadonlyContext>,
+        request: &mut LlmRequest,
+    ) -> Result<()> {
+        request.contents.insert(0, Content::new("user").with_text("runtime guidance"));
+        Ok(())
+    }
+}
+
 #[tokio::test]
 async fn runner_persists_skill_activation_before_the_next_model_turn() {
     let temp = tempfile::tempdir().expect("tempdir");
@@ -199,4 +222,53 @@ async fn runner_persists_skill_activation_before_the_next_model_turn() {
     let key = SkillToolset::activation_state_key("weather-agent");
     let activations = session.state().get(&key).expect("activation state persists");
     assert_eq!(activations[0]["name"], "weather");
+}
+
+#[tokio::test]
+async fn runtime_toolsets_enrich_each_model_request() {
+    let model = Arc::new(ScriptedModel::new(vec![ScriptedModel::text("done")]));
+    let agent = LlmAgentBuilder::new("runtime-toolset-agent")
+        .model(model.clone())
+        .build()
+        .expect("agent builds");
+    let sessions = Arc::new(InMemorySessionService::new());
+    sessions
+        .create(CreateRequest {
+            app_name: "runtime-toolset-test".to_string(),
+            user_id: "user-1".to_string(),
+            session_id: Some("session-1".to_string()),
+            state: HashMap::new(),
+        })
+        .await
+        .expect("session creates");
+    let runner = Runner::builder()
+        .app_name("runtime-toolset-test")
+        .agent(Arc::new(agent) as Arc<dyn Agent>)
+        .session_service(sessions as Arc<dyn SessionService>)
+        .build()
+        .expect("runner builds");
+    let mut config = RunConfig::default();
+    config.runtime_toolsets.push(RuntimeToolset::new(Arc::new(RequestGuidanceToolset)));
+
+    let mut stream = runner
+        .run_with_config(
+            UserId::new("user-1").expect("user ID"),
+            SessionId::new("session-1").expect("session ID"),
+            Content::new("user").with_text("hello"),
+            Some(config),
+        )
+        .await
+        .expect("runner starts");
+    while let Some(event) = stream.next().await {
+        event.expect("runner event");
+    }
+
+    let requests = model.requests.lock().expect("requests lock");
+    assert_eq!(requests.len(), 1);
+    assert!(requests[0].contents.iter().any(|content| {
+        content
+            .parts
+            .iter()
+            .any(|part| matches!(part, Part::Text { text } if text == "runtime guidance"))
+    }));
 }

--- a/adk-core/src/tool.rs
+++ b/adk-core/src/tool.rs
@@ -1,5 +1,6 @@
 use crate::{
-    CallbackContext, Event, EventActions, Memory, MemoryEntry, Result, RunConfig, Session,
+    CallbackContext, Event, EventActions, LlmRequest, Memory, MemoryEntry, ReadonlyContext, Result,
+    RunConfig, Session,
 };
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -308,6 +309,20 @@ pub trait Toolset: Send + Sync {
     fn name(&self) -> &str;
     /// Returns the tools available in this toolset for the given context.
     async fn tools(&self, ctx: Arc<dyn crate::ReadonlyContext>) -> Result<Vec<Arc<dyn Tool>>>;
+
+    /// Applies toolset-specific context to an LLM request before each model call.
+    ///
+    /// Toolsets can use this hook to describe a dynamic tool protocol without
+    /// requiring every agent that installs the toolset to repeat that guidance
+    /// in its instruction. The default implementation leaves the request
+    /// unchanged.
+    async fn process_llm_request(
+        &self,
+        _ctx: Arc<dyn ReadonlyContext>,
+        _request: &mut LlmRequest,
+    ) -> Result<()> {
+        Ok(())
+    }
 }
 
 /// Controls how multiple tool calls from a single LLM response are dispatched.

--- a/adk-core/src/tool.rs
+++ b/adk-core/src/tool.rs
@@ -316,6 +316,19 @@ pub trait Toolset: Send + Sync {
     /// requiring every agent that installs the toolset to repeat that guidance
     /// in its instruction. The default implementation leaves the request
     /// unchanged.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// async fn process_llm_request(
+    ///     &self,
+    ///     _ctx: std::sync::Arc<dyn adk_core::ReadonlyContext>,
+    ///     request: &mut adk_core::LlmRequest,
+    /// ) -> adk_core::Result<()> {
+    ///     request.contents.insert(0, adk_core::Content::new("user").with_text("Tool guidance"));
+    ///     Ok(())
+    /// }
+    /// ```
     async fn process_llm_request(
         &self,
         _ctx: Arc<dyn ReadonlyContext>,

--- a/adk-skill/README.md
+++ b/adk-skill/README.md
@@ -363,14 +363,21 @@ matching user message. It provides three always-available tools:
 1. `list_skills` — L1: names and descriptions only.
 2. `load_skill` — L2: loads one skill's instructions and activates its declared
    `allowed-tools` for the next model turn.
-3. `load_skill_resource` — L3: reads a file from an activated skill's
-   `references/`, `assets/`, or `scripts/` directory.
+3. `load_skill_resource` — L3: reads a file from a skill's `references/`,
+   `assets/`, or `scripts/` directory.
+
+`SkillToolset` automatically injects the progressive-disclosure protocol into
+each model request, so individual agents do not need to repeat it in their
+instructions. The protocol is generated at runtime from the tools actually
+available to the toolset. Use `build_skill_system_instruction(...)` to generate
+a variant for a prefixed or filtered toolset, or
+`DEFAULT_SKILL_SYSTEM_INSTRUCTION` for the default exported value.
 
 The activation record contains the skill's content ID and hash, so a changed or
-removed skill cannot silently retain its old permissions. Resources require
-activation by default and reject path traversal. Set
-`ResourceAccessPolicy::GoogleCompatible` only when direct resource reads are
-required for interoperability.
+removed skill cannot silently retain its old permissions. Resources allow direct
+reads by default, matching Google ADK Python, and reject path traversal. Set
+`ResourceAccessPolicy::ActivatedOnly` when resources must require activation
+first.
 
 ```rust,ignore
 use adk_core::ToolRegistry;

--- a/adk-skill/README.md
+++ b/adk-skill/README.md
@@ -374,10 +374,10 @@ a variant for a prefixed or filtered toolset, or
 `DEFAULT_SKILL_SYSTEM_INSTRUCTION` for the default exported value.
 
 The activation record contains the skill's content ID and hash, so a changed or
-removed skill cannot silently retain its old permissions. Resources allow direct
-reads by default, matching Google ADK Python, and reject path traversal. Set
-`ResourceAccessPolicy::ActivatedOnly` when resources must require activation
-first.
+removed skill cannot silently retain its old permissions. Resources require
+activation by default and reject path traversal. Set
+`ResourceAccessPolicy::GoogleCompatible` only when direct resource reads are
+required for interoperability.
 
 ```rust,ignore
 use adk_core::ToolRegistry;

--- a/adk-skill/src/lib.rs
+++ b/adk-skill/src/lib.rs
@@ -57,6 +57,9 @@ pub use model::{
 };
 pub use parser::{parse_instruction_markdown, parse_skill_markdown};
 #[cfg(feature = "progressive-disclosure")]
-pub use progressive::{ActivatedSkill, ResourceAccessPolicy, SkillToolset, SkillToolsetConfig};
+pub use progressive::{
+    ActivatedSkill, DEFAULT_SKILL_SYSTEM_INSTRUCTION, ResourceAccessPolicy, SkillToolset,
+    SkillToolsetConfig, build_skill_system_instruction,
+};
 pub use select::select_skills;
 pub use writer::{SkillDraft, SkillWriter, validate_skill_name};

--- a/adk-skill/src/progressive.rs
+++ b/adk-skill/src/progressive.rs
@@ -13,14 +13,16 @@
 //! ADK-Rust's strict [`ValidationMode`] and content-hash provenance guarantees.
 
 use crate::{SkillDocument, SkillIndex, SkillSummary, ToolRegistry, ValidationMode};
-use adk_core::{AdkError, ReadonlyContext, Result, Tool, ToolContext, Toolset};
+use adk_core::{
+    AdkError, Content, LlmRequest, ReadonlyContext, Result, Tool, ToolContext, Toolset,
+};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::HashSet;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 #[cfg(feature = "vertex-skill-registry")]
 use crate::registry::{SkillContent, SkillRegistryClient, SkillSearchTool};
@@ -33,18 +35,121 @@ const STATE_KEY_PREFIX: &str = "skill:active:";
 #[cfg(feature = "vertex-skill-registry")]
 const MAX_REMOTE_CACHE_INVOCATIONS: usize = 16;
 
+const LIST_SKILLS_TOOL_NAME: &str = "list_skills";
+const LOAD_SKILL_TOOL_NAME: &str = "load_skill";
+const LOAD_SKILL_RESOURCE_TOOL_NAME: &str = "load_skill_resource";
+const RUN_SKILL_SCRIPT_TOOL_NAME: &str = "run_skill_script";
+
+/// Builds the progressive-skill instructions injected into an LLM request.
+///
+/// This mirrors Google ADK Python's `_build_skill_system_instruction`: the
+/// text follows the tools actually exposed by the host, rather than assuming
+/// every skill capability is available.
+///
+/// `script_execution_enabled` must only be `true` when the host exposes a
+/// matching `run_skill_script` tool. ADK-Rust currently reads bundled scripts
+/// but does not execute them, so [`SkillToolset`] passes `false`.
+pub fn build_skill_system_instruction(
+    prefix: Option<&str>,
+    allowed_tools: Option<&[&str]>,
+    skills_folder: Option<&Path>,
+    script_execution_enabled: bool,
+) -> String {
+    let prefix = prefix.map_or(String::new(), |prefix| format!("{prefix}_"));
+    let scripts_bullet = if script_execution_enabled {
+        "- **scripts/** (Optional): Executable scripts that can be run via bash.\n\n".to_string()
+    } else {
+        format!(
+            "- **scripts/** (Optional): Scripts bundled with the skill. You cannot run them; use `{}{}` to read one and follow it yourself.\n\n",
+            prefix, LOAD_SKILL_RESOURCE_TOOL_NAME
+        )
+    };
+    let mut steps = vec![
+        format!(
+            "If a skill seems relevant to the current user query, you MUST use the `{}{}` tool with `skill_name=\"<SKILL_NAME>\"` to read its full instructions before proceeding.",
+            prefix, LOAD_SKILL_TOOL_NAME
+        ),
+        "Once you have read the instructions, follow them exactly as documented before replying to the user. For example, if the instruction lists multiple steps, make sure you complete all of them in order.".to_string(),
+        format!(
+            "The `{}{}` tool is for viewing files within a skill's directory (e.g., `references/*`, `assets/*`, `scripts/*`). It is ONLY for skill-bundled files — do NOT use it to access documents or files provided by the user at runtime. Do NOT use other tools to access skill files.",
+            prefix, LOAD_SKILL_RESOURCE_TOOL_NAME
+        ),
+    ];
+    if script_execution_enabled {
+        steps.push(format!(
+            "Use `{}{}` to run scripts from a skill's `scripts/` directory. Use `{}{}` to view script content first if needed.",
+            prefix, RUN_SKILL_SCRIPT_TOOL_NAME, prefix, LOAD_SKILL_RESOURCE_TOOL_NAME
+        ));
+    }
+    steps.push(format!(
+        "If `{}{}` returns any error, do not retry any path. Report the error to the user and stop.",
+        prefix, LOAD_SKILL_RESOURCE_TOOL_NAME
+    ));
+    if script_execution_enabled {
+        steps.push(format!(
+            "If `{}{}` returns an error (for example `SCRIPT_NOT_FOUND`), do not retry the same script or guess a different script path. Report the error to the user and stop.",
+            prefix, RUN_SKILL_SCRIPT_TOOL_NAME
+        ));
+    }
+    steps.push(format!(
+        "Loading a skill only retrieves its instructions; it does NOT complete your turn. After a `{}{}` call returns, continue in the SAME turn: call whatever tools the skill's steps require (search, data retrieval, render), then write your reply. Never end your turn with an empty response right after loading a skill.",
+        prefix, LOAD_SKILL_TOOL_NAME
+    ));
+    if script_execution_enabled && let Some(folder) = skills_folder {
+        let folder = folder.to_string_lossy();
+        steps.push(format!(
+            "NOTE ON ENVIRONMENT EXECUTION: When using `{}{}` with the `command` parameter, all skill resources (including scripts and assets) are materialized in the execution environment under `{}/<skill_name>/`. Always specify file and script paths relative to or starting with `{}/<skill_name>/` (e.g., `{}/<skill_name>/scripts/<script_name>`).",
+            prefix, RUN_SKILL_SCRIPT_TOOL_NAME, folder, folder, folder
+        ));
+    }
+
+    let mut instruction = format!(
+        "You can use specialized 'skills' to help you with complex tasks. You MUST use the skill tools to interact with these skills.\n\nSkills are folders of instructions and resources that extend your capabilities for specialized tasks. Each skill folder contains:\n- **SKILL.md** (required): The main instruction file with skill metadata and detailed markdown instructions.\n- **references/** (Optional): Additional documentation or examples for skill usage.\n- **assets/** (Optional): Templates, scripts or other resources used by the skill.\n\n{scripts_bullet}This is very important:\n\n{}",
+        steps
+            .iter()
+            .enumerate()
+            .map(|(index, step)| format!("{}. {step}\n", index + 1))
+            .collect::<String>()
+    );
+    if let Some(allowed_tools) = allowed_tools {
+        let banned = [
+            RUN_SKILL_SCRIPT_TOOL_NAME,
+            LOAD_SKILL_RESOURCE_TOOL_NAME,
+            LOAD_SKILL_TOOL_NAME,
+            LIST_SKILLS_TOOL_NAME,
+        ]
+        .into_iter()
+        .filter(|tool_name| !allowed_tools.contains(tool_name))
+        .map(|tool_name| format!("`{prefix}{tool_name}`"))
+        .collect::<Vec<_>>();
+        if !banned.is_empty() {
+            instruction.push_str(&format!(
+                "\n\nNote: The following tools are NOT available: {}. Do NOT call them. After loading a skill (if available), apply its instructions in context and write your final reply as normal model text. Never wrap the user-facing answer inside a tool call.\n",
+                banned.join(", ")
+            ));
+        }
+    }
+    instruction
+}
+
+/// Default progressive-skill instruction for ADK-Rust's supported discovery
+/// and resource-reading tools.
+pub static DEFAULT_SKILL_SYSTEM_INSTRUCTION: LazyLock<String> =
+    LazyLock::new(|| build_skill_system_instruction(None, None, None, false));
+
 /// Rules for reading bundled skill resources.
 ///
-/// [`ActivatedOnly`](Self::ActivatedOnly) is the secure default: a model must
-/// first receive the skill's instructions before it can inspect its auxiliary
-/// files. [`GoogleCompatible`](Self::GoogleCompatible) exists for applications
-/// that need the more permissive behavior of Google ADK's current toolset.
+/// [`GoogleCompatible`](Self::GoogleCompatible) is the default and matches
+/// Google ADK Python: a model may read a bundled resource directly when it
+/// knows the skill name. [`ActivatedOnly`](Self::ActivatedOnly) is an opt-in
+/// stricter policy for hosts that require the model to receive a skill's
+/// instructions before inspecting auxiliary files.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum ResourceAccessPolicy {
     /// Require an earlier successful `load_skill` call for this agent.
-    #[default]
     ActivatedOnly,
-    /// Permit direct reads of a known skill, matching Google ADK's current behavior.
+    /// Permit direct reads of a known skill, matching Google ADK Python.
+    #[default]
     GoogleCompatible,
 }
 
@@ -74,9 +179,10 @@ pub struct ActivatedSkill {
 
 /// Configuration for [`SkillToolset`].
 ///
-/// Defaults favor safe, bounded disclosure: resources require activation,
-/// missing declared tools reject an activation, and instructions/resources are
-/// character-limited before being returned to the model.
+/// Defaults mirror Google ADK Python resource access while retaining bounded
+/// instruction/resource output and strict declared-tool validation. Set
+/// [`ResourceAccessPolicy::ActivatedOnly`] when resource reads must require
+/// activation first.
 ///
 /// # Example
 ///
@@ -107,7 +213,7 @@ pub struct SkillToolsetConfig {
 impl Default for SkillToolsetConfig {
     fn default() -> Self {
         Self {
-            resource_access: ResourceAccessPolicy::ActivatedOnly,
+            resource_access: ResourceAccessPolicy::GoogleCompatible,
             validation_mode: ValidationMode::Strict,
             max_active_skills: 8,
             max_instruction_chars: 8_000,
@@ -516,6 +622,28 @@ impl Toolset for SkillToolset {
         tools.extend(self.resolve_business_tools(ctx.as_ref()).await?);
         Ok(tools)
     }
+
+    async fn process_llm_request(
+        &self,
+        _ctx: Arc<dyn ReadonlyContext>,
+        request: &mut LlmRequest,
+    ) -> Result<()> {
+        // LlmAgent instructions use user-role content for compatibility with
+        // providers that do not support a system role. Keep this protocol in
+        // the same request preamble, without persisting it to session history.
+        let available_tools =
+            [LIST_SKILLS_TOOL_NAME, LOAD_SKILL_TOOL_NAME, LOAD_SKILL_RESOURCE_TOOL_NAME];
+        request.contents.insert(
+            0,
+            Content::new("user").with_text(build_skill_system_instruction(
+                None,
+                Some(&available_tools),
+                None,
+                false,
+            )),
+        );
+        Ok(())
+    }
 }
 
 struct ListSkillsTool {
@@ -620,9 +748,11 @@ impl Tool for LoadSkillResourceTool {
                 .iter()
                 .any(|item| item.document().id == document.id)
         {
-            return Err(AdkError::tool(format!(
-                "skill '{name}' must be loaded before reading its resources"
-            )));
+            return Ok(json!({
+                "error": format!("skill '{name}' must be loaded before reading its resources"),
+                "errorCode": "SKILL_NOT_ACTIVATED",
+                "nextStep": format!("Call load_skill with skill_name '{name}' before calling load_skill_resource."),
+            }));
         }
         let content = skill.resource_content(path)?;
         Ok(json!({
@@ -777,6 +907,24 @@ mod tests {
         tools.iter().find(|tool| tool.name() == name).expect("tool present").clone()
     }
 
+    #[test]
+    fn skill_system_instruction_reflects_available_tools() {
+        let default_instruction = build_skill_system_instruction(None, None, None, false);
+        assert_eq!(&*DEFAULT_SKILL_SYSTEM_INSTRUCTION, &default_instruction);
+        assert!(default_instruction.contains("`load_skill`"));
+        assert!(default_instruction.contains("You cannot run them"));
+
+        let filtered = build_skill_system_instruction(
+            Some("workspace"),
+            Some(&[LIST_SKILLS_TOOL_NAME, LOAD_SKILL_TOOL_NAME]),
+            None,
+            false,
+        );
+        assert!(filtered.contains("`workspace_load_skill`"));
+        assert!(filtered.contains("`workspace_load_skill_resource`"));
+        assert!(filtered.contains("The following tools are NOT available"));
+    }
+
     #[tokio::test]
     async fn loading_a_skill_activates_its_declared_tool_and_resource_access() {
         let (_temp, toolset) = setup();
@@ -812,20 +960,36 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resources_require_activation_and_reject_path_traversal() {
+    async fn google_compatible_default_reads_resources_without_activation() {
         let (_temp, toolset) = setup();
+        let context = Arc::new(TestContext::new());
+        let resource = tool_by_name(
+            &toolset.tools(context.clone()).await.expect("tools"),
+            "load_skill_resource",
+        );
+        let loaded_resource = resource
+            .execute(context, json!({"skill_name": "weather", "file_path": "references/units.md"}))
+            .await
+            .expect("Google-compatible resource read");
+        assert_eq!(loaded_resource["content"], "Use Celsius.");
+    }
+
+    #[tokio::test]
+    async fn resources_require_activation_and_reject_path_traversal() {
+        let (_temp, mut toolset) = setup();
+        toolset.config.resource_access = ResourceAccessPolicy::ActivatedOnly;
         let context = Arc::new(TestContext::new());
         let tools = toolset.tools(context.clone()).await.expect("tools");
         let resource = tool_by_name(&tools, "load_skill_resource");
-        assert!(
-            resource
-                .execute(
-                    context.clone(),
-                    json!({"skill_name": "weather", "file_path": "references/units.md"})
-                )
-                .await
-                .is_err()
-        );
+        let not_activated = resource
+            .execute(
+                context.clone(),
+                json!({"skill_name": "weather", "file_path": "references/units.md"}),
+            )
+            .await
+            .expect("activation guidance");
+        assert_eq!(not_activated["errorCode"], "SKILL_NOT_ACTIVATED");
+        assert!(not_activated["nextStep"].as_str().expect("next step").contains("load_skill"));
 
         let load = tool_by_name(&tools, "load_skill");
         load.execute(context.clone(), json!({"skill_name": "weather"})).await.expect("load skill");

--- a/adk-skill/src/progressive.rs
+++ b/adk-skill/src/progressive.rs
@@ -49,6 +49,22 @@ const RUN_SKILL_SCRIPT_TOOL_NAME: &str = "run_skill_script";
 /// `script_execution_enabled` must only be `true` when the host exposes a
 /// matching `run_skill_script` tool. ADK-Rust currently reads bundled scripts
 /// but does not execute them, so [`SkillToolset`] passes `false`.
+///
+/// # Example
+///
+/// ```rust
+/// use adk_skill::build_skill_system_instruction;
+///
+/// let instruction = build_skill_system_instruction(
+///     Some("workspace"),
+///     Some(&["list_skills", "load_skill"]),
+///     None,
+///     false,
+/// );
+/// assert!(instruction.contains("`workspace_load_skill`"));
+/// assert!(instruction.contains("`workspace_load_skill_resource`"));
+/// assert!(!instruction.contains("The `workspace_load_skill_resource` tool is for viewing"));
+/// ```
 pub fn build_skill_system_instruction(
     prefix: Option<&str>,
     allowed_tools: Option<&[&str]>,
@@ -56,46 +72,71 @@ pub fn build_skill_system_instruction(
     script_execution_enabled: bool,
 ) -> String {
     let prefix = prefix.map_or(String::new(), |prefix| format!("{prefix}_"));
-    let scripts_bullet = if script_execution_enabled {
+    let tool_is_available =
+        |tool_name| allowed_tools.is_none_or(|tools| tools.contains(&tool_name));
+    let can_load_skill = tool_is_available(LOAD_SKILL_TOOL_NAME);
+    let can_load_resource = tool_is_available(LOAD_SKILL_RESOURCE_TOOL_NAME);
+    let can_run_script = script_execution_enabled && tool_is_available(RUN_SKILL_SCRIPT_TOOL_NAME);
+    let scripts_bullet = if can_run_script {
         "- **scripts/** (Optional): Executable scripts that can be run via bash.\n\n".to_string()
-    } else {
+    } else if can_load_resource {
         format!(
             "- **scripts/** (Optional): Scripts bundled with the skill. You cannot run them; use `{}{}` to read one and follow it yourself.\n\n",
             prefix, LOAD_SKILL_RESOURCE_TOOL_NAME
         )
+    } else {
+        "- **scripts/** (Optional): Scripts bundled with the skill.\n\n".to_string()
     };
-    let mut steps = vec![
-        format!(
+    let mut steps = Vec::new();
+    if can_load_skill {
+        steps.push(format!(
             "If a skill seems relevant to the current user query, you MUST use the `{}{}` tool with `skill_name=\"<SKILL_NAME>\"` to read its full instructions before proceeding.",
             prefix, LOAD_SKILL_TOOL_NAME
-        ),
-        "Once you have read the instructions, follow them exactly as documented before replying to the user. For example, if the instruction lists multiple steps, make sure you complete all of them in order.".to_string(),
-        format!(
+        ));
+        steps.push("Once you have read the instructions, follow them exactly as documented before replying to the user. For example, if the instruction lists multiple steps, make sure you complete all of them in order.".to_string());
+    }
+    if can_load_resource {
+        steps.push(format!(
             "The `{}{}` tool is for viewing files within a skill's directory (e.g., `references/*`, `assets/*`, `scripts/*`). It is ONLY for skill-bundled files — do NOT use it to access documents or files provided by the user at runtime. Do NOT use other tools to access skill files.",
             prefix, LOAD_SKILL_RESOURCE_TOOL_NAME
-        ),
-    ];
-    if script_execution_enabled {
-        steps.push(format!(
-            "Use `{}{}` to run scripts from a skill's `scripts/` directory. Use `{}{}` to view script content first if needed.",
-            prefix, RUN_SKILL_SCRIPT_TOOL_NAME, prefix, LOAD_SKILL_RESOURCE_TOOL_NAME
         ));
+        if can_load_skill {
+            steps.push(format!(
+                "If `{}{}` reports that a skill must be loaded first, call `{}{}` for that skill, then retry the resource request once. For any other resource error, do not retry any path; report the error to the user and stop.",
+                prefix, LOAD_SKILL_RESOURCE_TOOL_NAME, prefix, LOAD_SKILL_TOOL_NAME
+            ));
+        } else {
+            steps.push(format!(
+                "If `{}{}` returns an error, do not retry any path. Report the error to the user and stop.",
+                prefix, LOAD_SKILL_RESOURCE_TOOL_NAME
+            ));
+        }
     }
-    steps.push(format!(
-        "If `{}{}` returns any error, do not retry any path. Report the error to the user and stop.",
-        prefix, LOAD_SKILL_RESOURCE_TOOL_NAME
-    ));
-    if script_execution_enabled {
+    if can_run_script {
+        let view_before_running = if can_load_resource {
+            format!(
+                " Use `{}{}` to view script content first if needed.",
+                prefix, LOAD_SKILL_RESOURCE_TOOL_NAME
+            )
+        } else {
+            String::new()
+        };
+        steps.push(format!(
+            "Use `{}{}` to run scripts from a skill's `scripts/` directory.{view_before_running}",
+            prefix, RUN_SKILL_SCRIPT_TOOL_NAME
+        ));
         steps.push(format!(
             "If `{}{}` returns an error (for example `SCRIPT_NOT_FOUND`), do not retry the same script or guess a different script path. Report the error to the user and stop.",
             prefix, RUN_SKILL_SCRIPT_TOOL_NAME
         ));
     }
-    steps.push(format!(
-        "Loading a skill only retrieves its instructions; it does NOT complete your turn. After a `{}{}` call returns, continue in the SAME turn: call whatever tools the skill's steps require (search, data retrieval, render), then write your reply. Never end your turn with an empty response right after loading a skill.",
-        prefix, LOAD_SKILL_TOOL_NAME
-    ));
-    if script_execution_enabled && let Some(folder) = skills_folder {
+    if can_load_skill {
+        steps.push(format!(
+            "Loading a skill only retrieves its instructions; it does NOT complete your turn. After a `{}{}` call returns, continue in the SAME turn: call whatever tools the skill's steps require (search, data retrieval, render), then write your reply. Never end your turn with an empty response right after loading a skill.",
+            prefix, LOAD_SKILL_TOOL_NAME
+        ));
+    }
+    if can_run_script && let Some(folder) = skills_folder {
         let folder = folder.to_string_lossy();
         steps.push(format!(
             "NOTE ON ENVIRONMENT EXECUTION: When using `{}{}` with the `command` parameter, all skill resources (including scripts and assets) are materialized in the execution environment under `{}/<skill_name>/`. Always specify file and script paths relative to or starting with `{}/<skill_name>/` (e.g., `{}/<skill_name>/scripts/<script_name>`).",
@@ -139,17 +180,15 @@ pub static DEFAULT_SKILL_SYSTEM_INSTRUCTION: LazyLock<String> =
 
 /// Rules for reading bundled skill resources.
 ///
-/// [`GoogleCompatible`](Self::GoogleCompatible) is the default and matches
-/// Google ADK Python: a model may read a bundled resource directly when it
-/// knows the skill name. [`ActivatedOnly`](Self::ActivatedOnly) is an opt-in
-/// stricter policy for hosts that require the model to receive a skill's
-/// instructions before inspecting auxiliary files.
+/// [`ActivatedOnly`](Self::ActivatedOnly) is the default: a model must load a
+/// skill before inspecting its auxiliary files. [`GoogleCompatible`](Self::GoogleCompatible)
+/// is an explicit opt-in for hosts that need Google ADK Python interoperability.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum ResourceAccessPolicy {
     /// Require an earlier successful `load_skill` call for this agent.
+    #[default]
     ActivatedOnly,
     /// Permit direct reads of a known skill, matching Google ADK Python.
-    #[default]
     GoogleCompatible,
 }
 
@@ -179,10 +218,10 @@ pub struct ActivatedSkill {
 
 /// Configuration for [`SkillToolset`].
 ///
-/// Defaults mirror Google ADK Python resource access while retaining bounded
+/// Defaults require resource activation while retaining bounded
 /// instruction/resource output and strict declared-tool validation. Set
-/// [`ResourceAccessPolicy::ActivatedOnly`] when resource reads must require
-/// activation first.
+/// [`ResourceAccessPolicy::GoogleCompatible`] only when direct reads are
+/// required for interoperability.
 ///
 /// # Example
 ///
@@ -213,7 +252,7 @@ pub struct SkillToolsetConfig {
 impl Default for SkillToolsetConfig {
     fn default() -> Self {
         Self {
-            resource_access: ResourceAccessPolicy::GoogleCompatible,
+            resource_access: ResourceAccessPolicy::ActivatedOnly,
             validation_mode: ValidationMode::Strict,
             max_active_skills: 8,
             max_instruction_chars: 8_000,
@@ -748,11 +787,9 @@ impl Tool for LoadSkillResourceTool {
                 .iter()
                 .any(|item| item.document().id == document.id)
         {
-            return Ok(json!({
-                "error": format!("skill '{name}' must be loaded before reading its resources"),
-                "errorCode": "SKILL_NOT_ACTIVATED",
-                "nextStep": format!("Call load_skill with skill_name '{name}' before calling load_skill_resource."),
-            }));
+            return Err(AdkError::tool(format!(
+                "skill '{name}' must be loaded before reading its resources; call load_skill first"
+            )));
         }
         let content = skill.resource_content(path)?;
         Ok(json!({
@@ -913,6 +950,8 @@ mod tests {
         assert_eq!(&*DEFAULT_SKILL_SYSTEM_INSTRUCTION, &default_instruction);
         assert!(default_instruction.contains("`load_skill`"));
         assert!(default_instruction.contains("You cannot run them"));
+        assert!(default_instruction.contains("must be loaded first"));
+        assert!(default_instruction.contains("then retry the resource request once"));
 
         let filtered = build_skill_system_instruction(
             Some("workspace"),
@@ -921,7 +960,8 @@ mod tests {
             false,
         );
         assert!(filtered.contains("`workspace_load_skill`"));
-        assert!(filtered.contains("`workspace_load_skill_resource`"));
+        assert!(!filtered.contains("The `workspace_load_skill_resource` tool is for viewing"));
+        assert!(!filtered.contains("If `workspace_load_skill_resource` returns any error"));
         assert!(filtered.contains("The following tools are NOT available"));
     }
 
@@ -960,18 +1000,34 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn google_compatible_default_reads_resources_without_activation() {
+    async fn default_resources_require_activation() {
         let (_temp, toolset) = setup();
         let context = Arc::new(TestContext::new());
         let resource = tool_by_name(
             &toolset.tools(context.clone()).await.expect("tools"),
             "load_skill_resource",
         );
-        let loaded_resource = resource
+        let error = resource
             .execute(context, json!({"skill_name": "weather", "file_path": "references/units.md"}))
             .await
-            .expect("Google-compatible resource read");
-        assert_eq!(loaded_resource["content"], "Use Celsius.");
+            .expect_err("resource access must require activation by default");
+        assert!(error.to_string().contains("must be loaded"));
+    }
+
+    #[tokio::test]
+    async fn google_compatible_policy_allows_direct_resource_reads() {
+        let (_temp, mut toolset) = setup();
+        toolset.config.resource_access = ResourceAccessPolicy::GoogleCompatible;
+        let context = Arc::new(TestContext::new());
+        let resource = tool_by_name(
+            &toolset.tools(context.clone()).await.expect("tools"),
+            "load_skill_resource",
+        );
+        let loaded = resource
+            .execute(context, json!({"skill_name": "weather", "file_path": "references/units.md"}))
+            .await
+            .expect("explicit Google-compatible resource read");
+        assert_eq!(loaded["content"], "Use Celsius.");
     }
 
     #[tokio::test]
@@ -981,15 +1037,14 @@ mod tests {
         let context = Arc::new(TestContext::new());
         let tools = toolset.tools(context.clone()).await.expect("tools");
         let resource = tool_by_name(&tools, "load_skill_resource");
-        let not_activated = resource
+        let error = resource
             .execute(
                 context.clone(),
                 json!({"skill_name": "weather", "file_path": "references/units.md"}),
             )
             .await
-            .expect("activation guidance");
-        assert_eq!(not_activated["errorCode"], "SKILL_NOT_ACTIVATED");
-        assert!(not_activated["nextStep"].as_str().expect("next step").contains("load_skill"));
+            .expect_err("activation denial must remain a tool error");
+        assert!(error.to_string().contains("call load_skill first"));
 
         let load = tool_by_name(&tools, "load_skill");
         load.execute(context.clone(), json!({"skill_name": "weather"})).await.expect("load skill");


### PR DESCRIPTION
## What

Add automatic progressive-disclosure guidance for `SkillToolset`.

This introduces a `Toolset::process_llm_request` hook, injects runtime-generated skill guidance before model calls, exports `build_skill_system_instruction` and `DEFAULT_SKILL_SYSTEM_INSTRUCTION`, and defaults skill resource reads to Google ADK-compatible behavior.

## Why

Close #658 

`SkillToolset` exposed discovery/loading tools but required each host application to manually repeat the usage protocol in agent instructions. The previous default resource policy also required activation before reading a bundled resource, which differs from Google ADK Python’s `SkillToolset`.

## How

- Add a no-op-by-default `process_llm_request` hook to `adk_core::Toolset`.
- Invoke the hook for static and invocation-scoped toolsets in `LlmAgent` before every model request.
- Generate progressive-skill instructions dynamically from the available tool surface.
- Export a default generated instruction value for hosts that need it.
- Default `ResourceAccessPolicy` to `GoogleCompatible`; retain `ActivatedOnly` as an explicit stricter opt-in.
- Add unit and runner-level regression tests for request injection, dynamic tool activation, and direct resource reads.

## PR Checklist

### Quality Gates (all required)

- [x] Formatting passed via `cargo fmt --all -- --check` (`devenv` is not installed locally)
- [x] Clippy passed via `cargo clippy --workspace --all-targets -- -D warnings` (`devenv` is not installed locally)
- [ ] `devenv shell test` / `cargo nextest run --workspace` — `cargo-nextest` is not installed locally
- [x] Workspace compilation passed via `cargo check --workspace` (`devenv` is not installed locally)

### Code Quality

- [x] New code has tests (unit, integration, or property tests as appropriate)
- [ ] Public APIs have rustdoc comments with `# Example` sections
- [x] No `println!`/`eprintln!` in library code (use `tracing` instead)
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts (`.env`, `.DS_Store`, IDE configs, build dirs)
- [x] No unrelated changes mixed in (formatting, refactoring, other features)
- [x] Branch naming follows convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages follow conventional format (`feat:`, `fix:`, `docs:`, etc.)
- [x] PR targets `main` branch

### Documentation (if applicable)

- [ ] CHANGELOG.md updated for user-facing changes
- [x] README updated if crate capabilities changed
- [ ] Examples added or updated for new features