### PR TITLE
fix: keep the account name out of stdout when warning about UI sign-in

### DIFF
--- a/examples/bi_analyst/src/main.rs
+++ b/examples/bi_analyst/src/main.rs
@@ -533,6 +533,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // because the sign-in the browser needs is not always the API's credentials.
     let ui_user = std::env::var("BI_UI_USERNAME").or_else(|_| std::env::var("SUPERSET_USERNAME"));
     let ui_pass = std::env::var("BI_UI_PASSWORD").or_else(|_| std::env::var("SUPERSET_PASSWORD"));
+    // Which variable supplied the account, for the warning below. Naming the source is
+    // more useful than naming the account — it says whether the fallback was taken — and
+    // it keeps an identity out of stdout, which in CI or a container is a retained log.
+    let ui_source = if std::env::var("BI_UI_USERNAME").is_ok() {
+        "BI_UI_USERNAME"
+    } else {
+        "SUPERSET_USERNAME"
+    };
     let ui_login = match (std::env::var("BI_UI_LOGIN").is_ok(), ui_user, ui_pass) {
         (true, Ok(username), Ok(password)) => {
             // Registered so the value is scrubbed wherever it surfaces, including a
@@ -540,7 +548,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             // it back. Name-based rules alone cannot see either.
             register_secret(&password);
             println!(
-                "  \u{26a0} BI_UI_LOGIN set \u{2014} the browser sign-in for {username:?} will be \
+                "  \u{26a0} BI_UI_LOGIN set \u{2014} the browser sign-in from {ui_source} will be \
                  sent to the model so it can log in on screen. Use a throwaway account."
             );
             Some((username, password))


### PR DESCRIPTION
CodeQL flagged this on #666 (`rust/cleartext-logging`, high). The alert arrived after that
PR had already merged, so the finding is currently live on `main` — this carries only the
fix.

## What it caught

#666 added value-based secret redaction: a credential handed to the driver is registered so
it is scrubbed wherever it surfaces, including through a generic text field whose name
announces nothing and a tool result that echoes it back. That closed the password hole and
left the account name printed verbatim in the warning beside it:

```rust
println!(
    "  ⚠ BI_UI_LOGIN set — the browser sign-in for {username:?} will be \
     sent to the model so it can log in on screen. Use a throwaway account."
);
```

stdout in CI or a container is a retained log, and a username is half a credential pair.
Registering it for redaction is not the answer either — the registry deliberately ignores
short values, and scrubbing something like `admin` would redact ordinary prose.

## The fix

The warning exists to tell an operator that credentials are about to enter the model's
context. That purpose does not need the account spelled out, so it now names the *variable*
the account came from:

```
⚠ BI_UI_LOGIN set — the browser sign-in from SUPERSET_USERNAME will be sent to the model …
```

Which is more useful to the reader anyway: it says whether the `BI_UI_USERNAME` lookup or
the `SUPERSET_USERNAME` fallback was taken, which the account name alone does not.

## What is deliberately unchanged

The brief still contains the username. Handing the agent credentials so it can sign in on
screen is exactly what `BI_UI_LOGIN` opts into, and the code says so out loud two lines
above the warning. CodeQL agrees — it flagged the log sink and not the brief.

9 tests in `bi_analyst`, 15 in `run_console_driver`, clippy clean, and no `println!` in the
example carries a username.