### PR TITLE
fix(model): preserve OpenAI-compatible usage metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **OpenAI-compatible usage metadata** (`adk-model`): Chat Completions
+  streaming and non-streaming responses now use one normalization path,
+  preserve the complete provider-native `usage` object in `provider_usage`,
+  and project reported cache-write tokens alongside cache reads.
+
 ## [2.2.0] - 2026-09-01
 
 ### Added

--- a/adk-core/src/model.rs
+++ b/adk-core/src/model.rs
@@ -254,7 +254,8 @@ pub struct UsageMetadata {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub is_byok: Option<bool>,
 
-    /// Provider-specific usage details (e.g., server tool use, video tokens).
+    /// Provider-native usage data retained when available, including fields
+    /// that are not yet projected into the normalized counters above.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub provider_usage: Option<serde_json::Value>,
 }

--- a/adk-model/src/openai/convert.rs
+++ b/adk-model/src/openai/convert.rs
@@ -350,6 +350,36 @@ pub fn from_openai_response(resp: &CreateChatCompletionResponse) -> LlmResponse 
     }
 }
 
+/// Normalize one raw Chat Completions `usage` object while retaining the
+/// provider payload for diagnostics and future provider-specific projections.
+pub(crate) fn usage_metadata_from_raw(usage: &serde_json::Value) -> Option<UsageMetadata> {
+    let usage = usage.as_object()?;
+    let prompt_details = usage.get("prompt_tokens_details");
+    let completion_details = usage.get("completion_tokens_details");
+
+    Some(UsageMetadata {
+        prompt_token_count: json_i32(usage.get("prompt_tokens")).unwrap_or_default(),
+        candidates_token_count: json_i32(usage.get("completion_tokens")).unwrap_or_default(),
+        total_token_count: json_i32(usage.get("total_tokens")).unwrap_or_default(),
+        cache_read_input_token_count: prompt_details
+            .and_then(|details| json_i32(details.get("cached_tokens"))),
+        cache_creation_input_token_count: prompt_details
+            .and_then(|details| json_i32(details.get("cache_write_tokens"))),
+        thinking_token_count: completion_details
+            .and_then(|details| json_i32(details.get("reasoning_tokens"))),
+        audio_input_token_count: prompt_details
+            .and_then(|details| json_i32(details.get("audio_tokens"))),
+        audio_output_token_count: completion_details
+            .and_then(|details| json_i32(details.get("audio_tokens"))),
+        provider_usage: Some(serde_json::Value::Object(usage.clone())),
+        ..Default::default()
+    })
+}
+
+fn json_i32(value: Option<&serde_json::Value>) -> Option<i32> {
+    i32::try_from(value?.as_i64()?).ok()
+}
+
 /// Convert a raw OpenAI JSON response to ADK LlmResponse.
 ///
 /// Unlike [`from_openai_response`], this parses the raw JSON directly so it can
@@ -412,38 +442,7 @@ pub fn from_raw_openai_response(json: &serde_json::Value) -> LlmResponse {
     });
 
     // Parse usage metadata
-    let usage_metadata = json.get("usage").map(|u| {
-        let prompt_tokens = u.get("prompt_tokens").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
-        let completion_tokens =
-            u.get("completion_tokens").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
-        let total_tokens = u.get("total_tokens").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
-
-        let prompt_details = u.get("prompt_tokens_details");
-        let completion_details = u.get("completion_tokens_details");
-
-        UsageMetadata {
-            prompt_token_count: prompt_tokens,
-            candidates_token_count: completion_tokens,
-            total_token_count: total_tokens,
-            cache_read_input_token_count: prompt_details
-                .and_then(|d| d.get("cached_tokens"))
-                .and_then(|v| v.as_i64())
-                .map(|v| v as i32),
-            thinking_token_count: completion_details
-                .and_then(|d| d.get("reasoning_tokens"))
-                .and_then(|v| v.as_i64())
-                .map(|v| v as i32),
-            audio_input_token_count: prompt_details
-                .and_then(|d| d.get("audio_tokens"))
-                .and_then(|v| v.as_i64())
-                .map(|v| v as i32),
-            audio_output_token_count: completion_details
-                .and_then(|d| d.get("audio_tokens"))
-                .and_then(|v| v.as_i64())
-                .map(|v| v as i32),
-            ..Default::default()
-        }
-    });
+    let usage_metadata = json.get("usage").and_then(usage_metadata_from_raw);
 
     // Parse finish reason
     let finish_reason =
@@ -786,6 +785,45 @@ mod tests {
         let usage = resp.usage_metadata.unwrap();
         assert_eq!(usage.prompt_token_count, 5);
         assert_eq!(usage.candidates_token_count, 3);
+    }
+
+    #[test]
+    fn raw_response_preserves_complete_provider_usage() {
+        let provider_usage = serde_json::json!({
+            "prompt_tokens": 120,
+            "completion_tokens": 30,
+            "total_tokens": 150,
+            "prompt_tokens_details": {
+                "cached_tokens": 80,
+                "cache_write_tokens": 12,
+                "audio_tokens": 4
+            },
+            "completion_tokens_details": {
+                "reasoning_tokens": 18,
+                "audio_tokens": 2
+            },
+            "provider_meter": {"units": 9}
+        });
+        let json = serde_json::json!({
+            "choices": [{
+                "message": {"role": "assistant", "content": "done"},
+                "finish_reason": "stop"
+            }],
+            "usage": provider_usage.clone()
+        });
+
+        let response = from_raw_openai_response(&json);
+        let usage = response.usage_metadata.expect("usage should be parsed");
+
+        assert_eq!(usage.prompt_token_count, 120);
+        assert_eq!(usage.candidates_token_count, 30);
+        assert_eq!(usage.total_token_count, 150);
+        assert_eq!(usage.cache_read_input_token_count, Some(80));
+        assert_eq!(usage.cache_creation_input_token_count, Some(12));
+        assert_eq!(usage.thinking_token_count, Some(18));
+        assert_eq!(usage.audio_input_token_count, Some(4));
+        assert_eq!(usage.audio_output_token_count, Some(2));
+        assert_eq!(usage.provider_usage, Some(provider_usage));
     }
 
     #[test]

--- a/adk-model/src/openai_compatible.rs
+++ b/adk-model/src/openai_compatible.rs
@@ -482,36 +482,7 @@ fn parse_finish_reason(fr: &str) -> FinishReason {
 
 /// Parse usage metadata from a raw SSE chunk JSON value.
 fn parse_usage_from_chunk(chunk: &serde_json::Value) -> Option<UsageMetadata> {
-    let u = chunk.get("usage")?.as_object()?;
-    let prompt_tokens = u.get("prompt_tokens").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
-    let completion_tokens = u.get("completion_tokens").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
-    let total_tokens = u.get("total_tokens").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
-
-    let prompt_details = u.get("prompt_tokens_details");
-    let completion_details = u.get("completion_tokens_details");
-
-    Some(UsageMetadata {
-        prompt_token_count: prompt_tokens,
-        candidates_token_count: completion_tokens,
-        total_token_count: total_tokens,
-        cache_read_input_token_count: prompt_details
-            .and_then(|d| d.get("cached_tokens"))
-            .and_then(|v| v.as_i64())
-            .map(|v| v as i32),
-        thinking_token_count: completion_details
-            .and_then(|d| d.get("reasoning_tokens"))
-            .and_then(|v| v.as_i64())
-            .map(|v| v as i32),
-        audio_input_token_count: prompt_details
-            .and_then(|d| d.get("audio_tokens"))
-            .and_then(|v| v.as_i64())
-            .map(|v| v as i32),
-        audio_output_token_count: completion_details
-            .and_then(|d| d.get("audio_tokens"))
-            .and_then(|v| v.as_i64())
-            .map(|v| v as i32),
-        ..Default::default()
-    })
+    chunk.get("usage").and_then(convert::usage_metadata_from_raw)
 }
 
 #[async_trait]

--- a/adk-model/tests/openai_streaming_exploration_tests.rs
+++ b/adk-model/tests/openai_streaming_exploration_tests.rs
@@ -162,7 +162,7 @@ mod streaming_exploration {
         let sse_body = [
             "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"},\"finish_reason\":null}]}\n\n",
             "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":null}\n\n",
-            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[],\"usage\":{\"prompt_tokens\":11,\"completion_tokens\":5,\"total_tokens\":16}}\n\n",
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[],\"usage\":{\"prompt_tokens\":11,\"completion_tokens\":5,\"total_tokens\":16,\"prompt_tokens_details\":{\"cached_tokens\":7,\"cache_write_tokens\":2},\"provider_meter\":{\"units\":3}}}\n\n",
             "data: [DONE]\n\n",
         ]
         .join("");
@@ -199,6 +199,21 @@ mod streaming_exploration {
         assert_eq!(usage.prompt_token_count, 11);
         assert_eq!(usage.candidates_token_count, 5);
         assert_eq!(usage.total_token_count, 16);
+        assert_eq!(usage.cache_read_input_token_count, Some(7));
+        assert_eq!(usage.cache_creation_input_token_count, Some(2));
+        assert_eq!(
+            usage.provider_usage,
+            Some(serde_json::json!({
+                "prompt_tokens": 11,
+                "completion_tokens": 5,
+                "total_tokens": 16,
+                "prompt_tokens_details": {
+                    "cached_tokens": 7,
+                    "cache_write_tokens": 2
+                },
+                "provider_meter": {"units": 3}
+            }))
+        );
     }
 
     // ── Test 3: reasoning_content chunks yield Part::Thinking ────────────


### PR DESCRIPTION
## What

- Normalize raw OpenAI-compatible Chat Completions usage through one shared parser for streaming and non-streaming responses.
- Preserve the complete provider-native `usage` object in `UsageMetadata::provider_usage`.
- Project standard cached input tokens and reported cache-write tokens into the normalized ADK counters.

## Why

The compatible streaming and non-streaming paths previously duplicated usage parsing and discarded fields not modeled by ADK. This prevented downstream consumers from auditing the original provider payload or projecting newly introduced usage fields later.

No linked issue; this was found while validating downstream Sailry Code usage reporting.

## How

The raw usage normalizer lives beside the existing OpenAI response conversion and is reused by the SSE parser. It uses checked integer conversion, maps only established usage fields, and keeps the untouched JSON object for future diagnostics and projections. Regression tests cover a real usage-only terminal SSE chunk as well as non-streaming raw responses.

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo nextest run --workspace` — 4508 passed, 88 credential-gated tests skipped
- `cargo test -p adk-model --features openai`
- `cargo clippy -p adk-agent --features codeact --all-targets -- -D warnings`
- `cargo clippy -p adk-rust --features full --all-targets -- -D warnings`
- `cargo test -p adk-rust --features full --doc`
- `cargo doc --workspace --no-deps`
- `scripts/check-doc-examples.sh` — 105 markdown files
- standalone example compile gate — 112/112 passed
- `scripts/check-cargo-adk-templates.sh`
- downstream `sailry-platform` and `sailry-code` full workspace tests and clippy with all ADK crates patched to this local branch

## PR Checklist

### Quality Gates

- [x] Formatting passes (Edition 2024)
- [x] Clippy passes with zero Rust warnings (`-D warnings`)
- [x] All non-ignored tests pass
- [x] Workspace compilation check passes

### Code Quality

- [x] New behavior has unit and integration regression coverage
- [x] No new public API was added; existing public field documentation was clarified
- [x] No `println!`/`eprintln!` added to library code
- [x] No hardcoded secrets, API keys, or local paths

### Hygiene

- [x] No local development artifacts
- [x] No unrelated changes
- [x] Branch naming follows convention
- [x] Commit message follows conventional format
- [x] PR targets `main`

### Documentation

- [x] CHANGELOG.md updated
- [x] README unchanged because crate capabilities and public usage remain compatible
- [x] Existing examples remain valid; no new example is required for an internal normalization fix