### PR TITLE
fix: make OpenAI-compatible agent runs resilient

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -886,7 +886,7 @@ cargo publish -p <crate-name>
 - `McpServerManager` — lifecycle management for multiple MCP server processes with auto-restart
 - Graph durable resume: `PregelExecutor` resumes from last checkpoint on startup
 - `ServerBuilder` — register custom Axum controllers alongside built-in routes
-- `ToolExecutionStrategy` — `Sequential`, `Parallel`, `ParallelDelegations`, or `Auto` dispatch for tool calls
+- `ToolExecutionStrategy` — `Sequential`, `Parallel`, or `Auto` dispatch for tool calls
 - `StatefulTool<S>` — generic wrapper for stateful tool closures
 - `SimpleToolContext` — lightweight context for non-agent callers (testing, MCP servers)
 - `SchemaAdapter` trait — provider-aware schema normalization (Gemini, OpenAI strict/non-strict, Anthropic, Generic)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -886,7 +886,7 @@ cargo publish -p <crate-name>
 - `McpServerManager` — lifecycle management for multiple MCP server processes with auto-restart
 - Graph durable resume: `PregelExecutor` resumes from last checkpoint on startup
 - `ServerBuilder` — register custom Axum controllers alongside built-in routes
-- `ToolExecutionStrategy` — `Sequential`, `Parallel`, or `Auto` dispatch for tool calls
+- `ToolExecutionStrategy` — `Sequential`, `Parallel`, `ParallelDelegations`, or `Auto` dispatch for tool calls
 - `StatefulTool<S>` — generic wrapper for stateful tool closures
 - `SimpleToolContext` — lightweight context for non-agent callers (testing, MCP servers)
 - `SchemaAdapter` trait — provider-aware schema normalization (Gemini, OpenAI strict/non-strict, Anthropic, Generic)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Overlapping and interrupted tool history** (`adk-runner`): model requests
+  retain actual tool results from overlapping turns and omit unresolved calls
+  from earlier turns without fabricating interruption results. Persisted events
+  remain unchanged.
 - **OpenAI Responses stream completion** (`adk-model`): completion events retain
   model errors and usage metadata. Open Responses mode ignores empty SSE data
   frames, restores missing arguments by tool identity or output index, and keeps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   also accepts compatible endpoints that omit output-message IDs, statuses, or
   empty `output_text.annotations`, and reconstructs final function arguments
   from their streaming events when the completed response omits them.
+- **OpenAI-compatible usage metadata** (`adk-model`): Chat Completions
+  streaming and non-streaming responses now use one normalization path,
+  preserve the complete provider-native `usage` object in `provider_usage`,
+  and project reported cache-write tokens alongside cache reads.
 
 ## [2.2.0] - 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **OpenAI Responses stream completion** (`adk-model`): completion events retain
+  model errors and usage metadata. Open Responses mode ignores empty SSE data
+  frames, restores missing arguments by tool identity or output index, and keeps
+  streamed arguments when a terminal snapshot is blank.
 - **OpenAI-compatible structured tool arguments** (`adk-model`): Chat
   Completions streaming now preserves structured JSON `function.arguments`
   emitted by compatible intermediaries, including repeated and empty snapshot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   streaming and non-streaming responses now use one normalization path,
   preserve the complete provider-native `usage` object in `provider_usage`,
   and project reported cache-write tokens alongside cache reads.
+- **OpenAI tool request stability** (`adk-model`): Chat Completions and
+  Responses requests now serialize function tools in deterministic name order,
+  preserving identical cacheable prefixes across repeated executions.
 
 ## [2.2.0] - 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **OpenAI-compatible structured tool arguments** (`adk-model`): Chat
+  Completions streaming now preserves structured JSON `function.arguments`
+  emitted by compatible intermediaries, including repeated and empty snapshot
+  chunks, instead of converting the tool call to empty arguments.
+- **OpenAI Responses web search** (`adk-tool`): the stable built-in tool now
+  serializes as `web_search`, matching the OpenAI Responses API. The explicit
+  preview variant remains `web_search_preview_2025_03_11`. URL annotations from
+  response text are preserved as ADK citation metadata. Open Responses mode now
+  also accepts compatible endpoints that omit output-message IDs, statuses, or
+  empty `output_text.annotations`, and reconstructs final function arguments
+  from their streaming events when the completed response omits them.
+
 ## [2.2.0] - 2026-09-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Open Responses argument identity** (`adk-model`): conflicting item or call
+  identities terminate compatible streams before cached arguments can cross
+  tool calls. Blank completed snapshots restore matching streamed arguments
+  without replacing explicit nonblank values.
+
 - **Overlapping and interrupted tool history** (`adk-runner`): model requests
   retain actual tool results from overlapping turns and omit unresolved calls
   from earlier turns without fabricating interruption results. Persisted events

--- a/adk-agent/README.md
+++ b/adk-agent/README.md
@@ -95,7 +95,8 @@ let agent = LlmAgentBuilder::new("assistant")
 | `require_tool_confirmation(name)` | Require user confirmation for a specific tool |
 | `require_tool_confirmation_for_all()` | Require user confirmation for all tools |
 | `tool_confirmation_policy(policy)` | Set custom tool confirmation policy |
-| `tool_execution_strategy(strategy)` | Tool dispatch mode: `Sequential`, `Parallel`, `ParallelDelegations`, or `Auto` |
+| `tool_execution_strategy(strategy)` | Tool dispatch mode: `Sequential`, `Parallel`, or `Auto` |
+| `parallelize_agent_delegations(bool)` | Overlap consecutive agent-delegation calls without parallelizing ordinary tools |
 | `disallow_transfer_to_parent(bool)` | Prevent agent from transferring back to parent |
 | `disallow_transfer_to_peers(bool)` | Prevent agent from transferring to sibling agents |
 | `include_contents(mode)` | Control content inclusion in sub-agent context |

--- a/adk-agent/README.md
+++ b/adk-agent/README.md
@@ -95,7 +95,7 @@ let agent = LlmAgentBuilder::new("assistant")
 | `require_tool_confirmation(name)` | Require user confirmation for a specific tool |
 | `require_tool_confirmation_for_all()` | Require user confirmation for all tools |
 | `tool_confirmation_policy(policy)` | Set custom tool confirmation policy |
-| `tool_execution_strategy(strategy)` | Tool dispatch mode: `Sequential`, `Parallel`, or `Auto` |
+| `tool_execution_strategy(strategy)` | Tool dispatch mode: `Sequential`, `Parallel`, `ParallelDelegations`, or `Auto` |
 | `disallow_transfer_to_parent(bool)` | Prevent agent from transferring back to parent |
 | `disallow_transfer_to_peers(bool)` | Prevent agent from transferring to sibling agents |
 | `include_contents(mode)` | Control content inclusion in sub-agent context |

--- a/adk-agent/src/llm_agent.rs
+++ b/adk-agent/src/llm_agent.rs
@@ -261,6 +261,8 @@ pub struct LlmAgent {
     /// Per-agent tool execution strategy override. When `Some`, overrides the
     /// `RunConfig` strategy for this agent's dispatch loop.
     tool_execution_strategy: Option<ToolExecutionStrategy>,
+    /// Whether consecutive agent-delegation calls may execute concurrently.
+    parallelize_agent_delegations: bool,
     input_guardrails: Arc<GuardrailSet>,
     output_guardrails: Arc<GuardrailSet>,
     tool_guardrails: Arc<ToolGuardrailSet>,
@@ -705,6 +707,7 @@ pub struct LlmAgentBuilder {
     circuit_breaker_threshold: Option<u32>,
     tool_confirmation_policy: ToolConfirmationPolicy,
     tool_execution_strategy: Option<ToolExecutionStrategy>,
+    parallelize_agent_delegations: bool,
     input_guardrails: GuardrailSet,
     output_guardrails: GuardrailSet,
     tool_guardrails: ToolGuardrailSet,
@@ -756,6 +759,7 @@ impl LlmAgentBuilder {
             circuit_breaker_threshold: None,
             tool_confirmation_policy: ToolConfirmationPolicy::Never,
             tool_execution_strategy: None,
+            parallelize_agent_delegations: false,
             input_guardrails: GuardrailSet::new(),
             output_guardrails: GuardrailSet::new(),
             tool_guardrails: ToolGuardrailSet::new(),
@@ -1136,6 +1140,16 @@ impl LlmAgentBuilder {
         self
     }
 
+    /// Allow consecutive agent-delegation calls to execute concurrently.
+    ///
+    /// Ordinary tools remain sequential and retain their position relative to
+    /// each delegation batch. This setting takes precedence over the general
+    /// tool execution strategy for the agent.
+    pub fn parallelize_agent_delegations(mut self, parallelize: bool) -> Self {
+        self.parallelize_agent_delegations = parallelize;
+        self
+    }
+
     /// Set input guardrails to validate user input before processing.
     ///
     /// Input guardrails run before the agent processes the request and can:
@@ -1364,6 +1378,7 @@ impl LlmAgentBuilder {
             circuit_breaker_threshold: self.circuit_breaker_threshold,
             tool_confirmation_policy: self.tool_confirmation_policy,
             tool_execution_strategy: self.tool_execution_strategy,
+            parallelize_agent_delegations: self.parallelize_agent_delegations,
             input_guardrails: Arc::new(self.input_guardrails),
             output_guardrails: Arc::new(self.output_guardrails),
             tool_guardrails: Arc::new(self.tool_guardrails),
@@ -1783,6 +1798,27 @@ struct ToolExecutionResult {
     content: Content,
     actions: EventActions,
     escalate_or_skip: bool,
+}
+
+#[derive(Clone, Copy)]
+enum ToolDispatchMode {
+    Sequential,
+    Parallel,
+    ParallelDelegations,
+    Auto,
+}
+
+impl ToolDispatchMode {
+    fn resolve(strategy: ToolExecutionStrategy, parallelize_agent_delegations: bool) -> Self {
+        if parallelize_agent_delegations {
+            return Self::ParallelDelegations;
+        }
+        match strategy {
+            ToolExecutionStrategy::Sequential => Self::Sequential,
+            ToolExecutionStrategy::Parallel => Self::Parallel,
+            ToolExecutionStrategy::Auto => Self::Auto,
+        }
+    }
 }
 
 struct ToolExecutor<'a> {
@@ -2423,6 +2459,7 @@ impl Agent for LlmAgent {
         let tool_guardrails = Arc::clone(&self.tool_guardrails);
         let output_guardrails = self.output_guardrails.clone();
         let agent_tool_execution_strategy = self.tool_execution_strategy;
+        let parallelize_agent_delegations = self.parallelize_agent_delegations;
         #[cfg(feature = "enhanced-plugins")]
         let enhanced_plugin_manager = self.enhanced_plugin_manager.clone();
 
@@ -3028,8 +3065,10 @@ impl Agent for LlmAgent {
                 if let Some(content) = &accumulated_content {
                     // ===== RESOLVE TOOL EXECUTION STRATEGY =====
                     // Per-agent override; defaults to Sequential if not set.
-                    let strategy = agent_tool_execution_strategy
-                        .unwrap_or(ToolExecutionStrategy::Sequential);
+                    let strategy = ToolDispatchMode::resolve(
+                        agent_tool_execution_strategy.unwrap_or(ToolExecutionStrategy::Sequential),
+                        parallelize_agent_delegations,
+                    );
 
                     let fc_parts = collect_function_calls(content, &invocation_id);
 
@@ -3228,14 +3267,14 @@ impl Agent for LlmAgent {
                     let mut results = {
                         let dispatch = async {
                             let results: Vec<ToolExecutionResult> = match strategy {
-                                ToolExecutionStrategy::Sequential => {
+                                ToolDispatchMode::Sequential => {
                                     let mut results = Vec::with_capacity(fc_parts.len());
                                     for call in fc_parts {
                                         results.push(executor.execute(call).await);
                                     }
                                     results
                                 }
-                                ToolExecutionStrategy::Parallel => {
+                                ToolDispatchMode::Parallel => {
                                     use futures::StreamExt as _;
                                     // Parallel is an explicit caller override. Tool
                                     // safety metadata is intentionally not inspected.
@@ -3251,7 +3290,7 @@ impl Agent for LlmAgent {
                                     .collect()
                                     .await
                                 }
-                                ToolExecutionStrategy::ParallelDelegations => {
+                                ToolDispatchMode::ParallelDelegations => {
                                     use futures::StreamExt as _;
 
                                     let mut all_results = Vec::with_capacity(fc_parts.len());
@@ -3290,7 +3329,7 @@ impl Agent for LlmAgent {
                                     }
                                     all_results
                                 }
-                                ToolExecutionStrategy::Auto => {
+                                ToolDispatchMode::Auto => {
                                     // A call may overlap another only when its tool is
                                     // read-only *and* declares concurrency safety.
                                     let (concurrent_fcs, sequential_fcs): (Vec<_>, Vec<_>) =

--- a/adk-agent/src/llm_agent.rs
+++ b/adk-agent/src/llm_agent.rs
@@ -3251,6 +3251,45 @@ impl Agent for LlmAgent {
                                     .collect()
                                     .await
                                 }
+                                ToolExecutionStrategy::ParallelDelegations => {
+                                    use futures::StreamExt as _;
+
+                                    let mut all_results = Vec::with_capacity(fc_parts.len());
+                                    let mut calls = fc_parts.into_iter().peekable();
+                                    while let Some(call) = calls.next() {
+                                        let is_delegation = tool_map
+                                            .get(&call.name)
+                                            .is_some_and(|tool| tool.is_agent_delegation());
+                                        if !is_delegation {
+                                            all_results.push(executor.execute(call).await);
+                                            continue;
+                                        }
+
+                                        let mut delegation_batch = vec![call];
+                                        while calls.peek().is_some_and(|next| {
+                                            tool_map.get(&next.name).is_some_and(|tool| {
+                                                tool.is_agent_delegation()
+                                            })
+                                        }) {
+                                            if let Some(next) = calls.next() {
+                                                delegation_batch.push(next);
+                                            }
+                                        }
+
+                                        let buffer_size = delegation_batch.len();
+                                        all_results.extend(
+                                            futures::stream::iter(
+                                                delegation_batch
+                                                    .into_iter()
+                                                    .map(|call| executor.execute(call)),
+                                            )
+                                            .buffer_unordered(buffer_size)
+                                            .collect::<Vec<_>>()
+                                            .await,
+                                        );
+                                    }
+                                    all_results
+                                }
                                 ToolExecutionStrategy::Auto => {
                                     // A call may overlap another only when its tool is
                                     // read-only *and* declares concurrency safety.

--- a/adk-agent/src/team.rs
+++ b/adk-agent/src/team.rs
@@ -2364,6 +2364,10 @@ impl Tool for BoundedDelegateTool {
         self.inner.is_concurrency_safe()
     }
 
+    fn is_agent_delegation(&self) -> bool {
+        self.inner.is_agent_delegation()
+    }
+
     async fn execute(
         &self,
         ctx: Arc<dyn adk_core::ToolContext>,

--- a/adk-agent/tests/agent_property_tests.rs
+++ b/adk-agent/tests/agent_property_tests.rs
@@ -140,7 +140,6 @@ fn arb_tool_execution_strategy() -> impl Strategy<Value = ToolExecutionStrategy>
     prop_oneof![
         Just(ToolExecutionStrategy::Sequential),
         Just(ToolExecutionStrategy::Parallel),
-        Just(ToolExecutionStrategy::ParallelDelegations),
         Just(ToolExecutionStrategy::Auto),
     ]
 }
@@ -340,9 +339,7 @@ proptest! {
                 ToolExecutionStrategy::Sequential => {
                     Arc::new(SequentialAgent::new("seq_orchestrator", sub_agents))
                 }
-                ToolExecutionStrategy::Parallel
-                | ToolExecutionStrategy::ParallelDelegations
-                | ToolExecutionStrategy::Auto => {
+                ToolExecutionStrategy::Parallel | ToolExecutionStrategy::Auto => {
                     Arc::new(ParallelAgent::new("par_orchestrator", sub_agents))
                 }
             };

--- a/adk-agent/tests/agent_property_tests.rs
+++ b/adk-agent/tests/agent_property_tests.rs
@@ -140,6 +140,7 @@ fn arb_tool_execution_strategy() -> impl Strategy<Value = ToolExecutionStrategy>
     prop_oneof![
         Just(ToolExecutionStrategy::Sequential),
         Just(ToolExecutionStrategy::Parallel),
+        Just(ToolExecutionStrategy::ParallelDelegations),
         Just(ToolExecutionStrategy::Auto),
     ]
 }
@@ -339,7 +340,9 @@ proptest! {
                 ToolExecutionStrategy::Sequential => {
                     Arc::new(SequentialAgent::new("seq_orchestrator", sub_agents))
                 }
-                ToolExecutionStrategy::Parallel | ToolExecutionStrategy::Auto => {
+                ToolExecutionStrategy::Parallel
+                | ToolExecutionStrategy::ParallelDelegations
+                | ToolExecutionStrategy::Auto => {
                     Arc::new(ParallelAgent::new("par_orchestrator", sub_agents))
                 }
             };

--- a/adk-agent/tests/review_regression_tests.rs
+++ b/adk-agent/tests/review_regression_tests.rs
@@ -816,7 +816,7 @@ async fn test_parallel_delegations_only_overlaps_consecutive_agent_tools() {
         .model(model.clone())
         .tool(delegate_tool)
         .tool(ordinary_tool)
-        .tool_execution_strategy(adk_core::ToolExecutionStrategy::ParallelDelegations)
+        .parallelize_agent_delegations(true)
         .build()
         .unwrap();
 

--- a/adk-agent/tests/review_regression_tests.rs
+++ b/adk-agent/tests/review_regression_tests.rs
@@ -451,6 +451,59 @@ struct CountingTool {
     calls: Arc<Mutex<usize>>,
 }
 
+#[derive(Default)]
+struct DelegationDispatchState {
+    delegation_active: AtomicUsize,
+    delegation_max_active: AtomicUsize,
+    ordinary_active: AtomicUsize,
+    ordinary_max_active: AtomicUsize,
+    delegation_overlapped_ordinary: AtomicBool,
+    ordinary_overlapped_delegation: AtomicBool,
+}
+
+struct DelegationDispatchTool {
+    name: &'static str,
+    delegation: bool,
+    state: Arc<DelegationDispatchState>,
+}
+
+#[async_trait]
+impl Tool for DelegationDispatchTool {
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    fn description(&self) -> &str {
+        "Records delegation-only dispatch behavior"
+    }
+
+    fn is_agent_delegation(&self) -> bool {
+        self.delegation
+    }
+
+    async fn execute(&self, _ctx: Arc<dyn ToolContext>, args: Value) -> Result<Value> {
+        if self.delegation {
+            if self.state.ordinary_active.load(Ordering::SeqCst) != 0 {
+                self.state.delegation_overlapped_ordinary.store(true, Ordering::SeqCst);
+            }
+            let active = self.state.delegation_active.fetch_add(1, Ordering::SeqCst) + 1;
+            self.state.delegation_max_active.fetch_max(active, Ordering::SeqCst);
+            let delay_ms = args.get("delay_ms").and_then(Value::as_u64).unwrap_or(50);
+            tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+            self.state.delegation_active.fetch_sub(1, Ordering::SeqCst);
+        } else {
+            if self.state.delegation_active.load(Ordering::SeqCst) != 0 {
+                self.state.ordinary_overlapped_delegation.store(true, Ordering::SeqCst);
+            }
+            let active = self.state.ordinary_active.fetch_add(1, Ordering::SeqCst) + 1;
+            self.state.ordinary_max_active.fetch_max(active, Ordering::SeqCst);
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            self.state.ordinary_active.fetch_sub(1, Ordering::SeqCst);
+        }
+        Ok(json!({ "ok": true }))
+    }
+}
+
 impl CountingTool {
     fn new() -> Self {
         Self { calls: Arc::new(Mutex::new(0)) }
@@ -715,6 +768,79 @@ async fn test_parallel_is_explicit_tool_metadata_override() {
         max_concurrent_tool_calls(adk_core::ToolExecutionStrategy::Parallel, false).await;
 
     assert_eq!(max_active, 2);
+}
+
+#[tokio::test]
+async fn test_parallel_delegations_only_overlaps_consecutive_agent_tools() {
+    let model = Arc::new(RecordingModel::new(vec![
+        RecordingModel::function_calls(vec![
+            Part::FunctionCall {
+                name: "ordinary_probe".to_string(),
+                args: json!({}),
+                id: Some("ordinary-before".to_string()),
+                thought_signature: None,
+            },
+            Part::FunctionCall {
+                name: "delegate_probe".to_string(),
+                args: json!({ "delay_ms": 80 }),
+                id: Some("delegate-a".to_string()),
+                thought_signature: None,
+            },
+            Part::FunctionCall {
+                name: "delegate_probe".to_string(),
+                args: json!({ "delay_ms": 10 }),
+                id: Some("delegate-b".to_string()),
+                thought_signature: None,
+            },
+            Part::FunctionCall {
+                name: "ordinary_probe".to_string(),
+                args: json!({}),
+                id: Some("ordinary-after".to_string()),
+                thought_signature: None,
+            },
+        ]),
+        RecordingModel::text_response("done"),
+    ]));
+    let state = Arc::new(DelegationDispatchState::default());
+    let delegate_tool = Arc::new(DelegationDispatchTool {
+        name: "delegate_probe",
+        delegation: true,
+        state: state.clone(),
+    });
+    let ordinary_tool = Arc::new(DelegationDispatchTool {
+        name: "ordinary_probe",
+        delegation: false,
+        state: state.clone(),
+    });
+    let agent = LlmAgentBuilder::new("delegation-dispatch-agent")
+        .model(model.clone())
+        .tool(delegate_tool)
+        .tool(ordinary_tool)
+        .tool_execution_strategy(adk_core::ToolExecutionStrategy::ParallelDelegations)
+        .build()
+        .unwrap();
+
+    let stream = agent.run(Arc::new(TestContext::new("delegate safely"))).await.unwrap();
+    tokio::time::timeout(Duration::from_secs(2), drain_stream(stream))
+        .await
+        .expect("delegation dispatch timed out")
+        .unwrap();
+
+    assert_eq!(state.delegation_max_active.load(Ordering::SeqCst), 2);
+    assert_eq!(state.ordinary_max_active.load(Ordering::SeqCst), 1);
+    assert!(!state.delegation_overlapped_ordinary.load(Ordering::SeqCst));
+    assert!(!state.ordinary_overlapped_delegation.load(Ordering::SeqCst));
+    let requests = model.requests.lock().unwrap_or_else(|error| error.into_inner());
+    let response_ids = requests[1]
+        .contents
+        .iter()
+        .flat_map(|content| &content.parts)
+        .filter_map(|part| match part {
+            Part::FunctionResponse { id, .. } => id.as_deref(),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(response_ids, ["ordinary-before", "delegate-a", "delegate-b", "ordinary-after"]);
 }
 
 #[tokio::test]

--- a/adk-core/README.md
+++ b/adk-core/README.md
@@ -61,11 +61,14 @@ pub trait Tool: Send + Sync {
     fn is_long_running(&self) -> bool;
     fn is_read_only(&self) -> bool;           // default: false
     fn is_concurrency_safe(&self) -> bool;    // default: false
+    fn is_agent_delegation(&self) -> bool;    // default: false
     async fn execute(&self, ctx: Arc<dyn ToolContext>, args: Value) -> Result<Value>;
 }
 ```
 
 `ToolExecutionStrategy::Auto` includes a call in its concurrent subset only when the selected tool returns `true` from both `is_read_only()` and `is_concurrency_safe()`. It runs that safe subset first, then executes the remaining calls sequentially. Both methods default to `false`, so existing implementations remain sequential.
+
+`ToolExecutionStrategy::ParallelDelegations` overlaps only consecutive tools that return `true` from `is_agent_delegation()`. Ordinary tools keep their original sequential phase ordering.
 
 ### Toolset
 
@@ -357,11 +360,12 @@ Controls how multiple tool calls from a single LLM response are dispatched:
 pub enum ToolExecutionStrategy {
     Sequential,  // One at a time, in order (default)
     Parallel,    // All concurrently; caller owns safety
+    ParallelDelegations, // Consecutive agent delegations concurrently
     Auto,        // Safe read-only subset concurrently, then the rest sequentially
 }
 ```
 
-Set per-agent via `LlmAgentBuilder::tool_execution_strategy()`. `Parallel` is an explicit override that does not inspect tool metadata.
+Set per-agent via `LlmAgentBuilder::tool_execution_strategy()`. `Parallel` is an explicit override that does not inspect tool metadata. `ParallelDelegations` is intended for routed teams that may dispatch several independent subagents from one model response without also parallelizing ordinary tools.
 
 ## Related Crates
 

--- a/adk-core/README.md
+++ b/adk-core/README.md
@@ -68,7 +68,7 @@ pub trait Tool: Send + Sync {
 
 `ToolExecutionStrategy::Auto` includes a call in its concurrent subset only when the selected tool returns `true` from both `is_read_only()` and `is_concurrency_safe()`. It runs that safe subset first, then executes the remaining calls sequentially. Both methods default to `false`, so existing implementations remain sequential.
 
-`ToolExecutionStrategy::ParallelDelegations` overlaps only consecutive tools that return `true` from `is_agent_delegation()`. Ordinary tools keep their original sequential phase ordering.
+Agent implementations may use `is_agent_delegation()` to identify consecutive delegation calls that can overlap without parallelizing ordinary tools.
 
 ### Toolset
 
@@ -360,12 +360,11 @@ Controls how multiple tool calls from a single LLM response are dispatched:
 pub enum ToolExecutionStrategy {
     Sequential,  // One at a time, in order (default)
     Parallel,    // All concurrently; caller owns safety
-    ParallelDelegations, // Consecutive agent delegations concurrently
     Auto,        // Safe read-only subset concurrently, then the rest sequentially
 }
 ```
 
-Set per-agent via `LlmAgentBuilder::tool_execution_strategy()`. `Parallel` is an explicit override that does not inspect tool metadata. `ParallelDelegations` is intended for routed teams that may dispatch several independent subagents from one model response without also parallelizing ordinary tools.
+Set per-agent via `LlmAgentBuilder::tool_execution_strategy()`. `Parallel` is an explicit override that does not inspect tool metadata.
 
 ## Related Crates
 

--- a/adk-core/src/model.rs
+++ b/adk-core/src/model.rs
@@ -254,7 +254,8 @@ pub struct UsageMetadata {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub is_byok: Option<bool>,
 
-    /// Provider-specific usage details (e.g., server tool use, video tokens).
+    /// Provider-native usage data retained when available, including fields
+    /// that are not yet projected into the normalized counters above.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub provider_usage: Option<serde_json::Value>,
 }

--- a/adk-core/src/tool.rs
+++ b/adk-core/src/tool.rs
@@ -122,9 +122,9 @@ pub trait Tool: Send + Sync {
 
     /// Indicates whether this tool delegates work to another agent.
     ///
-    /// [`ToolExecutionStrategy::ParallelDelegations`] uses this marker to
-    /// overlap consecutive delegation calls while preserving sequential
-    /// execution for ordinary tools.
+    /// Agent implementations can use this marker to overlap consecutive
+    /// delegation calls while preserving sequential execution for ordinary
+    /// tools.
     fn is_agent_delegation(&self) -> bool {
         false
     }
@@ -330,10 +330,6 @@ pub enum ToolExecutionStrategy {
     /// This is an explicit caller override. The caller is responsible for
     /// ensuring every selected tool is safe to execute concurrently.
     Parallel,
-    /// Execute consecutive agent-delegation calls concurrently while keeping
-    /// ordinary tools sequential and preserving their position in the call
-    /// sequence.
-    ParallelDelegations,
     /// Execute calls whose tools report both read-only and concurrency-safe
     /// concurrently, then execute all remaining calls sequentially.
     Auto,

--- a/adk-core/src/tool.rs
+++ b/adk-core/src/tool.rs
@@ -32,7 +32,7 @@ pub trait Tool: Send + Sync {
     ///         "name": self.name(),
     ///         "description": self.description(),
     ///         "x-adk-openai-tool": {
-    ///             "type": "web_search_2025_08_26"
+    ///             "type": "web_search"
     ///         }
     ///     })
     /// }

--- a/adk-core/src/tool.rs
+++ b/adk-core/src/tool.rs
@@ -120,6 +120,15 @@ pub trait Tool: Send + Sync {
         false
     }
 
+    /// Indicates whether this tool delegates work to another agent.
+    ///
+    /// [`ToolExecutionStrategy::ParallelDelegations`] uses this marker to
+    /// overlap consecutive delegation calls while preserving sequential
+    /// execution for ordinary tools.
+    fn is_agent_delegation(&self) -> bool {
+        false
+    }
+
     /// Executes the tool with the given context and arguments.
     async fn execute(&self, ctx: Arc<dyn ToolContext>, args: Value) -> Result<Value>;
 }
@@ -321,6 +330,10 @@ pub enum ToolExecutionStrategy {
     /// This is an explicit caller override. The caller is responsible for
     /// ensuring every selected tool is safe to execute concurrently.
     Parallel,
+    /// Execute consecutive agent-delegation calls concurrently while keeping
+    /// ordinary tools sequential and preserving their position in the call
+    /// sequence.
+    ParallelDelegations,
     /// Execute calls whose tools report both read-only and concurrency-safe
     /// concurrently, then execute all remaining calls sequentially.
     Auto,

--- a/adk-model/src/openai/client.rs
+++ b/adk-model/src/openai/client.rs
@@ -289,7 +289,15 @@ impl Llm for AzureOpenAIClient {
             })
             .await?;
 
-            let adk_response = convert::from_raw_openai_response(&response);
+            let adk_response = convert::from_raw_openai_response(&response).map_err(|error| {
+                AdkError::new(
+                    ErrorComponent::Model,
+                    ErrorCategory::Internal,
+                    "model.azure_openai.invalid_tool_arguments",
+                    format!("Azure OpenAI returned {error}"),
+                )
+                .with_provider("azure-openai")
+            })?;
             yield adk_response;
         };
 

--- a/adk-model/src/openai/convert.rs
+++ b/adk-model/src/openai/convert.rs
@@ -350,6 +350,36 @@ pub fn from_openai_response(resp: &CreateChatCompletionResponse) -> LlmResponse 
     }
 }
 
+/// Normalize one raw Chat Completions `usage` object while retaining the
+/// provider payload for diagnostics and future provider-specific projections.
+pub(crate) fn usage_metadata_from_raw(usage: &serde_json::Value) -> Option<UsageMetadata> {
+    let usage = usage.as_object()?;
+    let prompt_details = usage.get("prompt_tokens_details");
+    let completion_details = usage.get("completion_tokens_details");
+
+    Some(UsageMetadata {
+        prompt_token_count: json_i32(usage.get("prompt_tokens")).unwrap_or_default(),
+        candidates_token_count: json_i32(usage.get("completion_tokens")).unwrap_or_default(),
+        total_token_count: json_i32(usage.get("total_tokens")).unwrap_or_default(),
+        cache_read_input_token_count: prompt_details
+            .and_then(|details| json_i32(details.get("cached_tokens"))),
+        cache_creation_input_token_count: prompt_details
+            .and_then(|details| json_i32(details.get("cache_write_tokens"))),
+        thinking_token_count: completion_details
+            .and_then(|details| json_i32(details.get("reasoning_tokens"))),
+        audio_input_token_count: prompt_details
+            .and_then(|details| json_i32(details.get("audio_tokens"))),
+        audio_output_token_count: completion_details
+            .and_then(|details| json_i32(details.get("audio_tokens"))),
+        provider_usage: Some(serde_json::Value::Object(usage.clone())),
+        ..Default::default()
+    })
+}
+
+fn json_i32(value: Option<&serde_json::Value>) -> Option<i32> {
+    i32::try_from(value?.as_i64()?).ok()
+}
+
 /// Convert a raw OpenAI JSON response to ADK LlmResponse.
 ///
 /// Unlike [`from_openai_response`], this parses the raw JSON directly so it can
@@ -412,38 +442,7 @@ pub fn from_raw_openai_response(json: &serde_json::Value) -> LlmResponse {
     });
 
     // Parse usage metadata
-    let usage_metadata = json.get("usage").map(|u| {
-        let prompt_tokens = u.get("prompt_tokens").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
-        let completion_tokens =
-            u.get("completion_tokens").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
-        let total_tokens = u.get("total_tokens").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
-
-        let prompt_details = u.get("prompt_tokens_details");
-        let completion_details = u.get("completion_tokens_details");
-
-        UsageMetadata {
-            prompt_token_count: prompt_tokens,
-            candidates_token_count: completion_tokens,
-            total_token_count: total_tokens,
-            cache_read_input_token_count: prompt_details
-                .and_then(|d| d.get("cached_tokens"))
-                .and_then(|v| v.as_i64())
-                .map(|v| v as i32),
-            thinking_token_count: completion_details
-                .and_then(|d| d.get("reasoning_tokens"))
-                .and_then(|v| v.as_i64())
-                .map(|v| v as i32),
-            audio_input_token_count: prompt_details
-                .and_then(|d| d.get("audio_tokens"))
-                .and_then(|v| v.as_i64())
-                .map(|v| v as i32),
-            audio_output_token_count: completion_details
-                .and_then(|d| d.get("audio_tokens"))
-                .and_then(|v| v.as_i64())
-                .map(|v| v as i32),
-            ..Default::default()
-        }
-    });
+    let usage_metadata = json.get("usage").and_then(usage_metadata_from_raw);
 
     // Parse finish reason
     let finish_reason =
@@ -786,6 +785,45 @@ mod tests {
         let usage = resp.usage_metadata.unwrap();
         assert_eq!(usage.prompt_token_count, 5);
         assert_eq!(usage.candidates_token_count, 3);
+    }
+
+    #[test]
+    fn raw_response_preserves_complete_provider_usage() {
+        let provider_usage = serde_json::json!({
+            "prompt_tokens": 120,
+            "completion_tokens": 30,
+            "total_tokens": 150,
+            "prompt_tokens_details": {
+                "cached_tokens": 80,
+                "cache_write_tokens": 12,
+                "audio_tokens": 4
+            },
+            "completion_tokens_details": {
+                "reasoning_tokens": 18,
+                "audio_tokens": 2
+            },
+            "provider_meter": {"units": 9}
+        });
+        let json = serde_json::json!({
+            "choices": [{
+                "message": {"role": "assistant", "content": "done"},
+                "finish_reason": "stop"
+            }],
+            "usage": provider_usage.clone()
+        });
+
+        let response = from_raw_openai_response(&json);
+        let usage = response.usage_metadata.expect("usage should be parsed");
+
+        assert_eq!(usage.prompt_token_count, 120);
+        assert_eq!(usage.candidates_token_count, 30);
+        assert_eq!(usage.total_token_count, 150);
+        assert_eq!(usage.cache_read_input_token_count, Some(80));
+        assert_eq!(usage.cache_creation_input_token_count, Some(12));
+        assert_eq!(usage.thinking_token_count, Some(18));
+        assert_eq!(usage.audio_input_token_count, Some(4));
+        assert_eq!(usage.audio_output_token_count, Some(2));
+        assert_eq!(usage.provider_usage, Some(provider_usage));
     }
 
     #[test]

--- a/adk-model/src/openai/convert.rs
+++ b/adk-model/src/openai/convert.rs
@@ -275,35 +275,48 @@ pub fn convert_tools(
 /// goes through `async-openai`'s typed client.
 #[allow(dead_code)]
 pub fn from_openai_response(resp: &CreateChatCompletionResponse) -> LlmResponse {
-    let content = resp.choices.first().map(|choice| {
-        let mut parts = Vec::new();
+    let content = resp
+        .choices
+        .first()
+        .map(|choice| -> Result<Content, String> {
+            let mut parts = Vec::new();
 
-        // Add text content (skip empty strings from reasoning models)
-        if let Some(text) = &choice.message.content
-            && !text.is_empty()
-        {
-            parts.push(Part::Text { text: text.clone() });
-        }
+            // Add text content (skip empty strings from reasoning models)
+            if let Some(text) = &choice.message.content
+                && !text.is_empty()
+            {
+                parts.push(Part::Text { text: text.clone() });
+            }
 
-        // Add tool calls with IDs
-        if let Some(tool_calls) = &choice.message.tool_calls {
-            for tc in tool_calls {
-                if let ChatCompletionMessageToolCalls::Function(func_call) = tc {
-                    let args: serde_json::Value =
-                        serde_json::from_str(&func_call.function.arguments)
-                            .unwrap_or(serde_json::json!({}));
-                    parts.push(Part::FunctionCall {
-                        name: func_call.function.name.clone(),
-                        args,
-                        id: Some(func_call.id.clone()),
-                        thought_signature: None,
-                    });
+            // Add tool calls with IDs
+            if let Some(tool_calls) = &choice.message.tool_calls {
+                for tc in tool_calls {
+                    if let ChatCompletionMessageToolCalls::Function(func_call) = tc {
+                        let encoded =
+                            serde_json::Value::String(func_call.function.arguments.clone());
+                        let args = decode_tool_call_arguments(Some(&encoded)).map_err(|error| {
+                            format!(
+                                "invalid arguments for tool '{}': {error}",
+                                func_call.function.name
+                            )
+                        })?;
+                        parts.push(Part::FunctionCall {
+                            name: func_call.function.name.clone(),
+                            args,
+                            id: Some(func_call.id.clone()),
+                            thought_signature: None,
+                        });
+                    }
                 }
             }
-        }
 
-        Content { role: "model".to_string(), parts }
-    });
+            Ok(Content { role: "model".to_string(), parts })
+        })
+        .transpose();
+    let (content, argument_error) = match content {
+        Ok(content) => (content, None),
+        Err(error) => (None, Some(error)),
+    };
 
     let usage_metadata = resp.usage.as_ref().map(|u| {
         let mut meta = UsageMetadata {
@@ -330,12 +343,13 @@ pub fn from_openai_response(resp: &CreateChatCompletionResponse) -> LlmResponse 
         OaiFinishReason::ContentFilter => FinishReason::Safety,
         OaiFinishReason::FunctionCall => FinishReason::Stop,
     });
-    let tool_call_turn = resp.choices.first().is_some_and(|choice| {
-        matches!(
-            choice.finish_reason,
-            Some(OaiFinishReason::ToolCalls | OaiFinishReason::FunctionCall)
-        )
-    }) || content.as_ref().is_some_and(Content::has_function_calls);
+    let tool_call_turn = argument_error.is_none()
+        && (resp.choices.first().is_some_and(|choice| {
+            matches!(
+                choice.finish_reason,
+                Some(OaiFinishReason::ToolCalls | OaiFinishReason::FunctionCall)
+            )
+        }) || content.as_ref().is_some_and(Content::has_function_calls));
 
     LlmResponse {
         content,
@@ -343,10 +357,12 @@ pub fn from_openai_response(resp: &CreateChatCompletionResponse) -> LlmResponse 
         finish_reason,
         citation_metadata: None,
         partial: false,
-        turn_complete: !tool_call_turn,
+        turn_complete: argument_error.is_some() || !tool_call_turn,
         interrupted: false,
-        error_code: None,
-        error_message: None,
+        error_code: argument_error
+            .as_ref()
+            .map(|_| "model.openai.invalid_tool_arguments".to_owned()),
+        error_message: argument_error,
         provider_metadata: None,
         interaction_id: None,
     }
@@ -387,61 +403,62 @@ fn json_i32(value: Option<&serde_json::Value>) -> Option<i32> {
 /// Unlike [`from_openai_response`], this parses the raw JSON directly so it can
 /// extract fields that `async-openai` does not model, such as `reasoning_content`
 /// returned by reasoning models (o3, gpt-5-mini, etc.).
-pub fn from_raw_openai_response(json: &serde_json::Value) -> LlmResponse {
+pub(crate) fn from_raw_openai_response(json: &serde_json::Value) -> Result<LlmResponse, String> {
     let choice = json.get("choices").and_then(|c| c.get(0));
 
-    let content = choice.map(|choice| {
-        let message = &choice["message"];
-        let mut parts = Vec::new();
+    let content = choice
+        .map(|choice| -> Result<Content, String> {
+            let message = &choice["message"];
+            let mut parts = Vec::new();
 
-        // Extract reasoning_content (returned by reasoning models like o3, gpt-5-mini)
-        // Fallback to "reasoning" field for OpenRouter, Kilo Gateway, SambaNova, Cerebras, Groq
-        let reasoning = message
-            .get("reasoning_content")
-            .or_else(|| message.get("reasoning"))
-            .and_then(|v| v.as_str());
-        if let Some(reasoning) = reasoning
-            && !reasoning.is_empty()
-        {
-            parts.push(Part::Thinking { thinking: reasoning.to_string(), signature: None });
-        }
-
-        // Extract visible text content (skip empty strings)
-        if let Some(text) = message.get("content").and_then(|v| v.as_str())
-            && !text.is_empty()
-        {
-            // Check for text-based tool calls (Qwen, Llama, Mistral Nemo format)
-            // before adding as plain text
-            if let Some(parsed_parts) = crate::tool_call_parser::parse_text_tool_calls(text) {
-                parts.extend(parsed_parts);
-            } else {
-                parts.push(Part::Text { text: text.to_string() });
+            // Extract reasoning_content (returned by reasoning models like o3, gpt-5-mini)
+            // Fallback to "reasoning" field for OpenRouter, Kilo Gateway, SambaNova, Cerebras, Groq
+            let reasoning = message
+                .get("reasoning_content")
+                .or_else(|| message.get("reasoning"))
+                .and_then(|v| v.as_str());
+            if let Some(reasoning) = reasoning
+                && !reasoning.is_empty()
+            {
+                parts.push(Part::Thinking { thinking: reasoning.to_string(), signature: None });
             }
-        }
 
-        // Extract structured tool calls (OpenAI native format)
-        if let Some(tool_calls) = message.get("tool_calls").and_then(|v| v.as_array()) {
-            for tc in tool_calls {
-                let func = &tc["function"];
-                if let Some(name) = func.get("name").and_then(|n| n.as_str()) {
-                    let args: serde_json::Value = func
-                        .get("arguments")
-                        .and_then(|a| a.as_str())
-                        .and_then(|a| serde_json::from_str(a).ok())
-                        .unwrap_or(serde_json::json!({}));
-                    let id = tc.get("id").and_then(|i| i.as_str()).map(String::from);
-                    parts.push(Part::FunctionCall {
-                        name: name.to_string(),
-                        args,
-                        id,
-                        thought_signature: None,
-                    });
+            // Extract visible text content (skip empty strings)
+            if let Some(text) = message.get("content").and_then(|v| v.as_str())
+                && !text.is_empty()
+            {
+                // Check for text-based tool calls (Qwen, Llama, Mistral Nemo format)
+                // before adding as plain text
+                if let Some(parsed_parts) = crate::tool_call_parser::parse_text_tool_calls(text) {
+                    parts.extend(parsed_parts);
+                } else {
+                    parts.push(Part::Text { text: text.to_string() });
                 }
             }
-        }
 
-        Content { role: "model".to_string(), parts }
-    });
+            // Extract structured tool calls (OpenAI native format)
+            if let Some(tool_calls) = message.get("tool_calls").and_then(|v| v.as_array()) {
+                for tc in tool_calls {
+                    let func = &tc["function"];
+                    if let Some(name) = func.get("name").and_then(|n| n.as_str()) {
+                        let args =
+                            decode_tool_call_arguments(func.get("arguments")).map_err(|error| {
+                                format!("invalid arguments for tool '{name}': {error}")
+                            })?;
+                        let id = tc.get("id").and_then(|i| i.as_str()).map(String::from);
+                        parts.push(Part::FunctionCall {
+                            name: name.to_string(),
+                            args,
+                            id,
+                            thought_signature: None,
+                        });
+                    }
+                }
+            }
+
+            Ok(Content { role: "model".to_string(), parts })
+        })
+        .transpose()?;
 
     // Parse usage metadata
     let usage_metadata = json.get("usage").and_then(usage_metadata_from_raw);
@@ -462,7 +479,7 @@ pub fn from_raw_openai_response(json: &serde_json::Value) -> LlmResponse {
         .is_some_and(|reason| matches!(reason, "tool_calls" | "function_call"))
         || content.as_ref().is_some_and(Content::has_function_calls);
 
-    LlmResponse {
+    Ok(LlmResponse {
         content,
         usage_metadata,
         finish_reason,
@@ -474,6 +491,52 @@ pub fn from_raw_openai_response(json: &serde_json::Value) -> LlmResponse {
         error_message: None,
         provider_metadata: None,
         interaction_id: None,
+    })
+}
+
+/// Normalizes tool arguments returned by OpenAI-compatible wire protocols.
+///
+/// Compatible providers sometimes encode a no-argument call as a missing value,
+/// `null`, an empty string, or an empty array. These representations are all
+/// equivalent to an empty JSON object. Non-empty arguments must still resolve
+/// to an object so malformed payloads cannot silently invoke a tool.
+pub(crate) fn decode_tool_call_arguments(
+    arguments: Option<&serde_json::Value>,
+) -> Result<serde_json::Value, String> {
+    let decoded = match arguments {
+        None | Some(serde_json::Value::Null) => serde_json::json!({}),
+        Some(serde_json::Value::String(encoded)) if encoded.trim().is_empty() => {
+            serde_json::json!({})
+        }
+        Some(serde_json::Value::String(encoded)) => {
+            let decoded: serde_json::Value = serde_json::from_str(encoded)
+                .map_err(|error| format!("arguments are not valid JSON: {error}"))?;
+            match decoded {
+                serde_json::Value::Null => serde_json::json!({}),
+                serde_json::Value::Array(items) if items.is_empty() => serde_json::json!({}),
+                decoded => decoded,
+            }
+        }
+        Some(serde_json::Value::Object(fields)) => serde_json::Value::Object(fields.clone()),
+        Some(serde_json::Value::Array(items)) if items.is_empty() => serde_json::json!({}),
+        Some(other) => {
+            return Err(format!(
+                "arguments must be a JSON object or an encoded JSON object, got {}",
+                match other {
+                    serde_json::Value::Array(_) => "array",
+                    serde_json::Value::Bool(_) => "boolean",
+                    serde_json::Value::Number(_) => "number",
+                    serde_json::Value::String(_) => "string",
+                    serde_json::Value::Null => "null",
+                    serde_json::Value::Object(_) => "object",
+                }
+            ));
+        }
+    };
+    if decoded.is_object() {
+        Ok(decoded)
+    } else {
+        Err("arguments must decode to a JSON object".to_owned())
     }
 }
 
@@ -683,6 +746,68 @@ mod tests {
     }
 
     #[test]
+    fn typed_response_normalizes_empty_tool_arguments() {
+        let response: CreateChatCompletionResponse = serde_json::from_value(serde_json::json!({
+            "id": "chatcmpl_empty",
+            "object": "chat.completion",
+            "created": 0,
+            "model": "compatible-model",
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call_empty",
+                        "type": "function",
+                        "function": {"name": "no_args", "arguments": "null"}
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }]
+        }))
+        .expect("typed response should deserialize");
+
+        let converted = from_openai_response(&response);
+        let parts = converted.content.expect("tool content").parts;
+        assert!(matches!(
+            &parts[0],
+            Part::FunctionCall { args, .. } if args == &serde_json::json!({})
+        ));
+        assert!(converted.error_code.is_none());
+        assert!(!converted.turn_complete);
+    }
+
+    #[test]
+    fn typed_response_surfaces_malformed_tool_arguments() {
+        let response: CreateChatCompletionResponse = serde_json::from_value(serde_json::json!({
+            "id": "chatcmpl_invalid",
+            "object": "chat.completion",
+            "created": 0,
+            "model": "compatible-model",
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call_invalid",
+                        "type": "function",
+                        "function": {"name": "bash", "arguments": "{\"command\":\""}
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }]
+        }))
+        .expect("typed response should deserialize");
+
+        let converted = from_openai_response(&response);
+        assert_eq!(converted.error_code.as_deref(), Some("model.openai.invalid_tool_arguments"));
+        assert!(converted.content.is_none());
+        assert!(converted.turn_complete);
+    }
+
+    #[test]
     fn test_raw_response_extracts_reasoning_content() {
         let json = serde_json::json!({
             "choices": [{
@@ -701,7 +826,7 @@ mod tests {
             }
         });
 
-        let resp = from_raw_openai_response(&json);
+        let resp = from_raw_openai_response(&json).expect("response should parse");
         let content = resp.content.unwrap();
         assert_eq!(content.parts.len(), 2);
         assert!(
@@ -729,7 +854,7 @@ mod tests {
             }
         });
 
-        let resp = from_raw_openai_response(&json);
+        let resp = from_raw_openai_response(&json).expect("response should parse");
         let content = resp.content.unwrap();
         assert!(content.parts.is_empty(), "empty text should be filtered out");
         assert_eq!(resp.finish_reason, Some(FinishReason::MaxTokens));
@@ -756,7 +881,7 @@ mod tests {
             "usage": { "prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30 }
         });
 
-        let resp = from_raw_openai_response(&json);
+        let resp = from_raw_openai_response(&json).expect("response should parse");
         let content = resp.content.unwrap();
         assert_eq!(content.parts.len(), 1);
         if let Part::FunctionCall { name, args, id, .. } = &content.parts[0] {
@@ -770,6 +895,114 @@ mod tests {
     }
 
     #[test]
+    fn test_raw_response_accepts_structured_and_empty_tool_arguments() {
+        let json = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [
+                        {
+                            "id": "call_structured",
+                            "type": "function",
+                            "function": {
+                                "name": "bash",
+                                "arguments": {"command": "pwd"}
+                            }
+                        },
+                        {
+                            "id": "call_empty",
+                            "type": "function",
+                            "function": {
+                                "name": "no_args",
+                                "arguments": "   "
+                            }
+                        },
+                        {
+                            "id": "call_empty_array",
+                            "type": "function",
+                            "function": {
+                                "name": "no_args_array",
+                                "arguments": []
+                            }
+                        }
+                    ]
+                },
+                "finish_reason": "tool_calls"
+            }]
+        });
+
+        let response = from_raw_openai_response(&json).expect("compatible arguments should parse");
+        let parts = response.content.expect("tool content").parts;
+        assert!(matches!(
+            &parts[0],
+            Part::FunctionCall { name, args, .. }
+                if name == "bash" && args == &serde_json::json!({"command": "pwd"})
+        ));
+        assert!(matches!(
+            &parts[1],
+            Part::FunctionCall { name, args, .. }
+                if name == "no_args" && args == &serde_json::json!({})
+        ));
+        assert!(matches!(
+            &parts[2],
+            Part::FunctionCall { name, args, .. }
+                if name == "no_args_array" && args == &serde_json::json!({})
+        ));
+    }
+
+    #[test]
+    fn test_raw_response_rejects_truncated_tool_arguments() {
+        let json = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call_invalid",
+                        "type": "function",
+                        "function": {
+                            "name": "bash",
+                            "arguments": "{\"command\":\""
+                        }
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }]
+        });
+
+        let error = from_raw_openai_response(&json)
+            .expect_err("truncated tool arguments must remain invalid");
+        assert!(error.contains("bash"));
+    }
+
+    #[test]
+    fn test_raw_response_rejects_non_empty_array_tool_arguments() {
+        let json = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call_invalid",
+                        "type": "function",
+                        "function": {
+                            "name": "bash",
+                            "arguments": ["pwd"]
+                        }
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }]
+        });
+
+        let error = from_raw_openai_response(&json)
+            .expect_err("non-empty array arguments must remain invalid");
+        assert!(error.contains("bash"));
+        assert!(error.contains("array"));
+    }
+
+    #[test]
     fn test_raw_response_standard_text() {
         let json = serde_json::json!({
             "choices": [{
@@ -779,7 +1012,7 @@ mod tests {
             "usage": { "prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8 }
         });
 
-        let resp = from_raw_openai_response(&json);
+        let resp = from_raw_openai_response(&json).expect("response should parse");
         let content = resp.content.unwrap();
         assert_eq!(content.parts.len(), 1);
         assert!(matches!(&content.parts[0], Part::Text { text } if text == "Hello there!"));
@@ -814,7 +1047,7 @@ mod tests {
             "usage": provider_usage.clone()
         });
 
-        let response = from_raw_openai_response(&json);
+        let response = from_raw_openai_response(&json).expect("response should parse");
         let usage = response.usage_metadata.expect("usage should be parsed");
 
         assert_eq!(usage.prompt_token_count, 120);

--- a/adk-model/src/openai/convert.rs
+++ b/adk-model/src/openai/convert.rs
@@ -239,8 +239,10 @@ pub fn convert_tools(
     adapter: &dyn SchemaAdapter,
     cache: &SchemaCache,
 ) -> Vec<ChatCompletionTools> {
+    let mut tools = tools.iter().collect::<Vec<_>>();
+    tools.sort_unstable_by_key(|(name, _)| *name);
     tools
-        .iter()
+        .into_iter()
         .map(|(name, decl)| {
             let description = decl.get("description").and_then(|d| d.as_str()).map(String::from);
 
@@ -852,6 +854,30 @@ mod tests {
             assert_eq!(tool.function.name, "get_weather");
         } else {
             panic!("Expected Function variant");
+        }
+    }
+
+    #[test]
+    fn convert_tools_has_deterministic_name_order() {
+        use super::super::schema_adapter::OpenAiSchemaAdapter;
+
+        let adapter = OpenAiSchemaAdapter;
+        let cache = SchemaCache::for_adapter(std::sync::Arc::new(OpenAiSchemaAdapter));
+        for _ in 0..32 {
+            let tools = HashMap::from([
+                ("zeta".to_string(), serde_json::json!({})),
+                ("alpha".to_string(), serde_json::json!({})),
+                ("middle".to_string(), serde_json::json!({})),
+            ]);
+            let names = convert_tools(&tools, &adapter, &cache)
+                .into_iter()
+                .map(|tool| match tool {
+                    ChatCompletionTools::Function(tool) => tool.function.name,
+                    ChatCompletionTools::Custom(_) => panic!("expected a function tool"),
+                })
+                .collect::<Vec<_>>();
+
+            assert_eq!(names, ["alpha", "middle", "zeta"]);
         }
     }
 

--- a/adk-model/src/openai/responses_client.rs
+++ b/adk-model/src/openai/responses_client.rs
@@ -60,16 +60,7 @@ fn completed_stream_response(full: LlmResponse) -> LlmResponse {
     let content = (!trailing_parts.is_empty())
         .then_some(Content { role: "model".to_string(), parts: trailing_parts });
 
-    LlmResponse {
-        content,
-        usage_metadata: full.usage_metadata,
-        finish_reason: full.finish_reason,
-        citation_metadata: full.citation_metadata,
-        provider_metadata: full.provider_metadata,
-        partial: false,
-        turn_complete: true,
-        ..Default::default()
-    }
+    LlmResponse { content, partial: false, turn_complete: true, ..full }
 }
 
 impl OpenAIResponsesClient {
@@ -348,14 +339,19 @@ fn normalize_responses_bytes(
     if !open_responses_mode {
         return normalized;
     }
+    // Empty SSE data fields are heartbeats, not JSON model events.
+    if normalized.strip_prefix(b"data:").is_some_and(|payload| payload.trim_ascii().is_empty()) {
+        return Vec::new();
+    }
 
     let payload_start = normalized
         .strip_prefix(b"data:")
         .map_or(0, |payload| normalized.len() - payload.trim_ascii_start().len());
     let payload_end = normalized.trim_ascii_end().len();
-    let Ok(mut value) =
-        serde_json::from_slice::<serde_json::Value>(&normalized[payload_start..payload_end])
-    else {
+    let Some(payload) = normalized.get(payload_start..payload_end) else {
+        return normalized;
+    };
+    let Ok(mut value) = serde_json::from_slice::<serde_json::Value>(payload) else {
         return normalized;
     };
     let message_status = value
@@ -382,49 +378,122 @@ fn normalize_responses_bytes(
 
 #[derive(Default)]
 struct OpenResponsesStreamState {
-    function_arguments: std::collections::BTreeMap<u64, String>,
+    function_calls: std::collections::BTreeMap<u64, StreamedFunctionCall>,
+}
+
+#[derive(Default)]
+struct StreamedFunctionCall {
+    item_id: Option<String>,
+    call_id: Option<String>,
+    arguments: Option<String>,
 }
 
 impl OpenResponsesStreamState {
     fn normalize_event(&mut self, event: &mut serde_json::Value) {
         let event_type = event.get("type").and_then(serde_json::Value::as_str);
         match event_type {
+            Some("response.output_item.added" | "response.output_item.done") => {
+                let is_done = event_type == Some("response.output_item.done");
+                if let Some(output_index) =
+                    event.get("output_index").and_then(serde_json::Value::as_u64)
+                    && let Some(item) = event.get_mut("item")
+                    && item.get("type").and_then(serde_json::Value::as_str) == Some("function_call")
+                {
+                    let call = self.function_calls.entry(output_index).or_default();
+                    if let Some(id) = item.get("id").and_then(serde_json::Value::as_str) {
+                        call.item_id = Some(id.to_string());
+                    }
+                    if let Some(id) = item.get("call_id").and_then(serde_json::Value::as_str) {
+                        call.call_id = Some(id.to_string());
+                    }
+                    if is_done
+                        && let Some(arguments) =
+                            item.get("arguments").and_then(serde_json::Value::as_str)
+                        && (!arguments.trim().is_empty() || call.arguments.is_none())
+                    {
+                        call.arguments = Some(arguments.to_string());
+                    } else if is_done
+                        && let Some(arguments) = &call.arguments
+                        && item.get("arguments").is_none_or(|value| {
+                            value.as_str().is_some_and(|arguments| arguments.trim().is_empty())
+                        })
+                    {
+                        item["arguments"] = arguments.clone().into();
+                    }
+                }
+            }
             Some("response.function_call_arguments.delta") => {
                 if let (Some(output_index), Some(delta)) = (
                     event.get("output_index").and_then(serde_json::Value::as_u64),
                     event.get("delta").and_then(serde_json::Value::as_str),
                 ) {
-                    self.function_arguments.entry(output_index).or_default().push_str(delta);
+                    let call = self.function_calls.entry(output_index).or_default();
+                    if let Some(id) = event.get("item_id").and_then(serde_json::Value::as_str) {
+                        call.item_id = Some(id.to_string());
+                    }
+                    call.arguments.get_or_insert_default().push_str(delta);
                 }
             }
             Some("response.function_call_arguments.done") => {
                 if let Some(output_index) =
                     event.get("output_index").and_then(serde_json::Value::as_u64)
                 {
+                    let call = self.function_calls.entry(output_index).or_default();
+                    if let Some(id) = event.get("item_id").and_then(serde_json::Value::as_str) {
+                        call.item_id = Some(id.to_string());
+                    }
                     if let Some(arguments) =
                         event.get("arguments").and_then(serde_json::Value::as_str)
+                        && (!arguments.trim().is_empty() || call.arguments.is_none())
                     {
-                        self.function_arguments.insert(output_index, arguments.to_string());
-                    } else if let Some(arguments) = self.function_arguments.get(&output_index) {
+                        call.arguments = Some(arguments.to_string());
+                    } else if let Some(arguments) = &call.arguments
+                        && event.get("arguments").is_none_or(|value| {
+                            value.as_str().is_some_and(|arguments| arguments.trim().is_empty())
+                        })
+                    {
                         event["arguments"] = serde_json::Value::String(arguments.clone());
                     }
                 }
             }
             Some("response.completed") => {
-                let mut streamed_arguments = self.function_arguments.values();
                 if let Some(output) =
                     event.pointer_mut("/response/output").and_then(serde_json::Value::as_array_mut)
                 {
-                    for item in output {
+                    for (output_index, item) in output.iter_mut().enumerate() {
                         let is_function_call = item.get("type").and_then(serde_json::Value::as_str)
                             == Some("function_call");
-                        if is_function_call {
-                            let arguments = streamed_arguments.next();
-                            if item.get("arguments").is_none()
-                                && let Some(arguments) = arguments
-                            {
-                                item["arguments"] = serde_json::Value::String(arguments.clone());
-                            }
+                        if !is_function_call || item.get("arguments").is_some() {
+                            continue;
+                        }
+                        let item_id = item.get("id").and_then(serde_json::Value::as_str);
+                        let call_id = item.get("call_id").and_then(serde_json::Value::as_str);
+                        let call = self
+                            .function_calls
+                            .values()
+                            .find(|call| {
+                                ((item_id.is_some() && item_id == call.item_id.as_deref())
+                                    || (call_id.is_some() && call_id == call.call_id.as_deref()))
+                                    && item_id
+                                        .zip(call.item_id.as_deref())
+                                        .is_none_or(|(left, right)| left == right)
+                                    && call_id
+                                        .zip(call.call_id.as_deref())
+                                        .is_none_or(|(left, right)| left == right)
+                            })
+                            .or_else(|| {
+                                self.function_calls.get(&(output_index as u64)).filter(|call| {
+                                    // An index must not override a contradictory item identity.
+                                    item_id
+                                        .zip(call.item_id.as_deref())
+                                        .is_none_or(|(left, right)| left == right)
+                                        && call_id
+                                            .zip(call.call_id.as_deref())
+                                            .is_none_or(|(left, right)| left == right)
+                                })
+                            });
+                        if let Some(arguments) = call.and_then(|call| call.arguments.as_ref()) {
+                            item["arguments"] = arguments.clone().into();
                         }
                     }
                 }
@@ -719,6 +788,107 @@ mod tests {
     use async_openai::error::{ApiError, ApiErrorResponse, OpenAIError};
 
     #[test]
+    fn completed_stream_response_preserves_errors() {
+        let full = LlmResponse {
+            error_code: Some("model.openai_responses.invalid_tool_arguments".to_string()),
+            error_message: Some("invalid function arguments".to_string()),
+            ..Default::default()
+        };
+        let expected = LlmResponse { turn_complete: true, ..full.clone() };
+
+        assert_eq!(
+            serde_json::to_value(completed_stream_response(full)).unwrap(),
+            serde_json::to_value(expected).unwrap()
+        );
+    }
+
+    #[test]
+    fn open_responses_mode_ignores_empty_sse_payloads() {
+        for frame in ["data:\n", "data: \r\n", "data:"] {
+            assert!(normalize_responses_bytes(frame.as_bytes(), false, true, None).is_empty());
+        }
+        for frame in ["\n", ": keepalive\n"] {
+            assert_eq!(
+                normalize_responses_bytes(frame.as_bytes(), false, true, None),
+                frame.as_bytes()
+            );
+        }
+    }
+
+    #[test]
+    fn open_responses_mode_restores_sparse_arguments_by_output_index() {
+        for first_arguments in [None, Some("{}"), Some(r#"{"path":"first.txt"}"#)] {
+            let mut state = OpenResponsesStreamState::default();
+            state.normalize_event(&mut serde_json::json!({
+                "type": "response.function_call_arguments.delta", "output_index": 1,
+                "item_id": "fc_b", "delta": r#"{"path":"second.txt"}"#
+            }));
+            let mut event = serde_json::json!({
+                "type": "response.completed", "response": {"output": [
+                    {"type": "function_call", "call_id": "call_a", "name": "read_file"},
+                    {"type": "function_call", "call_id": "call_b", "name": "read_file"}
+                ]}
+            });
+            if let Some(arguments) = first_arguments {
+                event["response"]["output"][0]["arguments"] = arguments.into();
+            }
+            let mut expected = event.clone();
+            expected["response"]["output"][1]["arguments"] = r#"{"path":"second.txt"}"#.into();
+
+            state.normalize_event(&mut event);
+
+            assert_eq!(event, expected);
+        }
+    }
+
+    #[test]
+    fn open_responses_mode_matches_item_identity_in_sparse_completed_output() {
+        let mut state = OpenResponsesStreamState::default();
+        for (index, id, path) in [(1, "fc_a", "first.txt"), (3, "fc_b", "second.txt")] {
+            state.normalize_event(&mut serde_json::json!({
+                "type": "response.function_call_arguments.delta", "output_index": index,
+                "item_id": id, "delta": serde_json::json!({"path": path}).to_string()
+            }));
+        }
+        let mut event = serde_json::json!({
+            "type": "response.completed", "response": {"output": [
+                {"type": "function_call", "id": "fc_b", "call_id": "call_b", "name": "read_file"}
+            ]}
+        });
+        let mut expected = event.clone();
+        expected["response"]["output"][0]["arguments"] = r#"{"path":"second.txt"}"#.into();
+
+        state.normalize_event(&mut event);
+
+        assert_eq!(event, expected);
+    }
+
+    #[test]
+    fn open_responses_mode_matches_call_identity_from_output_item_events() {
+        let mut state = OpenResponsesStreamState::default();
+        state.normalize_event(&mut serde_json::json!({
+            "type": "response.output_item.added", "output_index": 2,
+            "item": {"type": "function_call", "id": "fc_b", "call_id": "call_b",
+                "name": "read_file", "arguments": "{}"}
+        }));
+        state.normalize_event(&mut serde_json::json!({
+            "type": "response.function_call_arguments.delta", "output_index": 2,
+            "item_id": "fc_b", "delta": r#"{"path":"second.txt"}"#
+        }));
+        let mut event = serde_json::json!({
+            "type": "response.completed", "response": {"output": [
+                {"type": "function_call", "call_id": "call_b", "name": "read_file"}
+            ]}
+        });
+        let mut expected = event.clone();
+        expected["response"]["output"][0]["arguments"] = r#"{"path":"second.txt"}"#.into();
+
+        state.normalize_event(&mut event);
+
+        assert_eq!(event, expected);
+    }
+
+    #[test]
     fn completed_stream_response_preserves_citations() {
         let full = LlmResponse {
             content: Some(Content::new("model").with_text("answer")),
@@ -826,7 +996,7 @@ mod tests {
 
 "#
             .as_slice(),
-            br#"data: {"type":"response.completed","response":{"status":"completed","output":[{"type":"function_call","call_id":"call_1","name":"bash"}]}}
+            br#"data: {"type":"response.completed","response":{"status":"completed","output":[{"type":"function_call","id":"fc_1","call_id":"call_1","name":"bash"}]}}
 
 "#
             .as_slice(),
@@ -854,6 +1024,68 @@ mod tests {
 
         assert_eq!(done["arguments"], r#"{"command":"pwd"}"#);
         assert_eq!(completed["response"]["output"][0]["arguments"], r#"{"command":"pwd"}"#);
+    }
+
+    #[test]
+    fn open_responses_mode_preserves_deltas_after_blank_done_snapshots() {
+        for event_type in ["response.function_call_arguments.done", "response.output_item.done"] {
+            for blank_arguments in ["", " \t\r\n"] {
+                let mut state = OpenResponsesStreamState::default();
+                state.normalize_event(&mut serde_json::json!({
+                    "type": "response.function_call_arguments.delta", "output_index": 0,
+                    "item_id": "fc_a", "delta": r#"{"path":"first.txt"}"#
+                }));
+                let mut done = serde_json::json!({
+                    "type": event_type, "output_index": 0, "item_id": "fc_a",
+                    "arguments": blank_arguments,
+                    "item": {"type": "function_call", "id": "fc_a", "arguments": blank_arguments}
+                });
+                state.normalize_event(&mut done);
+                let restored_done_arguments =
+                    if event_type == "response.function_call_arguments.done" {
+                        &done["arguments"]
+                    } else {
+                        &done["item"]["arguments"]
+                    };
+                assert_eq!(
+                    restored_done_arguments, r#"{"path":"first.txt"}"#,
+                    "{event_type} should restore deltas into a whitespace-only done snapshot"
+                );
+                let mut completed = serde_json::json!({
+                    "type": "response.completed", "response": {"output": [
+                        {"type": "function_call", "id": "fc_a", "call_id": "call_a", "name": "read_file"}
+                    ]}
+                });
+                state.normalize_event(&mut completed);
+                assert_eq!(
+                    completed["response"]["output"][0]["arguments"], r#"{"path":"first.txt"}"#,
+                    "{event_type} should ignore a whitespace-only done snapshot"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn open_responses_mode_never_restores_arguments_from_conflicting_ids() {
+        let mut state = OpenResponsesStreamState::default();
+        for (index, id, call_id, arguments) in
+            [(0, "fc_a", "call_a", "1"), (1, "fc_b", "call_b", "2")]
+        {
+            state.normalize_event(&mut serde_json::json!({
+                "type": "response.output_item.done", "output_index": index,
+                "item": {"type": "function_call", "id": id, "call_id": call_id, "arguments": arguments}
+            }));
+        }
+        for (id, call_id) in [("fc_b", "call_a"), ("fc_a", "call_b")] {
+            let mut event = serde_json::json!({
+                "type": "response.completed", "response": {"output": [
+                    {"type": "function_call", "id": id, "call_id": call_id, "name": "read_file"}
+                ]}
+            });
+            let expected = event.clone();
+            state.normalize_event(&mut event);
+            assert_eq!(event, expected);
+        }
     }
 
     #[test]

--- a/adk-model/src/openai/responses_client.rs
+++ b/adk-model/src/openai/responses_client.rs
@@ -44,6 +44,34 @@ pub struct OpenAIResponsesClient {
     open_responses_mode: bool,
 }
 
+fn completed_stream_response(full: LlmResponse) -> LlmResponse {
+    let trailing_parts = full
+        .content
+        .as_ref()
+        .map(|content| {
+            content
+                .parts
+                .iter()
+                .filter(|part| !matches!(part, Part::Text { .. } | Part::Thinking { .. }))
+                .cloned()
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let content = (!trailing_parts.is_empty())
+        .then_some(Content { role: "model".to_string(), parts: trailing_parts });
+
+    LlmResponse {
+        content,
+        usage_metadata: full.usage_metadata,
+        finish_reason: full.finish_reason,
+        citation_metadata: full.citation_metadata,
+        provider_metadata: full.provider_metadata,
+        partial: false,
+        turn_complete: true,
+        ..Default::default()
+    }
+}
+
 impl OpenAIResponsesClient {
     /// Create a new Responses API client from the given config.
     ///
@@ -106,8 +134,9 @@ impl OpenAIResponsesClient {
             openai_config = openai_config.with_api_base(base_url);
         }
         let client = async_openai::Client::with_config(openai_config);
-        let client = if matches!(reasoning_effort, Some(OpenAIReasoningEffort::Max)) {
-            with_max_reasoning_middleware(client)
+        let uses_max_reasoning = matches!(reasoning_effort, Some(OpenAIReasoningEffort::Max));
+        let client = if uses_max_reasoning || open_responses_mode {
+            with_responses_compatibility_middleware(client, uses_max_reasoning, open_responses_mode)
         } else {
             client
         };
@@ -176,8 +205,10 @@ impl OpenAIResponsesClient {
     }
 }
 
-fn with_max_reasoning_middleware(
+fn with_responses_compatibility_middleware(
     client: async_openai::Client<async_openai::config::OpenAIConfig>,
+    uses_max_reasoning: bool,
+    open_responses_mode: bool,
 ) -> async_openai::Client<async_openai::config::OpenAIConfig> {
     use async_openai::error::OpenAIError;
     use async_openai::middleware::retry::OpenAIRetryLayer;
@@ -195,7 +226,7 @@ fn with_max_reasoning_middleware(
                 let original = original.clone();
                 async move {
                     let mut request = original.build().await?;
-                    if request.url().path().ends_with("/responses") {
+                    if uses_max_reasoning && request.url().path().ends_with("/responses") {
                         let body =
                             request.body().and_then(|body| body.as_bytes()).ok_or_else(|| {
                                 OpenAIError::InvalidArgument(
@@ -217,15 +248,17 @@ fn with_max_reasoning_middleware(
                 }
             });
             let response = transport.oneshot(rewritten).await?;
-            normalize_max_reasoning_response(response).await
+            normalize_responses_response(response, uses_max_reasoning, open_responses_mode).await
         }
     });
 
     client.with_http_service(service)
 }
 
-async fn normalize_max_reasoning_response(
+async fn normalize_responses_response(
     response: reqwest_openai::Response,
+    uses_max_reasoning: bool,
+    open_responses_mode: bool,
 ) -> Result<reqwest_openai::Response, async_openai::error::OpenAIError> {
     use reqwest_openai::ResponseBuilderExt;
 
@@ -248,26 +281,42 @@ async fn normalize_max_reasoning_response(
         let mut upstream = response.bytes_stream();
         let normalized = async_stream::stream! {
             let mut pending = Vec::new();
+            let mut stream_state = OpenResponsesStreamState::default();
             while let Some(chunk) = upstream.next().await {
                 match chunk {
                     Ok(chunk) => {
                         pending.extend_from_slice(&chunk);
                         while let Some(line_end) = pending.iter().position(|byte| *byte == b'\n') {
                             let line: Vec<u8> = pending.drain(..=line_end).collect();
-                            yield Ok::<Vec<u8>, reqwest_openai::Error>(normalize_max_reasoning_bytes(&line));
+                            yield Ok::<Vec<u8>, reqwest_openai::Error>(normalize_responses_bytes(
+                                &line,
+                                uses_max_reasoning,
+                                open_responses_mode,
+                                Some(&mut stream_state),
+                            ));
                         }
                     }
                     Err(error) => yield Err(error),
                 }
             }
             if !pending.is_empty() {
-                yield Ok::<Vec<u8>, reqwest_openai::Error>(normalize_max_reasoning_bytes(&pending));
+                yield Ok::<Vec<u8>, reqwest_openai::Error>(normalize_responses_bytes(
+                    &pending,
+                    uses_max_reasoning,
+                    open_responses_mode,
+                    Some(&mut stream_state),
+                ));
             }
         };
         reqwest_openai::Body::wrap_stream(normalized)
     } else {
         let bytes = response.bytes().await.map_err(async_openai::error::OpenAIError::Reqwest)?;
-        reqwest_openai::Body::from(normalize_max_reasoning_bytes(&bytes))
+        reqwest_openai::Body::from(normalize_responses_bytes(
+            &bytes,
+            uses_max_reasoning,
+            open_responses_mode,
+            None,
+        ))
     };
 
     let mut rebuilt =
@@ -282,11 +331,139 @@ async fn normalize_max_reasoning_response(
     Ok(reqwest_openai::Response::from(rebuilt))
 }
 
-fn normalize_max_reasoning_bytes(bytes: &[u8]) -> Vec<u8> {
-    String::from_utf8_lossy(bytes)
-        .replace("\"effort\":\"max\"", "\"effort\":\"xhigh\"")
-        .replace("\"effort\": \"max\"", "\"effort\": \"xhigh\"")
-        .into_bytes()
+fn normalize_responses_bytes(
+    bytes: &[u8],
+    uses_max_reasoning: bool,
+    open_responses_mode: bool,
+    stream_state: Option<&mut OpenResponsesStreamState>,
+) -> Vec<u8> {
+    let normalized = if uses_max_reasoning {
+        String::from_utf8_lossy(bytes)
+            .replace("\"effort\":\"max\"", "\"effort\":\"xhigh\"")
+            .replace("\"effort\": \"max\"", "\"effort\": \"xhigh\"")
+            .into_bytes()
+    } else {
+        bytes.to_vec()
+    };
+    if !open_responses_mode {
+        return normalized;
+    }
+
+    let payload_start = normalized
+        .strip_prefix(b"data:")
+        .map_or(0, |payload| normalized.len() - payload.trim_ascii_start().len());
+    let payload_end = normalized.trim_ascii_end().len();
+    let Ok(mut value) =
+        serde_json::from_slice::<serde_json::Value>(&normalized[payload_start..payload_end])
+    else {
+        return normalized;
+    };
+    let message_status = value
+        .pointer("/response/status")
+        .or_else(|| value.get("status"))
+        .and_then(serde_json::Value::as_str)
+        .filter(|status| matches!(*status, "in_progress" | "completed" | "incomplete"))
+        .unwrap_or("in_progress")
+        .to_string();
+    if let Some(stream_state) = stream_state {
+        stream_state.normalize_event(&mut value);
+    }
+    add_open_responses_defaults(&mut value, &message_status);
+
+    let Ok(encoded) = serde_json::to_vec(&value) else {
+        return normalized;
+    };
+    let mut rebuilt = Vec::with_capacity(normalized.len().max(encoded.len()));
+    rebuilt.extend_from_slice(&normalized[..payload_start]);
+    rebuilt.extend_from_slice(&encoded);
+    rebuilt.extend_from_slice(&normalized[payload_end..]);
+    rebuilt
+}
+
+#[derive(Default)]
+struct OpenResponsesStreamState {
+    function_arguments: std::collections::BTreeMap<u64, String>,
+}
+
+impl OpenResponsesStreamState {
+    fn normalize_event(&mut self, event: &mut serde_json::Value) {
+        let event_type = event.get("type").and_then(serde_json::Value::as_str);
+        match event_type {
+            Some("response.function_call_arguments.delta") => {
+                if let (Some(output_index), Some(delta)) = (
+                    event.get("output_index").and_then(serde_json::Value::as_u64),
+                    event.get("delta").and_then(serde_json::Value::as_str),
+                ) {
+                    self.function_arguments.entry(output_index).or_default().push_str(delta);
+                }
+            }
+            Some("response.function_call_arguments.done") => {
+                if let Some(output_index) =
+                    event.get("output_index").and_then(serde_json::Value::as_u64)
+                {
+                    if let Some(arguments) =
+                        event.get("arguments").and_then(serde_json::Value::as_str)
+                    {
+                        self.function_arguments.insert(output_index, arguments.to_string());
+                    } else if let Some(arguments) = self.function_arguments.get(&output_index) {
+                        event["arguments"] = serde_json::Value::String(arguments.clone());
+                    }
+                }
+            }
+            Some("response.completed") => {
+                let mut streamed_arguments = self.function_arguments.values();
+                if let Some(output) =
+                    event.pointer_mut("/response/output").and_then(serde_json::Value::as_array_mut)
+                {
+                    for item in output {
+                        let is_function_call = item.get("type").and_then(serde_json::Value::as_str)
+                            == Some("function_call");
+                        if is_function_call {
+                            let arguments = streamed_arguments.next();
+                            if item.get("arguments").is_none()
+                                && let Some(arguments) = arguments
+                            {
+                                item["arguments"] = serde_json::Value::String(arguments.clone());
+                            }
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn add_open_responses_defaults(value: &mut serde_json::Value, message_status: &str) {
+    match value {
+        serde_json::Value::Array(items) => {
+            for item in items {
+                add_open_responses_defaults(item, message_status);
+            }
+        }
+        serde_json::Value::Object(fields) => {
+            match fields.get("type").and_then(serde_json::Value::as_str) {
+                Some("message") => {
+                    fields.entry("id").or_insert_with(|| {
+                        serde_json::Value::String("msg_open_responses".to_string())
+                    });
+                    fields
+                        .entry("status")
+                        .or_insert_with(|| serde_json::Value::String(message_status.to_string()));
+                }
+                Some("output_text") => {
+                    fields
+                        .entry("annotations")
+                        .or_insert_with(|| serde_json::Value::Array(Vec::new()));
+                }
+                _ => {}
+            }
+            for field in fields.values_mut() {
+                add_open_responses_defaults(field, message_status);
+            }
+        }
+        _ => {}
+    }
 }
 
 fn set_max_reasoning_effort(
@@ -458,43 +635,7 @@ impl Llm for OpenAIResponsesClient {
                             // via delta events) and mark the turn complete.
                             ResponseStreamEvent::ResponseCompleted(evt) => {
                                 let full = responses_convert::from_response(&evt.response);
-                                // Extract only non-textual protocol parts (text/thinking were already
-                                // streamed via delta events, but tool protocol items need to survive).
-                                let trailing_parts: Vec<Part> = full
-                                    .content
-                                    .as_ref()
-                                    .map(|c| {
-                                        c.parts
-                                            .iter()
-                                            .filter(|part| {
-                                                !matches!(
-                                                    part,
-                                                    Part::Text { .. } | Part::Thinking { .. }
-                                                )
-                                            })
-                                            .cloned()
-                                            .collect()
-                                    })
-                                    .unwrap_or_default();
-
-                                let content = if trailing_parts.is_empty() {
-                                    None
-                                } else {
-                                    Some(Content {
-                                        role: "model".to_string(),
-                                        parts: trailing_parts,
-                                    })
-                                };
-
-                                Some(Ok(LlmResponse {
-                                    content,
-                                    usage_metadata: full.usage_metadata,
-                                    finish_reason: full.finish_reason,
-                                    provider_metadata: full.provider_metadata,
-                                    partial: false,
-                                    turn_complete: true,
-                                    ..Default::default()
-                                }))
+                                Some(Ok(completed_stream_response(full)))
                             }
 
                             ResponseStreamEvent::ResponseFailed(evt) => {
@@ -577,6 +718,37 @@ mod tests {
     use crate::openai::config::OpenAIResponsesConfig;
     use async_openai::error::{ApiError, ApiErrorResponse, OpenAIError};
 
+    #[test]
+    fn completed_stream_response_preserves_citations() {
+        let full = LlmResponse {
+            content: Some(Content::new("model").with_text("answer")),
+            citation_metadata: Some(adk_core::CitationMetadata {
+                citation_sources: vec![adk_core::CitationSource {
+                    uri: Some("https://example.test".to_string()),
+                    title: Some("Example".to_string()),
+                    start_index: Some(0),
+                    end_index: Some(6),
+                    license: None,
+                    publication_date: None,
+                }],
+            }),
+            ..Default::default()
+        };
+
+        let completed = completed_stream_response(full);
+
+        assert!(completed.content.is_none());
+        assert_eq!(
+            completed
+                .citation_metadata
+                .expect("citations should survive stream completion")
+                .citation_sources[0]
+                .uri
+                .as_deref(),
+            Some("https://example.test")
+        );
+    }
+
     fn api_error(status_code: u16) -> OpenAIError {
         OpenAIError::ApiError(ApiErrorResponse {
             status_code: reqwest::StatusCode::from_u16(status_code)
@@ -607,11 +779,81 @@ mod tests {
         let compact = br#"{"reasoning":{"effort":"max"}}"#;
         let spaced = br#"data: {"response":{"reasoning":{"effort": "max"}}}\n\n"#;
 
-        assert_eq!(normalize_max_reasoning_bytes(compact), br#"{"reasoning":{"effort":"xhigh"}}"#);
         assert_eq!(
-            normalize_max_reasoning_bytes(spaced),
+            normalize_responses_bytes(compact, true, false, None),
+            br#"{"reasoning":{"effort":"xhigh"}}"#
+        );
+        assert_eq!(
+            normalize_responses_bytes(spaced, true, false, None),
             br#"data: {"response":{"reasoning":{"effort": "xhigh"}}}\n\n"#
         );
+    }
+
+    #[test]
+    fn open_responses_mode_defaults_omitted_output_message_fields() {
+        let event = br#"data: {"type":"response.completed","response":{"status":"completed","output":[{"type":"message","content":[{"type":"output_text","text":"done"}]}]}}
+
+"#;
+
+        let normalized = normalize_responses_bytes(event, false, true, None);
+        let payload = normalized
+            .strip_prefix(b"data: ")
+            .expect("SSE data prefix should survive")
+            .trim_ascii_end();
+        let value: serde_json::Value =
+            serde_json::from_slice(payload).expect("normalized event should remain JSON");
+
+        assert_eq!(
+            value["response"]["output"][0]["content"][0]["annotations"],
+            serde_json::json!([])
+        );
+        assert_eq!(value["response"]["output"][0]["id"], "msg_open_responses");
+        assert_eq!(value["response"]["output"][0]["status"], "completed");
+    }
+
+    #[test]
+    fn open_responses_mode_restores_streamed_function_arguments() {
+        let events = [
+            br#"data: {"type":"response.function_call_arguments.delta","output_index":1,"item_id":"fc_1","delta":"{\"command\":"}
+
+"#
+            .as_slice(),
+            br#"data: {"type":"response.function_call_arguments.delta","output_index":1,"item_id":"fc_1","delta":"\"pwd\"}"}
+
+"#
+            .as_slice(),
+            br#"data: {"type":"response.function_call_arguments.done","output_index":1,"item_id":"fc_1"}
+
+"#
+            .as_slice(),
+            br#"data: {"type":"response.completed","response":{"status":"completed","output":[{"type":"function_call","call_id":"call_1","name":"bash"}]}}
+
+"#
+            .as_slice(),
+        ];
+        let mut stream_state = OpenResponsesStreamState::default();
+        let normalized: Vec<Vec<u8>> = events
+            .iter()
+            .map(|event| normalize_responses_bytes(event, false, true, Some(&mut stream_state)))
+            .collect();
+
+        let done: serde_json::Value = serde_json::from_slice(
+            normalized[2]
+                .strip_prefix(b"data: ")
+                .expect("SSE data prefix should survive")
+                .trim_ascii_end(),
+        )
+        .expect("normalized arguments event should remain JSON");
+        let completed: serde_json::Value = serde_json::from_slice(
+            normalized[3]
+                .strip_prefix(b"data: ")
+                .expect("SSE data prefix should survive")
+                .trim_ascii_end(),
+        )
+        .expect("normalized completion event should remain JSON");
+
+        assert_eq!(done["arguments"], r#"{"command":"pwd"}"#);
+        assert_eq!(completed["response"]["output"][0]["arguments"], r#"{"command":"pwd"}"#);
     }
 
     #[test]

--- a/adk-model/src/openai/responses_client.rs
+++ b/adk-model/src/openai/responses_client.rs
@@ -279,24 +279,30 @@ async fn normalize_responses_response(
                         pending.extend_from_slice(&chunk);
                         while let Some(line_end) = pending.iter().position(|byte| *byte == b'\n') {
                             let line: Vec<u8> = pending.drain(..=line_end).collect();
-                            yield Ok::<Vec<u8>, reqwest_openai::Error>(normalize_responses_bytes(
+                            let normalized = stream_state.normalize_line(
                                 &line,
                                 uses_max_reasoning,
                                 open_responses_mode,
-                                Some(&mut stream_state),
-                            ));
+                            );
+                            let failed = normalized.is_err();
+                            yield normalized;
+                            if failed {
+                                return;
+                            }
                         }
                     }
-                    Err(error) => yield Err(error),
+                    Err(error) => {
+                        yield Err(std::io::Error::other(error));
+                        return;
+                    }
                 }
             }
             if !pending.is_empty() {
-                yield Ok::<Vec<u8>, reqwest_openai::Error>(normalize_responses_bytes(
+                yield stream_state.normalize_line(
                     &pending,
                     uses_max_reasoning,
                     open_responses_mode,
-                    Some(&mut stream_state),
-                ));
+                );
             }
         };
         reqwest_openai::Body::wrap_stream(normalized)
@@ -379,6 +385,7 @@ fn normalize_responses_bytes(
 #[derive(Default)]
 struct OpenResponsesStreamState {
     function_calls: std::collections::BTreeMap<u64, StreamedFunctionCall>,
+    identity_conflict: bool,
 }
 
 #[derive(Default)]
@@ -389,7 +396,50 @@ struct StreamedFunctionCall {
 }
 
 impl OpenResponsesStreamState {
+    fn normalize_line(
+        &mut self,
+        bytes: &[u8],
+        uses_max_reasoning: bool,
+        open_responses_mode: bool,
+    ) -> std::io::Result<Vec<u8>> {
+        let normalized =
+            normalize_responses_bytes(bytes, uses_max_reasoning, open_responses_mode, Some(self));
+        if self.identity_conflict {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "conflicting tool-call identities in Open Responses stream",
+            ));
+        }
+        Ok(normalized)
+    }
+
+    fn bind_call(
+        &mut self,
+        output_index: u64,
+        item_id: Option<&str>,
+        call_id: Option<&str>,
+    ) -> Option<&mut StreamedFunctionCall> {
+        let call = self.function_calls.entry(output_index).or_default();
+        if item_id.zip(call.item_id.as_deref()).is_some_and(|(next, previous)| next != previous)
+            || call_id.zip(call.call_id.as_deref()).is_some_and(|(next, previous)| next != previous)
+        {
+            // A reused index cannot transfer accumulated arguments to another call.
+            self.identity_conflict = true;
+            return None;
+        }
+        if call.item_id.is_none() {
+            call.item_id = item_id.map(str::to_owned);
+        }
+        if call.call_id.is_none() {
+            call.call_id = call_id.map(str::to_owned);
+        }
+        Some(call)
+    }
+
     fn normalize_event(&mut self, event: &mut serde_json::Value) {
+        if self.identity_conflict {
+            return;
+        }
         let event_type = event.get("type").and_then(serde_json::Value::as_str);
         match event_type {
             Some("response.output_item.added" | "response.output_item.done") => {
@@ -399,13 +449,13 @@ impl OpenResponsesStreamState {
                     && let Some(item) = event.get_mut("item")
                     && item.get("type").and_then(serde_json::Value::as_str) == Some("function_call")
                 {
-                    let call = self.function_calls.entry(output_index).or_default();
-                    if let Some(id) = item.get("id").and_then(serde_json::Value::as_str) {
-                        call.item_id = Some(id.to_string());
-                    }
-                    if let Some(id) = item.get("call_id").and_then(serde_json::Value::as_str) {
-                        call.call_id = Some(id.to_string());
-                    }
+                    let Some(call) = self.bind_call(
+                        output_index,
+                        item.get("id").and_then(serde_json::Value::as_str),
+                        item.get("call_id").and_then(serde_json::Value::as_str),
+                    ) else {
+                        return;
+                    };
                     if is_done
                         && let Some(arguments) =
                             item.get("arguments").and_then(serde_json::Value::as_str)
@@ -414,9 +464,7 @@ impl OpenResponsesStreamState {
                         call.arguments = Some(arguments.to_string());
                     } else if is_done
                         && let Some(arguments) = &call.arguments
-                        && item.get("arguments").is_none_or(|value| {
-                            value.as_str().is_some_and(|arguments| arguments.trim().is_empty())
-                        })
+                        && missing_or_blank_arguments(item.get("arguments"))
                     {
                         item["arguments"] = arguments.clone().into();
                     }
@@ -427,10 +475,13 @@ impl OpenResponsesStreamState {
                     event.get("output_index").and_then(serde_json::Value::as_u64),
                     event.get("delta").and_then(serde_json::Value::as_str),
                 ) {
-                    let call = self.function_calls.entry(output_index).or_default();
-                    if let Some(id) = event.get("item_id").and_then(serde_json::Value::as_str) {
-                        call.item_id = Some(id.to_string());
-                    }
+                    let Some(call) = self.bind_call(
+                        output_index,
+                        event.get("item_id").and_then(serde_json::Value::as_str),
+                        event.get("call_id").and_then(serde_json::Value::as_str),
+                    ) else {
+                        return;
+                    };
                     call.arguments.get_or_insert_default().push_str(delta);
                 }
             }
@@ -438,19 +489,20 @@ impl OpenResponsesStreamState {
                 if let Some(output_index) =
                     event.get("output_index").and_then(serde_json::Value::as_u64)
                 {
-                    let call = self.function_calls.entry(output_index).or_default();
-                    if let Some(id) = event.get("item_id").and_then(serde_json::Value::as_str) {
-                        call.item_id = Some(id.to_string());
-                    }
+                    let Some(call) = self.bind_call(
+                        output_index,
+                        event.get("item_id").and_then(serde_json::Value::as_str),
+                        event.get("call_id").and_then(serde_json::Value::as_str),
+                    ) else {
+                        return;
+                    };
                     if let Some(arguments) =
                         event.get("arguments").and_then(serde_json::Value::as_str)
                         && (!arguments.trim().is_empty() || call.arguments.is_none())
                     {
                         call.arguments = Some(arguments.to_string());
                     } else if let Some(arguments) = &call.arguments
-                        && event.get("arguments").is_none_or(|value| {
-                            value.as_str().is_some_and(|arguments| arguments.trim().is_empty())
-                        })
+                        && missing_or_blank_arguments(event.get("arguments"))
                     {
                         event["arguments"] = serde_json::Value::String(arguments.clone());
                     }
@@ -463,7 +515,7 @@ impl OpenResponsesStreamState {
                     for (output_index, item) in output.iter_mut().enumerate() {
                         let is_function_call = item.get("type").and_then(serde_json::Value::as_str)
                             == Some("function_call");
-                        if !is_function_call || item.get("arguments").is_some() {
+                        if !is_function_call || !missing_or_blank_arguments(item.get("arguments")) {
                             continue;
                         }
                         let item_id = item.get("id").and_then(serde_json::Value::as_str);
@@ -501,6 +553,10 @@ impl OpenResponsesStreamState {
             _ => {}
         }
     }
+}
+
+fn missing_or_blank_arguments(value: Option<&serde_json::Value>) -> bool {
+    value.is_none_or(|value| value.as_str().is_some_and(|arguments| arguments.trim().is_empty()))
 }
 
 fn add_open_responses_defaults(value: &mut serde_json::Value, message_status: &str) {
@@ -786,6 +842,140 @@ mod tests {
     use super::*;
     use crate::openai::config::OpenAIResponsesConfig;
     use async_openai::error::{ApiError, ApiErrorResponse, OpenAIError};
+    use serde_json::json;
+
+    const FIRST_ARGUMENTS: &str = r#"{"path":"first.txt"}"#;
+    fn stream_with_first_call() -> OpenResponsesStreamState {
+        let mut state = OpenResponsesStreamState::default();
+        state.normalize_event(&mut json!({"type":"response.output_item.added", "output_index":0,
+            "item":{"type":"function_call", "id":"item_A", "call_id":"call_A", "name":"read_file"}}));
+        state.normalize_event(
+            &mut json!({"type":"response.function_call_arguments.delta", "output_index":0,
+            "item_id":"item_A", "delta":FIRST_ARGUMENTS}),
+        );
+        state
+    }
+    #[test]
+    fn output_done_does_not_reuse_another_calls_arguments() {
+        let mut state = stream_with_first_call();
+        let mut done = json!({"type":"response.output_item.done", "output_index":0,
+            "item":{"type":"function_call", "id":"item_B", "call_id":"call_B", "name":"read_file"}});
+        state.normalize_event(&mut done);
+        assert_ne!(
+            done["item"]["arguments"], FIRST_ARGUMENTS,
+            "arguments from the first call were injected into the second: {done}"
+        );
+    }
+    #[test]
+    fn output_added_does_not_overwrite_accumulated_call_identity() {
+        let mut state = stream_with_first_call();
+        state.normalize_event(&mut json!({"type":"response.output_item.added", "output_index":0,
+            "item":{"type":"function_call", "id":"item_B", "call_id":"call_B", "name":"read_file"}}));
+        let mut completed = json!({"type":"response.completed", "response":{"output":[
+            {"type":"function_call","id":"item_B","call_id":"call_B","name":"read_file"}]}});
+        state.normalize_event(&mut completed);
+        assert_ne!(completed["response"]["output"][0]["arguments"], FIRST_ARGUMENTS, "{completed}");
+    }
+    #[test]
+    fn argument_done_does_not_reuse_another_items_arguments() {
+        let mut state = stream_with_first_call();
+        let mut done = json!({"type":"response.function_call_arguments.done", "output_index":0,
+            "item_id":"item_B"});
+        state.normalize_event(&mut done);
+        assert_ne!(done["arguments"], FIRST_ARGUMENTS, "{done}");
+    }
+    #[test]
+    fn argument_delta_does_not_concatenate_different_items() {
+        let mut state = stream_with_first_call();
+        state.normalize_event(
+            &mut json!({"type":"response.function_call_arguments.delta", "output_index":0,
+            "item_id":"item_B", "delta":r#"{"path":"B"}"#}),
+        );
+        let mut done = json!({"type":"response.function_call_arguments.done","output_index":0,"item_id":"item_B"});
+        state.normalize_event(&mut done);
+        assert!(!done["arguments"].as_str().unwrap_or("").contains(FIRST_ARGUMENTS), "{done}");
+    }
+    #[test]
+    fn blank_completed_arguments_restore_valid_deltas() {
+        let mut state = stream_with_first_call();
+        let mut done = json!({"type":"response.function_call_arguments.done", "output_index":0,
+            "item_id":"item_A", "arguments":""});
+        state.normalize_event(&mut done);
+        assert_eq!(done["arguments"], FIRST_ARGUMENTS);
+        let mut item_done = json!({"type":"response.output_item.done", "output_index":0,
+            "item":{"type":"function_call","id":"item_A","call_id":"call_A","arguments":""}});
+        state.normalize_event(&mut item_done);
+        assert_eq!(item_done["item"]["arguments"], FIRST_ARGUMENTS);
+        let mut completed = json!({"type":"response.completed","response":{"output":[
+            {"type":"function_call","id":"item_A","call_id":"call_A","name":"read_file","arguments":""}]}});
+        state.normalize_event(&mut completed);
+        assert_eq!(completed["response"]["output"][0]["arguments"], FIRST_ARGUMENTS, "{completed}");
+    }
+    #[test]
+    fn whitespace_completed_arguments_restore_valid_deltas() {
+        let mut state = stream_with_first_call();
+        let mut completed = json!({"type":"response.completed","response":{"output":[
+            {"type":"function_call","id":"item_A","call_id":"call_A","name":"read_file","arguments":" \t\r\n"}]}});
+        state.normalize_event(&mut completed);
+        assert_eq!(completed["response"]["output"][0]["arguments"], FIRST_ARGUMENTS, "{completed}");
+    }
+    #[test]
+    fn omitted_completed_arguments_restore_the_matching_call() {
+        let mut state = stream_with_first_call();
+        let mut completed = json!({"type":"response.completed","response":{"output":[
+            {"type":"function_call","id":"item_A","call_id":"call_A","name":"read_file"}]}});
+        state.normalize_event(&mut completed);
+        assert_eq!(completed["response"]["output"][0]["arguments"], FIRST_ARGUMENTS);
+    }
+
+    #[test]
+    fn every_stream_update_rejects_item_and_call_identity_conflicts() {
+        for event_type in [
+            "response.output_item.added",
+            "response.output_item.done",
+            "response.function_call_arguments.delta",
+            "response.function_call_arguments.done",
+        ] {
+            for (item_id, call_id) in
+                [("item_A", "call_B"), ("item_B", "call_A"), ("item_B", "call_B")]
+            {
+                let mut state = stream_with_first_call();
+                let event = json!({
+                    "type": event_type, "output_index": 0,
+                    "item_id": item_id, "call_id": call_id, "delta": " ",
+                    "arguments": r#"{"path":"second.txt"}"#,
+                    "item": {"type":"function_call", "id":item_id, "call_id":call_id,
+                        "name":"read_file", "arguments":r#"{"path":"second.txt"}"#},
+                });
+                let line = format!("data: {event}\n");
+                let error = state.normalize_line(line.as_bytes(), false, true).unwrap_err();
+                assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+                let call = &state.function_calls[&0];
+                assert_eq!(
+                    (call.item_id.as_deref(), call.call_id.as_deref(), call.arguments.as_deref()),
+                    (Some("item_A"), Some("call_A"), Some(FIRST_ARGUMENTS)),
+                );
+                assert!(state.normalize_line(b"data: {}\n", false, true).is_err());
+            }
+        }
+    }
+
+    #[test]
+    fn completed_explicit_arguments_are_not_replaced_by_cached_deltas() {
+        for arguments in [
+            json!("{}"),
+            json!(r#"{"path":"explicit.txt"}"#),
+            json!(null),
+            json!({"path":"object"}),
+        ] {
+            let mut state = stream_with_first_call();
+            let mut event = json!({"type":"response.completed", "response":{"output":[
+                {"type":"function_call","id":"item_A","call_id":"call_A","name":"read_file","arguments":arguments}]}});
+            let expected = event.clone();
+            state.normalize_event(&mut event);
+            assert_eq!(event, expected);
+        }
+    }
 
     #[test]
     fn completed_stream_response_preserves_errors() {

--- a/adk-model/src/openai/responses_convert.rs
+++ b/adk-model/src/openai/responses_convert.rs
@@ -5,11 +5,11 @@
 
 use crate::attachment;
 use adk_core::{
-    AdkError, Content, ErrorCategory, ErrorComponent, FinishReason, LlmRequest, LlmResponse, Part,
-    UsageMetadata,
+    AdkError, CitationMetadata, CitationSource, Content, ErrorCategory, ErrorComponent,
+    FinishReason, LlmRequest, LlmResponse, Part, UsageMetadata,
 };
 use async_openai::types::responses::{
-    ApplyPatchToolCallItemParam, ApplyPatchToolCallOutputItemParam, ConversationParam,
+    Annotation, ApplyPatchToolCallItemParam, ApplyPatchToolCallOutputItemParam, ConversationParam,
     CreateResponse, CreateResponseArgs, EasyInputContent, EasyInputMessage, FunctionCallOutput,
     FunctionCallOutputItemParam, FunctionShellCallItemParam, FunctionShellCallOutputItemParam,
     FunctionTool, FunctionToolCall, IncludeEnum, InputContent, InputImageContent, InputItem,
@@ -588,12 +588,53 @@ pub fn from_response(response: &Response) -> LlmResponse {
     let usage_metadata = response.usage.as_ref().map(convert_usage);
     let finish_reason = map_finish_reason(response);
     let provider_metadata = build_provider_metadata(response);
+    let citation_sources = response
+        .output
+        .iter()
+        .filter_map(|item| match item {
+            OutputItem::Message(message) => Some(&message.content),
+            _ => None,
+        })
+        .flatten()
+        .filter_map(|content| match content {
+            OutputMessageContent::OutputText(text) => Some(&text.annotations),
+            OutputMessageContent::Refusal(_) => None,
+        })
+        .flatten()
+        .filter_map(|annotation| match annotation {
+            Annotation::UrlCitation(citation) => {
+                let value = serde_json::to_value(citation).ok()?;
+                Some(CitationSource {
+                    uri: value.get("url").and_then(serde_json::Value::as_str).map(str::to_owned),
+                    title: value
+                        .get("title")
+                        .and_then(serde_json::Value::as_str)
+                        .map(str::to_owned),
+                    start_index: value
+                        .get("start_index")
+                        .and_then(serde_json::Value::as_u64)
+                        .and_then(|index| i32::try_from(index).ok()),
+                    end_index: value
+                        .get("end_index")
+                        .and_then(serde_json::Value::as_u64)
+                        .and_then(|index| i32::try_from(index).ok()),
+                    license: None,
+                    publication_date: None,
+                })
+            }
+            Annotation::FileCitation(_)
+            | Annotation::ContainerFileCitation(_)
+            | Annotation::FilePath(_) => None,
+        })
+        .collect::<Vec<_>>();
+    let citation_metadata =
+        (!citation_sources.is_empty()).then_some(CitationMetadata { citation_sources });
 
     LlmResponse {
         content,
         usage_metadata,
         finish_reason,
-        citation_metadata: None,
+        citation_metadata,
         partial: false,
         turn_complete: true,
         interrupted: false,
@@ -1060,7 +1101,7 @@ mod tests {
             "openai_web_search".to_string(),
             serde_json::json!({
                 "x-adk-openai-tool": {
-                    "type": "web_search_2025_08_26"
+                    "type": "web_search"
                 }
             }),
         );
@@ -1360,7 +1401,7 @@ mod tests {
             "openai".to_string(),
             serde_json::json!({
                 "built_in_tools": [
-                    { "type": "web_search_2025_08_26" },
+                    { "type": "web_search" },
                     { "type": "image_generation", "size": "1024x1024", "quality": "high" }
                 ]
             }),
@@ -1414,7 +1455,7 @@ mod tests {
                 "prompt_cache_retention": "24h",
                 "service_tier": "priority",
                 "built_in_tools": [
-                    { "type": "web_search_2025_08_26" }
+                    { "type": "web_search" }
                 ]
             }),
         );
@@ -1469,6 +1510,56 @@ mod tests {
         let metadata = llm_response.provider_metadata.expect("metadata should exist");
         assert_eq!(metadata["openai"]["response_id"], "resp_status_test");
         assert_eq!(metadata["openai"]["status"], "completed");
+    }
+
+    #[test]
+    fn test_from_response_maps_url_citations() {
+        let response: Response = serde_json::from_value(serde_json::json!({
+            "id": "resp_citation_test",
+            "object": "response",
+            "created_at": 0,
+            "model": "gpt-5.4",
+            "status": "completed",
+            "output": [{
+                "type": "message",
+                "id": "msg_citation_test",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{
+                    "type": "output_text",
+                    "text": "OpenAI",
+                    "annotations": [{
+                        "type": "url_citation",
+                        "start_index": 0,
+                        "end_index": 6,
+                        "title": "OpenAI",
+                        "url": "https://openai.com"
+                    }]
+                }]
+            }],
+            "usage": {
+                "input_tokens": 10,
+                "input_tokens_details": { "cached_tokens": 0 },
+                "output_tokens": 5,
+                "output_tokens_details": { "reasoning_tokens": 0 },
+                "total_tokens": 15
+            }
+        }))
+        .expect("response should deserialize");
+
+        let llm_response = from_response(&response);
+        let citations = llm_response.citation_metadata.expect("citation metadata should exist");
+        assert_eq!(
+            citations.citation_sources,
+            vec![adk_core::CitationSource {
+                uri: Some("https://openai.com".to_string()),
+                title: Some("OpenAI".to_string()),
+                start_index: Some(0),
+                end_index: Some(6),
+                license: None,
+                publication_date: None,
+            }]
+        );
     }
 
     #[test]

--- a/adk-model/src/openai/responses_convert.rs
+++ b/adk-model/src/openai/responses_convert.rs
@@ -231,8 +231,10 @@ fn content_to_input_items(content: &Content) -> Vec<InputItem> {
 /// If the type is not recognized (e.g., `tool_search`, `skill`), the tool falls back to
 /// being treated as a regular function tool.
 pub fn convert_tools(tools: &HashMap<String, serde_json::Value>) -> Result<Vec<Tool>, AdkError> {
+    let mut tools = tools.iter().collect::<Vec<_>>();
+    tools.sort_unstable_by_key(|(name, _)| *name);
     tools
-        .iter()
+        .into_iter()
         .map(|(name, decl)| {
             if let Some(provider_tool) = decl.get("x-adk-openai-tool") {
                 convert_native_tool(name, decl, provider_tool)
@@ -1006,6 +1008,29 @@ mod tests {
         assert_eq!(converted.len(), 1);
         let value = serde_json::to_value(&converted[0]).expect("tool should serialize");
         assert_eq!(value["type"], "local_shell");
+    }
+
+    #[test]
+    fn convert_tools_has_deterministic_name_order() {
+        for _ in 0..32 {
+            let tools = HashMap::from([
+                ("zeta".to_string(), serde_json::json!({})),
+                ("alpha".to_string(), serde_json::json!({})),
+                ("middle".to_string(), serde_json::json!({})),
+            ]);
+            let names = convert_tools(&tools)
+                .expect("tool conversion should succeed")
+                .into_iter()
+                .map(|tool| {
+                    serde_json::to_value(tool).expect("tool should serialize")["name"]
+                        .as_str()
+                        .expect("function tool should have a name")
+                        .to_string()
+                })
+                .collect::<Vec<_>>();
+
+            assert_eq!(names, ["alpha", "middle", "zeta"]);
+        }
     }
 
     #[test]

--- a/adk-model/src/openai/responses_convert.rs
+++ b/adk-model/src/openai/responses_convert.rs
@@ -582,7 +582,11 @@ pub fn build_create_response(
 /// collects all parts into a single `Content`, and maps usage, finish reason,
 /// and provider metadata.
 pub fn from_response(response: &Response) -> LlmResponse {
-    let parts: Vec<Part> = response.output.iter().flat_map(output_item_to_parts).collect();
+    let parts = response.output.iter().map(output_item_to_parts).collect::<Result<Vec<_>, _>>();
+    let (parts, argument_error) = match parts {
+        Ok(parts) => (parts.into_iter().flatten().collect::<Vec<_>>(), None),
+        Err(error) => (Vec::new(), Some(error)),
+    };
 
     let content =
         if parts.is_empty() { None } else { Some(Content { role: "model".to_string(), parts }) };
@@ -640,8 +644,10 @@ pub fn from_response(response: &Response) -> LlmResponse {
         partial: false,
         turn_complete: true,
         interrupted: false,
-        error_code: None,
-        error_message: None,
+        error_code: argument_error
+            .as_ref()
+            .map(|_| "model.openai_responses.invalid_tool_arguments".to_owned()),
+        error_message: argument_error,
         provider_metadata,
         interaction_id: None,
     }
@@ -653,8 +659,8 @@ pub fn from_response(response: &Response) -> LlmResponse {
 /// - `Reasoning` → `Part::Thinking` with concatenated summary text
 /// - `FunctionCall` → `Part::FunctionCall` with parsed JSON args
 /// - Other variants (WebSearchCall, FileSearchCall, etc.) → empty vec (handled in provider_metadata)
-fn output_item_to_parts(item: &OutputItem) -> Vec<Part> {
-    match item {
+fn output_item_to_parts(item: &OutputItem) -> Result<Vec<Part>, String> {
+    let parts = match item {
         OutputItem::Message(msg) => msg
             .content
             .iter()
@@ -682,8 +688,9 @@ fn output_item_to_parts(item: &OutputItem) -> Vec<Part> {
             }
         }
         OutputItem::FunctionCall(fc) => {
-            let args: serde_json::Value =
-                serde_json::from_str(&fc.arguments).unwrap_or(serde_json::json!({}));
+            let encoded = serde_json::Value::String(fc.arguments.clone());
+            let args = super::convert::decode_tool_call_arguments(Some(&encoded))
+                .map_err(|error| format!("invalid arguments for tool '{}': {error}", fc.name))?;
             vec![Part::FunctionCall {
                 name: fc.name.clone(),
                 args,
@@ -736,7 +743,8 @@ fn output_item_to_parts(item: &OutputItem) -> Vec<Part> {
             response_item_part(Item::CustomToolCall(call.clone()), false)
         }
         _ => Vec::new(),
-    }
+    };
+    Ok(parts)
 }
 
 fn response_item_part(item: Item, is_output: bool) -> Vec<Part> {
@@ -1042,7 +1050,8 @@ mod tests {
             })),
             id: "ws_123".to_string(),
             status: WebSearchToolCallStatus::Completed,
-        }));
+        }))
+        .expect("server tool output should convert");
 
         assert!(matches!(parts[0], Part::ServerToolCall { .. }));
 
@@ -1056,6 +1065,34 @@ mod tests {
             }
             other => panic!("expected web_search_call item, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn function_tool_arguments_share_compatible_normalization() {
+        let empty = output_item_to_parts(&OutputItem::FunctionCall(FunctionToolCall {
+            call_id: "call_empty".to_string(),
+            name: "no_args".to_string(),
+            arguments: "null".to_string(),
+            namespace: None,
+            id: None,
+            status: None,
+        }))
+        .expect("an empty compatible payload should normalize");
+        assert!(matches!(
+            &empty[0],
+            Part::FunctionCall { args, .. } if args == &serde_json::json!({})
+        ));
+
+        let error = output_item_to_parts(&OutputItem::FunctionCall(FunctionToolCall {
+            call_id: "call_invalid".to_string(),
+            name: "bash".to_string(),
+            arguments: r#"{"command":"#.to_string(),
+            namespace: None,
+            id: None,
+            status: None,
+        }))
+        .expect_err("truncated arguments must remain invalid");
+        assert!(error.contains("bash"));
     }
 
     #[test]

--- a/adk-model/src/openai_compatible.rs
+++ b/adk-model/src/openai_compatible.rs
@@ -376,14 +376,6 @@ pub(crate) fn build_request_json(
         body["reasoning_effort"] = serde_json::Value::String("max".to_string());
     }
 
-    // GPT-5.6 defaults to medium reasoning, while Chat Completions function
-    // tools require effective reasoning `none`. ADK's public reasoning enum
-    // predates that value, so preserve source compatibility and make the safe
-    // effective setting explicit only for this otherwise-invalid combination.
-    if model.starts_with("gpt-5.6") && !request.tools.is_empty() && reasoning_effort.is_none() {
-        body["reasoning_effort"] = serde_json::Value::String("none".to_string());
-    }
-
     // Merge provider-specific extensions from config.extensions["openai"] into
     // the request body.  This allows users to pass provider-specific fields
     // that the typed builder doesn't cover (e.g. provider-specific parameters
@@ -494,6 +486,24 @@ fn append_tool_call_arguments(accumulator: &mut String, arguments: &serde_json::
             }
         }
     }
+}
+
+fn parse_tool_call_arguments(
+    provider_name: &str,
+    tool_name: &str,
+    arguments: &str,
+) -> Result<serde_json::Value, AdkError> {
+    serde_json::from_str(arguments).map_err(|error| {
+        AdkError::new(
+            ErrorComponent::Model,
+            ErrorCategory::Internal,
+            "model.openai_compat.invalid_tool_arguments",
+            format!(
+                "{provider_name} returned invalid JSON arguments for tool '{tool_name}': {error}"
+            ),
+        )
+        .with_provider(provider_name)
+    })
 }
 
 /// Parse usage metadata from a raw SSE chunk JSON value.
@@ -685,17 +695,19 @@ impl Llm for OpenAICompatible {
                                     let parts: Vec<Part> = sorted_calls
                                         .into_iter()
                                         .map(|(_, (id, name, args_str))| {
-                                            let args: serde_json::Value =
-                                                serde_json::from_str(&args_str)
-                                                    .unwrap_or(serde_json::json!({}));
-                                            Part::FunctionCall {
+                                            let args = parse_tool_call_arguments(
+                                                &provider_name,
+                                                &name,
+                                                &args_str,
+                                            )?;
+                                            Ok(Part::FunctionCall {
                                                 name,
                                                 args,
                                                 id: Some(id),
                                                 thought_signature: None,
-                                            }
+                                            })
                                         })
-                                        .collect();
+                                        .collect::<Result<Vec<_>, AdkError>>()?;
 
                                     let response = LlmResponse {
                                         content: Some(Content {
@@ -925,7 +937,22 @@ mod tests {
     }
 
     #[test]
-    fn gpt_56_chat_tools_default_to_no_reasoning() {
+    fn streamed_tool_arguments_require_valid_json() {
+        let parsed =
+            parse_tool_call_arguments("compatible-provider", "bash", r#"{"command":"pwd"}"#)
+                .expect("valid arguments should parse");
+        assert_eq!(parsed["command"], "pwd");
+
+        let error = parse_tool_call_arguments("compatible-provider", "bash", "")
+            .expect_err("empty arguments are not a valid function call payload");
+        assert_eq!(error.component, ErrorComponent::Model);
+        assert_eq!(error.category, ErrorCategory::Internal);
+        assert_eq!(error.code, "model.openai_compat.invalid_tool_arguments");
+        assert_eq!(error.details.provider.as_deref(), Some("compatible-provider"));
+    }
+
+    #[test]
+    fn gpt_56_chat_tools_preserve_configured_reasoning() {
         let adapter = GenericSchemaAdapter;
         let cache = SchemaCache::for_adapter(Arc::new(GenericSchemaAdapter));
         let mut request = LlmRequest {
@@ -943,17 +970,23 @@ mod tests {
             }),
         );
 
-        let body = build_request_json(
-            crate::catalog::OPENAI_DEFAULT,
-            &request,
-            &None,
-            true,
-            &adapter,
-            &cache,
-        )
-        .expect("request should build");
+        for (configured_effort, expected) in [
+            (None, None),
+            (Some(OpenAIReasoningEffort::Medium), Some("medium")),
+            (Some(OpenAIReasoningEffort::Max), Some("max")),
+        ] {
+            let body = build_request_json(
+                crate::catalog::OPENAI_DEFAULT,
+                &request,
+                &configured_effort,
+                true,
+                &adapter,
+                &cache,
+            )
+            .expect("request should build");
 
-        assert_eq!(body["reasoning_effort"], "none");
+            assert_eq!(body.get("reasoning_effort").and_then(serde_json::Value::as_str), expected);
+        }
     }
 
     #[test]

--- a/adk-model/src/openai_compatible.rs
+++ b/adk-model/src/openai_compatible.rs
@@ -493,7 +493,8 @@ fn parse_tool_call_arguments(
     tool_name: &str,
     arguments: &str,
 ) -> Result<serde_json::Value, AdkError> {
-    serde_json::from_str(arguments).map_err(|error| {
+    let encoded = serde_json::Value::String(arguments.to_owned());
+    convert::decode_tool_call_arguments(Some(&encoded)).map_err(|error| {
         AdkError::new(
             ErrorComponent::Model,
             ErrorCategory::Internal,
@@ -900,7 +901,15 @@ impl Llm for OpenAICompatible {
                 })
                 .await?;
 
-                let adk_response = convert::from_raw_openai_response(&response);
+                let adk_response = convert::from_raw_openai_response(&response).map_err(|error| {
+                    AdkError::new(
+                        ErrorComponent::Model,
+                        ErrorCategory::Internal,
+                        "model.openai_compat.invalid_tool_arguments",
+                        format!("{provider_name} returned {error}"),
+                    )
+                    .with_provider(&provider_name)
+                })?;
                 yield adk_response;
             };
 
@@ -943,12 +952,44 @@ mod tests {
                 .expect("valid arguments should parse");
         assert_eq!(parsed["command"], "pwd");
 
-        let error = parse_tool_call_arguments("compatible-provider", "bash", "")
-            .expect_err("empty arguments are not a valid function call payload");
+        assert_eq!(
+            parse_tool_call_arguments("compatible-provider", "no_args", "")
+                .expect("an empty compatible payload should normalize"),
+            serde_json::json!({})
+        );
+        assert_eq!(
+            parse_tool_call_arguments("compatible-provider", "no_args", "   ")
+                .expect("a whitespace-only compatible payload should normalize"),
+            serde_json::json!({})
+        );
+        assert_eq!(
+            parse_tool_call_arguments("compatible-provider", "no_args", "[]")
+                .expect("an empty array compatible payload should normalize"),
+            serde_json::json!({})
+        );
+
+        let error = parse_tool_call_arguments("compatible-provider", "bash", r#"{"command":"#)
+            .expect_err("truncated arguments must remain invalid");
         assert_eq!(error.component, ErrorComponent::Model);
         assert_eq!(error.category, ErrorCategory::Internal);
         assert_eq!(error.code, "model.openai_compat.invalid_tool_arguments");
         assert_eq!(error.details.provider.as_deref(), Some("compatible-provider"));
+
+        let error = parse_tool_call_arguments("compatible-provider", "bash", r#"["pwd"]"#)
+            .expect_err("non-empty array arguments must remain invalid");
+        assert_eq!(error.code, "model.openai_compat.invalid_tool_arguments");
+    }
+
+    #[test]
+    fn streamed_structured_tool_arguments_are_canonicalized() {
+        let mut arguments = String::new();
+        append_tool_call_arguments(&mut arguments, &serde_json::json!({"command": "pwd"}));
+
+        assert_eq!(
+            parse_tool_call_arguments("compatible-provider", "bash", &arguments)
+                .expect("a structured object should normalize"),
+            serde_json::json!({"command": "pwd"})
+        );
     }
 
     #[test]

--- a/adk-model/src/openai_compatible.rs
+++ b/adk-model/src/openai_compatible.rs
@@ -480,6 +480,22 @@ fn parse_finish_reason(fr: &str) -> FinishReason {
     }
 }
 
+/// Accumulate string deltas while treating structured values as complete snapshots.
+fn append_tool_call_arguments(accumulator: &mut String, arguments: &serde_json::Value) {
+    match arguments {
+        serde_json::Value::String(fragment) => accumulator.push_str(fragment),
+        serde_json::Value::Null => {}
+        structured => {
+            let empty_snapshot = matches!(structured, serde_json::Value::Object(fields) if fields.is_empty())
+                || matches!(structured, serde_json::Value::Array(items) if items.is_empty());
+            if accumulator.is_empty() || !empty_snapshot {
+                accumulator.clear();
+                accumulator.push_str(&structured.to_string());
+            }
+        }
+    }
+}
+
 /// Parse usage metadata from a raw SSE chunk JSON value.
 fn parse_usage_from_chunk(chunk: &serde_json::Value) -> Option<UsageMetadata> {
     let u = chunk.get("usage")?.as_object()?;
@@ -678,10 +694,8 @@ impl Llm for OpenAICompatible {
                                         if let Some(name) = func.get("name").and_then(|v| v.as_str()) {
                                             entry.1 = name.to_string();
                                         }
-                                        if let Some(args_chunk) =
-                                            func.get("arguments").and_then(|v| v.as_str())
-                                        {
-                                            entry.2.push_str(args_chunk);
+                                        if let Some(arguments) = func.get("arguments") {
+                                            append_tool_call_arguments(&mut entry.2, arguments);
                                         }
                                     }
                                 }

--- a/adk-model/src/openai_compatible.rs
+++ b/adk-model/src/openai_compatible.rs
@@ -480,7 +480,7 @@ fn append_tool_call_arguments(accumulator: &mut String, arguments: &serde_json::
         structured => {
             let empty_snapshot = matches!(structured, serde_json::Value::Object(fields) if fields.is_empty())
                 || matches!(structured, serde_json::Value::Array(items) if items.is_empty());
-            if accumulator.is_empty() || !empty_snapshot {
+            if !empty_snapshot {
                 accumulator.clear();
                 accumulator.push_str(&structured.to_string());
             }
@@ -990,6 +990,28 @@ mod tests {
                 .expect("a structured object should normalize"),
             serde_json::json!({"command": "pwd"})
         );
+    }
+
+    #[test]
+    fn streamed_empty_snapshot_before_string_fragments_is_ignored() {
+        for placeholder in [serde_json::json!({}), serde_json::json!([])] {
+            let mut arguments = String::new();
+            append_tool_call_arguments(&mut arguments, &placeholder);
+            assert_eq!(
+                parse_tool_call_arguments("compatible-provider", "no_args", &arguments)
+                    .expect("an empty snapshot should remain a no-argument call"),
+                serde_json::json!({})
+            );
+
+            append_tool_call_arguments(&mut arguments, &serde_json::json!(r#"{"command""#));
+            append_tool_call_arguments(&mut arguments, &serde_json::json!(r#": "pwd"}"#));
+
+            assert_eq!(
+                parse_tool_call_arguments("compatible-provider", "bash", &arguments)
+                    .expect("empty snapshots must not prefix string fragments"),
+                serde_json::json!({"command": "pwd"})
+            );
+        }
     }
 
     #[test]

--- a/adk-model/src/openai_compatible.rs
+++ b/adk-model/src/openai_compatible.rs
@@ -498,36 +498,7 @@ fn append_tool_call_arguments(accumulator: &mut String, arguments: &serde_json::
 
 /// Parse usage metadata from a raw SSE chunk JSON value.
 fn parse_usage_from_chunk(chunk: &serde_json::Value) -> Option<UsageMetadata> {
-    let u = chunk.get("usage")?.as_object()?;
-    let prompt_tokens = u.get("prompt_tokens").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
-    let completion_tokens = u.get("completion_tokens").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
-    let total_tokens = u.get("total_tokens").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
-
-    let prompt_details = u.get("prompt_tokens_details");
-    let completion_details = u.get("completion_tokens_details");
-
-    Some(UsageMetadata {
-        prompt_token_count: prompt_tokens,
-        candidates_token_count: completion_tokens,
-        total_token_count: total_tokens,
-        cache_read_input_token_count: prompt_details
-            .and_then(|d| d.get("cached_tokens"))
-            .and_then(|v| v.as_i64())
-            .map(|v| v as i32),
-        thinking_token_count: completion_details
-            .and_then(|d| d.get("reasoning_tokens"))
-            .and_then(|v| v.as_i64())
-            .map(|v| v as i32),
-        audio_input_token_count: prompt_details
-            .and_then(|d| d.get("audio_tokens"))
-            .and_then(|v| v.as_i64())
-            .map(|v| v as i32),
-        audio_output_token_count: completion_details
-            .and_then(|d| d.get("audio_tokens"))
-            .and_then(|v| v.as_i64())
-            .map(|v| v as i32),
-        ..Default::default()
-    })
+    chunk.get("usage").and_then(convert::usage_metadata_from_raw)
 }
 
 #[async_trait]

--- a/adk-model/tests/openai_responses_stream_tests.rs
+++ b/adk-model/tests/openai_responses_stream_tests.rs
@@ -1,0 +1,122 @@
+#![cfg(feature = "openai")]
+
+use adk_core::{Content, Llm, LlmRequest, LlmResponse, Part};
+use adk_model::openai::{OpenAIResponsesClient, OpenAIResponsesConfig};
+use futures::TryStreamExt;
+use serde_json::{Value, json};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn completion(output: Value) -> Value {
+    json!({
+        "type": "response.completed", "sequence_number": 10,
+        "response": {
+            "id": "resp_test", "object": "response", "created_at": 0,
+            "model": "test-model", "status": "completed", "output": output,
+            "usage": {
+                "input_tokens": 100, "input_tokens_details": {"cached_tokens": 42},
+                "output_tokens": 20, "output_tokens_details": {"reasoning_tokens": 5},
+                "total_tokens": 120
+            }
+        }
+    })
+}
+
+async fn responses(events: &[Value], open_responses_mode: bool, prefix: &str) -> Vec<LlmResponse> {
+    let server = MockServer::start().await;
+    let mut body = prefix.to_string();
+    for event in events {
+        body.push_str(&format!("data: {event}\n\n"));
+    }
+    Mock::given(method("POST"))
+        .and(path("/responses"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(body, "text/event-stream"))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let client = OpenAIResponsesClient::new(
+        OpenAIResponsesConfig::new("test-key", "test-model")
+            .with_base_url(server.uri())
+            .with_open_responses_mode(open_responses_mode),
+    )
+    .unwrap();
+    let request = LlmRequest::new("test-model", vec![Content::new("user").with_text("read files")]);
+    let result = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        client.generate_content(request, true).await.unwrap().try_collect::<Vec<_>>().await
+    })
+    .await
+    .expect("stream must terminate")
+    .expect("SSE events must deserialize");
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(serde_json::from_slice::<Value>(&requests[0].body).unwrap()["stream"], true);
+    result
+}
+
+#[tokio::test]
+async fn streamed_invalid_arguments_preserve_errors_and_usage_in_both_modes() {
+    for compatible in [false, true] {
+        let results = responses(
+            &[completion(json!([{
+                "type": "function_call", "id": "fc_bad", "call_id": "call_bad",
+                "name": "read_file", "arguments": "{invalid", "status": "completed"
+            }]))],
+            compatible,
+            "",
+        )
+        .await;
+        assert_eq!(results.len(), 1);
+        let result = &results[0];
+        assert_eq!(
+            result.error_code.as_deref(),
+            Some("model.openai_responses.invalid_tool_arguments")
+        );
+        assert!(result.error_message.as_deref().is_some_and(|message| !message.is_empty()));
+        assert!(result.turn_complete);
+        assert!(!result.partial);
+        assert_eq!(result.usage_metadata.as_ref().unwrap().cache_read_input_token_count, Some(42));
+        assert_eq!(
+            result.provider_metadata.as_ref().unwrap()["openai"]["response_id"],
+            "resp_test"
+        );
+        assert!(result.content.as_ref().is_none_or(|content| content.parts.is_empty()));
+    }
+}
+
+#[tokio::test]
+async fn compatible_stream_restores_only_the_matching_tools_arguments() {
+    let results = responses(
+        &[
+            json!({
+                "type": "response.function_call_arguments.delta", "sequence_number": 1,
+                "output_index": 1, "item_id": "fc_b", "delta": r#"{"path":"second.txt"}"#
+            }),
+            completion(json!([
+                {"type": "function_call", "id": "fc_a", "call_id": "call_a",
+                    "name": "read_file", "arguments": r#"{"path":"first.txt"}"#},
+                {"type": "function_call", "id": "fc_b", "call_id": "call_b", "name": "read_file"}
+            ])),
+        ],
+        true,
+        "data:\n\ndata: \r\n\r\n: keepalive\n\n",
+    )
+    .await;
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].error_code, None);
+    assert_eq!(
+        results[0].content.as_ref().unwrap().parts,
+        vec![
+            Part::FunctionCall {
+                id: Some("call_a".into()),
+                name: "read_file".into(),
+                args: json!({"path": "first.txt"}),
+                thought_signature: None
+            },
+            Part::FunctionCall {
+                id: Some("call_b".into()),
+                name: "read_file".into(),
+                args: json!({"path": "second.txt"}),
+                thought_signature: None
+            },
+        ]
+    );
+}

--- a/adk-model/tests/openai_responses_stream_tests.rs
+++ b/adk-model/tests/openai_responses_stream_tests.rs
@@ -23,6 +23,14 @@ fn completion(output: Value) -> Value {
 }
 
 async fn responses(events: &[Value], open_responses_mode: bool, prefix: &str) -> Vec<LlmResponse> {
+    try_responses(events, open_responses_mode, prefix).await.expect("SSE events must deserialize")
+}
+
+async fn try_responses(
+    events: &[Value],
+    open_responses_mode: bool,
+    prefix: &str,
+) -> Result<Vec<LlmResponse>, adk_core::AdkError> {
     let server = MockServer::start().await;
     let mut body = prefix.to_string();
     for event in events {
@@ -45,11 +53,95 @@ async fn responses(events: &[Value], open_responses_mode: bool, prefix: &str) ->
         client.generate_content(request, true).await.unwrap().try_collect::<Vec<_>>().await
     })
     .await
-    .expect("stream must terminate")
-    .expect("SSE events must deserialize");
+    .expect("stream must terminate");
     let requests = server.received_requests().await.unwrap();
     assert_eq!(serde_json::from_slice::<Value>(&requests[0].body).unwrap()["stream"], true);
     result
+}
+
+#[tokio::test]
+async fn compatible_stream_rejects_conflicting_tool_identities_before_completion() {
+    for conflict in [
+        json!({"type":"response.output_item.added", "sequence_number":3, "output_index":0,
+            "item":{"type":"function_call","id":"fc_b","call_id":"call_b","name":"read_file","arguments":"","status":"in_progress"}}),
+        json!({"type":"response.output_item.done", "sequence_number":3, "output_index":0,
+            "item":{"type":"function_call","id":"fc_b","call_id":"call_b","name":"read_file","arguments":"","status":"completed"}}),
+        json!({"type":"response.function_call_arguments.delta", "sequence_number":3, "output_index":0,
+            "item_id":"fc_b","delta":" "}),
+        json!({"type":"response.function_call_arguments.done", "sequence_number":3, "output_index":0,
+            "item_id":"fc_b","arguments":""}),
+    ] {
+        let events = [
+            json!({"type":"response.output_item.added", "sequence_number":1, "output_index":0,
+                "item":{"type":"function_call","id":"fc_a","call_id":"call_a","name":"read_file","arguments":"","status":"in_progress"}}),
+            json!({"type":"response.function_call_arguments.delta", "sequence_number":2, "output_index":0,
+                "item_id":"fc_a","delta":r#"{"path":"A"}"#}),
+            conflict.clone(),
+            json!({"type":"response.output_item.done", "sequence_number":4, "output_index":0,
+                "item":{"type":"function_call","id":"fc_b","call_id":"call_b","name":"read_file","arguments":"","status":"completed"}}),
+            completion(
+                json!([{"type":"function_call","id":"fc_b","call_id":"call_b","name":"read_file"}]),
+            ),
+        ];
+        assert!(
+            try_responses(&events, true, "").await.is_err(),
+            "conflicting event was accepted: {conflict}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn compatible_stream_restores_blank_done_and_completed_arguments() {
+    for blank in ["", " \t\r\n"] {
+        let results = responses(&[
+            json!({"type":"response.function_call_arguments.delta", "sequence_number":1, "output_index":0,
+                "item_id":"fc_a","delta":r#"{"path":"first.txt"}"#}),
+            json!({"type":"response.function_call_arguments.done", "sequence_number":2, "output_index":0,
+                "item_id":"fc_a","arguments":blank}),
+            json!({"type":"response.output_item.done", "sequence_number":3, "output_index":0,
+                "item":{"type":"function_call","id":"fc_a","call_id":"call_a","name":"read_file","arguments":blank,"status":"completed"}}),
+            completion(json!([{"type":"function_call","id":"fc_a","call_id":"call_a","name":"read_file","arguments":blank}])),
+        ], true, "").await;
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].error_code, None);
+        assert_eq!(
+            results[0].content.as_ref().unwrap().parts,
+            vec![Part::FunctionCall {
+                id: Some("call_a".into()),
+                name: "read_file".into(),
+                args: json!({"path":"first.txt"}),
+                thought_signature: None,
+            }]
+        );
+        assert_eq!(
+            results[0].usage_metadata.as_ref().unwrap().cache_read_input_token_count,
+            Some(42)
+        );
+    }
+}
+
+#[tokio::test]
+async fn standard_mode_does_not_apply_compatibility_identity_rules() {
+    let results = responses(&[
+        json!({"type":"response.output_item.added", "sequence_number":1, "output_index":0,
+            "item":{"type":"function_call","id":"fc_a","call_id":"call_a","name":"read_file","arguments":"","status":"in_progress"}}),
+        json!({"type":"response.function_call_arguments.delta", "sequence_number":2, "output_index":0,
+            "item_id":"fc_a","delta":r#"{"path":"first.txt"}"#}),
+        json!({"type":"response.output_item.done", "sequence_number":3, "output_index":0,
+            "item":{"type":"function_call","id":"fc_b","call_id":"call_b","name":"read_file","arguments":r#"{"path":"second.txt"}"#,"status":"completed"}}),
+        completion(json!([{"type":"function_call","id":"fc_b","call_id":"call_b","name":"read_file",
+            "arguments":r#"{"path":"second.txt"}"#,"status":"completed"}])),
+    ], false, "").await;
+    assert_eq!(results.len(), 1);
+    assert_eq!(
+        results[0].content.as_ref().unwrap().parts,
+        vec![Part::FunctionCall {
+            id: Some("call_b".into()),
+            name: "read_file".into(),
+            args: json!({"path":"second.txt"}),
+            thought_signature: None,
+        }]
+    );
 }
 
 #[tokio::test]

--- a/adk-model/tests/openai_streaming_exploration_tests.rs
+++ b/adk-model/tests/openai_streaming_exploration_tests.rs
@@ -162,7 +162,7 @@ mod streaming_exploration {
         let sse_body = [
             "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"},\"finish_reason\":null}]}\n\n",
             "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":null}\n\n",
-            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[],\"usage\":{\"prompt_tokens\":11,\"completion_tokens\":5,\"total_tokens\":16}}\n\n",
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[],\"usage\":{\"prompt_tokens\":11,\"completion_tokens\":5,\"total_tokens\":16,\"prompt_tokens_details\":{\"cached_tokens\":7,\"cache_write_tokens\":2},\"provider_meter\":{\"units\":3}}}\n\n",
             "data: [DONE]\n\n",
         ]
         .join("");
@@ -199,6 +199,21 @@ mod streaming_exploration {
         assert_eq!(usage.prompt_token_count, 11);
         assert_eq!(usage.candidates_token_count, 5);
         assert_eq!(usage.total_token_count, 16);
+        assert_eq!(usage.cache_read_input_token_count, Some(7));
+        assert_eq!(usage.cache_creation_input_token_count, Some(2));
+        assert_eq!(
+            usage.provider_usage,
+            Some(serde_json::json!({
+                "prompt_tokens": 11,
+                "completion_tokens": 5,
+                "total_tokens": 16,
+                "prompt_tokens_details": {
+                    "cached_tokens": 7,
+                    "cache_write_tokens": 2
+                },
+                "provider_meter": {"units": 3}
+            }))
+        );
     }
 
     // ── Test 3: reasoning_content chunks yield Part::Thinking ────────────

--- a/adk-model/tests/openai_streaming_exploration_tests.rs
+++ b/adk-model/tests/openai_streaming_exploration_tests.rs
@@ -372,6 +372,106 @@ mod streaming_exploration {
         assert_eq!(usage.total_token_count, 25);
     }
 
+    #[tokio::test]
+    async fn structured_tool_call_arguments_are_preserved() {
+        let server = MockServer::start().await;
+
+        let sse_body = [
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"tool_calls\":[{\"index\":0,\"id\":\"call_abc\",\"type\":\"function\",\"function\":{\"name\":\"run_command\",\"arguments\":{\"command\":\"printf 'OK\\\\n'\"}}}]},\"finish_reason\":null}]}\n\n",
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}],\"usage\":null}\n\n",
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":15,\"total_tokens\":25}}\n\n",
+            "data: [DONE]\n\n",
+        ]
+        .join("");
+
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string(&sse_body)
+                    .insert_header("content-type", "text/event-stream"),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = make_client(&server.uri());
+        let mut stream = client
+            .generate_content(make_request(), true)
+            .await
+            .expect("generate_content should not error");
+
+        let mut function_call = None;
+        while let Some(item) = stream.next().await {
+            let response = item.expect("stream should not yield an error");
+            function_call = response
+                .content
+                .as_ref()
+                .into_iter()
+                .flat_map(|content| &content.parts)
+                .find_map(|part| match part {
+                    Part::FunctionCall { name, args, id, .. } => {
+                        Some((name.clone(), args.clone(), id.clone()))
+                    }
+                    _ => None,
+                })
+                .or(function_call);
+        }
+
+        let (name, args, id) = function_call.expect("expected a function call");
+        assert_eq!(name, "run_command");
+        assert_eq!(args["command"], "printf 'OK\\n'");
+        assert_eq!(id.as_deref(), Some("call_abc"));
+    }
+
+    #[tokio::test]
+    async fn repeated_structured_tool_call_snapshots_do_not_corrupt_arguments() {
+        let server = MockServer::start().await;
+
+        let sse_body = [
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"tool_calls\":[{\"index\":0,\"id\":\"call_abc\",\"type\":\"function\",\"function\":{\"name\":\"run_command\",\"arguments\":{\"command\":\"printf 'OK\\\\n'\"}}}]},\"finish_reason\":null}]}\n\n",
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":{}}}]},\"finish_reason\":null}]}\n\n",
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}],\"usage\":null}\n\n",
+            "data: [DONE]\n\n",
+        ]
+        .join("");
+
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string(&sse_body)
+                    .insert_header("content-type", "text/event-stream"),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = make_client(&server.uri());
+        let mut stream = client
+            .generate_content(make_request(), true)
+            .await
+            .expect("generate_content should not error");
+
+        let mut function_call = None;
+        while let Some(item) = stream.next().await {
+            let response = item.expect("stream should not yield an error");
+            function_call = response
+                .content
+                .as_ref()
+                .into_iter()
+                .flat_map(|content| &content.parts)
+                .find_map(|part| match part {
+                    Part::FunctionCall { args, .. } => Some(args.clone()),
+                    _ => None,
+                })
+                .or(function_call);
+        }
+
+        let args = function_call.expect("expected a function call");
+        assert_eq!(args["command"], "printf 'OK\\n'");
+    }
+
     /// Regression test for providers using "delta.reasoning" field instead of "delta.reasoning_content"
     /// (OpenRouter, Kilo Gateway, SambaNova, Cerebras, Groq).
     /// Without the fallback fix, this test would fail — reasoning silently dropped in streaming.

--- a/adk-runner/README.md
+++ b/adk-runner/README.md
@@ -120,6 +120,13 @@ before executing the target. The default allows the transfer, preserving
 existing behavior; portable teams and other composite roots can deny it with an
 auditable reason. Denials surface as `agent.transfer.denied`.
 
+## Model History After Overlapping or Interrupted Turns
+
+- **Actual results:** late tool responses are paired with their calls before a later user turn.
+- **Missing results:** unresolved calls from earlier turns are omitted from model history; no result is fabricated.
+- **Current execution:** unresolved calls at the history tail remain available for tool execution and confirmation.
+- **Persistence:** source session events are unchanged by this projection.
+
 ## State Propagation
 
 Runner applies state changes immediately:

--- a/adk-runner/src/context.rs
+++ b/adk-runner/src/context.rs
@@ -1,7 +1,7 @@
 use adk_core::{
     AdkIdentity, Agent, AppName, Artifacts, CallbackContext, Content, Event, ExecutionIdentity,
-    FunctionResponseData, InvocationContext as InvocationContextTrait, InvocationId, Memory, Part,
-    ReadonlyContext, RequestContext, RunConfig, SecretService, SessionId, UserId,
+    InvocationContext as InvocationContextTrait, InvocationId, Memory, Part, ReadonlyContext,
+    RequestContext, RunConfig, SecretService, SessionId, UserId,
 };
 use adk_session::Session as AdkSession;
 use async_trait::async_trait;
@@ -128,7 +128,10 @@ impl MutableSession {
         let mut compaction_boundary = None;
         for event in events.iter().rev() {
             if let Some(ref compaction) = event.actions.compaction {
-                history.push(compaction.compacted_content.clone());
+                history.push(HistoryContent {
+                    content: compaction.compacted_content.clone(),
+                    invocation_id: None,
+                });
                 compaction_boundary = Some(compaction.end_timestamp);
                 break;
             }
@@ -174,7 +177,10 @@ impl MutableSession {
                     _ => "model",
                 }
                 .to_string();
-                history.push(mapped_content);
+                history.push(HistoryContent {
+                    content: mapped_content,
+                    invocation_id: Some(event.invocation_id.clone()),
+                });
             }
         }
 
@@ -182,58 +188,151 @@ impl MutableSession {
     }
 }
 
+struct HistoryContent {
+    content: Content,
+    invocation_id: Option<String>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+struct PartLocation {
+    content: usize,
+    part: usize,
+}
+
+struct PendingFunctionCall {
+    location: PartLocation,
+    id: Option<String>,
+    name: String,
+    user_turn: usize,
+    invocation_id: Option<String>,
+}
+
 /// Makes persisted conversation history valid for the next model turn without
 /// rewriting the source events.
 ///
 /// A runner interruption can happen after a model function call is persisted
-/// but before its tool response is available. Once a later user message exists,
-/// that unfinished call belongs to a closed turn and cannot still be executed.
-/// Providers also require every replayed function call to have a matching
-/// response before accepting the next user message, so insert a provider-neutral
-/// cancellation response at that durable turn boundary.
-fn close_interrupted_tool_calls(history: Vec<Content>) -> Vec<Content> {
-    let mut normalized = Vec::with_capacity(history.len());
-    let mut pending = Vec::<(Option<String>, String)>::new();
+/// but before its tool response is available. Responses from overlapping runs
+/// may also be persisted after a later user message, so known responses are
+/// paired first. An unmatched call is closed only when a later user turn exists
+/// and has no durable response in the retained history. Such calls are omitted
+/// from the model projection rather than assigned a result that did not occur.
+fn close_interrupted_tool_calls(history: Vec<HistoryContent>) -> Vec<Content> {
+    let mut pending = Vec::<PendingFunctionCall>::new();
+    let mut removed_parts = std::collections::HashSet::<PartLocation>::new();
+    let mut responses_after = HashMap::<usize, Vec<(usize, String, Part)>>::new();
+    let mut user_turn = 0;
 
-    for content in history {
-        for part in &content.parts {
-            if let Part::FunctionResponse { function_response, id, .. } = part {
-                let matching_index = match id.as_deref() {
-                    Some(response_id) => pending
-                        .iter()
-                        .position(|(call_id, _)| call_id.as_deref() == Some(response_id)),
-                    None => pending.iter().position(|(_, name)| name == &function_response.name),
-                };
-                if let Some(index) = matching_index {
-                    pending.remove(index);
+    // Reconcile against the complete retained history first. Concurrent runs can
+    // persist a response after another run's user event, and that response still
+    // completes the original call.
+    for (content_index, history_content) in history.iter().enumerate() {
+        let content = &history_content.content;
+        for (part_index, part) in content.parts.iter().enumerate() {
+            match part {
+                Part::FunctionCall { name, id, .. } => {
+                    pending.push(PendingFunctionCall {
+                        location: PartLocation { content: content_index, part: part_index },
+                        id: id.clone(),
+                        name: name.clone(),
+                        user_turn,
+                        invocation_id: history_content.invocation_id.clone(),
+                    });
                 }
+                Part::FunctionResponse { function_response, id, .. } => {
+                    // Idless responses prefer their own invocation. Fall back
+                    // by name only when provenance is missing and unambiguous.
+                    let matching_index = match id.as_deref() {
+                        Some(response_id) => {
+                            pending.iter().position(|call| call.id.as_deref() == Some(response_id))
+                        }
+                        None => pending
+                            .iter()
+                            .position(|call| {
+                                call.name == function_response.name
+                                    && history_content.invocation_id.is_some()
+                                    && call.invocation_id.as_deref()
+                                        == history_content.invocation_id.as_deref()
+                            })
+                            .or_else(|| {
+                                let mut same_name =
+                                    pending.iter().enumerate().filter(|(_, call)| {
+                                        call.name == function_response.name
+                                            && (call.invocation_id.is_none()
+                                                || history_content.invocation_id.is_none())
+                                    });
+                                let first = same_name.next().map(|(index, _)| index);
+                                match (first, same_name.next()) {
+                                    (Some(index), None) => Some(index),
+                                    _ => None,
+                                }
+                            }),
+                    };
+                    if let Some(index) = matching_index {
+                        let call = pending.remove(index);
+                        if call.user_turn < user_turn {
+                            removed_parts
+                                .insert(PartLocation { content: content_index, part: part_index });
+                            let mut insertion_index = call.location.content;
+                            while let Some(next) = history.get(insertion_index + 1) {
+                                if next.content.parts.is_empty()
+                                    || !next
+                                        .content
+                                        .parts
+                                        .iter()
+                                        .all(|part| matches!(part, Part::FunctionResponse { .. }))
+                                {
+                                    break;
+                                }
+                                insertion_index += 1;
+                            }
+                            responses_after.entry(insertion_index).or_default().push((
+                                call.location.part,
+                                content.role.clone(),
+                                part.clone(),
+                            ));
+                        }
+                    }
+                }
+                _ => {}
             }
         }
-
-        let starts_user_turn = content.role == "user"
-            && content.parts.iter().any(|part| !matches!(part, Part::FunctionResponse { .. }));
-        if starts_user_turn && !pending.is_empty() {
-            normalized.extend(pending.drain(..).map(|(id, name)| Content {
-                role: "function".to_string(),
-                parts: vec![Part::FunctionResponse {
-                    function_response: FunctionResponseData::new(
-                        name,
-                        serde_json::json!({
-                            "error": "Tool execution was interrupted before completion."
-                        }),
-                    ),
-                    id,
-                    annotations: None,
-                }],
-            }));
+        if content.role == "user"
+            && content.parts.iter().any(|part| !matches!(part, Part::FunctionResponse { .. }))
+        {
+            user_turn += 1;
         }
+    }
 
-        for part in &content.parts {
-            if let Part::FunctionCall { name, id, .. } = part {
-                pending.push((id.clone(), name.clone()));
-            }
+    for call in pending {
+        if call.user_turn == user_turn {
+            continue;
         }
-        normalized.push(content);
+        removed_parts.insert(call.location);
+    }
+
+    let mut normalized = Vec::with_capacity(history.len());
+    for (content_index, history_content) in history.into_iter().enumerate() {
+        let mut content = history_content.content;
+        content.parts = content
+            .parts
+            .into_iter()
+            .enumerate()
+            .filter(|(part_index, _)| {
+                !removed_parts.contains(&PartLocation { content: content_index, part: *part_index })
+            })
+            .map(|(_, part)| part)
+            .collect();
+        if !content.parts.is_empty() {
+            normalized.push(content);
+        }
+        if let Some(mut responses) = responses_after.remove(&content_index) {
+            responses.sort_by_key(|(call_part, _, _)| *call_part);
+            normalized.extend(
+                responses
+                    .into_iter()
+                    .map(|(_, role, response)| Content { role, parts: vec![response] }),
+            );
+        }
     }
 
     normalized

--- a/adk-runner/src/context.rs
+++ b/adk-runner/src/context.rs
@@ -1,7 +1,7 @@
 use adk_core::{
     AdkIdentity, Agent, AppName, Artifacts, CallbackContext, Content, Event, ExecutionIdentity,
-    InvocationContext as InvocationContextTrait, InvocationId, Memory, ReadonlyContext,
-    RequestContext, RunConfig, SecretService, SessionId, UserId,
+    FunctionResponseData, InvocationContext as InvocationContextTrait, InvocationId, Memory, Part,
+    ReadonlyContext, RequestContext, RunConfig, SecretService, SessionId, UserId,
 };
 use adk_session::Session as AdkSession;
 use async_trait::async_trait;
@@ -178,8 +178,65 @@ impl MutableSession {
             }
         }
 
-        history
+        close_interrupted_tool_calls(history)
     }
+}
+
+/// Makes persisted conversation history valid for the next model turn without
+/// rewriting the source events.
+///
+/// A runner interruption can happen after a model function call is persisted
+/// but before its tool response is available. Once a later user message exists,
+/// that unfinished call belongs to a closed turn and cannot still be executed.
+/// Providers also require every replayed function call to have a matching
+/// response before accepting the next user message, so insert a provider-neutral
+/// cancellation response at that durable turn boundary.
+fn close_interrupted_tool_calls(history: Vec<Content>) -> Vec<Content> {
+    let mut normalized = Vec::with_capacity(history.len());
+    let mut pending = Vec::<(Option<String>, String)>::new();
+
+    for content in history {
+        for part in &content.parts {
+            if let Part::FunctionResponse { function_response, id, .. } = part {
+                let matching_index = match id.as_deref() {
+                    Some(response_id) => pending
+                        .iter()
+                        .position(|(call_id, _)| call_id.as_deref() == Some(response_id)),
+                    None => pending.iter().position(|(_, name)| name == &function_response.name),
+                };
+                if let Some(index) = matching_index {
+                    pending.remove(index);
+                }
+            }
+        }
+
+        let starts_user_turn = content.role == "user"
+            && content.parts.iter().any(|part| !matches!(part, Part::FunctionResponse { .. }));
+        if starts_user_turn && !pending.is_empty() {
+            normalized.extend(pending.drain(..).map(|(id, name)| Content {
+                role: "function".to_string(),
+                parts: vec![Part::FunctionResponse {
+                    function_response: FunctionResponseData::new(
+                        name,
+                        serde_json::json!({
+                            "error": "Tool execution was interrupted before completion."
+                        }),
+                    ),
+                    id,
+                    annotations: None,
+                }],
+            }));
+        }
+
+        for part in &content.parts {
+            if let Part::FunctionCall { name, id, .. } = part {
+                pending.push((id.clone(), name.clone()));
+            }
+        }
+        normalized.push(content);
+    }
+
+    normalized
 }
 
 impl adk_core::Session for MutableSession {

--- a/adk-runner/src/lib.rs
+++ b/adk-runner/src/lib.rs
@@ -62,7 +62,7 @@ pub use callbacks::{
 };
 pub use context::{InvocationContext, MutableSession};
 pub use launcher::Launcher;
-pub use runner::{Runner, RunnerConfig};
+pub use runner::{Runner, RunnerConfig, RunnerInvocation};
 
 // Re-export RequestContext for convenience
 pub use adk_core::RequestContext;

--- a/adk-runner/src/runner.rs
+++ b/adk-runner/src/runner.rs
@@ -3,8 +3,8 @@ use crate::cache::CacheManager;
 #[cfg(feature = "artifacts")]
 use adk_artifact::ArtifactService;
 use adk_core::{
-    Agent, AppName, CacheCapable, Content, ContextCacheConfig, Event, EventStream, Memory,
-    ReadonlyContext, Result, RunConfig, SessionId, UserId,
+    Agent, AppName, CacheCapable, Content, ContextCacheConfig, Event, EventStream, InvocationId,
+    Memory, ReadonlyContext, Result, RunConfig, SessionId, UserId,
 };
 #[cfg(feature = "plugins")]
 use adk_plugin::PluginManager;
@@ -50,6 +50,36 @@ fn preserve_streamed_content(accumulated: &mut HashMap<String, Content>, event: 
 struct ActiveRunCleanup {
     active_runs: ActiveRuns,
     run_id: u64,
+}
+
+/// A newly registered runner invocation and its event stream.
+///
+/// The invocation identity is available before the stream is polled, so hosts
+/// can durably correlate failures that happen before the first agent event.
+pub struct RunnerInvocation {
+    invocation_id: InvocationId,
+    events: EventStream,
+}
+
+impl RunnerInvocation {
+    /// Returns the identity assigned to this invocation.
+    pub fn invocation_id(&self) -> &InvocationId {
+        &self.invocation_id
+    }
+
+    /// Consumes the invocation and returns its event stream.
+    pub fn into_events(self) -> EventStream {
+        self.events
+    }
+}
+
+impl std::fmt::Debug for RunnerInvocation {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RunnerInvocation")
+            .field("invocation_id", &self.invocation_id)
+            .finish_non_exhaustive()
+    }
 }
 
 impl Drop for ActiveRunCleanup {
@@ -328,6 +358,31 @@ impl Runner {
         user_content: Content,
         run_config: Option<RunConfig>,
     ) -> Result<EventStream> {
+        Ok(self
+            .start_with_config(user_id, session_id, user_content, run_config)
+            .await?
+            .into_events())
+    }
+
+    /// Registers one invocation and returns its identity with the event stream.
+    ///
+    /// Prefer this method when a host must durably associate its own turn or
+    /// operation record before the first agent event can be produced.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if invocation setup fails before the stream is created.
+    /// Session lookup and agent execution failures are yielded by the returned
+    /// stream.
+    pub async fn start_with_config(
+        &self,
+        user_id: UserId,
+        session_id: SessionId,
+        user_content: Content,
+        run_config: Option<RunConfig>,
+    ) -> Result<RunnerInvocation> {
+        let invocation_id = InvocationId::try_from(format!("inv-{}", uuid::Uuid::new_v4()))?;
+        let stream_invocation_id = invocation_id.to_string();
         let app_name = self.app_name.clone();
         let typed_app_name = AppName::try_from(app_name.clone())?;
         let session_service = self.session_service.clone();
@@ -437,7 +492,7 @@ impl Runner {
             let memory_service_clone = memory_service.clone();
 
             // Create invocation context with MutableSession
-            let invocation_id = format!("inv-{}", uuid::Uuid::new_v4());
+            let invocation_id = stream_invocation_id;
             #[cfg(any(feature = "skills", feature = "plugins"))]
             let mut effective_user_content = user_content.clone();
             #[cfg(not(any(feature = "skills", feature = "plugins")))]
@@ -1319,7 +1374,7 @@ impl Runner {
             }
         };
 
-        Ok(Box::pin(s))
+        Ok(RunnerInvocation { invocation_id, events: Box::pin(s) })
     }
 
     /// Convenience method that accepts string arguments.

--- a/adk-runner/tests/context_tests.rs
+++ b/adk-runner/tests/context_tests.rs
@@ -506,7 +506,7 @@ fn conversation_history_preserves_tool_role() {
 }
 
 #[test]
-fn conversation_history_closes_interrupted_tool_calls_before_next_user_turn() {
+fn conversation_history_omits_interrupted_tool_calls_before_next_user_turn() {
     let session = Arc::new(MockSessionWithState::new());
     let mutable = MutableSession::new(session);
 
@@ -544,10 +544,65 @@ fn conversation_history_closes_interrupted_tool_calls_before_next_user_turn() {
     mutable.append_event(next_user);
 
     let history = mutable.conversation_history();
-    assert_eq!(history.len(), 5);
-    assert_eq!(history[2].role, "function");
-    assert_eq!(history[3].role, "function");
-    assert_eq!(history[4].role, "user");
+    assert_eq!(history.len(), 2);
+    assert_eq!(history[0].role, "user");
+    assert_eq!(history[1].role, "user");
+    assert!(
+        !history.iter().flat_map(|content| &content.parts).any(|part| {
+            matches!(part, Part::FunctionCall { .. } | Part::FunctionResponse { .. })
+        })
+    );
+}
+
+#[test]
+fn conversation_history_does_not_interrupt_a_call_completed_after_an_overlapping_user_turn() {
+    let session = Arc::new(MockSessionWithState::new());
+    let mutable = MutableSession::new(session);
+
+    let mut first_user = Event::new("inv-1");
+    first_user.author = "user".to_string();
+    first_user.llm_response.content = Some(Content::new("user").with_text("run the slow tool"));
+    mutable.append_event(first_user);
+
+    let mut tool_call = Event::new("inv-1");
+    tool_call.author = "assistant".to_string();
+    tool_call.llm_response.content = Some(Content {
+        role: "model".to_string(),
+        parts: vec![Part::FunctionCall {
+            name: "slow_tool".to_string(),
+            args: serde_json::json!({}),
+            id: Some("call-1".to_string()),
+            thought_signature: None,
+        }],
+    });
+    mutable.append_event(tool_call);
+
+    // A second run may append its user event while the first run's tool is
+    // still executing. The later response proves that the call completed.
+    let mut overlapping_user = Event::new("inv-2");
+    overlapping_user.author = "user".to_string();
+    overlapping_user.llm_response.content =
+        Some(Content::new("user").with_text("start another task"));
+    mutable.append_event(overlapping_user);
+
+    let mut tool_response = Event::new("inv-1");
+    tool_response.author = "assistant".to_string();
+    tool_response.llm_response.content = Some(Content {
+        role: "tool".to_string(),
+        parts: vec![Part::FunctionResponse {
+            function_response: FunctionResponseData::new(
+                "slow_tool",
+                serde_json::json!({"ok": true}),
+            ),
+            id: Some("call-1".to_string()),
+            annotations: None,
+        }],
+    });
+    mutable.append_event(tool_response);
+
+    let history = mutable.conversation_history();
+    assert_eq!(history.len(), 4);
+    assert_eq!(history[2].role, "tool");
     assert!(matches!(
         &history[2].parts[..],
         [Part::FunctionResponse {
@@ -555,23 +610,88 @@ fn conversation_history_closes_interrupted_tool_calls_before_next_user_turn() {
             function_response,
             ..
         }] if id == "call-1"
-            && function_response.name == "bash"
-            && function_response.response == serde_json::json!({
-                "error": "Tool execution was interrupted before completion."
-            })
+            && function_response.response == serde_json::json!({"ok": true})
+    ));
+    assert_eq!(history[3].role, "user");
+}
+
+#[test]
+fn conversation_history_keeps_completed_batch_responses_before_late_response() {
+    let session = Arc::new(MockSessionWithState::new());
+    let mutable = MutableSession::new(session);
+
+    let mut first_user = Event::new("inv-1");
+    first_user.author = "user".to_string();
+    first_user.llm_response.content = Some(Content::new("user").with_text("run both tools"));
+    mutable.append_event(first_user);
+
+    let mut tool_calls = Event::new("inv-1");
+    tool_calls.author = "assistant".to_string();
+    tool_calls.llm_response.content = Some(Content {
+        role: "model".to_string(),
+        parts: vec![
+            Part::FunctionCall {
+                name: "fast_tool".to_string(),
+                args: serde_json::json!({}),
+                id: Some("call-1".to_string()),
+                thought_signature: None,
+            },
+            Part::FunctionCall {
+                name: "slow_tool".to_string(),
+                args: serde_json::json!({}),
+                id: Some("call-2".to_string()),
+                thought_signature: None,
+            },
+        ],
+    });
+    mutable.append_event(tool_calls);
+
+    let mut fast_response = Event::new("inv-1");
+    fast_response.author = "assistant".to_string();
+    fast_response.llm_response.content = Some(Content {
+        role: "function".to_string(),
+        parts: vec![Part::FunctionResponse {
+            function_response: FunctionResponseData::new(
+                "fast_tool",
+                serde_json::json!({"fast": true}),
+            ),
+            id: Some("call-1".to_string()),
+            annotations: None,
+        }],
+    });
+    mutable.append_event(fast_response);
+
+    let mut overlapping_user = Event::new("inv-2");
+    overlapping_user.author = "user".to_string();
+    overlapping_user.llm_response.content = Some(Content::new("user").with_text("next request"));
+    mutable.append_event(overlapping_user);
+
+    let mut slow_response = Event::new("inv-1");
+    slow_response.author = "assistant".to_string();
+    slow_response.llm_response.content = Some(Content {
+        role: "function".to_string(),
+        parts: vec![Part::FunctionResponse {
+            function_response: FunctionResponseData::new(
+                "slow_tool",
+                serde_json::json!({"slow": true}),
+            ),
+            id: Some("call-2".to_string()),
+            annotations: None,
+        }],
+    });
+    mutable.append_event(slow_response);
+
+    let history = mutable.conversation_history();
+    assert_eq!(history.len(), 5);
+    assert!(matches!(
+        &history[2].parts[..],
+        [Part::FunctionResponse { id: Some(id), .. }] if id == "call-1"
     ));
     assert!(matches!(
         &history[3].parts[..],
-        [Part::FunctionResponse {
-            id: Some(id),
-            function_response,
-            ..
-        }] if id == "call-2"
-            && function_response.name == "read_file"
-            && function_response.response == serde_json::json!({
-                "error": "Tool execution was interrupted before completion."
-            })
+        [Part::FunctionResponse { id: Some(id), .. }] if id == "call-2"
     ));
+    assert_eq!(history[4].role, "user");
 }
 
 #[test]
@@ -621,6 +741,79 @@ fn conversation_history_matches_idless_tool_responses_by_name() {
     assert_eq!(history.len(), 4);
     assert_eq!(history[2].role, "function");
     assert_eq!(history[3].role, "user");
+}
+
+#[test]
+fn conversation_history_matches_idless_responses_within_their_invocation() {
+    let session = Arc::new(MockSessionWithState::new());
+    let mutable = MutableSession::new(session);
+
+    let mut first_user = Event::new("inv-1");
+    first_user.author = "user".to_string();
+    first_user.llm_response.content = Some(Content::new("user").with_text("first request"));
+    mutable.append_event(first_user);
+
+    let mut first_call = Event::new("inv-1");
+    first_call.author = "assistant".to_string();
+    first_call.llm_response.content = Some(Content {
+        role: "model".to_string(),
+        parts: vec![Part::FunctionCall {
+            name: "slow_tool".to_string(),
+            args: serde_json::json!({"request": 1}),
+            id: None,
+            thought_signature: None,
+        }],
+    });
+    mutable.append_event(first_call);
+
+    let mut second_user = Event::new("inv-2");
+    second_user.author = "user".to_string();
+    second_user.llm_response.content = Some(Content::new("user").with_text("second request"));
+    mutable.append_event(second_user);
+
+    let mut second_call = Event::new("inv-2");
+    second_call.author = "assistant".to_string();
+    second_call.llm_response.content = Some(Content {
+        role: "model".to_string(),
+        parts: vec![Part::FunctionCall {
+            name: "slow_tool".to_string(),
+            args: serde_json::json!({"request": 2}),
+            id: None,
+            thought_signature: None,
+        }],
+    });
+    mutable.append_event(second_call);
+
+    let mut second_response = Event::new("inv-2");
+    second_response.author = "assistant".to_string();
+    second_response.llm_response.content = Some(Content {
+        role: "function".to_string(),
+        parts: vec![Part::FunctionResponse {
+            function_response: FunctionResponseData::new(
+                "slow_tool",
+                serde_json::json!({"request": 2}),
+            ),
+            id: None,
+            annotations: None,
+        }],
+    });
+    mutable.append_event(second_response);
+
+    let history = mutable.conversation_history();
+    assert_eq!(history.len(), 4);
+    assert!(matches!(
+        &history[2].parts[..],
+        [Part::FunctionCall { args, id: None, .. }]
+            if args == &serde_json::json!({"request": 2})
+    ));
+    assert!(matches!(
+        &history[3].parts[..],
+        [Part::FunctionResponse {
+            function_response,
+            id: None,
+            ..
+        }] if function_response.response == serde_json::json!({"request": 2})
+    ));
 }
 
 #[test]

--- a/adk-runner/tests/context_tests.rs
+++ b/adk-runner/tests/context_tests.rs
@@ -506,6 +506,152 @@ fn conversation_history_preserves_tool_role() {
 }
 
 #[test]
+fn conversation_history_closes_interrupted_tool_calls_before_next_user_turn() {
+    let session = Arc::new(MockSessionWithState::new());
+    let mutable = MutableSession::new(session);
+
+    let mut first_user = Event::new("inv-1");
+    first_user.author = "user".to_string();
+    first_user.llm_response.content = Some(Content::new("user").with_text("run tests"));
+    mutable.append_event(first_user);
+
+    let mut tool_call = Event::new("inv-1");
+    tool_call.author = "assistant".to_string();
+    tool_call.llm_response.content = Some(Content {
+        role: "model".to_string(),
+        parts: vec![
+            Part::FunctionCall {
+                name: "bash".to_string(),
+                args: serde_json::json!({"command": "cargo test"}),
+                id: Some("call-1".to_string()),
+                thought_signature: None,
+            },
+            Part::FunctionCall {
+                name: "read_file".to_string(),
+                args: serde_json::json!({"path": "README.md"}),
+                id: Some("call-2".to_string()),
+                thought_signature: None,
+            },
+        ],
+    });
+    mutable.append_event(tool_call);
+
+    // The run is interrupted before the tool can persist its response. A new
+    // user message is the durable boundary that proves the previous turn ended.
+    let mut next_user = Event::new("inv-2");
+    next_user.author = "user".to_string();
+    next_user.llm_response.content = Some(Content::new("user").with_text("continue"));
+    mutable.append_event(next_user);
+
+    let history = mutable.conversation_history();
+    assert_eq!(history.len(), 5);
+    assert_eq!(history[2].role, "function");
+    assert_eq!(history[3].role, "function");
+    assert_eq!(history[4].role, "user");
+    assert!(matches!(
+        &history[2].parts[..],
+        [Part::FunctionResponse {
+            id: Some(id),
+            function_response,
+            ..
+        }] if id == "call-1"
+            && function_response.name == "bash"
+            && function_response.response == serde_json::json!({
+                "error": "Tool execution was interrupted before completion."
+            })
+    ));
+    assert!(matches!(
+        &history[3].parts[..],
+        [Part::FunctionResponse {
+            id: Some(id),
+            function_response,
+            ..
+        }] if id == "call-2"
+            && function_response.name == "read_file"
+            && function_response.response == serde_json::json!({
+                "error": "Tool execution was interrupted before completion."
+            })
+    ));
+}
+
+#[test]
+fn conversation_history_matches_idless_tool_responses_by_name() {
+    let session = Arc::new(MockSessionWithState::new());
+    let mutable = MutableSession::new(session);
+
+    let mut first_user = Event::new("inv-1");
+    first_user.author = "user".to_string();
+    first_user.llm_response.content = Some(Content::new("user").with_text("read the file"));
+    mutable.append_event(first_user);
+
+    let mut tool_call = Event::new("inv-1");
+    tool_call.author = "assistant".to_string();
+    tool_call.llm_response.content = Some(Content {
+        role: "model".to_string(),
+        parts: vec![Part::FunctionCall {
+            name: "read_file".to_string(),
+            args: serde_json::json!({"path": "README.md"}),
+            id: None,
+            thought_signature: None,
+        }],
+    });
+    mutable.append_event(tool_call);
+
+    let mut tool_response = Event::new("inv-1");
+    tool_response.author = "assistant".to_string();
+    tool_response.llm_response.content = Some(Content {
+        role: "function".to_string(),
+        parts: vec![Part::FunctionResponse {
+            function_response: FunctionResponseData::new(
+                "read_file",
+                serde_json::json!({"content": "Sailry"}),
+            ),
+            id: None,
+            annotations: None,
+        }],
+    });
+    mutable.append_event(tool_response);
+
+    let mut next_user = Event::new("inv-2");
+    next_user.author = "user".to_string();
+    next_user.llm_response.content = Some(Content::new("user").with_text("continue"));
+    mutable.append_event(next_user);
+
+    let history = mutable.conversation_history();
+    assert_eq!(history.len(), 4);
+    assert_eq!(history[2].role, "function");
+    assert_eq!(history[3].role, "user");
+}
+
+#[test]
+fn conversation_history_keeps_an_active_tool_call_open_at_the_tail() {
+    let session = Arc::new(MockSessionWithState::new());
+    let mutable = MutableSession::new(session);
+
+    let mut user = Event::new("inv-1");
+    user.author = "user".to_string();
+    user.llm_response.content = Some(Content::new("user").with_text("run tests"));
+    mutable.append_event(user);
+
+    let mut tool_call = Event::new("inv-1");
+    tool_call.author = "assistant".to_string();
+    tool_call.llm_response.content = Some(Content {
+        role: "model".to_string(),
+        parts: vec![Part::FunctionCall {
+            name: "bash".to_string(),
+            args: serde_json::json!({"command": "cargo test"}),
+            id: Some("call-1".to_string()),
+            thought_signature: None,
+        }],
+    });
+    mutable.append_event(tool_call);
+
+    let history = mutable.conversation_history();
+    assert_eq!(history.len(), 2);
+    assert!(matches!(history[1].parts.as_slice(), [Part::FunctionCall { .. }]));
+}
+
+#[test]
 fn conversation_history_maps_agent_events_to_model() {
     // Non-tool agent events should still map to "model"
     let session = Arc::new(MockSessionWithState::new());

--- a/adk-runner/tests/runner_tests.rs
+++ b/adk-runner/tests/runner_tests.rs
@@ -1,7 +1,9 @@
 use adk_core::{Agent, Content, EventStream, InvocationContext, Part, Result, SessionId, UserId};
 use adk_plugin::{Plugin, PluginConfig, PluginManager};
 use adk_runner::Runner;
-use adk_session::{Event, Events, GetRequest, Session, SessionService, State};
+use adk_session::{
+    Event, Events, GetRequest, InMemorySessionService, Session, SessionService, State,
+};
 use adk_skill::{SelectionPolicy, SkillInjector, SkillInjectorConfig};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -984,6 +986,135 @@ fn test_compute_transfer_context_nested() {
     let (parent, peers) = Runner::compute_transfer_context(&root, "mid");
     assert_eq!(parent, Some("root".to_string()));
     assert!(peers.is_empty());
+}
+
+struct InterruptedHistoryAgent {
+    call_persisted: Arc<tokio::sync::Notify>,
+    captured_history: Arc<Mutex<Option<Vec<Content>>>>,
+}
+
+#[async_trait]
+impl Agent for InterruptedHistoryAgent {
+    fn name(&self) -> &str {
+        "interrupted-history"
+    }
+
+    fn description(&self) -> &str {
+        "Captures history after an interrupted tool call"
+    }
+
+    fn sub_agents(&self) -> &[Arc<dyn Agent>] {
+        &[]
+    }
+
+    async fn run(&self, ctx: Arc<dyn InvocationContext>) -> Result<EventStream> {
+        let is_first =
+            ctx.user_content().parts.iter().filter_map(Part::text).any(|text| text == "first");
+        if !is_first {
+            *self.captured_history.lock().unwrap_or_else(|error| error.into_inner()) =
+                Some(ctx.session().conversation_history());
+            return Ok(Box::pin(futures::stream::empty()));
+        }
+
+        let invocation_id = ctx.invocation_id().to_string();
+        let call_persisted = self.call_persisted.clone();
+        Ok(Box::pin(async_stream::stream! {
+            let mut call = Event::new(&invocation_id);
+            call.author = "interrupted-history".to_string();
+            call.llm_response.content = Some(Content {
+                role: "model".to_string(),
+                parts: vec![Part::FunctionCall {
+                    name: "slow_tool".to_string(),
+                    args: serde_json::json!({}),
+                    id: Some("call-1".to_string()),
+                    thought_signature: None,
+                }],
+            });
+            yield Ok(call);
+
+            call_persisted.notify_one();
+            futures::future::pending::<()>().await;
+        }))
+    }
+}
+
+#[tokio::test]
+async fn interrupted_run_does_not_leave_an_orphaned_call_in_the_next_request() {
+    let session_service = Arc::new(InMemorySessionService::new());
+    session_service
+        .create(adk_session::CreateRequest {
+            app_name: "test_app".to_string(),
+            user_id: "user123".to_string(),
+            session_id: Some("interrupted-history".to_string()),
+            state: Default::default(),
+        })
+        .await
+        .unwrap();
+
+    let call_persisted = Arc::new(tokio::sync::Notify::new());
+    let captured_history = Arc::new(Mutex::new(None));
+    let agent = Arc::new(InterruptedHistoryAgent {
+        call_persisted: call_persisted.clone(),
+        captured_history: captured_history.clone(),
+    });
+    let runner = Runner::builder()
+        .app_name("test_app")
+        .agent(agent as Arc<dyn Agent>)
+        .session_service(session_service as Arc<dyn SessionService>)
+        .build()
+        .unwrap();
+
+    let first = runner
+        .run(
+            UserId::new("user123").unwrap(),
+            SessionId::new("interrupted-history").unwrap(),
+            Content::new("user").with_text("first"),
+        )
+        .await
+        .unwrap();
+    let first_task = tokio::spawn(async move {
+        let mut first = first;
+        while let Some(result) = first.next().await {
+            result.unwrap();
+        }
+    });
+    tokio::time::timeout(std::time::Duration::from_secs(2), call_persisted.notified())
+        .await
+        .expect("the first invocation must persist its tool call");
+
+    assert!(runner.interrupt("interrupted-history"));
+    tokio::time::timeout(std::time::Duration::from_secs(2), first_task)
+        .await
+        .expect("the interrupted invocation must stop promptly")
+        .unwrap();
+
+    let mut second = runner
+        .run(
+            UserId::new("user123").unwrap(),
+            SessionId::new("interrupted-history").unwrap(),
+            Content::new("user").with_text("second"),
+        )
+        .await
+        .unwrap();
+    while let Some(result) = second.next().await {
+        result.unwrap();
+    }
+
+    let history = captured_history
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .clone()
+        .expect("the second invocation must capture history");
+    assert_eq!(history.len(), 2);
+    assert!(history.iter().all(|content| content.role == "user"));
+    assert!(!history.iter().flat_map(|content| &content.parts).any(|part| {
+        matches!(
+            part,
+            Part::FunctionCall { id: Some(id), .. }
+                | Part::FunctionResponse { id: Some(id), .. }
+                if id == "call-1"
+        )
+    }));
 }
 
 // Agent that emits events in a loop until cancelled or `max_ticks` is reached.

--- a/adk-runner/tests/runner_tests.rs
+++ b/adk-runner/tests/runner_tests.rs
@@ -209,6 +209,33 @@ impl Agent for TransferAgent {
     }
 }
 
+#[tokio::test]
+async fn started_run_exposes_the_invocation_identity_before_polling() {
+    let runner = Runner::builder()
+        .app_name("test_app")
+        .agent(Arc::new(TransferAgent { name: "test_agent".to_string(), target: None })
+            as Arc<dyn Agent>)
+        .session_service(Arc::new(MockSessionService) as Arc<dyn SessionService>)
+        .build()
+        .unwrap();
+
+    let started = runner
+        .start_with_config(
+            UserId::new("user123").unwrap(),
+            SessionId::new("session456").unwrap(),
+            Content::new("user").with_text("Hello"),
+            None,
+        )
+        .await
+        .unwrap();
+    let invocation_id = started.invocation_id().to_string();
+    let events = started.into_events().collect::<Vec<_>>().await;
+
+    assert!(!invocation_id.is_empty());
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].as_ref().unwrap().invocation_id, invocation_id);
+}
+
 struct StrictTransferRoot {
     root: TransferAgent,
     children: Vec<Arc<dyn Agent>>,

--- a/adk-tool/src/agent_tool.rs
+++ b/adk-tool/src/agent_tool.rs
@@ -533,6 +533,10 @@ impl Tool for AgentTool {
         false
     }
 
+    fn is_agent_delegation(&self) -> bool {
+        true
+    }
+
     #[adk_telemetry::instrument(
         skip(self, ctx, args),
         fields(

--- a/adk-tool/src/builtin/openai.rs
+++ b/adk-tool/src/builtin/openai.rs
@@ -57,14 +57,14 @@ impl OpenAIApproximateLocation {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum OpenAIWebSearchVariant {
     #[default]
-    Stable20250826,
+    Stable,
     Preview20250311,
 }
 
 impl OpenAIWebSearchVariant {
     fn as_wire(self) -> &'static str {
         match self {
-            Self::Stable20250826 => "web_search_2025_08_26",
+            Self::Stable => "web_search",
             Self::Preview20250311 => "web_search_preview_2025_03_11",
         }
     }

--- a/adk-tool/tests/builtin_tests.rs
+++ b/adk-tool/tests/builtin_tests.rs
@@ -106,7 +106,9 @@ fn test_native_declarations_are_exposed() {
     assert_eq!(gemini_decl["x-adk-gemini-tool"]["google_search"], json!({}));
 
     let openai_decl = OpenAIWebSearchTool::new().declaration();
-    assert_eq!(openai_decl["x-adk-openai-tool"]["type"], "web_search_2025_08_26");
+    assert_eq!(openai_decl["x-adk-openai-tool"]["type"], "web_search");
+    let openai_preview_decl = OpenAIWebSearchTool::new().preview().declaration();
+    assert_eq!(openai_preview_decl["x-adk-openai-tool"]["type"], "web_search_preview_2025_03_11");
 
     let anthropic_decl = WebSearchTool::new().declaration();
     assert_eq!(anthropic_decl["x-adk-anthropic-tool"]["type"], "web_search_20250305");

--- a/docs/official_docs/agents/llm-agent.md
+++ b/docs/official_docs/agents/llm-agent.md
@@ -537,7 +537,8 @@ Intercept agent behavior:
 | `output_key(key)` | Saves response to state |
 | `include_contents(mode)` | History visibility |
 | `max_iterations(n)` | Maximum LLM round-trips (default: 100) |
-| `tool_execution_strategy(strategy)` | Tool dispatch mode: `Sequential`, `Parallel`, `ParallelDelegations`, or `Auto` |
+| `tool_execution_strategy(strategy)` | Tool dispatch mode: `Sequential`, `Parallel`, or `Auto` |
+| `parallelize_agent_delegations(bool)` | Overlap consecutive agent-delegation calls without parallelizing ordinary tools |
 | `default_retry_budget(RetryBudget)` | Retry failed tools up to N times with delay |
 | `tool_retry_budget(name, RetryBudget)` | Per-tool retry override |
 | `circuit_breaker_threshold(u32)` | Disable tool after N consecutive failures |
@@ -641,16 +642,16 @@ let agent = LlmAgentBuilder::new("fast_agent")
     .build()?;
 ```
 
-Four strategies are available:
+Three strategies are available:
 
 - `Sequential` (default) — tools execute one at a time in LLM order
 - `Parallel` — all tools execute concurrently; this explicit override bypasses safety metadata, so the caller owns safety
-- `ParallelDelegations` — consecutive agent-delegation tools execute concurrently while ordinary tools remain sequential in their original phases
 - `Auto` — calls whose tools are both read-only and concurrency-safe run concurrently first; all remaining calls then run sequentially
 
 Results are always returned in the original LLM order regardless of strategy. Failed tools produce a JSON error response without aborting the batch.
 
 The strategy is set per-agent via `LlmAgentBuilder::tool_execution_strategy()`. If not set, the default is `Sequential`.
+Use `LlmAgentBuilder::parallelize_agent_delegations(true)` when only consecutive agent-delegation calls should overlap. Ordinary tools remain sequential and keep their original phase ordering.
 
 ## Tool Resilience
 

--- a/docs/official_docs/agents/llm-agent.md
+++ b/docs/official_docs/agents/llm-agent.md
@@ -537,7 +537,7 @@ Intercept agent behavior:
 | `output_key(key)` | Saves response to state |
 | `include_contents(mode)` | History visibility |
 | `max_iterations(n)` | Maximum LLM round-trips (default: 100) |
-| `tool_execution_strategy(strategy)` | Tool dispatch mode: `Sequential`, `Parallel`, or `Auto` |
+| `tool_execution_strategy(strategy)` | Tool dispatch mode: `Sequential`, `Parallel`, `ParallelDelegations`, or `Auto` |
 | `default_retry_budget(RetryBudget)` | Retry failed tools up to N times with delay |
 | `tool_retry_budget(name, RetryBudget)` | Per-tool retry override |
 | `circuit_breaker_threshold(u32)` | Disable tool after N consecutive failures |
@@ -641,10 +641,11 @@ let agent = LlmAgentBuilder::new("fast_agent")
     .build()?;
 ```
 
-Three strategies are available:
+Four strategies are available:
 
 - `Sequential` (default) — tools execute one at a time in LLM order
 - `Parallel` — all tools execute concurrently; this explicit override bypasses safety metadata, so the caller owns safety
+- `ParallelDelegations` — consecutive agent-delegation tools execute concurrently while ordinary tools remain sequential in their original phases
 - `Auto` — calls whose tools are both read-only and concurrency-safe run concurrently first; all remaining calls then run sequentially
 
 Results are always returned in the original LLM order regardless of strategy. Failed tools produce a JSON error response without aborting the batch.

--- a/examples/developer_ergonomics/README.md
+++ b/examples/developer_ergonomics/README.md
@@ -4,7 +4,7 @@ Validates all seven developer ergonomics improvements in ADK-Rust 0.5.x.
 
 ## Features Demonstrated
 
-- `ToolExecutionStrategy` — Sequential, Parallel, Auto dispatch modes
+- `ToolExecutionStrategy` — Sequential, Parallel, ParallelDelegations, Auto dispatch modes
 - Tool metadata — `is_read_only()` / `is_concurrency_safe()` on the Tool trait
 - `RunnerConfigBuilder` — typestate builder with compile-time required field enforcement
 - `SimpleToolContext` — lightweight ToolContext for non-agent callers

--- a/examples/developer_ergonomics/README.md
+++ b/examples/developer_ergonomics/README.md
@@ -4,7 +4,7 @@ Validates all seven developer ergonomics improvements in ADK-Rust 0.5.x.
 
 ## Features Demonstrated
 
-- `ToolExecutionStrategy` — Sequential, Parallel, ParallelDelegations, Auto dispatch modes
+- `ToolExecutionStrategy` — Sequential, Parallel, and Auto dispatch modes
 - Tool metadata — `is_read_only()` / `is_concurrency_safe()` on the Tool trait
 - `RunnerConfigBuilder` — typestate builder with compile-time required field enforcement
 - `SimpleToolContext` — lightweight ToolContext for non-agent callers

--- a/examples/developer_ergonomics/src/main.rs
+++ b/examples/developer_ergonomics/src/main.rs
@@ -2,7 +2,7 @@
 //!
 //! Showcases all seven ergonomics improvements introduced in ADK-Rust 0.5.x:
 //!
-//! 1. **ToolExecutionStrategy** — Sequential, Parallel, Auto dispatch
+//! 1. **ToolExecutionStrategy** — Sequential, Parallel, ParallelDelegations, Auto dispatch
 //! 2. **Tool metadata** — `is_read_only()` / `is_concurrency_safe()` on Tool trait
 //! 3. **RunnerConfigBuilder** — typestate builder for Runner construction
 //! 4. **SimpleToolContext** — lightweight ToolContext for non-agent callers
@@ -85,14 +85,15 @@ fn validate_tool_execution_strategy() {
     assert_eq!(default, ToolExecutionStrategy::Sequential);
     println!("  ✓ Default is Sequential");
 
-    // All three variants exist and are comparable
+    // All four variants exist and are comparable
     let strategies = [
         ToolExecutionStrategy::Sequential,
         ToolExecutionStrategy::Parallel,
+        ToolExecutionStrategy::ParallelDelegations,
         ToolExecutionStrategy::Auto,
     ];
-    assert_eq!(strategies.len(), 3);
-    println!("  ✓ Three variants: Sequential, Parallel, Auto");
+    assert_eq!(strategies.len(), 4);
+    println!("  ✓ Four variants: Sequential, Parallel, ParallelDelegations, Auto");
 
     // Copy + Clone + Debug
     let s = ToolExecutionStrategy::Auto;

--- a/examples/developer_ergonomics/src/main.rs
+++ b/examples/developer_ergonomics/src/main.rs
@@ -2,7 +2,7 @@
 //!
 //! Showcases all seven ergonomics improvements introduced in ADK-Rust 0.5.x:
 //!
-//! 1. **ToolExecutionStrategy** — Sequential, Parallel, ParallelDelegations, Auto dispatch
+//! 1. **ToolExecutionStrategy** — Sequential, Parallel, and Auto dispatch
 //! 2. **Tool metadata** — `is_read_only()` / `is_concurrency_safe()` on Tool trait
 //! 3. **RunnerConfigBuilder** — typestate builder for Runner construction
 //! 4. **SimpleToolContext** — lightweight ToolContext for non-agent callers
@@ -85,15 +85,14 @@ fn validate_tool_execution_strategy() {
     assert_eq!(default, ToolExecutionStrategy::Sequential);
     println!("  ✓ Default is Sequential");
 
-    // All four variants exist and are comparable
+    // All three variants exist and are comparable
     let strategies = [
         ToolExecutionStrategy::Sequential,
         ToolExecutionStrategy::Parallel,
-        ToolExecutionStrategy::ParallelDelegations,
         ToolExecutionStrategy::Auto,
     ];
-    assert_eq!(strategies.len(), 4);
-    println!("  ✓ Four variants: Sequential, Parallel, ParallelDelegations, Auto");
+    assert_eq!(strategies.len(), 3);
+    println!("  ✓ Three variants: Sequential, Parallel, Auto");
 
     // Copy + Clone + Debug
     let s = ToolExecutionStrategy::Auto;


### PR DESCRIPTION
## What

Fix OpenAI-compatible streaming and interrupted/overlapping agent execution. This replaces the closed #647 and #661 with one review surface based on upstream `main`.

### Model adapters

- Serialize stable Responses web search as `web_search`, keeping the dated preview variant explicit.
- Preserve URL citations, response metadata, provider-native usage, cache counters, configured reasoning values, and tool-call identities.
- Keep Open Responses normalization opt-in. Restore omitted streamed arguments by item/call identity or output index, never by iteration position or across contradictory identities.
- Preserve valid argument deltas when a terminal snapshot is blank; ignore empty SSE data frames without panicking.
- Retain errors and usage in terminal Responses events instead of silently dropping the error fields.
- Handle no-argument representations and structured Chat Completions fragments. Empty structured placeholders do not corrupt subsequent string deltas; final arguments are validated before tool execution.
- Serialize function tools in deterministic name order for a stable request prefix.

### Runner and delegation

- Expose the invocation identity with the event stream before polling begins, while retaining existing runner entry points.
- Reconcile actual late tool responses with their calls before a later user message. Preserve response roles and completed batch ordering.
- Omit unresolved calls from earlier turns in the model-request projection without inventing cancellation results or changing persisted events. Leave unresolved tail calls available for the current execution.
- Match idless responses within their invocation; name-only fallback requires missing provenance and an unambiguous candidate.
- Provide opt-in `LlmAgentBuilder::parallelize_agent_delegations(true)`: overlap only consecutive delegation tools, keep ordinary tools sequential, and preserve result ordering. The public `ToolExecutionStrategy` enum is unchanged.

## Why

Protocol-compatible intermediaries can omit stream snapshots or metadata. Incorrect argument pairing, discarded terminal errors, and synthetic interruption results could produce invalid next requests or misleading tool outcomes. Delegation concurrency also needs to be independent of provider request flags.

## How

Use small private stream/history projections at the existing adapter and session boundaries. No new dependencies, process-wide active-run registry, persistence migration, or product-specific fallback is introduced. Public delegation parallelism remains disabled by default. Structured object fragments are a Chat Completions compatibility feature; this PR does not claim to accept arbitrary malformed Responses payloads.

## Validation

Verification of the follow-up fixes (the earlier delegation API checks remain in the existing commit history):

- Regression tests reproduced the failures before the fixes, including empty SSE frames, terminal error preservation, sparse/conflicting tool identities, blank terminal snapshots, overlapping histories, response roles, and idless invocation pairing.
- `cargo nextest run --locked -p adk-model --features openai --lib -E 'test(openai)' --no-fail-fast`: 139 passed; unrelated tests excluded by the scope filter.
- Four affected OpenAI wire/preservation integration binaries: 25 passed, including mocked HTTP/SSE requests in both regular and opt-in compatibility modes.
- `cargo nextest run -p adk-runner`: 130 passed.
- Model and runner all-target clippy gates passed with warnings denied, plus workspace check, workspace all-target clippy, formatting, and whitespace checks.
- Sailry uses the local ADK path dependencies: 78 platform adapter tests and 127 product agent/host tests passed.
- Native macOS desktop E2E: 4 passed, covering message lifecycle, orphaned restart state, draft/reading-position retention, and navigation.
- Real configured relay with `gpt-5.6-sol`, through Sailry's native runtime/controller: passed cache accounting, two tool approvals, durable tool output, actual overlapping subagents, interruption, and a new successful reply in the same session after interruption. The previous turn remained interrupted. Credentials and the private endpoint are not included here.

The full ADK workspace test suite is left to PR CI; only affected test scopes were rerun locally. Live validation covers the configured relay/model, not every provider or model. Cache hits depend on the upstream provider; no cache assertion was relaxed to obtain a pass.

## PR Checklist

- [x] Formatting, workspace compilation, and warning-free lint gates passed.
- [x] Affected unit/integration tests and native product integration passed.
- [x] New regression coverage and independent follow-up review.
- [x] No new dependencies, secrets, local artifacts, or unrelated product changes in this PR.
- [x] Existing public entry points and tool execution enum retained.
- [x] Conventional commits; targets `main`.
- [x] CHANGELOG and runner documentation updated.
- [ ] Latest-head PR CI and maintainer review/merge (pending after push).
